### PR TITLE
Annotate Fiber.current and Fiber.transfer

### DIFF
--- a/rbi/core/fiber.rbi
+++ b/rbi/core/fiber.rbi
@@ -147,6 +147,8 @@ class Fiber < Object
   # [`Fiber.yield`](https://docs.ruby-lang.org/en/2.7.0/Fiber.html#method-c-yield)
   def resume(*_); end
 
+  def transfer(*_); end
+
   # Also aliased as:
   # [`inspect`](https://docs.ruby-lang.org/en/2.7.0/Fiber.html#method-i-inspect)
   def to_s; end

--- a/rbi/core/fiber.rbi
+++ b/rbi/core/fiber.rbi
@@ -102,7 +102,7 @@
 # non-blocking manner. Its actual implementation is up to the scheduler.
 class Fiber < Object
   sig {returns(Fiber)}
-  def current; end
+  def self.current; end
 
   # Returns true if the fiber can still be resumed (or transferred to). After
   # finishing execution of the fiber block this method will always return


### PR DESCRIPTION
Fix the definition of `Fiber.current`, and add one for `Fiber.transfer`.

### Motivation

The signature for `Fiber.current` was wrongly marked as an instance method.
`Fiber.transfer` was missing.

### Test plan

Didn't see any existing tests for `Fiber` specifically.  Is this trivial enough or should I add some?