### PR TITLE
`min`/`max` on a non-empty tuple can't return `nil`

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3326,7 +3326,7 @@ public:
         if (tuple->elems.empty()) {
             res.returnType = Types::nilClass();
         } else {
-            res.returnType = tuple->elementType(gs);
+            res.returnType = Types::dropNil(gs, tuple->elementType(gs));
         }
     }
 } Tuple_minMax;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Even if some elements of a tuple are nil, the overall type for `min` or `max` can't be, since there would be an error otherwise.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
