### PR TITLE
Tidy up some import/export autocorrect code

### DIFF
--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -398,9 +398,10 @@ class VisibilityCheckerPass final {
     core::AutocorrectSuggestion combineImportExportAutocorrect(core::AutocorrectSuggestion &importAutocorrect,
                                                                core::AutocorrectSuggestion &exportAutocorrect) {
         auto combinedTitle = fmt::format("{} and {}", importAutocorrect.title, exportAutocorrect.title);
-        importAutocorrect.edits.insert(importAutocorrect.edits.end(), exportAutocorrect.edits.begin(),
-                                       exportAutocorrect.edits.end());
-        core::AutocorrectSuggestion combinedAutocorrect(combinedTitle, importAutocorrect.edits);
+        importAutocorrect.edits.insert(importAutocorrect.edits.end(),
+                                       make_move_iterator(exportAutocorrect.edits.begin()),
+                                       make_move_iterator(exportAutocorrect.edits.end()));
+        core::AutocorrectSuggestion combinedAutocorrect(combinedTitle, move(importAutocorrect.edits));
         return importAutocorrect;
     }
 

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -402,7 +402,7 @@ class VisibilityCheckerPass final {
                                        make_move_iterator(exportAutocorrect.edits.begin()),
                                        make_move_iterator(exportAutocorrect.edits.end()));
         core::AutocorrectSuggestion combinedAutocorrect(combinedTitle, move(importAutocorrect.edits));
-        return importAutocorrect;
+        return combinedAutocorrect;
     }
 
 public:

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -395,13 +395,14 @@ class VisibilityCheckerPass final {
         }
     }
 
-    core::AutocorrectSuggestion combineImportExportAutocorrect(core::AutocorrectSuggestion &importAutocorrect,
-                                                               core::AutocorrectSuggestion &exportAutocorrect) {
-        auto combinedTitle = fmt::format("{} and {}", importAutocorrect.title, exportAutocorrect.title);
-        importAutocorrect.edits.insert(importAutocorrect.edits.end(),
-                                       make_move_iterator(exportAutocorrect.edits.begin()),
-                                       make_move_iterator(exportAutocorrect.edits.end()));
-        core::AutocorrectSuggestion combinedAutocorrect(combinedTitle, move(importAutocorrect.edits));
+    core::AutocorrectSuggestion
+    combineImportExportAutocorrect(optional<core::AutocorrectSuggestion> &&importAutocorrect,
+                                   optional<core::AutocorrectSuggestion> &&exportAutocorrect) {
+        auto combinedTitle = fmt::format("{} and {}", importAutocorrect->title, exportAutocorrect->title);
+        importAutocorrect->edits.insert(importAutocorrect->edits.end(),
+                                        make_move_iterator(exportAutocorrect->edits.begin()),
+                                        make_move_iterator(exportAutocorrect->edits.end()));
+        core::AutocorrectSuggestion combinedAutocorrect(combinedTitle, move(importAutocorrect->edits));
         return combinedAutocorrect;
     }
 
@@ -522,8 +523,8 @@ public:
                                     litSymbol.show(ctx), pkg.show(ctx), pkg.show(ctx));
                         addExportInfo(ctx, e, litSymbol);
                         if (importAutocorrect.has_value() && exportAutocorrect.has_value()) {
-                            core::AutocorrectSuggestion combinedAutocorrect =
-                                combineImportExportAutocorrect(importAutocorrect.value(), exportAutocorrect.value());
+                            core::AutocorrectSuggestion combinedAutocorrect = combineImportExportAutocorrect(
+                                move(importAutocorrect.value()), move(exportAutocorrect.value()));
                             e.addAutocorrect(std::move(combinedAutocorrect));
                             if (!db.errorHint().empty()) {
                                 e.addErrorNote("{}", db.errorHint());
@@ -539,8 +540,8 @@ public:
                                     litSymbol.show(ctx), pkg.show(ctx), pkg.show(ctx), "test_import");
                         addExportInfo(ctx, e, litSymbol);
                         if (importAutocorrect.has_value() && exportAutocorrect.has_value()) {
-                            core::AutocorrectSuggestion combinedAutocorrect =
-                                combineImportExportAutocorrect(importAutocorrect.value(), exportAutocorrect.value());
+                            core::AutocorrectSuggestion combinedAutocorrect = combineImportExportAutocorrect(
+                                move(importAutocorrect.value()), move(exportAutocorrect.value()));
                             e.addAutocorrect(std::move(combinedAutocorrect));
                             if (!db.errorHint().empty()) {
                                 e.addErrorNote("{}", db.errorHint());
@@ -558,8 +559,8 @@ public:
                                        "test_import", "only: 'test_rb'", ".test.rb");
                         addExportInfo(ctx, e, litSymbol);
                         if (importAutocorrect.has_value() && exportAutocorrect.has_value()) {
-                            core::AutocorrectSuggestion combinedAutocorrect =
-                                combineImportExportAutocorrect(importAutocorrect.value(), exportAutocorrect.value());
+                            core::AutocorrectSuggestion combinedAutocorrect = combineImportExportAutocorrect(
+                                move(importAutocorrect.value()), move(exportAutocorrect.value()));
                             e.addAutocorrect(std::move(combinedAutocorrect));
                             if (!db.errorHint().empty()) {
                                 e.addErrorNote("{}", db.errorHint());


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I wanted to tweak the "resolves but is not exported" error only to find that I
would have had to change ~7 different places to have the logic apply uniformly.
Wanted to factor a helper function out before making those changes.

### Commit summary

- **Move more things** (5eb201d115)


- **Return the combined one** (846966b612)

  We had already mutated the `importAutocorrect`, so the autocorrect was 
  not wrong, but the title shown to users in the code action was.

  To my knowledge, we don't have an easy way to test these code action 
  messages.

- **no-op: Take `optional<...> &&`** (eee9caf7bf)


- **no-op: Push conditional into the helper** (6d151e3cc8)


- **Also use the helper even if there's only one of them** (c11508bfa4)





### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests