### PR TITLE
Use the current PID as the unique sufix for the session cache

### DIFF
--- a/main/cache/cache.h
+++ b/main/cache/cache.h
@@ -48,7 +48,7 @@ class SessionCache {
     std::string path;
 
     SessionCache() = delete;
-    SessionCache(std::string path);
+    explicit SessionCache(std::string path);
 
 public:
     // Removes the session cache.


### PR DESCRIPTION
Instead of picking a random number for the session cache suffix, use the PID of the current Sorbet process. This change means that we need to consider the case where a cache directory exists already, as we could be starting after a crash and thus may see a reused PID.

### Motivation
Working towards a process for reaping orphaned session caches during startup.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included tests.