### PR TITLE
Delete unused `RBSUnsupported` error code

### DIFF
--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -22,7 +22,7 @@ constexpr ErrorClass DuplicateProp{3515, StrictLevel::True};
 
 // Let's reserve 3550-3569 for RBS related errors
 constexpr ErrorClass RBSSyntaxError{3550, StrictLevel::False};
-constexpr ErrorClass RBSUnsupported{3551, StrictLevel::False};
+// constexpr ErrorClass RBSUnsupported{3551, StrictLevel::False };
 constexpr ErrorClass RBSParameterMismatch{3552, StrictLevel::False};
 constexpr ErrorClass RBSAssertionError{3553, StrictLevel::False};
 constexpr ErrorClass RBSUnusedComment{3554, StrictLevel::False};

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -489,12 +489,6 @@ end
 
 This error is raised when a RBS signature comment contains a syntax error. See the [RBS syntax reference](https://github.com/ruby/rbs/blob/master/docs/syntax.md) for more details on the RBS syntax.
 
-## 3551
-
-> This error is specific to RBS support when using the `--enable-experimental-rbs-comments` flag.
-
-This error is raised when a RBS signature comment contains a feature not supported by Sorbet. See [RBS support limitations](rbs-support.md#unsupported-features) for more details.
-
 ## 3552
 
 > This error is specific to RBS support when using the `--enable-experimental-rbs-comments` flag.


### PR DESCRIPTION
### Motivation

While looking at https://github.com/sorbet/sorbet/pull/9091 I realized we're not raising this error code anymore.

The error code can be removed along the reference.

Closes https://github.com/sorbet/sorbet/pull/9091.

### Test plan

See included automated tests.
