### PR TITLE
Fix suggestion title for code action to promote `test_import` to regular `import`

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -545,7 +545,7 @@ public:
             {insertionLoc, fmt::format("\n  {} {}{}", importTypeMethod, packageToImport, importTypeTrailing)}};
         if (deleteTestImportEdit.has_value()) {
             edits.push_back(deleteTestImportEdit.value());
-            suggestionTitle = fmt::format("Convert existing import to `{}`", "test_import", importTypeMethod);
+            suggestionTitle = fmt::format("Convert existing import to `{}`", importTypeMethod);
         }
 
         core::AutocorrectSuggestion suggestion(suggestionTitle, edits);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

The `"test_import"` arg was hiding the actual new import type (`importTypeMethod`).

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Inaccurate suggestion title.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested manually, `suggestionTitle` is only shown in LSP and not CLI mode, so difficult to write a test for it.

<img width="333" height="158" alt="image" src="https://github.com/user-attachments/assets/6bd3705c-a71a-471b-8a1d-7fc93eabed48" />
