### PR TITLE
Replace `<PackageSpecRegistry>::` with `::<PackageSpec>`

### DIFF
--- a/ast/packager/packager.cc
+++ b/ast/packager/packager.cc
@@ -5,15 +5,9 @@ using namespace std;
 
 namespace sorbet::ast::packager {
 
-ExpressionPtr prependRegistry(ExpressionPtr scope) {
-    auto lastConstLit = ast::cast_tree<ast::UnresolvedConstantLit>(scope);
-    ENFORCE(lastConstLit != nullptr);
-    while (auto constLit = ast::cast_tree<ast::UnresolvedConstantLit>(lastConstLit->scope)) {
-        lastConstLit = constLit;
-    }
-    lastConstLit->scope =
-        ast::MK::Constant(lastConstLit->scope.loc().copyWithZeroLength(), core::Symbols::PackageSpecRegistry());
-    return scope;
+ExpressionPtr appendRegistry(ExpressionPtr scope) {
+    return ast::MK::UnresolvedConstant(scope.loc().copyEndWithZeroLength(), move(scope),
+                                       core::Names::Constants::PackageSpec_Storage());
 }
 
 const ast::ClassDef *asPackageSpecClass(const ast::ExpressionPtr &expr) {

--- a/ast/packager/packager.cc
+++ b/ast/packager/packager.cc
@@ -6,8 +6,10 @@ using namespace std;
 namespace sorbet::ast::packager {
 
 ExpressionPtr appendRegistry(ExpressionPtr scope) {
-    return ast::MK::UnresolvedConstant(scope.loc().copyEndWithZeroLength(), move(scope),
-                                       core::Names::Constants::PackageSpec_Storage());
+    // We use the real loc (not a zero-width one) so that this constant does show up in LSP queries.
+    // Various other places will hide <PackageSpec> results from LSP queries, as needed.
+    auto loc = scope.loc();
+    return ast::MK::UnresolvedConstant(loc, move(scope), core::Names::Constants::PackageSpec_Storage());
 }
 
 const ast::ClassDef *asPackageSpecClass(const ast::ExpressionPtr &expr) {

--- a/ast/packager/packager.h
+++ b/ast/packager/packager.h
@@ -5,7 +5,7 @@
 
 namespace sorbet::ast::packager {
 
-ExpressionPtr prependRegistry(ExpressionPtr scope);
+ExpressionPtr appendRegistry(ExpressionPtr scope);
 
 const ast::ClassDef *asPackageSpecClass(const ast::ExpressionPtr &expr);
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -599,9 +599,6 @@ void GlobalState::initEmpty() {
                  .build();
     ENFORCE_NO_TIMER(method == Symbols::SorbetPrivateStaticSingleton_sig());
 
-    klass = enterClassSymbol(Loc::none(), Symbols::root(), Names::Constants::PackageSpecRegistry());
-    ENFORCE_NO_TIMER(klass == Symbols::PackageSpecRegistry());
-
     // PackageSpec is a class that can be subclassed.
     klass = enterClassSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), Names::Constants::PackageSpec());
     klass.data(*this)->setIsModule(false);

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -166,6 +166,9 @@ public:
     // Given a symbol like Project::Foo::<PackageSpec>, returns true.
     // Given any other symbol, returns false.
     // Also returns false if called on core::Symbols::noClassOrModule().
+    //
+    // TODO(jez) When we start entering symbols for packages, make this method more like the other
+    // `isFoo` methods (rename to `isPackage`, no GlobalState param).
     bool isPackageSpecSymbol(const GlobalState &gs) const;
 
     // Certain classes that need to be generic in the standard library already have a definition for

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -163,7 +163,7 @@ public:
 
     bool isOnlyDefinedInFile(const GlobalState &gs, core::FileRef file) const;
 
-    // Given a symbol like <PackageSpecRegistry>::Project::Foo, returns true.
+    // Given a symbol like Project::Foo::<PackageSpec>, returns true.
     // Given any other symbol, returns false.
     // Also returns false if called on core::Symbols::noClassOrModule().
     bool isPackageSpecSymbol(const GlobalState &gs) const;
@@ -1022,16 +1022,12 @@ public:
         return MethodRef::fromRaw(9);
     }
 
-    static ClassOrModuleRef PackageSpecRegistry() {
+    static ClassOrModuleRef PackageSpec() {
         return ClassOrModuleRef::fromRaw(85);
     }
 
-    static ClassOrModuleRef PackageSpec() {
-        return ClassOrModuleRef::fromRaw(86);
-    }
-
     static ClassOrModuleRef PackageSpecSingleton() {
-        return ClassOrModuleRef::fromRaw(87);
+        return ClassOrModuleRef::fromRaw(86);
     }
 
     static MethodRef PackageSpec_import() {
@@ -1047,11 +1043,11 @@ public:
     }
 
     static ClassOrModuleRef Encoding() {
-        return ClassOrModuleRef::fromRaw(88);
+        return ClassOrModuleRef::fromRaw(87);
     }
 
     static ClassOrModuleRef Thread() {
-        return ClassOrModuleRef::fromRaw(89);
+        return ClassOrModuleRef::fromRaw(88);
     }
 
     static MethodRef Class_new() {
@@ -1083,27 +1079,27 @@ public:
     }
 
     static ClassOrModuleRef MagicBindToAttachedClass() {
-        return ClassOrModuleRef::fromRaw(90);
+        return ClassOrModuleRef::fromRaw(89);
     }
 
     static ClassOrModuleRef MagicBindToSelfType() {
-        return ClassOrModuleRef::fromRaw(91);
+        return ClassOrModuleRef::fromRaw(90);
     }
 
     static ClassOrModuleRef T_Types() {
-        return ClassOrModuleRef::fromRaw(92);
+        return ClassOrModuleRef::fromRaw(91);
     }
 
     static ClassOrModuleRef T_Types_Base() {
-        return ClassOrModuleRef::fromRaw(93);
+        return ClassOrModuleRef::fromRaw(92);
     }
 
     static ClassOrModuleRef Data() {
-        return ClassOrModuleRef::fromRaw(94);
+        return ClassOrModuleRef::fromRaw(93);
     }
 
     static ClassOrModuleRef T_Class() {
-        return ClassOrModuleRef::fromRaw(95);
+        return ClassOrModuleRef::fromRaw(94);
     }
 
     static MethodRef T_Generic_squareBrackets() {
@@ -1131,7 +1127,7 @@ public:
     }
 
     static ClassOrModuleRef Magic_UntypedSource() {
-        return ClassOrModuleRef::fromRaw(96);
+        return ClassOrModuleRef::fromRaw(95);
     }
 
     static MethodRef Module_syntheticSquareBrackets() {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -33,8 +33,10 @@ constexpr string_view COLON_SEPARATOR = "::"sv;
 constexpr string_view HASH_SEPARATOR = "#"sv;
 
 string showInternal(const GlobalState &gs, core::SymbolRef owner, core::NameRef name, string_view separator) {
-    if (!owner.exists() || owner == Symbols::root() || owner == core::Symbols::PackageSpecRegistry()) {
+    if (!owner.exists() || owner == Symbols::root()) {
         return name.show(gs);
+    } else if (name == core::Names::Constants::PackageSpec_Storage()) {
+        return owner.show(gs);
     }
     return absl::StrCat(owner.show(gs), separator, name.show(gs));
 }
@@ -618,15 +620,7 @@ bool ClassOrModuleRef::isOnlyDefinedInFile(const GlobalState &gs, core::FileRef 
 // Documented in SymbolRef.h
 bool ClassOrModuleRef::isPackageSpecSymbol(const GlobalState &gs) const {
     auto sym = *this;
-    while (sym.exists() && sym != core::Symbols::root()) {
-        if (sym == core::Symbols::PackageSpecRegistry()) {
-            return true;
-        }
-
-        sym = sym.data(gs)->owner;
-    }
-
-    return false;
+    return sym.exists() && sym.data(gs)->name == core::Names::Constants::PackageSpec_Storage();
 }
 
 bool ClassOrModuleRef::isBuiltinGenericForwarder() const {
@@ -2655,7 +2649,6 @@ void ClassOrModule::addLoc(const core::GlobalState &gs, core::Loc loc) {
     // We shouldn't add locs for <root>, otherwise it'll end up with a massive loc list (O(number
     // of files)). Those locs aren't useful, either.
     ENFORCE(ref(gs) != Symbols::root());
-    ENFORCE(ref(gs) != Symbols::PackageSpecRegistry());
 
     addLocInternal(gs, loc, this->loc(), locs_);
 }

--- a/core/packages/MangledName.cc
+++ b/core/packages/MangledName.cc
@@ -6,7 +6,7 @@ using namespace std;
 
 namespace sorbet::core::packages {
 MangledName MangledName::lookupMangledName(const GlobalState &gs, const vector<string> &parts) {
-    auto owner = core::Symbols::PackageSpecRegistry();
+    auto owner = core::Symbols::root();
     for (auto part : parts) {
         auto member = owner.data(gs)->findMember(gs, gs.lookupNameConstant(part));
         if (!member.exists() || !member.isClassOrModule()) {
@@ -16,11 +16,16 @@ MangledName MangledName::lookupMangledName(const GlobalState &gs, const vector<s
         owner = member.asClassOrModuleRef();
     }
 
-    if (owner == core::Symbols::PackageSpecRegistry()) {
-        owner = core::Symbols::noClassOrModule();
+    if (owner == core::Symbols::root()) {
+        return MangledName();
     }
 
-    return MangledName(owner);
+    auto packageSpecStorage = owner.data(gs)->findMember(gs, core::Names::Constants::PackageSpec_Storage());
+    if (!packageSpecStorage.isClassOrModule()) {
+        return MangledName();
+    }
+
+    return MangledName(packageSpecStorage.asClassOrModuleRef());
 }
 
 } // namespace sorbet::core::packages

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -67,7 +67,7 @@ public:
         return false;
     }
 
-    vector<VisibleTo> visibleTo() const {
+    absl::Span<const VisibleTo> visibleTo() const {
         return {};
     }
 

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -41,13 +41,11 @@ enum class StrictDependenciesLevel {
 
 std::string_view strictDependenciesLevelToString(core::packages::StrictDependenciesLevel level);
 
-// TODO(jez) Why is this struct different from the `struct VisibleTo` defined in packager.cc?
 struct VisibleTo {
-    MangledName packageName;
+    ClassOrModuleRef sym;
     VisibleToType visibleToType;
 
-    VisibleTo(MangledName packageName, VisibleToType visibleToType)
-        : packageName(std::move(packageName)), visibleToType(visibleToType){};
+    VisibleTo(ClassOrModuleRef sym, VisibleToType visibleToType) : sym(sym), visibleToType(visibleToType){};
 };
 
 class PackageInfo {
@@ -55,7 +53,7 @@ public:
     virtual MangledName mangledName() const = 0;
     virtual absl::Span<const core::NameRef> fullName() const = 0;
     virtual absl::Span<const std::string> pathPrefixes() const = 0;
-    virtual std::vector<VisibleTo> visibleTo() const = 0;
+    virtual absl::Span<const VisibleTo> visibleTo() const = 0;
     virtual std::unique_ptr<PackageInfo> deepCopy() const = 0;
     virtual std::optional<std::pair<core::packages::StrictDependenciesLevel, core::LocOffsets>>
     strictDependenciesLevel() const = 0;

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -468,7 +468,7 @@ NameDef names[] = {
     {"layeredDag", "layered_dag"},
     {"dag"},
     {"PackageSpec", "PackageSpec", true},
-    {"PackageSpecRegistry", "<PackageSpecRegistry>", true},
+    {"PackageSpec_Storage", "<PackageSpec>", true},
     {"only"},
     {"testRb", "test_rb"},
 

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -23,7 +23,7 @@ vector<core::SymbolRef> ReferencesTask::getSymsToCheckWithinPackage(const core::
     vector<core::NameRef> fullName;
 
     auto sym = symInPackage;
-    while (sym.exists() && sym != core::Symbols::PackageSpecRegistry() && sym != core::Symbols::root()) {
+    while (sym.exists() && sym != core::Symbols::root()) {
         fullName.emplace_back(sym.name(gs));
         sym = sym.owner(gs);
     }

--- a/main/lsp/requests/references.h
+++ b/main/lsp/requests/references.h
@@ -7,8 +7,10 @@ namespace sorbet::realmain::lsp {
 class ReferenceParams;
 class ReferencesTask final : public LSPRequestTask {
     std::unique_ptr<ReferenceParams> params;
-    std::vector<core::SymbolRef> getSymsToCheckWithinPackage(const core::GlobalState &gs, core::SymbolRef symInPackage,
-                                                             core::packages::MangledName packageName);
+    std::vector<core::SymbolRef>
+    getSymsToCheckWithinPackage(const core::GlobalState &gs, core::SymbolRef symInPackage,
+                                core::packages::MangledName packageName,
+                                const std::vector<std::unique_ptr<core::lsp::QueryResponse>> &queryResponses);
     core::SymbolRef findSym(const core::GlobalState &gs, const std::vector<core::NameRef> &fullName,
                             core::SymbolRef underNamespace);
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -728,6 +728,15 @@ bool isTestOnlyPackage(const core::GlobalState &gs, const PackageInfoImpl &pkg) 
 
 FullyQualifiedName getFullyQualifiedName(core::Context ctx, const ast::UnresolvedConstantLit *constantLit) {
     FullyQualifiedName fqn;
+
+    if (constantLit != nullptr && constantLit->cnst == core::Names::Constants::PackageSpec_Storage()) {
+        if (auto resolvedLit = ast::cast_tree<ast::ConstantLit>(constantLit->scope)) {
+            constantLit = resolvedLit->original();
+        } else {
+            constantLit = ast::cast_tree<ast::UnresolvedConstantLit>(constantLit->scope);
+        }
+    }
+
     fqn.loc = constantLit->loc;
     while (constantLit != nullptr) {
         fqn.parts.emplace_back(constantLit->cnst);
@@ -755,7 +764,7 @@ PackageName getUnresolvedPackageName(core::Context ctx, const ast::UnresolvedCon
     auto fullName = getFullyQualifiedName(ctx, constantLit);
 
     // Since packager now runs after namer, we know that these symbols are entered.
-    auto owner = core::Symbols::PackageSpecRegistry();
+    auto owner = core::Symbols::root();
     for (auto part : fullName.parts) {
         auto member = owner.data(ctx)->findMember(ctx, part);
         if (!member.exists() || !member.isClassOrModule()) {
@@ -765,7 +774,15 @@ PackageName getUnresolvedPackageName(core::Context ctx, const ast::UnresolvedCon
         owner = member.asClassOrModuleRef();
     }
 
-    if (owner == core::Symbols::PackageSpecRegistry()) {
+    if (owner.exists()) {
+        auto member = owner.data(ctx)->findMember(ctx, core::Names::Constants::PackageSpec_Storage());
+        if (!member.exists() || !member.isClassOrModule()) {
+            owner = core::Symbols::noClassOrModule();
+        }
+        owner = member.asClassOrModuleRef();
+    }
+
+    if (owner == core::Symbols::root()) {
         // This is a weird case, because I don't think it's possible to get here, but we can handle it anyways.
         // This whole function should go away with the switch to PackageRef anyways. As in, we
         // should probably be able to pre-resolve the constants in import/visible_to/etc. lines at
@@ -1302,10 +1319,10 @@ struct PackageSpecBodyWalk {
         if ((send.fun == core::Names::import() || send.fun == core::Names::testImport()) && send.numPosArgs() == 1) {
             // null indicates an invalid import.
             if (auto *target = verifyConstant(ctx, send.fun, send.getPosArg(0))) {
-                // Transform: `import Foo` -> `import <PackageSpecRegistry>::Foo`
+                // Transform: `import Foo` -> `import Foo::<PackageSpec>`
                 auto &posArg = send.getPosArg(0);
                 auto importArg = move(posArg);
-                posArg = ast::packager::prependRegistry(move(importArg));
+                posArg = ast::packager::appendRegistry(move(importArg));
 
                 info.importedPackageNames.emplace_back(getUnresolvedPackageName(ctx, target), method2ImportType(send),
                                                        send.loc);
@@ -1357,7 +1374,7 @@ struct PackageSpecBodyWalk {
                 if (auto *recv = verifyConstant(ctx, send.fun, target->recv)) {
                     auto &posArg = send.getPosArg(0);
                     auto importArg = move(target->recv);
-                    posArg = ast::packager::prependRegistry(move(importArg));
+                    posArg = ast::packager::appendRegistry(move(importArg));
                     info.visibleTo_.emplace_back(getUnresolvedPackageName(ctx, recv),
                                                  core::packages::VisibleToType::Wildcard);
                 } else {
@@ -1370,7 +1387,7 @@ struct PackageSpecBodyWalk {
             } else if (auto *target = verifyConstant(ctx, send.fun, send.getPosArg(0))) {
                 auto &posArg = send.getPosArg(0);
                 auto importArg = move(posArg);
-                posArg = ast::packager::prependRegistry(move(importArg));
+                posArg = ast::packager::appendRegistry(move(importArg));
 
                 info.visibleTo_.emplace_back(getUnresolvedPackageName(ctx, target),
                                              core::packages::VisibleToType::Normal);

--- a/rewriter/PackageSpec.cc
+++ b/rewriter/PackageSpec.cc
@@ -115,14 +115,13 @@ void PackageSpec::run(core::MutableContext ctx, ast::ClassDef *klass) {
         }
 
         // Pre-resolve the super class. This makes it easier to detect that this is a package
-        // spec-related class def in later passes without having to recursively walk up the constant
-        // lit's scope to find if it starts with <PackageSpecRegistry>.
+        // spec-related class def in later passes.
         superClass = ast::make_expression<ast::ConstantLit>(core::Symbols::PackageSpec(),
                                                             superClass.toUnique<ast::UnresolvedConstantLit>());
 
-        // `class Foo < PackageSpec` -> `class <PackageSpecRegistry>::Foo < PackageSpec`
+        // `class Foo < PackageSpec` -> `class Foo::<PackageSpec> < PackageSpec`
         // This removes the PackageSpec's themselves from the top-level namespace
-        packageSpecClass->name = ast::packager::prependRegistry(move(packageSpecClass->name));
+        packageSpecClass->name = ast::packager::appendRegistry(move(packageSpecClass->name));
 
         // Return eagerly so we don't report duplicate errors on subsequent statements:
         // we'll let those errors be reported in the tree walk later as a bad node type.

--- a/rewriter/PackageSpec.h
+++ b/rewriter/PackageSpec.h
@@ -16,12 +16,8 @@ namespace sorbet::rewriter {
  *
  * to
  *
- *     class <PackageSpecRegistry>::Foo::Bar < ::Sorbet::Private::Static::PackageSpec
+ *     class Foo::Bar::<PackageSpec> < ::Sorbet::Private::Static::PackageSpec
  *     end
- *
- * TODO(jez) When we move packages into the symbol table, we can drop the `<PackageSpecRegistry>`
- * bit, which is only required because there could be a class or module symbol with the `Foo::Bar`
- * name that collides with the package definition.
  */
 class PackageSpec final {
 public:

--- a/test/cli/package-bad-imports/test.out
+++ b/test/cli/package-bad-imports/test.out
@@ -5,13 +5,6 @@ example/__package.rb:5: Unable to resolve constant `NonexistentPackage` https://
 example/__package.rb:7: Unable to resolve constant `SUggestThis` https://srb.help/5002
      7 |  import DoNot::SUggestThis
                  ^^^^^^^^^^^^^^^^^^
-  Did you mean `Suggestion`? Use `-a` to autocorrect
-    example/__package.rb:7: Replace with `Suggestion`
-     7 |  import DoNot::SUggestThis
-                 ^^^^^^^^^^^^^^^^^^
-    suggestion/__package.rb:3: `Suggestion` defined here
-     3 |class Suggestion < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 example/__package.rb:9: Unable to resolve constant `SUggestion` https://srb.help/5002
      9 |  import SUggestion
@@ -22,7 +15,7 @@ example/__package.rb:9: Unable to resolve constant `SUggestion` https://srb.help
                  ^^^^^^^^^^
     suggestion/__package.rb:3: `Suggestion` defined here
      3 |class Suggestion < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^
 
 example/__package.rb:11: Unable to resolve constant `A` https://srb.help/5002
     11 |  import A::B::C

--- a/test/cli/package-import-conflicts/test.out
+++ b/test/cli/package-import-conflicts/test.out
@@ -8,6 +8,9 @@ a/__package.rb:4: Cannot export `A::B` because it is owned by another package ht
 ab/ab.rb:3: `A::B` was previously defined as a `class` https://srb.help/4012
      3 |module A::B
         ^^^^^^^^^^^
+    ab/__package.rb:3: Previous definition
+     3 |class A::B < PackageSpec
+              ^^^^
     a/a.rb:4: Previous definition
      4 |  class B; end
           ^^^^^^^

--- a/test/cli/packager_did_you_mean/test.out
+++ b/test/cli/packager_did_you_mean/test.out
@@ -1,4 +1,4 @@
-__package.rb:6: Unable to resolve constant `ProjectWithLongDiscernibleName` https://srb.help/5002
+__package.rb:6: Unable to resolve constant `Example` https://srb.help/5002
      6 |  export ProjectWithLongDiscernibleName::Foo::Example
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 1

--- a/test/cli/packager_export_self/test.out
+++ b/test/cli/packager_export_self/test.out
@@ -2,11 +2,7 @@ test/cli/packager_export_self/__package.rb:3: Invalid expression in package: Arg
      3 |  export_for_test Opus::Deploy
                           ^^^^^^^^^^^^
 
-test/cli/packager_export_self/__package.rb:3: Unable to resolve constant `Opus` https://srb.help/5002
-     3 |  export_for_test Opus::Deploy
-                          ^^^^
-
 test/cli/packager_export_self/__package.rb:3: Method `export_for_test` does not exist on `T.class_of(Opus::Deploy)` https://srb.help/7003
      3 |  export_for_test Opus::Deploy
           ^^^^^^^^^^^^^^^
-Errors: 3
+Errors: 2

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -721,6 +721,12 @@ TEST_CASE("LSPTest") {
                                                          importUsageAssertions.emplace_back(assertion);
                                                          return true;
                                                      }
+                                                     if (dynamic_pointer_cast<ImportAssertion>(assertion)) {
+                                                         importUsageAssertions.emplace_back(assertion);
+                                                         // Want to treat every ImportAssertion as ALSO an
+                                                         // ImportUsageAssertion, and also process as an `import:`
+                                                         return false;
+                                                     }
 
                                                      return false;
                                                  }),

--- a/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/deeply_nested_packages/pass.package-tree.exp
@@ -1,7 +1,7 @@
 # -- test/testdata/packager/deeply_nested_packages/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Package<<C Package>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.import(::<PackageSpecRegistry>::<C Package>::<C Subpackage>)
+  class ::Package::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
+    <self>.import(<emptyTree>::<C Package>::<C Subpackage>::<C <PackageSpec>>)
 
     <self>.export(<emptyTree>::<C Package>::<C PackageClass>)
 
@@ -10,8 +10,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/deeply_nested_packages/subdirectory/subpackage/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Package::Subpackage<<C Subpackage>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.import(::<PackageSpecRegistry>::<C Package>)
+  class ::Package::Subpackage::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
+    <self>.import(<emptyTree>::<C Package>::<C <PackageSpec>>)
 
     <self>.export(<emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass>)
   end

--- a/test/testdata/packager/export_for_test/pass.package-tree.exp
+++ b/test/testdata/packager/export_for_test/pass.package-tree.exp
@@ -1,16 +1,16 @@
 # -- test/testdata/packager/export_for_test/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::RootPkg<<C RootPkg>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::RootPkg::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
   end
 end
 # -- test/testdata/packager/export_for_test/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Opus::Foo<<C Foo>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.import(::<PackageSpecRegistry>::<C Opus>::<C Foo>::<C Bar>)
+  class ::Opus::Foo::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
+    <self>.import(<emptyTree>::<C Opus>::<C Foo>::<C Bar>::<C <PackageSpec>>)
 
-    <self>.import(::<PackageSpecRegistry>::<C Opus>::<C Util>)
+    <self>.import(<emptyTree>::<C Opus>::<C Util>::<C <PackageSpec>>)
 
-    <self>.test_import(::<PackageSpecRegistry>::<C Opus>::<C TestImported>)
+    <self>.test_import(<emptyTree>::<C Opus>::<C TestImported>::<C <PackageSpec>>)
 
     <self>.export(<emptyTree>::<C Opus>::<C Foo>::<C FooClass>)
 
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/foo/bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Opus::Foo::Bar<<C Bar>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::Opus::Foo::Bar::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Opus>::<C Foo>::<C Bar>::<C BarClass>)
 
     <self>.export(<emptyTree>::<C Test>::<C Opus>::<C Foo>::<C Bar>::<C BarClassTest>)
@@ -29,7 +29,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/test_imported/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Opus::TestImported<<C TestImported>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::Opus::TestImported::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Opus>::<C TestImported>::<C TIClass>)
 
     <self>.export(<emptyTree>::<C Test>::<C Opus>::<C TestImported>::<C TITestClass>)
@@ -37,7 +37,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/export_for_test/util/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Opus::Util<<C Util>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::Opus::Util::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Opus>::<C Util>::<C UtilClass>)
 
     <self>.export(<emptyTree>::<C Test>::<C Opus>::<C Util>::<C TestUtil>)

--- a/test/testdata/packager/export_imported/pass.package-tree.exp
+++ b/test/testdata/packager/export_imported/pass.package-tree.exp
@@ -1,14 +1,14 @@
 # -- test/testdata/packager/export_imported/a/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::A<<C A>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.import(::<PackageSpecRegistry>::<C B>)
+  class ::A::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
+    <self>.import(<emptyTree>::<C B>::<C <PackageSpec>>)
 
     <self>.export(<emptyTree>::<C B>::<C BClass>)
   end
 end
 # -- test/testdata/packager/export_imported/b/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::B<<C B>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::B::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C B>::<C BClass>)
   end
 end

--- a/test/testdata/packager/extra_package_paths/pass.package-tree.exp
+++ b/test/testdata/packager/extra_package_paths/pass.package-tree.exp
@@ -1,16 +1,16 @@
 # -- test/testdata/packager/extra_package_paths/bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Project::Bar<<C Bar>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.import(::<PackageSpecRegistry>::<C Project>::<C Foo>)
+  class ::Project::Bar::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
+    <self>.import(<emptyTree>::<C Project>::<C Foo>::<C <PackageSpec>>)
 
-    <self>.import(::<PackageSpecRegistry>::<C Project>::<C Baz>::<C Package>)
+    <self>.import(<emptyTree>::<C Project>::<C Baz>::<C Package>::<C <PackageSpec>>)
 
-    <self>.import(::<PackageSpecRegistry>::<C Project>::<C FooBar>)
+    <self>.import(<emptyTree>::<C Project>::<C FooBar>::<C <PackageSpec>>)
   end
 end
 # -- test/testdata/packager/extra_package_paths/baz/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Project::Baz::Package<<C Package>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::Project::Baz::Package::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Project>::<C Baz>::<C Package>::<C C>)
 
     <self>.export(<emptyTree>::<C Project>::<C Baz>::<C Package>::<C E>)
@@ -18,7 +18,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Project::Foo<<C Foo>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::Project::Foo::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Project>::<C Foo>::<C B>)
 
     <self>.export(<emptyTree>::<C Project>::<C Foo>::<C D>)
@@ -26,7 +26,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/extra_package_paths/foo_bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Project::FooBar<<C FooBar>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::Project::FooBar::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Project>::<C FooBar>::<C Z>)
   end
 end

--- a/test/testdata/packager/import_subpackage/pass.package-tree.exp
+++ b/test/testdata/packager/import_subpackage/pass.package-tree.exp
@@ -1,12 +1,12 @@
 # -- test/testdata/packager/import_subpackage/a/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Root<<C Root>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.import(::<PackageSpecRegistry>::<C Root>::<C B>)
+  class ::Root::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
+    <self>.import(<emptyTree>::<C Root>::<C B>::<C <PackageSpec>>)
   end
 end
 # -- test/testdata/packager/import_subpackage/a/b/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Root::B<<C B>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::Root::B::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Root>::<C B>::<C Foo>)
   end
 end

--- a/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.package-tree.exp
@@ -1,17 +1,17 @@
 # -- test/testdata/packager/invalid_imports_and_exports/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::A<<C A>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::A::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.import(123)
 
     <self>.import("hello")
 
     <self>.import(<self>.method())
 
-    <self>.import(::<PackageSpecRegistry>::<C REFERENCE>)
+    <self>.import(<emptyTree>::<C REFERENCE>::<C <PackageSpec>>)
 
-    <self>.import(::<PackageSpecRegistry>::<C B>)
+    <self>.import(<emptyTree>::<C B>::<C <PackageSpec>>)
 
-    <self>.import(::<PackageSpecRegistry>::<C B>)
+    <self>.import(<emptyTree>::<C B>::<C <PackageSpec>>)
 
     <self>.export(123)
 
@@ -25,27 +25,27 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.export(<emptyTree>::<C A>::<C AModule>)
 
-    <self>.test_import(::<PackageSpecRegistry>::<C B>)
+    <self>.test_import(<emptyTree>::<C B>::<C <PackageSpec>>)
 
-    <self>.test_import(::<PackageSpecRegistry>::<C C>)
+    <self>.test_import(<emptyTree>::<C C>::<C <PackageSpec>>)
 
-    <self>.test_import(::<PackageSpecRegistry>::<C C>, :only, :A_MYSTERIOUS_PURPOSE)
+    <self>.test_import(<emptyTree>::<C C>::<C <PackageSpec>>, :only, :A_MYSTERIOUS_PURPOSE)
 
-    <self>.test_import(::<PackageSpecRegistry>::<C C>, :only, "something else")
+    <self>.test_import(<emptyTree>::<C C>::<C <PackageSpec>>, :only, "something else")
 
-    <self>.test_import(::<PackageSpecRegistry>::<C C>, :only, <emptyTree>::<C Kernel>.lambda() do ||
+    <self>.test_import(<emptyTree>::<C C>::<C <PackageSpec>>, :only, <emptyTree>::<C Kernel>.lambda() do ||
         "naught"
       end)
 
-    <self>.test_import(::<PackageSpecRegistry>::<C C>, :only, "test_rb", :only, "test_rb")
+    <self>.test_import(<emptyTree>::<C C>::<C <PackageSpec>>, :only, "test_rb", :only, "test_rb")
 
-    <self>.test_import(::<PackageSpecRegistry>::<C C>, :with, "cheese")
+    <self>.test_import(<emptyTree>::<C C>::<C <PackageSpec>>, :with, "cheese")
   end
 end
 # -- test/testdata/packager/invalid_imports_and_exports/b/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::B<<C B>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.import(::<PackageSpecRegistry>::<C A>)
+  class ::B::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
+    <self>.import(<emptyTree>::<C A>::<C <PackageSpec>>)
 
     <self>.export(<emptyTree>::<C B>::<C BClass>)
 
@@ -54,7 +54,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/invalid_imports_and_exports/c/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::C<<C C>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::C::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
   end
 end
 # -- test/testdata/packager/invalid_imports_and_exports/a.rb --

--- a/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
@@ -2,7 +2,7 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   ::SomeConstant = <emptyTree>::<C PackageSpec>
 
-  class ::<PackageSpecRegistry>::MyPackage<<C MyPackage>> < (::Sorbet::Private::Static::PackageSpec, <emptyTree>::<C T>::<C Helpers>)
+  class ::MyPackage::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec, <emptyTree>::<C T>::<C Helpers>)
     ::Sorbet::Private::Static.sig(<self>) do ||
       <self>.void()
     end

--- a/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
+++ b/test/testdata/packager/nested_inner_namespaces/pass.package-tree.exp
@@ -1,12 +1,12 @@
 # -- test/testdata/packager/nested_inner_namespaces/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::RootPackage<<C RootPackage>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.import(::<PackageSpecRegistry>::<C RootPackage>::<C Foo>)
+  class ::RootPackage::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
+    <self>.import(<emptyTree>::<C RootPackage>::<C Foo>::<C <PackageSpec>>)
   end
 end
 # -- test/testdata/packager/nested_inner_namespaces/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::RootPackage::Foo<<C Foo>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::RootPackage::Foo::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C RootPackage>::<C Foo>::<C Constant>)
 
     <self>.export(<emptyTree>::<C RootPackage>::<C Foo>::<C Bar>::<C Constant>)

--- a/test/testdata/packager/nested_packages/pass.package-tree.exp
+++ b/test/testdata/packager/nested_packages/pass.package-tree.exp
@@ -1,15 +1,15 @@
 # -- test/testdata/packager/nested_packages/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Package<<C Package>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.import(::<PackageSpecRegistry>::<C Package>::<C Subpackage>)
+  class ::Package::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
+    <self>.import(<emptyTree>::<C Package>::<C Subpackage>::<C <PackageSpec>>)
 
     <self>.export(<emptyTree>::<C Package>::<C PackageClass>)
   end
 end
 # -- test/testdata/packager/nested_packages/subpackage/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Package::Subpackage<<C Subpackage>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.import(::<PackageSpecRegistry>::<C Package>)
+  class ::Package::Subpackage::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
+    <self>.import(<emptyTree>::<C Package>::<C <PackageSpec>>)
 
     <self>.export(<emptyTree>::<C Package>::<C Subpackage>::<C SubpackageClass>)
   end

--- a/test/testdata/packager/shared_prefix/pass.package-tree.exp
+++ b/test/testdata/packager/shared_prefix/pass.package-tree.exp
@@ -1,18 +1,18 @@
 # -- test/testdata/packager/shared_prefix/bar/that/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Project::Bar::That<<C That>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::Project::Bar::That::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Project>::<C Bar>::<C That>::<C Thing>)
   end
 end
 # -- test/testdata/packager/shared_prefix/bar/this/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Project::Bar::This<<C This>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::Project::Bar::This::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Project>::<C Bar>::<C This>::<C Thing>)
   end
 end
 # -- test/testdata/packager/shared_prefix/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Project::Foo<<C Foo>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::Project::Foo::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
   end
 end
 # -- test/testdata/packager/shared_prefix/bar/that/that.rb --

--- a/test/testdata/packager/simple_package/pass.package-tree.exp
+++ b/test/testdata/packager/simple_package/pass.package-tree.exp
@@ -1,7 +1,7 @@
 # -- test/testdata/packager/simple_package/bar/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Project::Bar<<C Bar>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.import(::<PackageSpecRegistry>::<C Project>::<C Foo>)
+  class ::Project::Bar::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
+    <self>.import(<emptyTree>::<C Project>::<C Foo>::<C <PackageSpec>>)
 
     <self>.export(<emptyTree>::<C Project>::<C Bar>::<C Bar>)
 
@@ -10,8 +10,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 end
 # -- test/testdata/packager/simple_package/foo/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Project::Foo<<C Foo>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.import(::<PackageSpecRegistry>::<C Project>::<C Bar>)
+  class ::Project::Foo::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
+    <self>.import(<emptyTree>::<C Project>::<C Bar>::<C <PackageSpec>>)
 
     <self>.export(<emptyTree>::<C Project>::<C Foo>::<C Foo>)
 

--- a/test/testdata/packager/simple_test_import/pass.package-tree.exp
+++ b/test/testdata/packager/simple_test_import/pass.package-tree.exp
@@ -1,22 +1,22 @@
 # -- test/testdata/packager/simple_test_import/main_lib/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Project::MainLib<<C MainLib>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.import(::<PackageSpecRegistry>::<C Project>::<C Util>)
+  class ::Project::MainLib::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
+    <self>.import(<emptyTree>::<C Project>::<C Util>::<C <PackageSpec>>)
 
-    <self>.test_import(::<PackageSpecRegistry>::<C Project>::<C TestOnly>)
+    <self>.test_import(<emptyTree>::<C Project>::<C TestOnly>::<C <PackageSpec>>)
 
     <self>.export_for_test(<emptyTree>::<C Project>::<C MainLib>::<C Lib>)
   end
 end
 # -- test/testdata/packager/simple_test_import/test_only/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Project::TestOnly<<C TestOnly>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::Project::TestOnly::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Project>::<C TestOnly>::<C SomeHelper>)
   end
 end
 # -- test/testdata/packager/simple_test_import/util/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::Project::Util<<C Util>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::Project::Util::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C Project>::<C Util>::<C MyUtil>)
 
     <self>.export(<emptyTree>::<C Test>::<C Project>::<C Util>::<C UtilHelper>)

--- a/test/testdata/packager/unimported_namespace/aaa/a_class.rb
+++ b/test/testdata/packager/unimported_namespace/aaa/a_class.rb
@@ -6,7 +6,7 @@ class AAA::AClass
 # ^^^ error: `BBB` resolves but its package is not imported
 
   CCC
-# ^^^ error: Unable to resolve constant `CCC`
+# ^^^ error: `CCC` resolves but its package is not imported
 
   C
 # ^ error: Unable to resolve constant `C`

--- a/test/testdata/packager/unimported_namespace/pass.package-tree.exp
+++ b/test/testdata/packager/unimported_namespace/pass.package-tree.exp
@@ -1,18 +1,18 @@
 # -- test/testdata/packager/unimported_namespace/aaa/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::AAA<<C AAA>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::AAA::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
     <self>.export(<emptyTree>::<C AAA>::<C AClass>)
   end
 end
 # -- test/testdata/packager/unimported_namespace/bbb/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::BBB<<C BBB>> < (::Sorbet::Private::Static::PackageSpec)
-    <self>.import(::<PackageSpecRegistry>::<C AAA>)
+  class ::BBB::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
+    <self>.import(<emptyTree>::<C AAA>::<C <PackageSpec>>)
   end
 end
 # -- test/testdata/packager/unimported_namespace/ccc/__package.rb --
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class ::<PackageSpecRegistry>::CCC<<C CCC>> < (::Sorbet::Private::Static::PackageSpec)
+  class ::CCC::<PackageSpec><<C <PackageSpec>>> < (::Sorbet::Private::Static::PackageSpec)
   end
 end
 # -- test/testdata/packager/unimported_namespace/aaa/a_class.rb --

--- a/test/testdata/packager/visibility/foo/__package.rb
+++ b/test/testdata/packager/visibility/foo/__package.rb
@@ -16,17 +16,17 @@ class Foo < PackageSpec
 
   visible_to Nested::*(0)
            # ^^^^^^^^^^^^ error: Argument to `visible_to` must be a constant or
-           # ^^^^^^ error: Unable to resolve constant `Nested`
+           #         ^       error: Method `*` does not exist on `T.class_of(Nested)`
   visible_to Nested::*(x: 0)
            # ^^^^^^^^^^^^^^^ error: Argument to `visible_to` must be a constant or
-           # ^^^^^^ error: Unable to resolve constant `Nested`
+           #         ^       error: Method `*` does not exist on `T.class_of(Nested)`
   visible_to Nested::* {}
            # ^^^^^^^^^^^^ error: Argument to `visible_to` must be a constant or
            # ^^^^^^^^^^^^ error: Invalid expression in package: `Block` not allowed
-           # ^^^^^^ error: Unable to resolve constant `Nested`
+           #         ^       error: Method `*` does not exist on `T.class_of(Nested)`
 
   visible_to Nested::*::Blah
            # ^^^^^^^^^^^^^^^ error: Argument to `visible_to` must be a constant
-           # ^^^^^^ error: Unable to resolve constant `Nested`
            # ^^^^^^^^^^^^^^^ error: Dynamic constant references
+           #         ^       error: Method `*` does not exist on `T.class_of(Nested)`
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Soon, we want to start entering symbols for packages, instead of having a
separate `PackageInfo` data structure.

When that happens, the strategy we're looking to take is to enter these packages
nested inside ClassOrModule symbols, instead of being in this
`<PackageSpecRegistry>` namespace.

Before we actually go about creating those symbols, we can "approximate" by
having a `ClassOrModule` symbol that takes its place. This PR sets that up, so
that for every package, we create a `<PackageSpec>` ClassOrModule symbol that's
nested inside the namespace.

Doing this separate from the actual `PackageInfo` → `core::Package` refactoring
makes it obvious what incidental parts of Sorbet change from this new structure
(e.g., LSP support, etc.)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Should be covered by existing tests. There are some tests that change, but I
have taken care to document why they change in the individual commit messages.