### PR TITLE
Print bad prop name when prop can't be created due to PII rules

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -384,7 +384,7 @@ class T::Props::Decorator
         #
         if sensitivity_and_pii[:pii] && @class.is_a?(Class) && !T.unsafe(@class).contains_pii?
           raise ArgumentError.new(
-            'Cannot include a pii prop in a class that declares `contains_no_pii`'
+            "Cannot define pii prop `#{@class}##{name.to_sym}` because `#{@class}` is declared as `contains_no_pii`"
           )
         end
       end

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -384,7 +384,7 @@ class T::Props::Decorator
         #
         if sensitivity_and_pii[:pii] && @class.is_a?(Class) && !T.unsafe(@class).contains_pii?
           raise ArgumentError.new(
-            "Cannot define pii prop `#{@class}##{name.to_sym}` because `#{@class}` is `contains_no_pii`"
+            "Cannot define pii prop `#{@class}##{name}` because `#{@class}` is `contains_no_pii`"
           )
         end
       end

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -384,7 +384,7 @@ class T::Props::Decorator
         #
         if sensitivity_and_pii[:pii] && @class.is_a?(Class) && !T.unsafe(@class).contains_pii?
           raise ArgumentError.new(
-            "Cannot define pii prop `#{@class}##{name.to_sym}` because `#{@class}` is declared as `contains_no_pii`"
+            "Cannot define pii prop `#{@class}##{name.to_sym}` because `#{@class}` is `contains_no_pii`"
           )
         end
       end

--- a/gems/sorbet-runtime/test/types/props/decorator.rb
+++ b/gems/sorbet-runtime/test/types/props/decorator.rb
@@ -406,4 +406,22 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
     T::Configuration.normalize_sensitivity_and_pii_handler = nil
 
   end
+
+  it 'tells the name of pii prop if bad pii' do
+    e = assert_raises do
+      T::Configuration.normalize_sensitivity_and_pii_handler = lambda do |meta|
+        meta[:pii] = :set
+        meta
+      end
+      class NoPII < T::Struct
+        def self.contains_pii?
+          false
+        end
+
+        prop :foo, Integer, sensitivity: true
+      end
+    end
+    assert_match(/NoPII#foo/, e.message)
+    assert_match(/because `.*::NoPII` is `contains_no_pii`/, e.message)
+  end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
I think this is just strictly better; the existing message buries the offending prop in a huge stack trace.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
