### PR TITLE
Ban `T.self_type` in `T.proc` (except `.bind`)

### DIFF
--- a/test/testdata/infer/yield_self.rb
+++ b/test/testdata/infer/yield_self.rb
@@ -1,0 +1,21 @@
+# typed: true
+extend T::Sig
+
+class MyObject
+  extend T::Sig
+
+  sig do
+    type_parameters(:U)
+    .params(
+      blk: T.proc.params(arg0: T.self_type).returns(T.type_parameter(:U)),
+    )
+    .returns(T.type_parameter(:U))
+  end
+  def my_yield_self(&blk) # error: Expression does not have a fully-defined type
+    yield self
+  end
+end
+
+MyObject.new.my_yield_self do |this| # error: Expression does not have a fully-defined type
+  T.reveal_type(this) # error: `T.untyped`
+end

--- a/test/testdata/infer/yield_self.rb
+++ b/test/testdata/infer/yield_self.rb
@@ -8,14 +8,15 @@ class MyObject
     type_parameters(:U)
     .params(
       blk: T.proc.params(arg0: T.self_type).returns(T.type_parameter(:U)),
+      #                        ^^^^^^^^^^^ error: Only top-level T.self_type is supported
     )
     .returns(T.type_parameter(:U))
   end
-  def my_yield_self(&blk) # error: Expression does not have a fully-defined type
+  def my_yield_self(&blk)
     yield self
   end
 end
 
-MyObject.new.my_yield_self do |this| # error: Expression does not have a fully-defined type
+MyObject.new.my_yield_self do |this|
   T.reveal_type(this) # error: `T.untyped`
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This already did not work, because Sorbet only supports top-level `T.self_type`.
Internally, `T.proc.returns(T.self_type)` is the same as `Proc0[T.self_type]`,
and is thus meant to be banned for the same reason that `T::Array[T.self_type]`
is banned. (To be clear, I don't know why.)

In any case, what happens in the `T.proc` case is very non-obvious, because the
failures show up downstream as "does not have a fully-defined type" which does
not mention anything about `T.self_type`.

This PR achieves parity on error messaging, but does not actually expand or
contract what programs are valid.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

- - - - -

**Update**: chatted with dmitry, he mentioned that the biggest problem with introducing `T.self_type` into your system is that you end up with infinite types if you're not careful. Saying that `T.self_type` cannot be nested is the simplest way to prevent infinite recursion at the type level, but there are other ways.