### PR TITLE
Create signature for Process::Waiter#value

### DIFF
--- a/rbi/core/process.rbi
+++ b/rbi/core/process.rbi
@@ -2106,4 +2106,7 @@ end
 class Process::Waiter < Thread
   sig {returns(Integer)}
   def pid(); end
+
+  sig {returns(Process::Status)}
+  def value; end
 end


### PR DESCRIPTION
This PR introduces a signature for `Process::Waiter#value` distinct from the parent `Thread#value`. 

My C isn't great, but as far as I can tell, `Process::Waiter#value` comes from [`rb_last_value_set`](https://github.com/ruby/ruby/blob/4c60e431e1fd8d196807c9d42cc0355cd339e1fc/process.c#L681-L685) and appears to always be a `Process::Status`; discard this PR otherwise. 

### Motivation

I had  type error related to `popen3` in 

```ruby
Open3.popen2e(*cmd) do |_stdin, stdout_err, wait_thr|
    stdout_err.each_line do |line|
      stdout.print(line) # Stream to console in real-time
      output += line # Capture for parsing
    end

    tests_passed = wait_thr.value.success? #=> Method success? does not exist on Object
end
```

### Test plan

I have not added tests
