### PR TITLE
Add --suggest-unsafe autocorrect for T::Struct constructors

### DIFF
--- a/test/testdata/infer/autocorrect_suggest_unsafe_struct.rb
+++ b/test/testdata/infer/autocorrect_suggest_unsafe_struct.rb
@@ -1,0 +1,15 @@
+# typed: true
+# enable-suggest-unsafe: true
+
+class S < T::Struct
+  prop :foo, String
+  prop :bar, Integer
+end
+
+# Missing required keyword arguments
+S.new
+S.new(foo: "hello")
+S.new(bar: 42)
+
+# This should work fine (no error)
+S.new(foo: "hello", bar: 42)

--- a/test/testdata/infer/autocorrect_suggest_unsafe_struct.rb.autocorrects.exp
+++ b/test/testdata/infer/autocorrect_suggest_unsafe_struct.rb.autocorrects.exp
@@ -1,0 +1,17 @@
+# -- test/testdata/infer/autocorrect_suggest_unsafe_struct.rb --
+# typed: true
+# enable-suggest-unsafe: true
+
+class S < T::Struct
+  prop :foo, String
+  prop :bar, Integer
+end
+
+# Missing required keyword arguments
+T.unsafe(S.new)
+T.unsafe(S.new(foo: "hello"))
+T.unsafe(S.new(bar: 42))
+
+# This should work fine (no error)
+S.new(foo: "hello", bar: 42)
+# ------------------------------


### PR DESCRIPTION
When T::Struct constructors are missing required parameters and --suggest-unsafe flag is enabled, suggest wrapping with T.unsafe().

Fixes #7332

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
