### PR TITLE
less unconstrained `resultType` usage

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1268,9 +1268,10 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                         tp.type = core::Types::untyped(symbol);
                     }
                 } else if (symbol.isTypeAlias(ctx)) {
-                    ENFORCE(symbol.resultType(ctx) != nullptr);
-                    tp.origins.emplace_back(symbol.loc(ctx));
-                    tp.type = core::make_type<core::MetaType>(symbol.resultType(ctx));
+                    auto sym = symbol.asFieldRef();
+                    ENFORCE(sym.data(ctx)->resultType != nullptr);
+                    tp.origins.emplace_back(sym.data(ctx)->loc());
+                    tp.type = core::make_type<core::MetaType>(sym.data(ctx)->resultType);
                 } else if (symbol.isTypeArgument()) {
                     auto sym = symbol.asTypeArgumentRef();
                     ENFORCE(sym.data(ctx)->resultType != nullptr);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1272,13 +1272,14 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                     tp.origins.emplace_back(symbol.loc(ctx));
                     tp.type = core::make_type<core::MetaType>(symbol.resultType(ctx));
                 } else if (symbol.isTypeArgument()) {
-                    ENFORCE(symbol.resultType(ctx) != nullptr);
+                    auto sym = symbol.asTypeArgumentRef();
+                    ENFORCE(sym.data(ctx)->resultType != nullptr);
                     tp.origins.emplace_back(ctx.locAt(bind.loc));
 
                     auto owner = ctx.owner.asMethodRef();
                     auto klass = owner.enclosingClass(ctx);
-                    ENFORCE(symbol.resultType(ctx) != nullptr);
-                    auto instantiated = core::Types::resultTypeAsSeenFrom(ctx, symbol.resultType(ctx), klass, klass,
+                    ENFORCE(sym.data(ctx)->resultType != nullptr);
+                    auto instantiated = core::Types::resultTypeAsSeenFrom(ctx, sym.data(ctx)->resultType, klass, klass,
                                                                           klass.data(ctx)->selfTypeArgs(ctx));
                     if (owner.data(ctx)->flags.isGenericMethod) {
                         // instantiate requires a frozen constraint, but the constraint might not be

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2061,14 +2061,16 @@ class ResolveTypeMembersAndFieldsWalk {
                         return;
                     }
                     result = move(externalType);
-                } else if (cnst.symbol().isStaticField(ctx) &&
-                           core::isa_type<core::ClassType>(cnst.symbol().resultType(ctx))) {
-                    const auto &resultType = cnst.symbol().resultType(ctx);
-                    auto classType = core::cast_type_nonnull<core::ClassType>(resultType);
-                    if (!classType.symbol.data(ctx)->derivesFrom(ctx, core::Symbols::T_Enum())) {
-                        return;
+                } else if (cnst.symbol().isStaticField(ctx)) {
+                    auto sym = cnst.symbol().asFieldRef();
+                    const auto &resultType = sym.data(ctx)->resultType;
+                    if (core::isa_type<core::ClassType>(resultType)) {
+                        auto classType = core::cast_type_nonnull<core::ClassType>(resultType);
+                        if (!classType.symbol.data(ctx)->derivesFrom(ctx, core::Symbols::T_Enum())) {
+                            return;
+                        }
+                        result = resultType;
                     }
-                    result = resultType;
                 }
             },
             [&](const ast::Cast &cast) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1844,7 +1844,7 @@ class ResolveTypeMembersAndFieldsWalk {
 
     static bool isLHSResolved(core::Context ctx, core::SymbolRef sym) {
         if (sym.isTypeMember()) {
-            auto lambdaParam = core::cast_type<core::LambdaParam>(sym.resultType(ctx));
+            auto lambdaParam = core::cast_type<core::LambdaParam>(sym.asTypeMemberRef().data(ctx)->resultType);
             ENFORCE(lambdaParam != nullptr);
 
             // both bounds are set to todo in the namer, so it's sufficient to

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2190,8 +2190,8 @@ class ResolveTypeMembersAndFieldsWalk {
         core::TypeMemberRef parentMember = core::Symbols::noTypeMember();
         if (parentMemberSymbol.exists()) {
             if (parentMemberSymbol.isTypeMember()) {
-                parentType = core::cast_type<core::LambdaParam>(parentMemberSymbol.resultType(ctx));
                 parentMember = parentMemberSymbol.asTypeMemberRef();
+                parentType = core::cast_type<core::LambdaParam>(parentMember.data(ctx)->resultType);
                 ENFORCE(parentType != nullptr);
             } else if (auto e = ctx.beginError(rhs->loc, core::errors::Resolver::ParentTypeBoundsMismatch)) {
                 const auto parentShow = parentMemberSymbol.show(ctx);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We have a TODO on a number of methods on `SymbolRef` to convert them to more-specific calls on more-specific `*Ref` types.  This PR is a tiny step in that direction.

You should be able to review commit-by-commit.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
