### PR TITLE
Always compute SCCs

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -2228,9 +2228,7 @@ void packageRunCore(core::GlobalState &gs, WorkerPool &workers, absl::Span<ast::
         Timer timeit(gs.tracer(), "packager.rewritePackagesAndFiles");
 
         if constexpr (buildPackageDB) {
-            if (gs.packageDB().enforceLayering()) {
-                ComputePackageSCCs::run(gs);
-            }
+            ComputePackageSCCs::run(gs);
         }
 
         {


### PR DESCRIPTION
As prework for typechecking in package dependency order, we need to ensure that we always have the condensation graph available.

We'll switch to computing SCCs when layering is disabled, but the only current use-case for `--stripe-packages` also enables layering which means that this shouldn't be a performance change for any uses of `--stripe-packages`.

### Motivation
Typechecking in dependency order.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a

