### PR TITLE
Add tests for Prism's direct desugaring

### DIFF
--- a/ast/TreeEquality.cc
+++ b/ast/TreeEquality.cc
@@ -365,6 +365,23 @@ struct StructurallyEqualComparator {
     }
 };
 
+// TODO: Clean up after Prism work is done. https://github.com/sorbet/sorbet/issues/9065
+struct ExactlyEqualComparator {
+    static bool compareNodes(const core::GlobalState &gs, const void *avoid, const ExpressionPtr &tree,
+                             const ExpressionPtr &other, const core::FileRef file) {
+        if (tree.loc() != other.loc()) {
+            return false;
+        }
+
+        return compareTrees<ExactlyEqualComparator>(gs, avoid, tree, other, file);
+    }
+
+    static bool compareSpans(const core::GlobalState &gs, const void *avoid, absl::Span<const ExpressionPtr> a,
+                             absl::Span<const ExpressionPtr> b, const core::FileRef file) {
+        return compareTreeSpans<ExactlyEqualComparator>(gs, avoid, a, b, file);
+    }
+};
+
 } // namespace
 
 bool ExpressionPtr::structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other,
@@ -379,18 +396,42 @@ bool ExpressionPtr::structurallyEqual(const core::GlobalState &gs, const Express
     }
 }
 
-#define EQUAL_IMPL(name)                                                                                            \
-    bool name::structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) \
-        const {                                                                                                     \
-        if (ExpressionToTag<name>::value != other.tag()) {                                                          \
-            return false;                                                                                           \
-        }                                                                                                           \
-        try {                                                                                                       \
-            return sorbet::ast::compareTrees<StructurallyEqualComparator>(gs, this, ExpressionToTag<name>::value,   \
-                                                                          this, other.get(), file, true);           \
-        } catch (StructurallyEqualError & e) {                                                                      \
-            return false;                                                                                           \
-        }                                                                                                           \
+bool ExpressionPtr::exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other,
+                                 const core::FileRef file) const {
+    if (tag() != other.tag()) {
+        return false;
+    }
+    try {
+        return sorbet::ast::compareTrees<ExactlyEqualComparator>(gs, get(), tag(), get(), other.get(), file, true);
+    } catch (StructurallyEqualError &e) {
+        return false;
+    }
+}
+
+#define EQUAL_IMPL(name)                                                                                               \
+    bool name::structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file)    \
+        const {                                                                                                        \
+        if (ExpressionToTag<name>::value != other.tag()) {                                                             \
+            return false;                                                                                              \
+        }                                                                                                              \
+        try {                                                                                                          \
+            return sorbet::ast::compareTrees<StructurallyEqualComparator>(gs, this, ExpressionToTag<name>::value,      \
+                                                                          this, other.get(), file, true);              \
+        } catch (StructurallyEqualError & e) {                                                                         \
+            return false;                                                                                              \
+        }                                                                                                              \
+    }                                                                                                                  \
+                                                                                                                       \
+    bool name::exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const { \
+        if (ExpressionToTag<name>::value != other.tag()) {                                                             \
+            return false;                                                                                              \
+        }                                                                                                              \
+        try {                                                                                                          \
+            return sorbet::ast::compareTrees<ExactlyEqualComparator>(gs, this, ExpressionToTag<name>::value, this,     \
+                                                                     other.get(), file, true);                         \
+        } catch (StructurallyEqualError & e) {                                                                         \
+            return false;                                                                                              \
+        }                                                                                                              \
     }
 
 EQUAL_IMPL(EmptyTree);

--- a/ast/TreeEquality.cc
+++ b/ast/TreeEquality.cc
@@ -10,18 +10,22 @@ namespace sorbet::ast {
 
 namespace {
 
-bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const ExpressionPtr &tree,
-                       const ExpressionPtr &other, const core::FileRef file, bool root = false);
+template <typename Comparator>
+bool compareTrees(const core::GlobalState &gs, const void *avoid, const ExpressionPtr &tree, const ExpressionPtr &other,
+                  const core::FileRef file, bool root = false);
 
-bool structurallyEqualSpan(const core::GlobalState &gs, const void *avoid, absl::Span<const ExpressionPtr> a,
-                           absl::Span<const ExpressionPtr> b, const core::FileRef file) {
-    return absl::c_equal(a, b, [&](const auto &a, const auto &b) { return structurallyEqual(gs, avoid, a, b, file); });
+template <typename Comparator>
+bool compareTreeSpans(const core::GlobalState &gs, const void *avoid, absl::Span<const ExpressionPtr> a,
+                      absl::Span<const ExpressionPtr> b, const core::FileRef file) {
+    return absl::c_equal(a, b,
+                         [&](const auto &a, const auto &b) { return compareTrees<Comparator>(gs, avoid, a, b, file); });
 }
 
 class StructurallyEqualError {};
 
-bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const Tag tag, const void *tree,
-                       const void *other, const core::FileRef file, bool root) {
+template <typename Comparator>
+bool compareTrees(const core::GlobalState &gs, const void *avoid, const Tag tag, const void *tree, const void *other,
+                  const core::FileRef file, bool root) {
     if (!root && tree == avoid) {
         throw StructurallyEqualError();
     }
@@ -45,11 +49,11 @@ bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const Tag
                 return false;
             }
 
-            if (!structurallyEqual(gs, avoid, a->recv, b->recv, file)) {
+            if (!Comparator::compareNodes(gs, avoid, a->recv, b->recv, file)) {
                 return false;
             }
 
-            return structurallyEqualSpan(gs, avoid, a->rawArgsDoNotUse(), b->rawArgsDoNotUse(), file);
+            return Comparator::compareSpans(gs, avoid, a->rawArgsDoNotUse(), b->rawArgsDoNotUse(), file);
         }
 
         case Tag::ClassDef: {
@@ -61,16 +65,16 @@ bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const Tag
             if (a->kind != b->kind) {
                 return false;
             }
-            if (!structurallyEqual(gs, avoid, a->name, b->name, file)) {
+            if (!Comparator::compareNodes(gs, avoid, a->name, b->name, file)) {
                 return false;
             }
-            if (!structurallyEqualSpan(gs, avoid, a->ancestors, b->ancestors, file)) {
+            if (!Comparator::compareSpans(gs, avoid, a->ancestors, b->ancestors, file)) {
                 return false;
             }
-            if (!structurallyEqualSpan(gs, avoid, a->singletonAncestors, b->singletonAncestors, file)) {
+            if (!Comparator::compareSpans(gs, avoid, a->singletonAncestors, b->singletonAncestors, file)) {
                 return false;
             }
-            if (!structurallyEqualSpan(gs, avoid, a->rhs, b->rhs, file)) {
+            if (!Comparator::compareSpans(gs, avoid, a->rhs, b->rhs, file)) {
                 return false;
             }
             return true;
@@ -88,10 +92,10 @@ bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const Tag
             if (a->flags != b->flags) {
                 return false;
             }
-            if (!structurallyEqual(gs, avoid, a->rhs, b->rhs, file)) {
+            if (!Comparator::compareNodes(gs, avoid, a->rhs, b->rhs, file)) {
                 return false;
             }
-            if (!structurallyEqualSpan(gs, avoid, a->args, b->args, file)) {
+            if (!Comparator::compareSpans(gs, avoid, a->args, b->args, file)) {
                 return false;
             }
             return true;
@@ -100,22 +104,22 @@ bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const Tag
         case Tag::If: {
             auto *a = reinterpret_cast<const If *>(tree);
             auto *b = reinterpret_cast<const If *>(other);
-            return structurallyEqual(gs, avoid, a->cond, b->cond, file) &&
-                   structurallyEqual(gs, avoid, a->thenp, b->thenp, file) &&
-                   structurallyEqual(gs, avoid, a->elsep, b->elsep, file);
+            return Comparator::compareNodes(gs, avoid, a->cond, b->cond, file) &&
+                   Comparator::compareNodes(gs, avoid, a->thenp, b->thenp, file) &&
+                   Comparator::compareNodes(gs, avoid, a->elsep, b->elsep, file);
         }
 
         case Tag::While: {
             auto *a = reinterpret_cast<const While *>(tree);
             auto *b = reinterpret_cast<const While *>(other);
-            return structurallyEqual(gs, avoid, a->cond, b->cond, file) &&
-                   structurallyEqual(gs, avoid, a->body, b->body, file);
+            return Comparator::compareNodes(gs, avoid, a->cond, b->cond, file) &&
+                   Comparator::compareNodes(gs, avoid, a->body, b->body, file);
         }
 
         case Tag::Break: {
             auto *a = reinterpret_cast<const Break *>(tree);
             auto *b = reinterpret_cast<const Break *>(other);
-            return structurallyEqual(gs, avoid, a->expr, b->expr, file);
+            return Comparator::compareNodes(gs, avoid, a->expr, b->expr, file);
         }
 
         case Tag::Retry: {
@@ -125,40 +129,40 @@ bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const Tag
         case Tag::Next: {
             auto *a = reinterpret_cast<const Next *>(tree);
             auto *b = reinterpret_cast<const Next *>(other);
-            return structurallyEqual(gs, avoid, a->expr, b->expr, file);
+            return Comparator::compareNodes(gs, avoid, a->expr, b->expr, file);
         }
 
         case Tag::Return: {
             auto *a = reinterpret_cast<const Return *>(tree);
             auto *b = reinterpret_cast<const Return *>(other);
-            return structurallyEqual(gs, avoid, a->expr, b->expr, file);
+            return Comparator::compareNodes(gs, avoid, a->expr, b->expr, file);
         }
 
         case Tag::RescueCase: {
             auto *a = reinterpret_cast<const RescueCase *>(tree);
             auto *b = reinterpret_cast<const RescueCase *>(other);
-            if (!structurallyEqual(gs, avoid, a->var, b->var, file)) {
+            if (!Comparator::compareNodes(gs, avoid, a->var, b->var, file)) {
                 return false;
             }
-            if (!structurallyEqual(gs, avoid, a->body, b->body, file)) {
+            if (!Comparator::compareNodes(gs, avoid, a->body, b->body, file)) {
                 return false;
             }
-            return structurallyEqualSpan(gs, avoid, a->exceptions, b->exceptions, file);
+            return Comparator::compareSpans(gs, avoid, a->exceptions, b->exceptions, file);
         }
 
         case Tag::Rescue: {
             auto *a = reinterpret_cast<const Rescue *>(tree);
             auto *b = reinterpret_cast<const Rescue *>(other);
-            if (!structurallyEqual(gs, avoid, a->body, b->body, file)) {
+            if (!Comparator::compareNodes(gs, avoid, a->body, b->body, file)) {
                 return false;
             }
-            if (!structurallyEqual(gs, avoid, a->else_, b->else_, file)) {
+            if (!Comparator::compareNodes(gs, avoid, a->else_, b->else_, file)) {
                 return false;
             }
-            if (!structurallyEqual(gs, avoid, a->ensure, b->ensure, file)) {
+            if (!Comparator::compareNodes(gs, avoid, a->ensure, b->ensure, file)) {
                 return false;
             }
-            return structurallyEqualSpan(gs, avoid, a->rescueCases, b->rescueCases, file);
+            return Comparator::compareSpans(gs, avoid, a->rescueCases, b->rescueCases, file);
         }
 
         case Tag::Local: {
@@ -176,39 +180,39 @@ bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const Tag
         case Tag::RestArg: {
             auto *a = reinterpret_cast<const RestArg *>(tree);
             auto *b = reinterpret_cast<const RestArg *>(other);
-            return structurallyEqual(gs, avoid, a->expr, b->expr, file);
+            return Comparator::compareNodes(gs, avoid, a->expr, b->expr, file);
         }
 
         case Tag::KeywordArg: {
             auto *a = reinterpret_cast<const KeywordArg *>(tree);
             auto *b = reinterpret_cast<const KeywordArg *>(other);
-            return structurallyEqual(gs, avoid, a->expr, b->expr, file);
+            return Comparator::compareNodes(gs, avoid, a->expr, b->expr, file);
         }
 
         case Tag::OptionalArg: {
             auto *a = reinterpret_cast<const OptionalArg *>(tree);
             auto *b = reinterpret_cast<const OptionalArg *>(other);
-            return structurallyEqual(gs, avoid, a->expr, b->expr, file) &&
-                   structurallyEqual(gs, avoid, a->default_, b->default_, file);
+            return Comparator::compareNodes(gs, avoid, a->expr, b->expr, file) &&
+                   Comparator::compareNodes(gs, avoid, a->default_, b->default_, file);
         }
 
         case Tag::BlockArg: {
             auto *a = reinterpret_cast<const BlockArg *>(tree);
             auto *b = reinterpret_cast<const BlockArg *>(other);
-            return structurallyEqual(gs, avoid, a->expr, b->expr, file);
+            return Comparator::compareNodes(gs, avoid, a->expr, b->expr, file);
         }
 
         case Tag::ShadowArg: {
             auto *a = reinterpret_cast<const ShadowArg *>(tree);
             auto *b = reinterpret_cast<const ShadowArg *>(other);
-            return structurallyEqual(gs, avoid, a->expr, b->expr, file);
+            return Comparator::compareNodes(gs, avoid, a->expr, b->expr, file);
         }
 
         case Tag::Assign: {
             auto *a = reinterpret_cast<const Assign *>(tree);
             auto *b = reinterpret_cast<const Assign *>(other);
-            return structurallyEqual(gs, avoid, a->lhs, b->lhs, file) &&
-                   structurallyEqual(gs, avoid, a->rhs, b->rhs, file);
+            return Comparator::compareNodes(gs, avoid, a->lhs, b->lhs, file) &&
+                   Comparator::compareNodes(gs, avoid, a->rhs, b->rhs, file);
         }
 
         case Tag::Cast: {
@@ -220,20 +224,20 @@ bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const Tag
             if (a->cast != b->cast) {
                 return false;
             }
-            return structurallyEqual(gs, avoid, a->arg, b->arg, file) &&
-                   structurallyEqual(gs, avoid, a->typeExpr, b->typeExpr, file);
+            return Comparator::compareNodes(gs, avoid, a->arg, b->arg, file) &&
+                   Comparator::compareNodes(gs, avoid, a->typeExpr, b->typeExpr, file);
         }
 
         case Tag::Hash: {
             auto *a = reinterpret_cast<const Hash *>(tree);
             auto *b = reinterpret_cast<const Hash *>(other);
-            return structurallyEqualSpan(gs, avoid, a->keys, b->keys, file) &&
-                   structurallyEqualSpan(gs, avoid, a->values, b->values, file);
+            return Comparator::compareSpans(gs, avoid, a->keys, b->keys, file) &&
+                   Comparator::compareSpans(gs, avoid, a->values, b->values, file);
         }
         case Tag::Array: {
             auto *a = reinterpret_cast<const Array *>(tree);
             auto *b = reinterpret_cast<const Array *>(other);
-            return structurallyEqualSpan(gs, avoid, a->elems, b->elems, file);
+            return Comparator::compareSpans(gs, avoid, a->elems, b->elems, file);
         }
 
         case Tag::Literal: {
@@ -271,7 +275,7 @@ bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const Tag
             if (a->cnst != b->cnst) {
                 return false;
             }
-            return structurallyEqual(gs, avoid, a->scope, b->scope, file);
+            return Comparator::compareNodes(gs, avoid, a->scope, b->scope, file);
         }
 
         case Tag::ConstantLit: {
@@ -286,7 +290,7 @@ bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const Tag
                 if (alit.cnst != blit.cnst) {
                     return false;
                 }
-                return structurallyEqual(gs, avoid, alit.scope, blit.scope, file);
+                return Comparator::compareNodes(gs, avoid, alit.scope, blit.scope, file);
             } else if (!a->original() && !b->original()) {
                 // This occurs when the constant is created using MK::Constant instead of MK::UnresolvedConstant
                 // (original points to the UnresolvedConstantLit that created this ConstantLit)
@@ -303,15 +307,15 @@ bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const Tag
         case Tag::Block: {
             auto *a = reinterpret_cast<const Block *>(tree);
             auto *b = reinterpret_cast<const Block *>(other);
-            return structurallyEqualSpan(gs, avoid, a->args, b->args, file) &&
-                   structurallyEqual(gs, avoid, a->body, b->body, file);
+            return Comparator::compareSpans(gs, avoid, a->args, b->args, file) &&
+                   Comparator::compareNodes(gs, avoid, a->body, b->body, file);
         }
 
         case Tag::InsSeq: {
             auto *a = reinterpret_cast<const InsSeq *>(tree);
             auto *b = reinterpret_cast<const InsSeq *>(other);
-            return structurallyEqualSpan(gs, avoid, a->stats, b->stats, file) &&
-                   structurallyEqual(gs, avoid, a->expr, b->expr, file);
+            return Comparator::compareSpans(gs, avoid, a->stats, b->stats, file) &&
+                   Comparator::compareNodes(gs, avoid, a->expr, b->expr, file);
         }
 
         case Tag::RuntimeMethodDefinition: {
@@ -326,8 +330,9 @@ bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const Tag
     }
 }
 
-bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const ExpressionPtr &tree,
-                       const ExpressionPtr &other, const core::FileRef file, bool root) {
+template <typename Comparator>
+bool compareTrees(const core::GlobalState &gs, const void *avoid, const ExpressionPtr &tree, const ExpressionPtr &other,
+                  const core::FileRef file, bool root) {
     ENFORCE(tree);
     ENFORCE(other);
     if (!tree) {
@@ -345,8 +350,20 @@ bool structurallyEqual(const core::GlobalState &gs, const void *avoid, const Exp
         return false;
     }
 
-    return structurallyEqual(gs, avoid, tree.tag(), tree.get(), other.get(), file, root);
+    return compareTrees<Comparator>(gs, avoid, tree.tag(), tree.get(), other.get(), file, root);
 }
+
+struct StructurallyEqualComparator {
+    static bool compareNodes(const core::GlobalState &gs, const void *avoid, const ExpressionPtr &tree,
+                             const ExpressionPtr &other, const core::FileRef file) {
+        return compareTrees<StructurallyEqualComparator>(gs, avoid, tree, other, file);
+    }
+
+    static bool compareSpans(const core::GlobalState &gs, const void *avoid, absl::Span<const ExpressionPtr> a,
+                             absl::Span<const ExpressionPtr> b, const core::FileRef file) {
+        return compareTreeSpans<StructurallyEqualComparator>(gs, avoid, a, b, file);
+    }
+};
 
 } // namespace
 
@@ -356,7 +373,7 @@ bool ExpressionPtr::structurallyEqual(const core::GlobalState &gs, const Express
         return false;
     }
     try {
-        return sorbet::ast::structurallyEqual(gs, get(), tag(), get(), other.get(), file, true);
+        return sorbet::ast::compareTrees<StructurallyEqualComparator>(gs, get(), tag(), get(), other.get(), file, true);
     } catch (StructurallyEqualError &e) {
         return false;
     }
@@ -369,8 +386,8 @@ bool ExpressionPtr::structurallyEqual(const core::GlobalState &gs, const Express
             return false;                                                                                           \
         }                                                                                                           \
         try {                                                                                                       \
-            return sorbet::ast::structurallyEqual(gs, this, ExpressionToTag<name>::value, this, other.get(), file,  \
-                                                  true);                                                            \
+            return sorbet::ast::compareTrees<StructurallyEqualComparator>(gs, this, ExpressionToTag<name>::value,   \
+                                                                          this, other.get(), file, true);           \
         } catch (StructurallyEqualError & e) {                                                                      \
             return false;                                                                                           \
         }                                                                                                           \

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -226,7 +226,10 @@ public:
     }
 
     ExpressionPtr deepCopy() const;
+    // Compare the entire tree for equality, ignoring locations.
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    // Compare the entire tree for equality, including locations.
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string_view nodeName() const;
 
@@ -418,6 +421,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -449,6 +453,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -471,6 +476,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -492,6 +498,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -512,6 +519,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -530,6 +538,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -550,6 +559,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -570,6 +580,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -598,6 +609,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -625,6 +637,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -645,6 +658,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -672,6 +686,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -692,6 +707,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -712,6 +728,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -733,6 +750,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -753,6 +771,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -773,6 +792,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -794,6 +814,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -869,6 +890,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     // Returns nullptr if no block present.
     const ast::Block *block() const;
@@ -1065,6 +1087,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1089,6 +1112,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1112,6 +1136,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1132,6 +1157,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1162,6 +1188,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1381,6 +1408,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1434,6 +1462,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1455,6 +1484,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1480,6 +1510,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1502,6 +1533,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1520,6 +1552,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1538,6 +1571,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;

--- a/parser/prism/Parser.cc
+++ b/parser/prism/Parser.cc
@@ -7,12 +7,13 @@ using namespace std;
 
 namespace sorbet::parser::Prism {
 
-unique_ptr<parser::Node> Parser::run(core::GlobalState &gs, core::FileRef file) {
+unique_ptr<parser::Node> Parser::run(core::GlobalState &gs, core::FileRef file, bool directlyDesugar) {
     auto source = file.data(gs).source();
     Prism::Parser parser{source};
     Prism::ParseResult parseResult = parser.parse();
 
-    return Prism::Translator(parser, gs, file, parseResult.parseErrors).translate(parseResult.getRawNodePointer());
+    return Prism::Translator(parser, gs, file, parseResult.parseErrors, directlyDesugar)
+        .translate(parseResult.getRawNodePointer());
 }
 
 pm_parser_t *Parser::getRawParserPointer() {

--- a/parser/prism/Parser.h
+++ b/parser/prism/Parser.h
@@ -54,7 +54,7 @@ public:
     Parser(Parser &&) = delete;
     Parser &operator=(Parser &&) = delete;
 
-    static std::unique_ptr<parser::Node> run(core::GlobalState &gs, core::FileRef file);
+    static std::unique_ptr<parser::Node> run(core::GlobalState &gs, core::FileRef file, bool directlyDesugar = true);
 
     ParseResult parse();
     core::LocOffsets translateLocation(pm_location_t location) const;

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -31,9 +31,13 @@ bool hasExpr(const parser::NodeVec &nodes) {
 
 // Allocates a new `NodeWithExpr` with a pre-computed `ExpressionPtr` AST.
 template <typename SorbetNode, typename... TArgs>
-unique_ptr<NodeWithExpr> make_node_with_expr(ast::ExpressionPtr desugaredExpr, TArgs &&...args) {
+unique_ptr<parser::Node> Translator::make_node_with_expr(ast::ExpressionPtr desugaredExpr, TArgs &&...args) {
     auto whiteQuarkNode = make_unique<SorbetNode>(std::forward<TArgs>(args)...);
-    return make_unique<NodeWithExpr>(move(whiteQuarkNode), move(desugaredExpr));
+    if (directlyDesugar) {
+        return make_unique<NodeWithExpr>(move(whiteQuarkNode), move(desugaredExpr));
+    } else {
+        return whiteQuarkNode;
+    }
 }
 
 // Indicates that a particular code path should never be reached, with an explanation of why.
@@ -1961,7 +1965,7 @@ template <typename PrismNode> unique_ptr<parser::Mlhs> Translator::translateMult
 // Context management methods
 Translator Translator::enterMethodDef() {
     auto isInMethodDef = true;
-    return Translator(parser, gs, file, parseErrors, isInMethodDef, uniqueCounter);
+    return Translator(parser, gs, file, parseErrors, directlyDesugar, isInMethodDef, uniqueCounter);
 }
 
 void Translator::reportError(core::LocOffsets loc, const string &message) {

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -703,15 +703,17 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
         // this replicates the logic of pipeline::indexOne
         parser::Parser::ParseResult parseResult;
+        unique_ptr<parser::Node> directlyDesugaredTree;
         switch (parser) {
             case realmain::options::Parser::ORIGINAL: {
                 auto settings = parser::Parser::Settings{false, false, false, gs->cacheSensitiveOptions.rbsEnabled};
                 parseResult = parser::Parser::run(*gs, f.file, settings);
+                directlyDesugaredTree = nullptr;
                 break;
             }
             case realmain::options::Parser::PRISM: {
-                auto nodes = parser::Prism::Parser::run(ctx, f.file);
-                parseResult = parser::Parser::ParseResult{move(nodes), {}};
+                parseResult = parser::Parser::ParseResult{parser::Prism::Parser::run(ctx, f.file, false), {}};
+                directlyDesugaredTree = parser::Prism::Parser::run(ctx, f.file, true);
                 break;
             }
         }
@@ -731,17 +733,29 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
         handler.addObserved(*gs, "rbs-rewrite-tree", [&]() { return nodes->toString(*gs); });
 
-        ast::ParsedFile file;
-        switch (parser) {
-            case realmain::options::Parser::ORIGINAL: {
-                file = testSerialize(*gs, ast::ParsedFile{ast::desugar::node2Tree(ctx, move(nodes)), f.file});
-                break;
-            }
-            case realmain::options::Parser::PRISM: {
-                file = testSerialize(*gs, ast::ParsedFile{ast::prismDesugar::node2Tree(ctx, move(nodes)), f.file});
-                break;
+        ast::ExpressionPtr ast;
+        {
+            core::UnfreezeNameTable nameTableAccess(ctx); // enters original strings
+            ast = ast::desugar::node2Tree(ctx, move(nodes));
+
+            if (directlyDesugaredTree != nullptr) {
+                // This AST would have been desugared deirectly by Prism::Translator
+                auto directlyDesugaredAST = ast::prismDesugar::node2Tree(ctx, move(directlyDesugaredTree));
+
+                if (!ast.exactlyEqual(*gs, directlyDesugaredAST, f.file)) {
+                    auto expected = ast.showRawWithLocs(*gs, f.file);
+                    auto actual = directlyDesugaredAST.showRawWithLocs(*gs, f.file);
+                    CHECK_EQ_DIFF(expected, actual,
+                                  fmt::format("Prism desugared tree does not match legacy desugared tree"));
+                }
+
+                // If we get to here, we know the two trees are equivalent, so it doesn't really matter which we use.
+                // Let's just use the directly desugared one.
+                ast = move(directlyDesugaredAST);
             }
         }
+
+        ast::ParsedFile file = testSerialize(*gs, ast::ParsedFile{move(ast), f.file});
 
         handler.addObserved(*gs, "desguar-tree", [&]() { return file.tree.toString(*gs); });
         handler.addObserved(*gs, "desugar-tree-raw", [&]() { return file.tree.showRaw(*gs); });


### PR DESCRIPTION
### Motivation

When using Prism, an ever-increasing amount of the desugaring will be done immediately in `Translator.cc`. This PR adds a test that compares that logic to the original `Desugar.cc` codepath.

We use `ast::ExpressionPtr.structurallyEqual()` to do an in-memory comparison. If there's a discrepancy, we use the new `showRawWithLocs` format (from #9120) to render a diff.

<details><summary>Example log output</summary>

```diff
==================== Test output for //test:test_PosTests/testdata/desugar/sclass_prism:
exec test/pipeline_test_runner --single_test=test/testdata/desugar/sclass.rb --parser=prism
[doctest] doctest version is "2.4.9"
[doctest] run with "--help" for options
===============================================================================
test/pipeline_test_runner.cc:347:
TEST CASE:  PerPhaseTest

test/pipeline_test_runner.cc:178: MESSAGE: symbol-table-raw OK

test/pipeline_test_runner.cc:178: MESSAGE: desugar-tree OK

test/pipeline_test_runner.cc:178: MESSAGE: flatten-tree OK

test/helpers/expectations.cc:209: ERROR: Prism desugared tree does not match legacy desugared tree
@@ -420,7 +420,7 @@
                       block = nullptr
                       pos_args = 1
                       args = [
-                        Self{ loc = 1561:31-1561:35 }
+                        Self{ loc = 1561:31-1561:31 }
                       ]
                     }
                   }
```
</details>