### PR TITLE
[static] Check `override` in prop DSL

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -393,17 +393,10 @@ public:
         return Override(loc, std::move(args));
     }
 
-    static ExpressionPtr OverrideAllowIncompatibleTrue(core::LocOffsets loc) {
+    static ExpressionPtr OverrideAllowIncompatible(core::LocOffsets loc, core::LocOffsets allowLoc, ExpressionPtr arg) {
         Send::ARGS_store args;
-        args.push_back(Symbol(loc, core::Names::allowIncompatible()));
-        args.push_back(True(loc));
-        return Override(loc, std::move(args));
-    }
-
-    static ExpressionPtr OverrideAllowIncompatibleVisibility(core::LocOffsets loc) {
-        Send::ARGS_store args;
-        args.push_back(Symbol(loc, core::Names::allowIncompatible()));
-        args.push_back(Symbol(loc, core::Names::visibility()));
+        args.push_back(Symbol(allowLoc, core::Names::allowIncompatible()));
+        args.push_back(std::move(arg));
         return Override(loc, std::move(args));
     }
 

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -344,8 +344,8 @@ private:
 
 public:
     static ExpressionPtr Sig(core::LocOffsets loc, Send::ARGS_store args, ExpressionPtr ret,
-                             std::optional<ExpressionPtr> recv_ = std::nullopt) {
-        auto recv = recv_ ? std::move(recv_.value()) : Self(loc);
+                             ExpressionPtr recv_ = nullptr) {
+        auto recv = recv_ ? std::move(recv_) : Self(loc);
         auto params = Params(loc, std::move(recv), std::move(args));
         auto returns = Send1(loc, std::move(params), core::Names::returns(), loc, std::move(ret));
         Send::Flags flags;
@@ -356,9 +356,8 @@ public:
                     flags);
     }
 
-    static ExpressionPtr SigVoid(core::LocOffsets loc, Send::ARGS_store args,
-                                 std::optional<ExpressionPtr> recv_ = std::nullopt) {
-        auto recv = recv_ ? std::move(recv_.value()) : Self(loc);
+    static ExpressionPtr SigVoid(core::LocOffsets loc, Send::ARGS_store args, ExpressionPtr recv_ = nullptr) {
+        auto recv = recv_ ? std::move(recv_) : Self(loc);
         auto params = Params(loc, std::move(recv), std::move(args));
         auto void_ = Send0(loc, std::move(params), core::Names::void_(), loc);
         Send::Flags flags;
@@ -369,9 +368,8 @@ public:
                     flags);
     }
 
-    static ExpressionPtr Sig0(core::LocOffsets loc, ExpressionPtr ret,
-                              std::optional<ExpressionPtr> recv_ = std::nullopt) {
-        auto recv = recv_ ? std::move(recv_.value()) : Self(loc);
+    static ExpressionPtr Sig0(core::LocOffsets loc, ExpressionPtr ret, ExpressionPtr recv_ = nullptr) {
+        auto recv = recv_ ? std::move(recv_) : Self(loc);
         auto returns = Send1(loc, std::move(recv), core::Names::returns(), loc, std::move(ret));
         Send::Flags flags;
         flags.isRewriterSynthesized = true;
@@ -382,7 +380,7 @@ public:
     }
 
     static ExpressionPtr Sig1(core::LocOffsets loc, ExpressionPtr key, ExpressionPtr value, ExpressionPtr ret,
-                              std::optional<ExpressionPtr> recv_ = std::nullopt) {
+                              ExpressionPtr recv_ = nullptr) {
         return Sig(loc, SendArgs(std::move(key), std::move(value)), std::move(ret), std::move(recv_));
     }
 

--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -20,6 +20,7 @@ constexpr ErrorClass NilableUntyped{3512, StrictLevel::False};
 constexpr ErrorClass ContravariantHasAttachedClass{3514, StrictLevel::False};
 constexpr ErrorClass DuplicateProp{3515, StrictLevel::True};
 constexpr ErrorClass VoidAttrReader{3516, StrictLevel::True};
+constexpr ErrorClass PropBadOverride{3517, StrictLevel::False};
 
 // Let's reserve 3550-3569 for RBS related errors
 constexpr ErrorClass RBSSyntaxError{3550, StrictLevel::False};
@@ -31,7 +32,6 @@ constexpr ErrorClass RBSMultilineMisformatted{3555, StrictLevel::False};
 constexpr ErrorClass RBSIncorrectParameterKind{3556, StrictLevel::False};
 constexpr ErrorClass RBSMultipleGenericSignatures{3557, StrictLevel::False};
 constexpr ErrorClass RBSAbstractMethodNoRaises{3558, StrictLevel::False};
-constexpr ErrorClass PropBadOverride{3559, StrictLevel::False};
 
 } // namespace sorbet::core::errors::Rewriter
 #endif

--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -31,6 +31,7 @@ constexpr ErrorClass RBSMultilineMisformatted{3555, StrictLevel::False};
 constexpr ErrorClass RBSIncorrectParameterKind{3556, StrictLevel::False};
 constexpr ErrorClass RBSMultipleGenericSignatures{3557, StrictLevel::False};
 constexpr ErrorClass RBSAbstractMethodNoRaises{3558, StrictLevel::False};
+constexpr ErrorClass PropBadOverride{3559, StrictLevel::False};
 
 } // namespace sorbet::core::errors::Rewriter
 #endif

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -117,6 +117,8 @@ NameDef names[] = {
     {"overridable"},
     {"allowIncompatible", "allow_incompatible"},
     {"visibility"},
+    {"reader"},
+    {"writer"},
     {"sigForMethod"},
 
     // Sig builders

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -604,7 +604,13 @@ constructOverrideAutocorrect(const core::Context ctx, const ast::ExpressionPtr &
         return nullopt;
     }
 
-    auto *block = parsedSig->origSend.block();
+    auto &origSend = parsedSig->origSend;
+
+    if (origSend.flags.isRewriterSynthesized) {
+        return nullopt;
+    }
+
+    auto *block = origSend.block();
     if (!block) {
         return nullopt;
     }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -604,8 +604,9 @@ constructOverrideAutocorrect(const core::Context ctx, const ast::ExpressionPtr &
         return nullopt;
     }
 
-    // If the sig itself is generated, it doesn't make much sense to suggest an autocorrect for it.
     auto &origSend = parsedSig->origSend;
+
+    // If the sig itself is generated, it doesn't make much sense to suggest an autocorrect for it.
     if (origSend.flags.isRewriterSynthesized) {
         return nullopt;
     }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -604,8 +604,8 @@ constructOverrideAutocorrect(const core::Context ctx, const ast::ExpressionPtr &
         return nullopt;
     }
 
+    // If the sig itself is generated, it doesn't make much sense to suggest an autocorrect for it.
     auto &origSend = parsedSig->origSend;
-
     if (origSend.flags.isRewriterSynthesized) {
         return nullopt;
     }

--- a/rewriter/MixinEncryptedProp.cc
+++ b/rewriter/MixinEncryptedProp.cc
@@ -70,10 +70,10 @@ vector<ast::ExpressionPtr> MixinEncryptedProp::run(core::MutableContext ctx, ast
     // Compute the getters
 
     stats.emplace_back(ast::MK::Sig(loc, {}, mkNilableString(loc)));
-    stats.emplace_back(ASTUtil::mkGet(ctx, loc, name, ast::MK::RaiseUnimplemented(loc)));
+    stats.emplace_back(ASTUtil::mkSyntheticGet(ctx, loc, name, ast::MK::RaiseUnimplemented(loc)));
 
     stats.emplace_back(ast::MK::Sig(loc, {}, mkNilableEncryptedValue(ctx, loc)));
-    stats.emplace_back(ASTUtil::mkGet(ctx, loc, enc_name, ast::MK::RaiseUnimplemented(loc)));
+    stats.emplace_back(ASTUtil::mkSyntheticGet(ctx, loc, enc_name, ast::MK::RaiseUnimplemented(loc)));
     core::NameRef setName = name.addEq(ctx);
     core::NameRef setEncName = enc_name.addEq(ctx);
 
@@ -81,11 +81,11 @@ vector<ast::ExpressionPtr> MixinEncryptedProp::run(core::MutableContext ctx, ast
     if (!isImmutable) {
         stats.emplace_back(ast::MK::Sig1(loc, ast::MK::Symbol(nameLoc, core::Names::arg0()), mkNilableString(loc),
                                          mkNilableString(loc)));
-        stats.emplace_back(ASTUtil::mkSet(ctx, loc, setName, nameLoc, ast::MK::RaiseUnimplemented(loc)));
+        stats.emplace_back(ASTUtil::mkSyntheticSet(ctx, loc, setName, nameLoc, ast::MK::RaiseUnimplemented(loc)));
 
         stats.emplace_back(ast::MK::Sig1(loc, ast::MK::Symbol(nameLoc, core::Names::arg0()),
                                          mkNilableEncryptedValue(ctx, loc), mkNilableEncryptedValue(ctx, loc)));
-        stats.emplace_back(ASTUtil::mkSet(ctx, loc, setEncName, nameLoc, ast::MK::RaiseUnimplemented(loc)));
+        stats.emplace_back(ASTUtil::mkSyntheticSet(ctx, loc, setEncName, nameLoc, ast::MK::RaiseUnimplemented(loc)));
     }
 
     return stats;

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -345,7 +345,8 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
             if (lit != nullptr && lit->isSymbol()) {
                 ret.computedByMethodNameLoc = lit->loc;
                 ret.computedByMethodName = lit->asSymbol();
-            } else {
+            } else if (auto e = ctx.beginIndexerError(val.loc(), core::errors::Rewriter::ComputedBySymbol)) {
+                e.setHeader("Value for `{}` must be a symbol literal", "computed_by");
             }
         }
 

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -418,7 +418,6 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
                     auto allowIncompatLoc = allowIncompatKey.loc();
                     if (auto lit = ast::cast_tree<ast::Literal>(allowIncompatArg)) {
                         if (lit->isTrue(ctx)) {
-                            // XXX cwong: Can we share these/are they interned somehow?
                             auto trueNodeGetter = ast::MK::True(lit->loc);
                             auto trueNodeSetter = ast::MK::True(lit->loc);
                             ret.getterOverride = ast::MK::OverrideAllowIncompatible(overrideLoc, allowIncompatLoc,

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -388,7 +388,7 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
             }
         }
         auto [overrideKey, overrideArg] = ASTUtil::extractHashValue(ctx, *rules, core::Names::override_());
-        auto overrideLoc = overrideKey.loc().copyWithZeroLength();
+        auto overrideLoc = overrideKey.loc();
         if (overrideArg != nullptr) {
             if (auto lit = ast::cast_tree<ast::Literal>(overrideArg)) {
                 if (lit->isTrue(ctx)) {
@@ -432,10 +432,8 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
                         e.addErrorNote("should be `{}` or `{}`", "true", ":visibility");
                     }
                 } else {
-                    ret.getterOverride =
-                        elaborateOverride(ctx, overrideKey.loc(), *opts, core::Names::reader(), "reader");
-                    ret.setterOverride =
-                        elaborateOverride(ctx, overrideKey.loc(), *opts, core::Names::writer(), "writer");
+                    ret.getterOverride = elaborateOverride(ctx, overrideLoc, *opts, core::Names::reader(), "reader");
+                    ret.setterOverride = elaborateOverride(ctx, overrideLoc, *opts, core::Names::writer(), "writer");
                 }
             } else {
                 emitBadOverride(ctx, overrideArg.loc());
@@ -466,8 +464,7 @@ vector<ast::ExpressionPtr> processProp(core::MutableContext ctx, PropInfo &prop,
 
     auto ivarName = name.addAt(ctx);
 
-    auto readerSig =
-        ast::MK::Sig0(loc.copyWithZeroLength(), ASTUtil::dupType(getType), std::exchange(prop.getterOverride, nullopt));
+    auto readerSig = ast::MK::Sig0(loc, ASTUtil::dupType(getType), std::exchange(prop.getterOverride, nullopt));
     nodes.emplace_back(std::move(readerSig));
 
     // Generate a real prop body for computed_by: props so Sorbet can assert the
@@ -513,7 +510,7 @@ vector<ast::ExpressionPtr> processProp(core::MutableContext ctx, PropInfo &prop,
         sigArgs.emplace_back(ast::MK::Symbol(nameLoc, core::Names::arg0()));
         sigArgs.emplace_back(ASTUtil::dupType(setType));
 
-        auto writerSig = ast::MK::Sig(loc.copyWithZeroLength(), std::move(sigArgs), ASTUtil::dupType(setType),
+        auto writerSig = ast::MK::Sig(loc, std::move(sigArgs), ASTUtil::dupType(setType),
                                       std::exchange(prop.setterOverride, nullopt));
         nodes.emplace_back(std::move(writerSig));
 

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -113,7 +113,7 @@ void emitBadOverride(core::MutableContext ctx, const core::LocOffsets loc, core:
 }
 
 ast::ExpressionPtr elaborateOverride(core::MutableContext ctx, core::LocOffsets overrideLoc, ast::Hash &opts,
-                                     core::NameRef propName, core::NameRef key, std::string rendered) {
+                                     core::NameRef propName, core::NameRef key, string_view rendered) {
     auto [_key, arg] = ASTUtil::extractHashValue(ctx, opts, key);
     if (auto lit = ast::cast_tree<ast::Literal>(arg)) {
         if (lit->isTrue(ctx)) {

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -107,7 +107,7 @@ struct NodesAndPropInfo {
 
 void emitBadOverride(core::MutableContext ctx, const core::LocOffsets loc, core::NameRef name) {
     if (auto e = ctx.beginIndexerError(loc, core::errors::Rewriter::PropBadOverride)) {
-        e.setHeader("Malformed `{}` in prop `{}`", "override", name);
+        e.setHeader("Malformed `{}` in prop `{}`", "override", name.show(ctx));
         e.addErrorNote("The argument to `{}` must be `{}`, `{}`, `{}`, or a hash literal", "override:", "true",
                        ":reader", ":writer");
     }

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -388,8 +388,8 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
             }
         }
         auto [overrideKey, overrideArg] = ASTUtil::extractHashValue(ctx, *rules, core::Names::override_());
-        auto overrideLoc = overrideKey.loc();
         if (overrideArg != nullptr) {
+            auto overrideLoc = overrideKey.loc();
             if (auto lit = ast::cast_tree<ast::Literal>(overrideArg)) {
                 if (lit->isTrue(ctx)) {
                     ret.getterOverride = ast::MK::OverrideStrict(overrideLoc);

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -115,7 +115,10 @@ void emitBadOverride(core::MutableContext ctx, const core::LocOffsets loc, core:
 ast::ExpressionPtr elaborateOverride(core::MutableContext ctx, core::LocOffsets overrideLoc, ast::Hash &opts,
                                      core::NameRef propName, core::NameRef key, string_view rendered) {
     auto [_key, arg] = ASTUtil::extractHashValue(ctx, opts, key);
-    if (auto lit = ast::cast_tree<ast::Literal>(arg)) {
+    // no override key present
+    if (arg == nullptr) {
+        return nullptr;
+    } else if (auto lit = ast::cast_tree<ast::Literal>(arg)) {
         if (lit->isTrue(ctx)) {
             return ast::MK::OverrideStrict(overrideLoc);
         } else if (lit->isFalse(ctx)) {
@@ -158,7 +161,7 @@ ast::ExpressionPtr elaborateOverride(core::MutableContext ctx, core::LocOffsets 
             e.setHeader("Malformed `{}` in override for prop `{}`: expected `{}`, `{}` or `{}`", rendered,
                         propName.show(ctx), "true", "{allow_incompatible: :visibility}", "{allow_incompatible: true}");
         }
-    } else if (arg != nullptr) {
+    } else {
         if (auto e = ctx.beginIndexerError(arg.loc(), core::errors::Rewriter::PropBadOverride)) {
             e.setHeader("Malformed `{}` in override for prop `{}`: expected `{}`, `{}` or `{}`", rendered,
                         propName.show(ctx), "true", "{allow_incompatible: :visibility}", "{allow_incompatible: true}");

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -388,7 +388,6 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
                 }
             }
         }
-
         auto [_overrideKey, overrideArg] = ASTUtil::extractHashValue(ctx, *rules, core::Names::override_());
         if (overrideArg != nullptr) {
             if (auto lit = ast::cast_tree<ast::Literal>(overrideArg)) {
@@ -414,7 +413,7 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
                 elaborateOverride(ctx, *opts, core::Names::reader(), "reader", ret.getterOverride);
                 elaborateOverride(ctx, *opts, core::Names::writer(), "writer", ret.setterOverride);
             } else {
-                emitBadOverride(ctx, lit->loc);
+                emitBadOverride(ctx, overrideArg.loc());
             }
         }
     }

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -481,7 +481,7 @@ vector<ast::ExpressionPtr> processProp(core::MutableContext ctx, PropInfo &prop,
 
     auto ivarName = name.addAt(ctx);
 
-    auto readerSig = ast::MK::Sig0(loc, ASTUtil::dupType(getType), std::exchange(prop.getterOverride, nullptr));
+    auto readerSig = ast::MK::Sig0(loc, ASTUtil::dupType(getType), move(prop.getterOverride));
     nodes.emplace_back(std::move(readerSig));
 
     // Generate a real prop body for computed_by: props so Sorbet can assert the

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -448,6 +448,7 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
     return ret;
 }
 
+// cwong: C++23 has `std::optional::transform`, which I think would be a better way to write this.
 optional<ast::Send::ARGS_store> mkOverrideParams(core::LocOffsets loc, optional<OverrideKind> cfg) {
     if (!cfg) {
         return nullopt;

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -527,8 +527,7 @@ vector<ast::ExpressionPtr> processProp(core::MutableContext ctx, PropInfo &prop,
         sigArgs.emplace_back(ast::MK::Symbol(nameLoc, core::Names::arg0()));
         sigArgs.emplace_back(ASTUtil::dupType(setType));
 
-        auto writerSig = ast::MK::Sig(loc, std::move(sigArgs), ASTUtil::dupType(setType),
-                                      std::exchange(prop.setterOverride, nullptr));
+        auto writerSig = ast::MK::Sig(loc, std::move(sigArgs), ASTUtil::dupType(setType), move(prop.setterOverride));
         nodes.emplace_back(std::move(writerSig));
 
         if (prop.enum_ == nullptr) {

--- a/rewriter/util/Util.cc
+++ b/rewriter/util/Util.cc
@@ -285,14 +285,14 @@ ast::ExpressionPtr ASTUtil::mkKwArgsHash(const ast::Send *send) {
 ast::ExpressionPtr ASTUtil::mkGet(core::Context ctx, core::LocOffsets loc, core::NameRef name, ast::ExpressionPtr rhs,
                                   ast::MethodDef::Flags flags) {
     flags.isAttrBestEffortUIOnly = true;
-    auto ret = ast::MK::SyntheticMethod0(loc, loc, name, move(rhs), flags);
+    auto ret = ast::MK::Method0(loc, loc, name, move(rhs), flags);
     return ret;
 }
 
 ast::ExpressionPtr ASTUtil::mkSet(core::Context ctx, core::LocOffsets loc, core::NameRef name, core::LocOffsets argLoc,
                                   ast::ExpressionPtr rhs, ast::MethodDef::Flags flags) {
     flags.isAttrBestEffortUIOnly = true;
-    return ast::MK::SyntheticMethod1(loc, loc, name, ast::MK::Local(argLoc, core::Names::arg0()), move(rhs), flags);
+    return ast::MK::Method1(loc, loc, name, ast::MK::Local(argLoc, core::Names::arg0()), move(rhs), flags);
 }
 
 ast::ExpressionPtr ASTUtil::mkNilable(core::LocOffsets loc, ast::ExpressionPtr type) {

--- a/rewriter/util/Util.cc
+++ b/rewriter/util/Util.cc
@@ -285,14 +285,26 @@ ast::ExpressionPtr ASTUtil::mkKwArgsHash(const ast::Send *send) {
 ast::ExpressionPtr ASTUtil::mkGet(core::Context ctx, core::LocOffsets loc, core::NameRef name, ast::ExpressionPtr rhs,
                                   ast::MethodDef::Flags flags) {
     flags.isAttrBestEffortUIOnly = true;
-    auto ret = ast::MK::Method0(loc, loc, name, move(rhs), flags);
-    return ret;
+    return ast::MK::Method0(loc, loc, name, move(rhs), flags);
 }
 
 ast::ExpressionPtr ASTUtil::mkSet(core::Context ctx, core::LocOffsets loc, core::NameRef name, core::LocOffsets argLoc,
                                   ast::ExpressionPtr rhs, ast::MethodDef::Flags flags) {
     flags.isAttrBestEffortUIOnly = true;
     return ast::MK::Method1(loc, loc, name, ast::MK::Local(argLoc, core::Names::arg0()), move(rhs), flags);
+}
+
+ast::ExpressionPtr ASTUtil::mkSyntheticGet(core::Context ctx, core::LocOffsets loc, core::NameRef name,
+                                           ast::ExpressionPtr rhs, ast::MethodDef::Flags flags) {
+    flags.isAttrBestEffortUIOnly = true;
+    return ast::MK::SyntheticMethod0(loc, loc, name, move(rhs), flags);
+}
+
+ast::ExpressionPtr ASTUtil::mkSyntheticSet(core::Context ctx, core::LocOffsets loc, core::NameRef name,
+                                           core::LocOffsets argLoc, ast::ExpressionPtr rhs,
+                                           ast::MethodDef::Flags flags) {
+    flags.isAttrBestEffortUIOnly = true;
+    return ast::MK::SyntheticMethod1(loc, loc, name, ast::MK::Local(argLoc, core::Names::arg0()), move(rhs), flags);
 }
 
 ast::ExpressionPtr ASTUtil::mkNilable(core::LocOffsets loc, ast::ExpressionPtr type) {

--- a/rewriter/util/Util.h
+++ b/rewriter/util/Util.h
@@ -30,6 +30,14 @@ public:
                                     core::LocOffsets argLoc, ast::ExpressionPtr rhs,
                                     ast::MethodDef::Flags flags = ast::MethodDef::Flags());
 
+    static ast::ExpressionPtr mkSyntheticGet(core::Context ctx, core::LocOffsets loc, core::NameRef name,
+                                             ast::ExpressionPtr rhs,
+                                             ast::MethodDef::Flags flags = ast::MethodDef::Flags());
+
+    static ast::ExpressionPtr mkSyntheticSet(core::Context ctx, core::LocOffsets loc, core::NameRef name,
+                                             core::LocOffsets argLoc, ast::ExpressionPtr rhs,
+                                             ast::MethodDef::Flags flags = ast::MethodDef::Flags());
+
     static ast::ExpressionPtr mkNilable(core::LocOffsets loc, ast::ExpressionPtr type);
 
     static ast::ExpressionPtr thunkBody(core::MutableContext ctx, ast::ExpressionPtr &node);

--- a/test/testdata/infer/generics/fixed_noreturn.rb
+++ b/test/testdata/infer/generics/fixed_noreturn.rb
@@ -38,8 +38,8 @@ class Cons < T::Struct
 
   Elem = type_member
 
-  const :head, Elem, override: true
-  const :tail, List[Elem], override: true
+  const :head, Elem
+  const :tail, List[Elem]
 
   sig {override.returns(Elem)}
   def head!; head; end

--- a/test/testdata/infer/sealed_list_fixed_noreturn.rb
+++ b/test/testdata/infer/sealed_list_fixed_noreturn.rb
@@ -16,7 +16,7 @@ module List
     include List
     Elem = type_member
 
-    prop :head, Elem
+    prop :head, Elem, override: :reader
     prop :tail, List[Elem]
   end
 

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -1358,7 +1358,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U foo><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -1426,7 +1426,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U foo=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -1720,7 +1720,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U default><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -1788,7 +1788,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U default=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -1858,7 +1858,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U t_nilable><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -1950,7 +1950,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U t_nilable=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -2008,7 +2008,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U array><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -2076,7 +2076,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U array=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -2149,7 +2149,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U t_array><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -2247,7 +2247,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U t_array=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -2324,7 +2324,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U hash_of><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -2430,7 +2430,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U hash_of=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -2488,7 +2488,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U const_explicit><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -2543,7 +2543,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U const><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -2598,7 +2598,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U enum_prop><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -2666,7 +2666,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U enum_prop=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -2724,7 +2724,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U foreign><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -2792,7 +2792,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U foreign=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -3040,7 +3040,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U foreign_lazy><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -3108,7 +3108,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U foreign_lazy=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -3356,7 +3356,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U foreign_proc><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -3424,7 +3424,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U foreign_proc=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -3672,7 +3672,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U foreign_invalid><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -3740,7 +3740,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U foreign_invalid=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -3992,7 +3992,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U ifunset><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -4060,7 +4060,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U ifunset=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -4130,7 +4130,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U ifunset_nilable><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -4222,7 +4222,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U ifunset_nilable=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -4280,7 +4280,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U empty_hash_rules><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -4348,7 +4348,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U empty_hash_rules=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -4406,7 +4406,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U hash_rules><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -4474,7 +4474,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U hash_rules=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -5047,7 +5047,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U token><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -5115,7 +5115,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U token=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -5173,7 +5173,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U created><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -5241,7 +5241,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U created=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -5400,7 +5400,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U token><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -5468,7 +5468,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U token=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -5526,7 +5526,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U created><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -5732,7 +5732,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U foo><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -5826,7 +5826,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U encrypted_foo><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -5930,7 +5930,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U foo=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -6067,7 +6067,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U encrypted_foo=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -6149,7 +6149,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U bar><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -6243,7 +6243,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {rewriterSynthesized}
+          flags = {}
           name = <U encrypted_bar><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -5732,7 +5732,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {}
+          flags = {rewriterSynthesized}
           name = <U foo><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -5826,7 +5826,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {}
+          flags = {rewriterSynthesized}
           name = <U encrypted_foo><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -5930,7 +5930,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {}
+          flags = {rewriterSynthesized}
           name = <U foo=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -6067,7 +6067,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {}
+          flags = {rewriterSynthesized}
           name = <U encrypted_foo=><<U <todo method>>>
           args = [UnresolvedIdent{
               kind = Local
@@ -6149,7 +6149,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {}
+          flags = {rewriterSynthesized}
           name = <U bar><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
@@ -6243,7 +6243,7 @@ ClassDef{
         }
 
         MethodDef{
-          flags = {}
+          flags = {rewriterSynthesized}
           name = <U encrypted_bar><<U <todo method>>>
           args = [BlockArg{ expr = UnresolvedIdent{
               kind = Local

--- a/test/testdata/rewriter/prop_override.rb
+++ b/test/testdata/rewriter/prop_override.rb
@@ -1,0 +1,91 @@
+# typed: true
+
+module Reader
+  extend T::Sig
+  extend T::Helpers
+
+  abstract!
+
+  sig { abstract.returns(Integer) }
+  def foo; end
+end
+
+module Writer
+  extend T::Sig
+  extend T::Helpers
+
+  abstract!
+
+  sig { abstract.params(arg0: Integer).returns(Integer) }
+  def foo=(arg0); end
+end
+
+class Good < T::Struct
+  include Reader
+  include Writer
+
+  prop :foo, Integer, override: true
+end
+
+class Bad < T::Struct
+  include Reader
+  include Writer
+
+  prop :foo, String, override: true
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Return type `String` does not match return type of abstract method `Reader#foo`
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Return type `String` does not match return type of abstract method `Writer#foo=`
+#       ^^^ error: Parameter `foo` of type `String` not compatible with type of abstract method `Writer#foo=`
+end
+
+class ReaderOnly < T::Struct
+  include Reader
+
+  prop :foo, Integer, override: :reader
+end
+
+class ReaderOnlyConst < T::Struct
+  include Reader
+
+  const :foo, Integer, override: true
+end
+
+class ReaderOnlyBad < T::Struct
+  include Reader
+
+  prop :foo, Integer, override: true # error: Method `ReaderOnlyBad#foo=` is marked `override` but does not override anything
+end
+
+class OverrideNothing < T::Struct
+  prop :foo, Integer, override: true
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Method `OverrideNothing#foo` is marked `override` but does not override anything
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Method `OverrideNothing#foo=` is marked `override` but does not override anything
+end
+
+class OverrideAllowIncompatible < T::Struct
+  include Reader
+
+  prop :foo, String, override: {reader: {allow_incompatible: true}}
+end
+
+class OverridePrivateGood < T::Struct
+  include Writer
+
+  prop :foo, Integer, override: {writer: {allow_incompatible: :visibility}}
+
+  private :foo=
+end
+
+class OverridePrivateBad < T::Struct
+  include Writer
+
+  prop :foo, Integer, override: {writer: true} # error: Method `foo=` is private in `OverridePrivateBad` but not in `Writer`
+
+  private :foo=
+end
+
+class OverrideIncompatibleTrue < T::Struct
+  include Reader
+  include Writer
+
+  prop :foo, String, override: {allow_incompatible: true}
+end

--- a/test/testdata/rewriter/prop_override.rb.autocorrects.exp
+++ b/test/testdata/rewriter/prop_override.rb.autocorrects.exp
@@ -1,0 +1,93 @@
+# -- test/testdata/rewriter/prop_override.rb --
+# typed: true
+
+module Reader
+  extend T::Sig
+  extend T::Helpers
+
+  abstract!
+
+  sig { abstract.returns(Integer) }
+  def foo; end
+end
+
+module Writer
+  extend T::Sig
+  extend T::Helpers
+
+  abstract!
+
+  sig { abstract.params(arg0: Integer).returns(Integer) }
+  def foo=(arg0); end
+end
+
+class Good < T::Struct
+  include Reader
+  include Writer
+
+  prop :foo, Integer, override: true
+end
+
+class Bad < T::Struct
+  include Reader
+  include Writer
+
+  prop :foo, String, override: true
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Return type `String` does not match return type of abstract method `Reader#foo`
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Return type `String` does not match return type of abstract method `Writer#foo=`
+#       ^^^ error: Parameter `foo` of type `String` not compatible with type of abstract method `Writer#foo=`
+end
+
+class ReaderOnly < T::Struct
+  include Reader
+
+  prop :foo, Integer, override: :reader
+end
+
+class ReaderOnlyConst < T::Struct
+  include Reader
+
+  const :foo, Integer, override: true
+end
+
+class ReaderOnlyBad < T::Struct
+  include Reader
+
+  prop :foo, Integer, override: true # error: Method `ReaderOnlyBad#foo=` is marked `override` but does not override anything
+end
+
+class OverrideNothing < T::Struct
+  prop :foo, Integer, override: true
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Method `OverrideNothing#foo` is marked `override` but does not override anything
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Method `OverrideNothing#foo=` is marked `override` but does not override anything
+end
+
+class OverrideAllowIncompatible < T::Struct
+  include Reader
+
+  prop :foo, String, override: {reader: {allow_incompatible: true}}
+end
+
+class OverridePrivateGood < T::Struct
+  include Writer
+
+  prop :foo, Integer, override: {writer: {allow_incompatible: :visibility}}
+
+  private :foo=
+end
+
+class OverridePrivateBad < T::Struct
+  include Writer
+
+  prop :foo, Integer, override: {writer: true} # error: Method `foo=` is private in `OverridePrivateBad` but not in `Writer`
+
+  private :foo=
+end
+
+class OverrideIncompatibleTrue < T::Struct
+  include Reader
+  include Writer
+
+  prop :foo, String, override: {allow_incompatible: true}
+end
+# ------------------------------

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -487,6 +487,10 @@ end
 
 `attr_reader` and `attr_accessor` may not be given a signature of `void`, as these accessor methods correspond to instance variables which cannot be assigned type `void`.
 
+## 3517
+
+This error indicates that the `override` argument passed to a `prop` or `const` is ill-formed. See [prop overrides](override-checking.md#overrides-and-the-prop-dsl).
+
 ## 3550
 
 > This error is specific to RBS support when using the `--enable-experimental-rbs-comments` flag.

--- a/website/docs/override-checking.md
+++ b/website/docs/override-checking.md
@@ -362,11 +362,11 @@ end
 
 Note that the previous values we've seen are aliases for the fully-expanded version:
 
-| Shorthand                             | is equivalent to:                                                                  |
-| ---                                   | ---                                                                                |
-| `override: true`                      | `override: {reader: true, writer: true}`                                           |
-| `override: :reader`                   | `override: {reader: true}`                                                         |
-| `override: :writer`                   | `override: {writer: true}`                                                         |
+| Shorthand | is equivalent to: |
+| --- | --- |
+| `override: true` | `override: {reader: true, writer: true}` |
+| `override: :reader` | `override: {reader: true}` |
+| `override: :writer` | `override: {writer: true}` |
 | `override: {allow_incompatible: ...}` | `override: {reader: {allow_incompatible: ...}, writer: {allow_incompatible: ...}}` |
 
 ## What's next?

--- a/website/docs/override-checking.md
+++ b/website/docs/override-checking.md
@@ -301,7 +301,7 @@ Compared to `override(allow_incompatible: true)`, this version will still check 
 
 ### Overrides and the `prop` DSL
 
-It is possible for a method defined via `prop` or `const` to override a method from a parent module or class. In such cases, pass the `override:` keyword argument:
+Methods defined via `prop` or `const` (from [`T::Struct`](tstruct.md)) must also declare if they override (or implement) another method. The syntax is special, because `prop` and `const` are not annotated with [`sig`](sigs.md). Use the `override:` keyword argument on a `prop` or `const` definition:
 
 ```ruby
 module Common

--- a/website/docs/override-checking.md
+++ b/website/docs/override-checking.md
@@ -304,7 +304,7 @@ Compared to `override(allow_incompatible: true)`, this version will still check 
 Methods defined via `prop` or `const` (from [`T::Struct`](tstruct.md)) must also declare if they override (or implement) another method. The syntax is special, because `prop` and `const` are not annotated with [`sig`](sigs.md). Use the `override:` keyword argument on a `prop` or `const` definition:
 
 ```ruby
-module Common
+module HasFoo
   extend T::Helpers
   extend T::Sig
   interface!

--- a/website/docs/override-checking.md
+++ b/website/docs/override-checking.md
@@ -362,9 +362,12 @@ end
 
 Note that the previous values we've seen are aliases for the fully-expanded version:
 
-- `true` expands to `{reader: true, writer: true}`.
-- `:reader` and `:writer` expand to `{reader: true}` and `{writer: true}`, respectively.
-- `{allow_incompatible: x}` expands to `{reader: {allow_incompatible: x}, writer: {allow_incompatible: x}}`.
+| Shorthand                             | is equivalent to:                                                                  |
+| ---                                   | ---                                                                                |
+| `override: true`                      | `override: {reader: true, writer: true}`                                           |
+| `override: :reader`                   | `override: {reader: true}`                                                         |
+| `override: :writer`                   | `override: {writer: true}`                                                         |
+| `override: {allow_incompatible: ...}` | `override: {reader: {allow_incompatible: ...}, writer: {allow_incompatible: ...}}` |
 
 ## What's next?
 

--- a/website/docs/override-checking.md
+++ b/website/docs/override-checking.md
@@ -330,60 +330,35 @@ end
 Passing `override: true` will mark both the reader (`foo`) and writer (`foo=`) functions as `override`. To only override one, you can pass `:reader` or `:writer`:
 
 ```ruby
-module ReaderOnly
-  extend T::Helpers
-  extend T::Sig
-  interface!
-  sig { abstract.returns(Integer) }
-  def foo; end
-end
-
-class Child < T::Struct
+class ReaderOnlyChild < T::Struct
   include ReaderOnly
   prop :foo, Integer, override: :reader
 end
 ```
 
+[→ View full example on sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0A%0Amodule%20ReaderOnly%0A%20%20extend%20T%3A%3AHelpers%0A%20%20extend%20T%3A%3ASig%0A%20%20interface!%0A%20%20sig%20%7B%20abstract.returns%28Integer%29%20%7D%0A%20%20def%20foo%3B%20end%0Aend%0A%0Aclass%20ReaderOnlyChild%20%3C%20T%3A%3AStruct%0A%20%20include%20ReaderOnly%0A%20%20prop%20%3Afoo%2C%20Integer%2C%20override%3A%20%3Areader%0Aend)
+
 To pass options such as `allow_incompatible`, we can instead pass a hash:
 
 ```ruby
-module IncompatibleParent
-  extend T::Helpers
-  extend T::Sig
-  interface!
-  sig { abstract.returns(T.nilable(Integer)) }
-  def foo; end
-  sig { abstract.params(arg0: T.nilable(Integer)).returns(T.nilable(Integer)) }
-  def foo=(arg0); end
-end
-
-class Child < T::Struct
-  include IncompatibleParent
+class IncompatibleChild < T::Struct
+  include Parent
   prop :foo, Integer, override: {allow_incompatible: true} # also accepts :visibility
 end
 ```
 
+[→ View full example on sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0A%0Amodule%20Parent%0A%20%20extend%20T%3A%3AHelpers%0A%20%20extend%20T%3A%3ASig%0A%20%20interface!%0A%20%20sig%20%7B%20abstract.returns%28T.nilable%28Integer%29%29%20%7D%0A%20%20def%20foo%3B%20end%0A%20%20sig%20%7B%20abstract.params%28arg0%3A%20T.nilable%28Integer%29%29.returns%28T.nilable%28Integer%29%29%20%7D%0A%20%20def%20foo%3D%28arg0%29%3B%20end%0Aend%0A%0Aclass%20IncompatibleChild%20%3C%20T%3A%3AStruct%0A%20%20include%20Parent%0A%20%20prop%20%3Afoo%2C%20Integer%2C%20override%3A%20%7Ballow_incompatible%3A%20true%7D%20%23%20also%20accepts%20%3Avisibility%0Aend)
+
 For the most fine-grained control, the hash can instead use the `reader` and `writer` keys:
 
 ```ruby
-module Parent
-  extend T::Sig
-  extend T::Helpers
-  abstract!
-
-  sig { abstract.returns(T.nilable(String)) }
-  def foo; end
-
-  sig { abstract.params(foo: String).returns(String) }
-  def foo=(foo); end
-end
-
 class Child < T::Struct
   include Parent
-
   prop :foo, String, override: {reader: {allow_incompatible: true}, writer: true}
 end
 ```
+
+[→ View full example on sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0A%0Amodule%20Parent%0A%20%20extend%20T%3A%3ASig%0A%20%20extend%20T%3A%3AHelpers%0A%20%20abstract!%0A%0A%20%20sig%20%7B%20abstract.returns%28T.nilable%28String%29%29%20%7D%0A%20%20def%20foo%3B%20end%0A%0A%20%20sig%20%7B%20abstract.params%28foo%3A%20String%29.returns%28String%29%20%7D%0A%20%20def%20foo%3D%28foo%29%3B%20end%0Aend%0A%0Aclass%20Child%20%3C%20T%3A%3AStruct%0A%20%20include%20Parent%0A%0A%20%20prop%20%3Afoo%2C%20String%2C%20override%3A%20%7Breader%3A%20%7Ballow_incompatible%3A%20true%7D%2C%20writer%3A%20true%7D%0Aend)
 
 Note that the previous values we've seen are aliases for the fully-expanded version:
 

--- a/website/docs/tstruct.md
+++ b/website/docs/tstruct.md
@@ -212,34 +212,7 @@ The remainder of this documentation is presented for completeness. Use the APIs 
 
 ## Fine-grained inheritance control with `override:`
 
-Under the hood, the declaration `prop :foo, Integer`
-
-```ruby
-class A < T::Struct
-  prop :foo, Integer
-end
-```
-
-expands to something like
-
-```ruby
-class A < T::Struct
-  @foo = T.let()
-
-  sig { returns(String) }
-  def foo; @foo; end
-
-  sig { params(arg0: String).returns(String) }
-  def foo=(arg0); @foo = arg0; end
-
-  sig { params(foo: String).void }
-  def initialize(foo)
-    @foo = foo
-  end
-end
-```
-
-If `foo` or `foo=` overrides an `overridable` or `abstract` method, however (such as in the interface method above), it is necessary to also annotate the generated sigs with `override`. To accomplish this with `prop`, you can pass the `override` keyword argument. In the simplest cases, this will be one of:
+Methods defined with `prop` or `const` must also annotate the methods they override (just like if the reader and writer methods had been defined as normal `def` methods). Use the `override` keyword argument on a `prop` or `const` to declare the override. In the simplest cases, this will be one of:
 
 - `override: :reader` (overrides `foo` only)
 - `override: :writer` (overrides `foo=` only)

--- a/website/docs/tstruct.md
+++ b/website/docs/tstruct.md
@@ -214,9 +214,9 @@ The remainder of this documentation is presented for completeness. Use the APIs 
 
 Methods defined with `prop` or `const` must also annotate the methods they override (just like if the reader and writer methods had been defined as normal `def` methods). Use the `override` keyword argument on a `prop` or `const` to declare the override. In the simplest cases, this will be one of:
 
-- `override: :reader` (overrides `foo` only)
-- `override: :writer` (overrides `foo=` only)
-- `override: true` (overrides both `foo` and `foo=`).
+- `..., override: :reader` (only overrides `foo`, the reader method)
+- `..., override: :writer` (only overrides `foo=`, the writer method)
+- `..., override: true` (overrides both `foo` and `foo=`).
 
 If more fine-grained control is needed (for example, because the override is [incompatible](https://sorbet.org/docs/override-checking#use-overrideallow_incompatible-true)), `override` also accepts a Hash containing the keys `reader` and `writer`. For example:
 

--- a/website/docs/tstruct.md
+++ b/website/docs/tstruct.md
@@ -267,6 +267,9 @@ class Concrete < T::Struct
 end
 ```
 
+See [Overrides and the `prop` DSL](override-checking.md#overrides-and-the-prop-dsl) for a full
+specification of what `override` accepts.
+
 ## `serialize` and `from_hash`: Converting `T::Struct` to and from `Hash`
 
 It's possible to convert a `T::Struct` instance to and from `Hash` instances:

--- a/website/docs/tstruct.md
+++ b/website/docs/tstruct.md
@@ -267,8 +267,7 @@ class Concrete < T::Struct
 end
 ```
 
-See [Overrides and the `prop` DSL](override-checking.md#overrides-and-the-prop-dsl) for a full
-specification of what `override` accepts.
+See [Overrides and the `prop` DSL](override-checking.md#overrides-and-the-prop-dsl) for a full specification of what `override` accepts.
 
 ## `serialize` and `from_hash`: Converting `T::Struct` to and from `Hash`
 

--- a/website/docs/tstruct.md
+++ b/website/docs/tstruct.md
@@ -173,13 +173,13 @@ end
 
 class ChildOne < T::Struct
   include Common
-  prop :foo, Integer
+  prop :foo, Integer, override: true
   prop :bar, String
 end
 
 class ChildTwo < T::Struct
   include Common
-  prop :foo, Integer
+  prop :foo, Integer, override: true
   prop :quz, Symbol
 end
 ```

--- a/website/docs/tstruct.md
+++ b/website/docs/tstruct.md
@@ -218,7 +218,7 @@ Methods defined with `prop` or `const` must also annotate the methods they overr
 - `..., override: :writer` (only overrides `foo=`, the writer method)
 - `..., override: true` (overrides both `foo` and `foo=`).
 
-If more fine-grained control is needed (for example, because the override is [incompatible](https://sorbet.org/docs/override-checking#use-overrideallow_incompatible-true)), `override` also accepts a Hash containing the keys `reader` and `writer`. For example:
+The `override` keyword also accepts a `Hash` to declare more fine-grained overrides (for example, if an override [incompatibly overrides](https://sorbet.org/docs/override-checking#use-overrideallow_incompatible-true) another method). Use the `reader` and `writer` keys:
 
 ```ruby
 module Interface

--- a/website/docs/tstruct.md
+++ b/website/docs/tstruct.md
@@ -210,7 +210,7 @@ Unfortunately, this process left warts in the publicly-accessible `T::Struct` AP
 
 The remainder of this documentation is presented for completeness. Use the APIs below at your own discretion. Our goal here is simply to outline the potential pitfalls that arise when using them.
 
-## Fine-grained inheritance control with `override`
+## Fine-grained inheritance control with `override:`
 
 Under the hood, the declaration `prop :foo, Integer`
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation

This primarily fixes #1694 by unmarking prop-generated methods as rewriter-synthesized, as well as expanding the `override` DSL to allow selective overrides of reader and writer.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
