### PR TITLE
Robust argument checking for override parameter lists

### DIFF
--- a/test/testdata/resolver/overrides.rb
+++ b/test/testdata/resolver/overrides.rb
@@ -74,7 +74,7 @@ class B6 < A6
   extend T::Sig
   sig {override.params(x: String).void}
   def foo(x); end
-# ^^^^^^^^^^ error: Override of method `A6#foo` must accept no more than `0` required argument(s)
+# ^^^^^^^^^^ error: Override of method `A6#foo` requires too many arguments
 end
 
 class A7
@@ -87,4 +87,17 @@ class B7 < A7
   extend T::Sig
   sig {override.returns(String)}
   def foo; 'foo' end
+end
+
+class A8
+  extend T::Sig
+  sig {params(x: Integer, y: String).void}
+  def foo(x, y); end
+end
+
+class B8 < A8
+  extend T::Sig
+  sig {override.params(x: Integer, y: Integer).void}
+#                                  ^ error: Parameter `y` of type `Integer` not compatible with type of overridden method `A8#foo`
+  def foo(x, y=0); end
 end

--- a/test/testdata/resolver/overrides.rb
+++ b/test/testdata/resolver/overrides.rb
@@ -172,3 +172,31 @@ class D10 < A10
   #                                           ^ error: Parameter `z` of type `String` not compatible with type of overridden method `A10#foo`
   def foo(x, *y, z); end
 end
+
+class A11
+  extend T::Sig
+  sig {params(x: Integer, y: Integer).void}
+  def foo(x=0, y); end
+end
+
+class B11 < A11
+  extend T::Sig
+  sig {override.params(x: Integer, y: Integer).void}
+  def foo(x, y=0); end
+end
+
+class C11 < A11
+  extend T::Sig
+  # This duplicate error is actually intentional; consider `foo(1)` and `foo(1,1)`.
+  sig {override.params(x: String, y: Integer).void}
+#                      ^ error: Parameter `x` of type `String` not compatible with type of overridden method `A11#foo`
+#                      ^ error: Parameter `x` of type `String` not compatible with type of overridden method `A11#foo`
+  def foo(x, y=0); end
+end
+
+class D11 < A11
+  extend T::Sig
+  sig {override.params(x: Integer, y: String).void}
+#                                  ^ error: Parameter `y` of type `String` not compatible with type of overridden method `A11#foo`
+  def foo(x, *y); end
+end

--- a/test/testdata/resolver/overrides.rb
+++ b/test/testdata/resolver/overrides.rb
@@ -89,6 +89,8 @@ class B7 < A7
   def foo; 'foo' end
 end
 
+class Unrelated; end
+
 class A8
   extend T::Sig
   sig {params(x: Integer, y: String).void}
@@ -100,4 +102,73 @@ class B8 < A8
   sig {override.params(x: Integer, y: Integer).void}
 #                                  ^ error: Parameter `y` of type `Integer` not compatible with type of overridden method `A8#foo`
   def foo(x, y=0); end
+end
+
+class C8 < A8
+  extend T::Sig
+  sig {override.params(x: String, y: String).void}
+#                      ^ error: Parameter `x` of type `String` not compatible with type of overridden method `A8#foo`
+  def foo(x="", y); end
+end
+
+# should be fine, `z` remains unbound
+class D8 < A8
+  extend T::Sig
+  sig {override.params(x: Integer, y: String, z: Integer).void}
+  def foo(x, y="", z=0); end
+end
+
+# should be fine, `y` is the tail argument of `A8#foo`
+class E8 < A8
+  extend T::Sig
+  sig {override.params(x: Integer, y: Integer, z: String).void}
+  def foo(x, y=0, z); end
+end
+
+# should be fine, no arguments added to splat
+class F8 < A8
+  extend T::Sig
+  sig {override.params(x: Integer, y: Unrelated, z: String).void}
+  def foo(x, *y, z); end
+end
+
+# https://github.com/sorbet/sorbet/issues/8343
+class A9
+  extend T::Sig
+
+  sig {params(x: Integer).void}
+  def foo(x); end
+end
+
+class B9 < A9
+  sig {override.params(args: String).void}
+  #                    ^^^^ error: Parameter `args` of type `String` not compatible with type of overridden method `A9#foo`
+  def foo(*args); end
+end
+
+class A10
+  extend T::Sig
+  sig {params(x: Integer, y: String, z: Integer).void}
+  def foo(x, y, z); end
+end
+
+class B10 < A10
+  extend T::Sig
+  sig {override.params(x: Integer, y: Integer, z: Integer).void}
+  #                                ^ error: Parameter `y` of type `Integer` not compatible with type of overridden method `A10#foo`
+  def foo(x, y=0, z); end
+end
+
+class C10 < A10
+  extend T::Sig
+  sig {override.params(x: Integer, y: Integer, z: Integer).void}
+  #                                ^ error: Parameter `y` of type `Integer` not compatible with type of overridden method `A10#foo`
+  def foo(x, *y, z); end
+end
+
+class D10 < A10
+  extend T::Sig
+  sig {override.params(x: Integer, y: String, z: String).void}
+  #                                           ^ error: Parameter `z` of type `String` not compatible with type of overridden method `A10#foo`
+  def foo(x, *y, z); end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Currently, Sorbet's checking of whether an override's parameter list is compatible with its parent is best-effort - we check positional args against the equivalent positional args, and likewise for optional args and splats.

This works in the straightforward cases, but does severely restrict what kinds of functions are allowed to override others. For example, it permits [laundering the type of a parameter by making it optional in the subclass](https://github.com/sorbet/sorbet/issues/9029). It also means we can't allow [mandatory args coming after optional args](https://github.com/sorbet/sorbet/issues/6551).

This PR (hopefully) addresses both issues by using a more robust algorithm, where all possible parent call configurations are tested against the child signature. This does increase the runtime from `O(num_parent_args)` to `O(num_parent_args * num_child_args)` in the worst case, but I'm not sure it's possible to do better while remaining sound.

TODO:
[] Fix case where the child has more leading mandatory positional arguments than the parent
[] Allow keyword arguments to be weakened from mandatory to optional in the child
[] Allow runtime to support trailing mandatory args (this may be a separate PR)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

It is possible that this change will introduce new type errors where optional args become checked against mandatory positional args where they weren't before. However, those errors would already be reported by sorbet-runtime at any callsites, so I expect this to be mostly an additive change.