### PR TITLE
RBS docs

### DIFF
--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -617,7 +617,7 @@ class Foo
 end
 ```
 
-The [`interface!`](abstract.md), [`final!`](final.md), and [`sealed!`](sealed.md) annotations are supported in the same way.
+Sorbet's [`interface!`](abstract.md), [`final!`](final.md), and [`sealed!`](sealed.md) annotations are supported in the same way.
 
 The [`@requires_ancestor`](requires-ancestor.md) annotation expects an argument to represent the ancestor to require:
 


### PR DESCRIPTION
Hello! I found a small error in the documentation. I also found one small part of the RBS docs confusing. Hope these changes help!

### Motivation

I was adding RBS comments for the first time and working on an interface. My first try looked like below, but `srb tc` wasn't picking up the behavior "interface" behavior I expected:

```ruby
# typed: true

# @interface!
# @requires_ancestor: Kernel
module MyInterface
  # @abstract
  #: () -> String
  def my_method = raise "not implemented"
end
```

I later realized that when the doc said `@interface!`, that it was referring to Sorbet syntax (confirmed by the trailing `!` and the links to Sorbet documentation), but that I'd interpreted it as RBS syntax (because of the leading `@`).

<details>
<summary>I confirmed that removing the exclamation point worked.</summary>

```ruby
# typed: true

# @interface
# @requires_ancestor: Kernel
module MyInterface
  # @abstract
  #: () -> String
  def my_method = raise "not implemented"
end
```

</details>

### Test plan

- This is a doc-only change
- I confirmed via `srb tc` that the comment `# @interface!` did not work, while `# @interface` did work. I did not confirm "sealed" or "final".