### PR TITLE
Also treat `return` as `blockreturn` inside `T.let`

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -115,7 +115,7 @@ bool sendRecvIsT(ast::Send &s) {
 }
 
 bool isKernelLambda(ast::Send &s) {
-    if (s.fun != core::Names::lambda()) {
+    if (s.fun != core::Names::lambda() && s.fun != core::Names::lambdaTLet()) {
         return false;
     }
 

--- a/test/testdata/infer/lambda_block_return.rb
+++ b/test/testdata/infer/lambda_block_return.rb
@@ -70,3 +70,18 @@ def block_inside_lambda
   T.reveal_type(f) # error: `T.proc.returns(NilClass)`
   f.call.to_s
 end
+
+sig { returns(Integer) }
+def t_let_return_keyword
+  f = T.let(
+    ->() {
+      return "not an int" # error: Expected `Integer` but found `String("not an int")` for block result type
+    },
+    T.proc.returns(Integer)
+  )
+
+  T.reveal_type(f) # error: `T.proc.returns(Integer)`
+
+  42
+end
+


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We have special logic for lambdas inside `T.let`, and that was
interferring with the logic Sorbet has to treat `return` as `next`
inside lambda bodies.

Behavior before this change (method vs block result type):

    + exec test/pipeline_test_runner --single_test=test/testdata/infer/lambda_block_return.rb --parser=original
    [doctest] doctest version is "2.4.9"
    [doctest] run with "--help" for options
    ===============================================================================
    test/pipeline_test_runner.cc:336:
    TEST CASE:  PerPhaseTest

    test/testdata/infer/lambda_block_return.rb:78: ERROR: Expected error of form:
    78:       return "not an int" # error: Expected `Integer` but found `String("not an int")` for block result type
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Integer` but found `String("not an int")` for block result type
    Found error:
    78:       return "not an int" # error: Expected `Integer` but found `String("not an int")` for block result type
              ^^^^^^^^^^^^^^^^^^^ error: Expected `Integer` but found `String("not an int")` for method result type

    ===============================================================================


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.