### PR TITLE
Stop implicitly exporting package roots

### DIFF
--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -274,8 +274,7 @@ class VisibilityCheckerPass final {
             importAutocorrect->edits.insert(importAutocorrect->edits.end(),
                                             make_move_iterator(exportAutocorrect->edits.begin()),
                                             make_move_iterator(exportAutocorrect->edits.end()));
-            core::AutocorrectSuggestion combinedAutocorrect(combinedTitle, move(importAutocorrect->edits));
-            e.addAutocorrect(move(combinedAutocorrect));
+            e.addAutocorrect(core::AutocorrectSuggestion{combinedTitle, move(importAutocorrect->edits)});
             if (!db.errorHint().empty()) {
                 e.addErrorNote("{}", db.errorHint());
             }

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -427,6 +427,12 @@ public:
                         symToExport = enumClass;
                     }
                     if (definesBehavior) {
+                        // For compatibility with gen-packages, we do _not_ add an export if it doesn't define
+                        // behavior. This is mostly because it's easier to get Sorbet to behave like gen-packages
+                        // than the other way around.
+                        //
+                        // If we move to a world where all __package.rb edits are done via Sorbet autocorrects,
+                        // we could make this addExport call unconditional.
                         if (auto exp = pkg.addExport(ctx, symToExport)) {
                             exportAutocorrect.emplace(exp.value());
                         }

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -269,25 +269,22 @@ class VisibilityCheckerPass final {
                                     optional<core::AutocorrectSuggestion> &&importAutocorrect,
                                     optional<core::AutocorrectSuggestion> &&exportAutocorrect) {
         auto &db = ctx.state.packageDB();
+        auto hasAutocorrect = importAutocorrect.has_value() || exportAutocorrect.has_value();
+
         if (importAutocorrect.has_value() && exportAutocorrect.has_value()) {
             auto combinedTitle = fmt::format("{} and {}", importAutocorrect->title, exportAutocorrect->title);
             importAutocorrect->edits.insert(importAutocorrect->edits.end(),
                                             make_move_iterator(exportAutocorrect->edits.begin()),
                                             make_move_iterator(exportAutocorrect->edits.end()));
             e.addAutocorrect(core::AutocorrectSuggestion{combinedTitle, move(importAutocorrect->edits)});
-            if (!db.errorHint().empty()) {
-                e.addErrorNote("{}", db.errorHint());
-            }
         } else if (importAutocorrect.has_value()) {
             e.addAutocorrect(std::move(importAutocorrect.value()));
-            if (!db.errorHint().empty()) {
-                e.addErrorNote("{}", db.errorHint());
-            }
         } else if (exportAutocorrect.has_value()) {
             e.addAutocorrect(std::move(exportAutocorrect.value()));
-            if (!db.errorHint().empty()) {
-                e.addErrorNote("{}", db.errorHint());
-            }
+        }
+
+        if (hasAutocorrect && !db.errorHint().empty()) {
+            e.addErrorNote("{}", db.errorHint());
         }
     }
 

--- a/test/cli/package-error-missing-export-import/other/other_class.rb
+++ b/test/cli/package-error-missing-export-import/other/other_class.rb
@@ -2,5 +2,6 @@
 
 module Other
   class OtherClass
+    puts("behavior")
   end
 end

--- a/test/cli/package-error-missing-export/other/other_class.rb
+++ b/test/cli/package-error-missing-export/other/other_class.rb
@@ -2,11 +2,14 @@
 
 module Foo::Bar::OtherPackage
   class OtherClass
+    puts("behavior")
   end
 
   class NotExported
+    puts("behavior")
   end
 
   class Inner::AlsoNotExported
+    puts("behavior")
   end
 end

--- a/test/cli/package-error-missing-export/test.out
+++ b/test/cli/package-error-missing-export/test.out
@@ -1,8 +1,8 @@
 use_other/foo_class.rb:10: `Foo::Bar::OtherPackage::NotExported` resolves but is not exported from `Foo::Bar::OtherPackage` https://srb.help/3717
     10 |      Foo::Bar::OtherPackage::NotExported
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/other_class.rb:7: Defined here
-     7 |  class NotExported
+    other/other_class.rb:8: Defined here
+     8 |  class NotExported
           ^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     other/__package.rb:3: Insert `export Foo::Bar::OtherPackage::NotExported`
@@ -14,8 +14,8 @@ use_other/foo_class.rb:10: `Foo::Bar::OtherPackage::NotExported` resolves but is
 use_other/foo_class.rb:11: `Foo::Bar::OtherPackage::NotExported` resolves but is not exported from `Foo::Bar::OtherPackage` https://srb.help/3717
     11 |      Bar::OtherPackage::NotExported
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/other_class.rb:7: Defined here
-     7 |  class NotExported
+    other/other_class.rb:8: Defined here
+     8 |  class NotExported
           ^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     other/__package.rb:3: Insert `export Foo::Bar::OtherPackage::NotExported`
@@ -27,8 +27,8 @@ use_other/foo_class.rb:11: `Foo::Bar::OtherPackage::NotExported` resolves but is
 use_other/foo_class.rb:12: `Foo::Bar::OtherPackage::Inner::AlsoNotExported` resolves but is not exported from `Foo::Bar::OtherPackage` https://srb.help/3717
     12 |      Foo::Bar::OtherPackage::Inner::AlsoNotExported
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/other_class.rb:10: Defined here
-    10 |  class Inner::AlsoNotExported
+    other/other_class.rb:12: Defined here
+    12 |  class Inner::AlsoNotExported
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     other/__package.rb:3: Insert `export Foo::Bar::OtherPackage::Inner::AlsoNotExported`
@@ -40,8 +40,8 @@ use_other/foo_class.rb:12: `Foo::Bar::OtherPackage::Inner::AlsoNotExported` reso
 use_other/foo_class.rb:13: `Foo::Bar::OtherPackage::Inner::AlsoNotExported` resolves but is not exported from `Foo::Bar::OtherPackage` https://srb.help/3717
     13 |      Bar::OtherPackage::Inner::AlsoNotExported
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/other_class.rb:10: Defined here
-    10 |  class Inner::AlsoNotExported
+    other/other_class.rb:12: Defined here
+    12 |  class Inner::AlsoNotExported
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     other/__package.rb:3: Insert `export Foo::Bar::OtherPackage::Inner::AlsoNotExported`

--- a/test/cli/package-file-table/test.out
+++ b/test/cli/package-file-table/test.out
@@ -12,13 +12,10 @@ foo/foo.rb:13: Unable to resolve constant `BardClass` https://srb.help/5002
 foo/foo.rb:14: `Project::Bar::UnexportedClass` resolves but is not exported from `Project::Bar` https://srb.help/3717
     14 |    Project::Bar::UnexportedClass
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    bar/bar.rb:14: Defined here
+  `Project::Bar::UnexportedClass` does not define behavior and thus will not be automatically exported
+    bar/bar.rb:14:
     14 |  class UnexportedClass; end
           ^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Use `-a` to autocorrect
-    bar/__package.rb:9: Insert `export Project::Bar::UnexportedClass`
-     9 |  export Project::Bar::BarMethods
-                                         ^
 Errors: 2
 {
  "files": [

--- a/test/cli/packager_suggest_nested_crash/consumer_auth/identity_type.rb
+++ b/test/cli/packager_suggest_nested_crash/consumer_auth/identity_type.rb
@@ -3,5 +3,6 @@
 
 class Project::ConsumerAuth
   class IdentifierType
+    puts("behavior")
   end
 end

--- a/test/cli/simple-package/test.out
+++ b/test/cli/simple-package/test.out
@@ -12,11 +12,8 @@ foo/foo.rb:13: Unable to resolve constant `BardClass` https://srb.help/5002
 foo/foo.rb:14: `Project::Bar::UnexportedClass` resolves but is not exported from `Project::Bar` https://srb.help/3717
     14 |    Project::Bar::UnexportedClass
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    bar/bar.rb:14: Defined here
+  `Project::Bar::UnexportedClass` does not define behavior and thus will not be automatically exported
+    bar/bar.rb:14:
     14 |  class UnexportedClass; end
           ^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Use `-a` to autocorrect
-    bar/__package.rb:9: Insert `export Project::Bar::UnexportedClass`
-     9 |  export Project::Bar::BarMethods
-                                         ^
 Errors: 2

--- a/test/testdata/packager/unimported_namespace/aaa/a_class.rb
+++ b/test/testdata/packager/unimported_namespace/aaa/a_class.rb
@@ -3,7 +3,7 @@
 
 class AAA::AClass
   BBB
-# ^^^ error: `BBB` resolves but its package is not imported
+# ^^^ error: `BBB` resolves but is not exported from `BBB` and `BBB` is not imported
 
   CCC
 # ^^^ error: Unable to resolve constant `CCC`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There are actually two changes here, because the first change exposed that we have to fix the second.

First, I wanted to make classes/modules that share a name with their enclosing package (e.g. `class Opus::Child < Parent` given `class Opus::Child < PackageSpec`) not be automatically exported. I wanted to remove this because the logic that implements this in Sorbet is one of the only remaining places that uses `fullName()` on a PackageInfo (which is the `vector<NameRef>`), instead of doing things based on the package's owner.

Making that change turned up a few dozen errors on Stripe's codebase.

Having removed the logic from Sorbet, I went to remove the logic from Stripe's `gen-packages` script (which should make the same edits as Sorbet's autocorrects), but could not find a way to make that work easily, because it turns out that `gen-packages` will not add an export if that constant does not define behavior.

Making it export constants even if they did not define behavior meant that everything in the package would be exported (this implicit package root exporting behavior only exported the root, while writing an explicit export recursively exports the mentioned constant and all of its transitive members).

We thought about making a more surgical change to gen-packages, before realizing that this doesn't affect just when the name is the package root namespace—gen-packages will never introduce an export for something that does not define behavior.

At that point, it's easier for us to just make that determination in Sorbet, to match the gen-packages behavior. If we ever deprecate the `gen-packages` script internally, we could add back the autocorrects, but for now at least Sorbet won't suggest imports if `gen-packages` would not have suggested an import (at the cost of neither Sorbet autocorrects nor gen-packages being able to fix a certain class of visibility errors—you'll have to add behavior to the thing that you want exported before any code generation tool will actually suggest the export).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

There are some differences to the tests.

The `unimported_namespace` test shows the new behavior from not exporting namespaces implicitly (the `error:` assertion now also says "and is not exported").

The other tests shows in what circumstances we opt not to add an autocorrect. Some of those I've fixed by making the test define behavior, and some I've fixed by updating the expectation to capture the new way that Sorbet works.

So no new tests are required, even though we're adding new functionality.