### PR TITLE
Hide the storage of imports in PackageInfoImpl

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -377,7 +377,8 @@ public:
     vector<Export> exports_ = {};
 
     const Imports imports() const {
-        // Imports holds a non-const reference, but exposes a const interface.
+        // As we're returning `const Imports`, casting away the constness of `importedPackageNames` won't mean that we
+        // have non-const access to it.
         return Imports{const_cast<vector<Import> &>(this->importedPackageNames)};
     }
 


### PR DESCRIPTION
In order to make the implicit imports of prelude packages harder to ignore, this PR makes the imports of `PackageInfoImpl` private and adds an `Imports` type for interacting with them. This view on the imports can be iterated, yielding `WrappedImport` values that act as a proxy to the underlying storage of the `Import`.

### Motivation
Making it easier to iterate imports of a package that don't necessarily all come from `import` or `test_import` declarations.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavioral changes
