### PR TITLE
Clean up Send desugar logic

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -842,8 +842,6 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 // Deconstruct the kwargs hash if it's present.
                 optional<parser::NodeVec> kwargElements = flattenKwargs(std::move(kwargsHash));
 
-                int numPosArgs = send->args.size();
-
                 if (hasFwdArgs || hasFwdRestArg || hasSplat) {
                     // If we have a splat anywhere in the argument list, desugar
                     // the argument list as a single Array node, and then
@@ -931,6 +929,9 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     }
                     result = std::move(res);
                 } else {
+                    // Count the arguments before we concat in the Kwarg key/value pairs
+                    int numPosArgs = send->args.size();
+
                     if (kwargElements.has_value()) {
                         // Concat the flattened Hash elements on the end of the args list.
                         send->args.insert(send->args.end(), make_move_iterator(kwargElements->begin()),

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -852,6 +852,9 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                                 block = std::move(bp->block);
                             }
                             send->args.erase(blockPassIt);
+
+                            // we don't count the block arg as part of the positional arguments anymore.
+                            numPosArgs = max(0, numPosArgs - 1);
                         }
                     }
 
@@ -956,26 +959,31 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                                           make_move_iterator(kwargElements->end()));
                     }
 
-                    Send::ARGS_store args;
                     unique_ptr<parser::Node> block;
-                    args.reserve(send->args.size());
                     bool anonymousBlockPass = false;
                     core::LocOffsets bpLoc;
-                    for (auto &stat : send->args) {
-                        if (auto bp = parser::cast_node<parser::BlockPass>(stat.get())) {
-                            ENFORCE(block == nullptr, "passing a block where there is no block");
+                    { // Pull out the BlockPass, if any (e.g. the `&b` in `a.map(&b)`)
+                        auto blockPassIt = absl::c_find_if(
+                            send->args, [](auto &arg) { return parser::isa_node<parser::BlockPass>(arg.get()); });
+                        if (blockPassIt != send->args.end()) {
+                            auto *bp = parser::cast_node<parser::BlockPass>(blockPassIt->get());
                             if (bp->block == nullptr) {
                                 anonymousBlockPass = true;
                                 bpLoc = bp->loc;
                             } else {
                                 block = std::move(bp->block);
                             }
+                            send->args.erase(blockPassIt);
 
                             // we don't count the block arg as part of the positional arguments anymore.
                             numPosArgs = max(0, numPosArgs - 1);
-                        } else {
-                            args.emplace_back(node2TreeImpl(dctx, stat));
                         }
+                    }
+
+                    Send::ARGS_store args;
+                    args.reserve(send->args.size());
+                    for (auto &stat : send->args) {
+                        args.emplace_back(node2TreeImpl(dctx, stat));
                     };
 
                     DuplicateHashKeyCheck::checkSendArgs(dctx, numPosArgs, args);

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -804,6 +804,27 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     flags.isPrivateOk = true;
                 }
 
+                // Pop the BlockPass off the end of the arguments, if there is one.
+                unique_ptr<parser::Node> block;
+                bool anonymousBlockPass = false;
+                core::LocOffsets bpLoc;
+                if (!send->args.empty() && parser::isa_node<parser::BlockPass>(send->args.back().get())) {
+                    auto *bp = parser::cast_node<parser::BlockPass>(send->args.back().get());
+                    if (bp->block == nullptr) {
+                        anonymousBlockPass = true;
+                        bpLoc = bp->loc;
+                    } else {
+                        block = std::move(bp->block);
+                    }
+
+                    send->args.pop_back();
+                }
+
+                int numPosArgs = send->args.size();
+
+                // Deconstruct the kwargs hash if it's present.
+                optional<parser::NodeVec> kwargElements = flattenKwargs(send, numPosArgs);
+
                 if (absl::c_any_of(send->args, [](auto &arg) {
                         return parser::isa_node<parser::Splat>(arg.get()) ||
                                parser::isa_node<parser::ForwardedArgs>(arg.get()) ||
@@ -815,27 +836,6 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     //   Magic.callWithSplat(receiver, method, argArray, [&blk])
                     // The callWithSplat implementation (in C++) will unpack a
                     // tuple type and call into the normal call mechanism.
-
-                    // Pop the BlockPass off the end of the arguments, if there is one.
-                    unique_ptr<parser::Node> block;
-                    bool anonymousBlockPass = false;
-                    core::LocOffsets bpLoc;
-                    if (!send->args.empty() && parser::isa_node<parser::BlockPass>(send->args.back().get())) {
-                        auto *bp = parser::cast_node<parser::BlockPass>(send->args.back().get());
-                        if (bp->block == nullptr) {
-                            anonymousBlockPass = true;
-                            bpLoc = bp->loc;
-                        } else {
-                            block = std::move(bp->block);
-                        }
-
-                        send->args.pop_back();
-                    }
-
-                    int numPosArgs = send->args.size();
-
-                    // Deconstruct the kwargs hash if it's present.
-                    optional<parser::NodeVec> kwargElements = flattenKwargs(send, numPosArgs);
 
                     // Build up an array that represents the keyword args for the send.
                     // When there is a Kwsplat, treat all keyword arguments as a single argument.
@@ -939,27 +939,6 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     }
                     result = std::move(res);
                 } else {
-                    // Pop the BlockPass off the end of the arguments, if there is one.
-                    unique_ptr<parser::Node> block;
-                    bool anonymousBlockPass = false;
-                    core::LocOffsets bpLoc;
-                    if (!send->args.empty() && parser::isa_node<parser::BlockPass>(send->args.back().get())) {
-                        auto *bp = parser::cast_node<parser::BlockPass>(send->args.back().get());
-                        if (bp->block == nullptr) {
-                            anonymousBlockPass = true;
-                            bpLoc = bp->loc;
-                        } else {
-                            block = std::move(bp->block);
-                        }
-
-                        send->args.pop_back();
-                    }
-
-                    int numPosArgs = send->args.size();
-
-                    // Deconstruct the kwargs hash if it's present.
-                    optional<parser::NodeVec> kwargElements = flattenKwargs(send, numPosArgs);
-
                     if (kwargElements.has_value()) {
                         // Concat the flattened Hash elements on the end of the args list.
                         send->args.insert(send->args.end(), make_move_iterator(kwargElements->begin()),

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -710,7 +710,16 @@ public:
 // If Kwargs Hash contains any splats, we skip the flattening.
 //
 // Returns nullopt if there was no Kwargs Hash
+//
+// * Coming in, the numPosArgs is the *total* number of of arguments in the send node.
+// * Going out, the numPosArgs is decremented by 1 if there was a Kwargs Hash
+//   (it shouldn't be counted as a positional argument)
 optional<parser::NodeVec> flattenKwargs(parser::Send *send, int &numPosArgs) {
+    if (numPosArgs == 0) {
+        // There were no arguments, so there couldn't possibly by a Kwargs Hash.
+        return nullopt;
+    }
+
     // The keyword arguments hash can be the last argument if there is no block
     // or second to last argument otherwise
     int kwargsHashIndex = send->args.size() - 1;
@@ -730,6 +739,7 @@ optional<parser::NodeVec> flattenKwargs(parser::Send *send, int &numPosArgs) {
         return nullopt;
     }
 
+    // The send node's arguments includes a Kwargs Hash, which isn't a positional argument.
     numPosArgs--;
 
     // hold a reference to the node, and remove it from the back of the send list
@@ -820,11 +830,9 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     int numPosArgs = send->args.size();
 
                     // Deconstruct the kwargs hash if it's present.
-                    if (numPosArgs > 0) {
-                        optional<parser::NodeVec> kwargElements = flattenKwargs(send, numPosArgs);
-                        if (kwargElements.has_value()) {
-                            kwArray = make_unique<parser::Array>(loc, std::move(*kwargElements));
-                        }
+                    optional<parser::NodeVec> kwargElements = flattenKwargs(send, numPosArgs);
+                    if (kwargElements.has_value()) {
+                        kwArray = make_unique<parser::Array>(loc, std::move(*kwargElements));
                     }
 
                     // Put the &blk arg back, if present.
@@ -948,15 +956,14 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     result = std::move(res);
                 } else {
                     int numPosArgs = send->args.size();
-                    if (numPosArgs > 0) {
-                        // Deconstruct the kwargs hash if it's present.
-                        optional<parser::NodeVec> kwargElements = flattenKwargs(send, numPosArgs);
 
-                        if (kwargElements.has_value()) {
-                            // Concat the flattened Hash elements on the end of the args list.
-                            send->args.insert(send->args.end(), make_move_iterator(kwargElements->begin()),
-                                              make_move_iterator(kwargElements->end()));
-                        }
+                    // Deconstruct the kwargs hash if it's present.
+                    optional<parser::NodeVec> kwargElements = flattenKwargs(send, numPosArgs);
+
+                    if (kwargElements.has_value()) {
+                        // Concat the flattened Hash elements on the end of the args list.
+                        send->args.insert(send->args.end(), make_move_iterator(kwargElements->begin()),
+                                          make_move_iterator(kwargElements->end()));
                     }
 
                     Send::ARGS_store args;

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -766,7 +766,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                                 auto hashNode = std::move(send->args.back());
                                 send->args.pop_back();
 
-                                parser::NodeVec elts;
+                                parser::NodeVec kwargElements;
 
                                 // skip inlining the kwargs if there are any kwsplat nodes present
                                 if (absl::c_any_of(hash->pairs, [](auto &node) {
@@ -779,21 +779,21 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                                         return parser::isa_node<parser::Kwsplat>(node.get()) ||
                                                parser::isa_node<parser::ForwardedKwrestArg>(node.get());
                                     })) {
-                                    elts.emplace_back(std::move(hashNode));
+                                    kwargElements.emplace_back(std::move(hashNode));
                                 } else {
                                     // inline the hash into the send args
                                     for (auto &entry : hash->pairs) {
                                         typecase(
                                             entry.get(),
                                             [&](parser::Pair *pair) {
-                                                elts.emplace_back(std::move(pair->key));
-                                                elts.emplace_back(std::move(pair->value));
+                                                kwargElements.emplace_back(std::move(pair->key));
+                                                kwargElements.emplace_back(std::move(pair->value));
                                             },
                                             [&](parser::Node *node) { Exception::raise("Unhandled case"); });
                                     }
                                 }
 
-                                kwArray = make_unique<parser::Array>(loc, std::move(elts));
+                                kwArray = make_unique<parser::Array>(loc, std::move(kwargElements));
                             }
                         }
                     }
@@ -936,6 +936,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                                 auto hashNode = std::move(send->args[kwargsHashIndex]);
                                 send->args.erase(send->args.begin() + kwargsHashIndex);
 
+                                parser::NodeVec kwargElements;
+
                                 // skip inlining the kwargs if there are any non-key/value pairs present
                                 if (absl::c_any_of(hash->pairs, [](auto &node) {
                                         // the parser guarantees that if we see a kwargs hash it only contains pair,
@@ -947,19 +949,23 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                                                parser::isa_node<parser::ForwardedKwrestArg>(node.get());
                                     })) {
                                     // We pulled the Hash node out of the args list, so we need to put it back.
-                                    send->args.emplace_back(std::move(hashNode));
+                                    kwargElements.emplace_back(std::move(hashNode));
                                 } else {
                                     // inline the hash into the send args
                                     for (auto &entry : hash->pairs) {
                                         typecase(
                                             entry.get(),
                                             [&](parser::Pair *pair) {
-                                                send->args.emplace_back(std::move(pair->key));
-                                                send->args.emplace_back(std::move(pair->value));
+                                                kwargElements.emplace_back(std::move(pair->key));
+                                                kwargElements.emplace_back(std::move(pair->value));
                                             },
                                             [&](parser::Node *node) { Exception::raise("Unhandled case"); });
                                     }
                                 }
+
+                                // Concat the flattened Hash elements on the end of the args list.
+                                send->args.insert(send->args.end(), make_move_iterator(kwargElements.begin()),
+                                                  make_move_iterator(kwargElements.end()));
                             }
                         }
                     }

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -848,7 +848,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     // If we have a splat anywhere in the argument list, desugar
                     // the argument list as a single Array node, and then
                     // synthesize a call to
-                    //   Magic.callWithSplat(receiver, method, argArray, [&blk])
+                    //   Magic.callWithSplat(receiver, method, argArray[, &blk])
                     // The callWithSplat implementation (in C++) will unpack a
                     // tuple type and call into the normal call mechanism.
 

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -840,34 +840,41 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     unique_ptr<parser::Node> block;
                     bool anonymousBlockPass = false;
                     core::LocOffsets bpLoc;
-                    auto it = absl::c_find_if(send->args,
-                                              [](auto &arg) { return parser::isa_node<parser::BlockPass>(arg.get()); });
-                    if (it != send->args.end()) {
-                        auto *bp = parser::cast_node<parser::BlockPass>(it->get());
-                        if (bp->block == nullptr) {
-                            anonymousBlockPass = true;
-                            bpLoc = bp->loc;
-                        } else {
-                            block = std::move(bp->block);
+                    { // Pull out the BlockPass, if any (e.g. the `&b` in `a.map(&b)`)
+                        auto blockPassIt = absl::c_find_if(
+                            send->args, [](auto &arg) { return parser::isa_node<parser::BlockPass>(arg.get()); });
+                        if (blockPassIt != send->args.end()) {
+                            auto *bp = parser::cast_node<parser::BlockPass>(blockPassIt->get());
+                            if (bp->block == nullptr) {
+                                anonymousBlockPass = true;
+                                bpLoc = bp->loc;
+                            } else {
+                                block = std::move(bp->block);
+                            }
+                            send->args.erase(blockPassIt);
                         }
-                        send->args.erase(it);
                     }
 
                     auto hasFwdArgs = false;
-                    auto fwdIt = absl::c_find_if(
-                        send->args, [](auto &arg) { return parser::isa_node<parser::ForwardedArgs>(arg.get()); });
-                    if (fwdIt != send->args.end()) {
-                        block = make_unique<parser::LVar>(loc, core::Names::fwdBlock());
-                        hasFwdArgs = true;
-                        send->args.erase(fwdIt);
+                    { // Pull out the ForwardedArgs (the `...` argument in a method call, like `foo(...)`)
+                        auto fwdIt = absl::c_find_if(
+                            send->args, [](auto &arg) { return parser::isa_node<parser::ForwardedArgs>(arg.get()); });
+                        if (fwdIt != send->args.end()) {
+                            block = make_unique<parser::LVar>(loc, core::Names::fwdBlock());
+                            hasFwdArgs = true;
+                            send->args.erase(fwdIt);
+                        }
                     }
 
                     auto hasFwdRestArg = false;
-                    auto fwdRestIt = absl::c_find_if(
-                        send->args, [](auto &arg) { return parser::isa_node<parser::ForwardedRestArg>(arg.get()); });
-                    if (fwdRestIt != send->args.end()) {
-                        hasFwdRestArg = true;
-                        send->args.erase(fwdRestIt);
+                    { // Pull out the ForwardedRestArg (an anonymous splat like `f(*)`)
+                        auto fwdRestIt = absl::c_find_if(send->args, [](auto &arg) {
+                            return parser::isa_node<parser::ForwardedRestArg>(arg.get());
+                        });
+                        if (fwdRestIt != send->args.end()) {
+                            hasFwdRestArg = true;
+                            send->args.erase(fwdRestIt);
+                        }
                     }
 
                     unique_ptr<parser::Node> array = make_unique<parser::Array>(locZeroLen, std::move(send->args));

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -837,18 +837,6 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     // The callWithSplat implementation (in C++) will unpack a
                     // tuple type and call into the normal call mechanism.
 
-                    // Build up an array that represents the keyword args for the send.
-                    // When there is a Kwsplat, treat all keyword arguments as a single argument.
-                    // If the kwargs hash is not present, make a `nil` to put in the place of that argument.
-                    // This will be used in the implementation of the intrinsic to tell the difference between keyword
-                    // args, keyword args with kw splats, and no keyword args at all.
-                    unique_ptr<parser::Node> kwArray;
-                    if (kwargElements.has_value()) {
-                        kwArray = make_unique<parser::Array>(loc, std::move(*kwargElements));
-                    } else {
-                        kwArray = make_unique<parser::Nil>(loc);
-                    }
-
                     auto hasFwdArgs = false;
                     { // Pull out the ForwardedArgs (the `...` argument in a method call, like `foo(...)`)
                         auto fwdIt = absl::c_find_if(
@@ -902,12 +890,23 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         args = std::move(argsConcat);
                     }
 
-                    auto kwargs = node2TreeImpl(dctx, kwArray);
-                    auto method = MK::Symbol(locZeroLen, send->method);
+                    // Build up an array that represents the keyword args for the send.
+                    // When there is a Kwsplat, treat all keyword arguments as a single argument.
+                    // If the kwargs hash is not present, make a `nil` to put in the place of that argument.
+                    // This will be used in the implementation of the intrinsic to tell the difference between keyword
+                    // args, keyword args with kw splats, and no keyword args at all.
+                    ExpressionPtr kwargs;
+                    if (kwargElements.has_value()) {
+                        unique_ptr<parser::Node> kwArray = make_unique<parser::Array>(loc, std::move(*kwargElements));
 
-                    if (auto array = cast_tree<Array>(kwargs)) {
-                        DuplicateHashKeyCheck::checkSendArgs(dctx, 0, array->elems);
+                        kwargs = node2TreeImpl(dctx, kwArray);
+
+                        DuplicateHashKeyCheck::checkSendArgs(dctx, 0, cast_tree<Array>(kwargs)->elems);
+                    } else {
+                        kwargs = MK::Nil(loc);
                     }
+
+                    auto method = MK::Symbol(locZeroLen, send->method);
 
                     Send::ARGS_store sendargs;
                     sendargs.emplace_back(std::move(rec));

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -817,11 +817,11 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         send->args.pop_back();
                     }
 
-                    // Deconstruct the kwargs hash if it's present.
-                    if (!send->args.empty()) {
-                        auto _numPosArgs = INT_MAX; // Dummy value, this code path doesn't use it.
+                    int numPosArgs = send->args.size();
 
-                        optional<parser::NodeVec> kwargElements = flattenKwargs(send, _numPosArgs);
+                    // Deconstruct the kwargs hash if it's present.
+                    if (numPosArgs > 0) {
+                        optional<parser::NodeVec> kwargElements = flattenKwargs(send, numPosArgs);
                         if (kwargElements.has_value()) {
                             kwArray = make_unique<parser::Array>(loc, std::move(*kwargElements));
                         }

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -710,7 +710,14 @@ public:
 // If Kwargs Hash contains any splats, we skip the flattening.
 //
 // Returns nullopt if there was no Kwargs Hash
-optional<parser::NodeVec> flattenKwargs(parser::Send *send, int kwargsHashIndex, int &numPosArgs) {
+optional<parser::NodeVec> flattenKwargs(parser::Send *send, int &numPosArgs) {
+    // The keyword arguments hash can be the last argument if there is no block
+    // or second to last argument otherwise
+    int kwargsHashIndex = send->args.size() - 1;
+    if (!parser::isa_node<parser::Hash>(send->args[kwargsHashIndex].get())) {
+        kwargsHashIndex = max(0, kwargsHashIndex - 1);
+    }
+
     auto *hash = parser::cast_node<parser::Hash>(send->args[kwargsHashIndex].get());
 
     if (hash == nullptr) {
@@ -812,13 +819,9 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
 
                     // Deconstruct the kwargs hash if it's present.
                     if (!send->args.empty()) {
-                        // If we have a Kwargs Hash, it will always be at the last position,
-                        // because we already popped off our `savedBlockPass` above.
-                        auto kwargsHashIndex = send->args.size() - 1;
-
                         auto _numPosArgs = INT_MAX; // Dummy value, this code path doesn't use it.
 
-                        optional<parser::NodeVec> kwargElements = flattenKwargs(send, kwargsHashIndex, _numPosArgs);
+                        optional<parser::NodeVec> kwargElements = flattenKwargs(send, _numPosArgs);
                         if (kwargElements.has_value()) {
                             kwArray = make_unique<parser::Array>(loc, std::move(*kwargElements));
                         }
@@ -946,15 +949,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 } else {
                     int numPosArgs = send->args.size();
                     if (numPosArgs > 0) {
-                        // The keyword arguments hash can be the last argument if there is no block
-                        // or second to last argument otherwise
-                        int kwargsHashIndex = send->args.size() - 1;
-                        if (!parser::isa_node<parser::Hash>(send->args[kwargsHashIndex].get())) {
-                            kwargsHashIndex = max(0, kwargsHashIndex - 1);
-                        }
-
                         // Deconstruct the kwargs hash if it's present.
-                        optional<parser::NodeVec> kwargElements = flattenKwargs(send, kwargsHashIndex, numPosArgs);
+                        optional<parser::NodeVec> kwargElements = flattenKwargs(send, numPosArgs);
 
                         if (kwargElements.has_value()) {
                             // Concat the flattened Hash elements on the end of the args list.

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -838,12 +838,11 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     // The callWithSplat implementation (in C++) will unpack a
                     // tuple type and call into the normal call mechanism.
                     unique_ptr<parser::Node> block;
-                    auto argnodes = std::move(send->args);
                     bool anonymousBlockPass = false;
                     core::LocOffsets bpLoc;
-                    auto it = absl::c_find_if(argnodes,
+                    auto it = absl::c_find_if(send->args,
                                               [](auto &arg) { return parser::isa_node<parser::BlockPass>(arg.get()); });
-                    if (it != argnodes.end()) {
+                    if (it != send->args.end()) {
                         auto *bp = parser::cast_node<parser::BlockPass>(it->get());
                         if (bp->block == nullptr) {
                             anonymousBlockPass = true;
@@ -851,27 +850,27 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         } else {
                             block = std::move(bp->block);
                         }
-                        argnodes.erase(it);
+                        send->args.erase(it);
                     }
 
                     auto hasFwdArgs = false;
                     auto fwdIt = absl::c_find_if(
-                        argnodes, [](auto &arg) { return parser::isa_node<parser::ForwardedArgs>(arg.get()); });
-                    if (fwdIt != argnodes.end()) {
+                        send->args, [](auto &arg) { return parser::isa_node<parser::ForwardedArgs>(arg.get()); });
+                    if (fwdIt != send->args.end()) {
                         block = make_unique<parser::LVar>(loc, core::Names::fwdBlock());
                         hasFwdArgs = true;
-                        argnodes.erase(fwdIt);
+                        send->args.erase(fwdIt);
                     }
 
                     auto hasFwdRestArg = false;
                     auto fwdRestIt = absl::c_find_if(
-                        argnodes, [](auto &arg) { return parser::isa_node<parser::ForwardedRestArg>(arg.get()); });
-                    if (fwdRestIt != argnodes.end()) {
+                        send->args, [](auto &arg) { return parser::isa_node<parser::ForwardedRestArg>(arg.get()); });
+                    if (fwdRestIt != send->args.end()) {
                         hasFwdRestArg = true;
-                        argnodes.erase(fwdRestIt);
+                        send->args.erase(fwdRestIt);
                     }
 
-                    unique_ptr<parser::Node> array = make_unique<parser::Array>(locZeroLen, std::move(argnodes));
+                    unique_ptr<parser::Node> array = make_unique<parser::Array>(locZeroLen, std::move(send->args));
                     auto args = node2TreeImpl(dctx, array);
 
                     if (hasFwdArgs) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -966,6 +966,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                                 symbol2Proc(dctx, std::move(convertedBlock)));
                         } else {
                             Send::ARGS_store sendargs;
+                            sendargs.reserve(3 + args.size());
                             sendargs.emplace_back(std::move(rec));
                             sendargs.emplace_back(std::move(method));
                             sendargs.emplace_back(std::move(convertedBlock));

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -814,22 +814,20 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                                parser::isa_node<parser::ForwardedArgs>(arg.get()) ||
                                parser::isa_node<parser::ForwardedRestArg>(arg.get());
                     })) {
-                    // Build up an array that represents the keyword args for the send. When there is a Kwsplat, treat
-                    // all keyword arguments as a single argument.
-                    unique_ptr<parser::Node> kwArray;
-
                     int numPosArgs = send->args.size();
 
                     // Deconstruct the kwargs hash if it's present.
                     optional<parser::NodeVec> kwargElements = flattenKwargs(send, numPosArgs);
+
+                    // Build up an array that represents the keyword args for the send.
+                    // When there is a Kwsplat, treat all keyword arguments as a single argument.
+                    // If the kwargs hash is not present, make a `nil` to put in the place of that argument.
+                    // This will be used in the implementation of the intrinsic to tell the difference between keyword
+                    // args, keyword args with kw splats, and no keyword args at all.
+                    unique_ptr<parser::Node> kwArray;
                     if (kwargElements.has_value()) {
                         kwArray = make_unique<parser::Array>(loc, std::move(*kwargElements));
-                    }
-
-                    // If the kwargs hash is not present, make a `nil` to put in the place of that argument. This
-                    // will be used in the implementation of the intrinsic to tell the difference between keyword
-                    // args, keyword args with kw splats, and no keyword args at all.
-                    if (kwArray == nullptr) {
+                    } else {
                         kwArray = make_unique<parser::Nil>(loc);
                     }
 

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -706,7 +706,16 @@ public:
     }
 };
 
-parser::NodeVec flattenKwargs(parser::Send *send, parser::Hash *hash, int kwargsHashIndex, int &numPosArgs) {
+// Returns the flattened key/value pairs from the Kwargs Hash, if there was one.
+// If Kwargs Hash contains any splats, we skip the flattening.
+//
+// Returns nullopt if there was no Kwargs Hash
+optional<parser::NodeVec> flattenKwargs(parser::Send *send, parser::Hash *hash, int kwargsHashIndex, int &numPosArgs) {
+    if (!hash->kwargs) {
+        // This Hash was a regular Hash literal, not keyword arguments.
+        return nullopt;
+    }
+
     numPosArgs--;
 
     // hold a reference to the node, and remove it from the back of the send list
@@ -797,15 +806,16 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     // Deconstruct the kwargs hash if it's present.
                     if (!send->args.empty()) {
                         if (auto *hash = parser::cast_node<parser::Hash>(send->args.back().get())) {
-                            if (hash->kwargs) {
-                                // If we have a Kwargs Hash, it will always be at the last position,
-                                // because we already popped off our `savedBlockPass` above.
-                                auto kwargsHashIndex = send->args.size() - 1;
+                            // If we have a Kwargs Hash, it will always be at the last position,
+                            // because we already popped off our `savedBlockPass` above.
+                            auto kwargsHashIndex = send->args.size() - 1;
 
-                                auto _numPosArgs = INT_MAX; // Dummy value, this code path doesn't use it.
+                            auto _numPosArgs = INT_MAX; // Dummy value, this code path doesn't use it.
 
-                                parser::NodeVec kwargElements = flattenKwargs(send, hash, kwargsHashIndex, _numPosArgs);
-                                kwArray = make_unique<parser::Array>(loc, std::move(kwargElements));
+                            optional<parser::NodeVec> kwargElements =
+                                flattenKwargs(send, hash, kwargsHashIndex, _numPosArgs);
+                            if (kwargElements.has_value()) {
+                                kwArray = make_unique<parser::Array>(loc, std::move(*kwargElements));
                             }
                         }
                     }
@@ -941,12 +951,13 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
 
                         // Deconstruct the kwargs hash if it's present.
                         if (auto *hash = parser::cast_node<parser::Hash>(send->args[kwargsHashIndex].get())) {
-                            if (hash->kwargs) {
-                                parser::NodeVec kwargElements = flattenKwargs(send, hash, kwargsHashIndex, numPosArgs);
+                            optional<parser::NodeVec> kwargElements =
+                                flattenKwargs(send, hash, kwargsHashIndex, numPosArgs);
 
+                            if (kwargElements.has_value()) {
                                 // Concat the flattened Hash elements on the end of the args list.
-                                send->args.insert(send->args.end(), make_move_iterator(kwargElements.begin()),
-                                                  make_move_iterator(kwargElements.end()));
+                                send->args.insert(send->args.end(), make_move_iterator(kwargElements->begin()),
+                                                  make_move_iterator(kwargElements->end()));
                             }
                         }
                     }

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -720,14 +720,9 @@ optional<parser::NodeVec> flattenKwargs(parser::Send *send, int &numPosArgs) {
         return nullopt;
     }
 
-    // The keyword arguments hash can be the last argument if there is no block
-    // or second to last argument otherwise
-    int kwargsHashIndex = send->args.size() - 1;
-    if (!parser::isa_node<parser::Hash>(send->args[kwargsHashIndex].get())) {
-        kwargsHashIndex = max(0, kwargsHashIndex - 1);
-    }
-
-    auto *hash = parser::cast_node<parser::Hash>(send->args[kwargsHashIndex].get());
+    // If there is a Kwargs Hash, we know it will be in the last position,
+    // since we've already pulled out the BlockPass node before calling `flattenKwargs()`.
+    auto *hash = parser::cast_node<parser::Hash>(send->args.back().get());
 
     if (hash == nullptr) {
         // Not a Hash, so nothing to flatten.
@@ -743,8 +738,8 @@ optional<parser::NodeVec> flattenKwargs(parser::Send *send, int &numPosArgs) {
     numPosArgs--;
 
     // hold a reference to the node, and remove it from the back of the send list
-    auto hashNode = std::move(send->args[kwargsHashIndex]);
-    send->args.erase(send->args.begin() + kwargsHashIndex);
+    auto hashNode = std::move(send->args.back());
+    send->args.pop_back();
 
     parser::NodeVec kwargElements;
 
@@ -814,6 +809,29 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                                parser::isa_node<parser::ForwardedArgs>(arg.get()) ||
                                parser::isa_node<parser::ForwardedRestArg>(arg.get());
                     })) {
+                    // If we have a splat anywhere in the argument list, desugar
+                    // the argument list as a single Array node, and then
+                    // synthesize a call to
+                    //   Magic.callWithSplat(receiver, method, argArray, [&blk])
+                    // The callWithSplat implementation (in C++) will unpack a
+                    // tuple type and call into the normal call mechanism.
+
+                    // Pop the BlockPass off the end of the arguments, if there is one.
+                    unique_ptr<parser::Node> block;
+                    bool anonymousBlockPass = false;
+                    core::LocOffsets bpLoc;
+                    if (!send->args.empty() && parser::isa_node<parser::BlockPass>(send->args.back().get())) {
+                        auto *bp = parser::cast_node<parser::BlockPass>(send->args.back().get());
+                        if (bp->block == nullptr) {
+                            anonymousBlockPass = true;
+                            bpLoc = bp->loc;
+                        } else {
+                            block = std::move(bp->block);
+                        }
+
+                        send->args.pop_back();
+                    }
+
                     int numPosArgs = send->args.size();
 
                     // Deconstruct the kwargs hash if it's present.
@@ -829,33 +847,6 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         kwArray = make_unique<parser::Array>(loc, std::move(*kwargElements));
                     } else {
                         kwArray = make_unique<parser::Nil>(loc);
-                    }
-
-                    // If we have a splat anywhere in the argument list, desugar
-                    // the argument list as a single Array node, and then
-                    // synthesize a call to
-                    //   Magic.callWithSplat(receiver, method, argArray, [&blk])
-                    // The callWithSplat implementation (in C++) will unpack a
-                    // tuple type and call into the normal call mechanism.
-                    unique_ptr<parser::Node> block;
-                    bool anonymousBlockPass = false;
-                    core::LocOffsets bpLoc;
-                    { // Pull out the BlockPass, if any (e.g. the `&b` in `a.map(&b)`)
-                        auto blockPassIt = absl::c_find_if(
-                            send->args, [](auto &arg) { return parser::isa_node<parser::BlockPass>(arg.get()); });
-                        if (blockPassIt != send->args.end()) {
-                            auto *bp = parser::cast_node<parser::BlockPass>(blockPassIt->get());
-                            if (bp->block == nullptr) {
-                                anonymousBlockPass = true;
-                                bpLoc = bp->loc;
-                            } else {
-                                block = std::move(bp->block);
-                            }
-                            send->args.erase(blockPassIt);
-
-                            // we don't count the block arg as part of the positional arguments anymore.
-                            numPosArgs = max(0, numPosArgs - 1);
-                        }
                     }
 
                     auto hasFwdArgs = false;
@@ -948,6 +939,22 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     }
                     result = std::move(res);
                 } else {
+                    // Pop the BlockPass off the end of the arguments, if there is one.
+                    unique_ptr<parser::Node> block;
+                    bool anonymousBlockPass = false;
+                    core::LocOffsets bpLoc;
+                    if (!send->args.empty() && parser::isa_node<parser::BlockPass>(send->args.back().get())) {
+                        auto *bp = parser::cast_node<parser::BlockPass>(send->args.back().get());
+                        if (bp->block == nullptr) {
+                            anonymousBlockPass = true;
+                            bpLoc = bp->loc;
+                        } else {
+                            block = std::move(bp->block);
+                        }
+
+                        send->args.pop_back();
+                    }
+
                     int numPosArgs = send->args.size();
 
                     // Deconstruct the kwargs hash if it's present.
@@ -957,27 +964,6 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         // Concat the flattened Hash elements on the end of the args list.
                         send->args.insert(send->args.end(), make_move_iterator(kwargElements->begin()),
                                           make_move_iterator(kwargElements->end()));
-                    }
-
-                    unique_ptr<parser::Node> block;
-                    bool anonymousBlockPass = false;
-                    core::LocOffsets bpLoc;
-                    { // Pull out the BlockPass, if any (e.g. the `&b` in `a.map(&b)`)
-                        auto blockPassIt = absl::c_find_if(
-                            send->args, [](auto &arg) { return parser::isa_node<parser::BlockPass>(arg.get()); });
-                        if (blockPassIt != send->args.end()) {
-                            auto *bp = parser::cast_node<parser::BlockPass>(blockPassIt->get());
-                            if (bp->block == nullptr) {
-                                anonymousBlockPass = true;
-                                bpLoc = bp->loc;
-                            } else {
-                                block = std::move(bp->block);
-                            }
-                            send->args.erase(blockPassIt);
-
-                            // we don't count the block arg as part of the positional arguments anymore.
-                            numPosArgs = max(0, numPosArgs - 1);
-                        }
                     }
 
                     Send::ARGS_store args;

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -818,26 +818,12 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     // all keyword arguments as a single argument.
                     unique_ptr<parser::Node> kwArray;
 
-                    // If there's a &blk node in the last position, pop that off (we'll put it back later, but
-                    // subsequent logic for dealing with the kwargs hash is simpler this way).
-                    unique_ptr<parser::Node> savedBlockPass = nullptr;
-
-                    if (!send->args.empty() && parser::isa_node<parser::BlockPass>(send->args.back().get())) {
-                        savedBlockPass = std::move(send->args.back());
-                        send->args.pop_back();
-                    }
-
                     int numPosArgs = send->args.size();
 
                     // Deconstruct the kwargs hash if it's present.
                     optional<parser::NodeVec> kwargElements = flattenKwargs(send, numPosArgs);
                     if (kwargElements.has_value()) {
                         kwArray = make_unique<parser::Array>(loc, std::move(*kwargElements));
-                    }
-
-                    // Put the &blk arg back, if present.
-                    if (savedBlockPass) {
-                        send->args.emplace_back(std::move(savedBlockPass));
                     }
 
                     // If the kwargs hash is not present, make a `nil` to put in the place of that argument. This

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -977,6 +977,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                                 symbol2Proc(dctx, std::move(convertedBlock)));
                         } else {
                             Send::ARGS_store sendargs;
+                            sendargs.reserve(3 + args.size());
                             sendargs.emplace_back(std::move(rec));
                             sendargs.emplace_back(std::move(method));
                             sendargs.emplace_back(std::move(convertedBlock));

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -711,6 +711,40 @@ public:
         }
     }
 };
+parser::NodeVec flattenKwargs(parser::Send *send, parser::Hash *hash, int kwargsHashIndex) {
+    // hold a reference to the node, and remove it from the back of the send list
+    auto hashNode = std::move(send->args[kwargsHashIndex]);
+    send->args.erase(send->args.begin() + kwargsHashIndex);
+
+    parser::NodeVec kwargElements;
+
+    // skip inlining the kwargs if there are any kwsplat nodes present
+    if (absl::c_any_of(hash->pairs, [](auto &node) {
+            // the parser guarantees that if we see a kwargs hash it only contains pair,
+            // kwsplat, or forwarded kwrest arg nodes
+            ENFORCE(parser::NodeWithExpr::isa_node<parser::Kwsplat>(node.get()) ||
+                    parser::NodeWithExpr::isa_node<parser::Pair>(node.get()) ||
+                    parser::NodeWithExpr::isa_node<parser::ForwardedKwrestArg>(node.get()));
+
+            return parser::NodeWithExpr::isa_node<parser::Kwsplat>(node.get()) ||
+                   parser::NodeWithExpr::isa_node<parser::ForwardedKwrestArg>(node.get());
+        })) {
+        kwargElements.emplace_back(std::move(hashNode));
+    } else {
+        // inline the hash into the send args
+        for (auto &entry : hash->pairs) {
+            typecase(
+                entry.get(),
+                [&](parser::Pair *pair) {
+                    kwargElements.emplace_back(std::move(pair->key));
+                    kwargElements.emplace_back(std::move(pair->value));
+                },
+                [&](parser::Node *node) { Exception::raise("Unhandled case"); });
+        }
+    }
+
+    return kwargElements;
+}
 
 [[noreturn]] void desugaredByPrismTranslator(parser::Node *node) {
     Exception::raise("The {} node should have already been desugared by the Prism Translator.", node->nodeName());
@@ -773,36 +807,11 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     if (!send->args.empty()) {
                         if (auto *hash = parser::NodeWithExpr::cast_node<parser::Hash>(send->args.back().get())) {
                             if (hash->kwargs) {
-                                // hold a reference to the node, and remove it from the back of the send list
-                                auto hashNode = std::move(send->args.back());
-                                send->args.pop_back();
+                                // If we have a Kwargs Hash, it will always be at the last position,
+                                // because we already popped off our `savedBlockPass` above.
+                                auto kwargsHashIndex = send->args.size() - 1;
 
-                                parser::NodeVec kwargElements;
-
-                                // skip inlining the kwargs if there are any kwsplat nodes present
-                                if (absl::c_any_of(hash->pairs, [](auto &node) {
-                                        // the parser guarantees that if we see a kwargs hash it only contains pair,
-                                        // kwsplat, or forwarded kwrest arg nodes
-                                        ENFORCE(parser::NodeWithExpr::isa_node<parser::Kwsplat>(node.get()) ||
-                                                parser::NodeWithExpr::isa_node<parser::Pair>(node.get()) ||
-                                                parser::NodeWithExpr::isa_node<parser::ForwardedKwrestArg>(node.get()));
-
-                                        return parser::NodeWithExpr::isa_node<parser::Kwsplat>(node.get()) ||
-                                               parser::NodeWithExpr::isa_node<parser::ForwardedKwrestArg>(node.get());
-                                    })) {
-                                    kwargElements.emplace_back(std::move(hashNode));
-                                } else {
-                                    // inline the hash into the send args
-                                    for (auto &entry : hash->pairs) {
-                                        typecase(
-                                            entry.get(),
-                                            [&](parser::Pair *pair) {
-                                                kwargElements.emplace_back(std::move(pair->key));
-                                                kwargElements.emplace_back(std::move(pair->value));
-                                            },
-                                            [&](parser::Node *node) { Exception::raise("Unhandled case"); });
-                                    }
-                                }
+                                parser::NodeVec kwargElements = flattenKwargs(send, hash, kwargsHashIndex);
 
                                 kwArray = make_unique<parser::Array>(loc, std::move(kwargElements));
                             }
@@ -947,37 +956,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                             if (hash->kwargs) {
                                 numPosArgs--;
 
-                                // hold a reference to the node, and remove it from the back of the send list
-                                auto hashNode = std::move(send->args[kwargsHashIndex]);
-                                send->args.erase(send->args.begin() + kwargsHashIndex);
-
-                                parser::NodeVec kwargElements;
-
-                                // skip inlining the kwargs if there are any non-key/value pairs present
-                                if (absl::c_any_of(hash->pairs, [](auto &node) {
-                                        // the parser guarantees that if we see a kwargs hash it only contains pair,
-                                        // kwsplat, or forwarded kwrest nodes
-                                        ENFORCE(
-                                            parser::NodeWithExpr::isa_node<parser::Kwsplat>(node.get()) ||
-                                            parser::NodeWithExpr::isa_node<parser::ForwardedKwrestArg>(node.get()) ||
-                                            parser::NodeWithExpr::isa_node<parser::Pair>(node.get()));
-                                        return parser::NodeWithExpr::isa_node<parser::Kwsplat>(node.get()) ||
-                                               parser::NodeWithExpr::isa_node<parser::ForwardedKwrestArg>(node.get());
-                                    })) {
-                                    // We pulled the Hash node out of the args list, so we need to put it back.
-                                    kwargElements.emplace_back(std::move(hashNode));
-                                } else {
-                                    // inline the hash into the send args
-                                    for (auto &entry : hash->pairs) {
-                                        typecase(
-                                            entry.get(),
-                                            [&](parser::Pair *pair) {
-                                                kwargElements.emplace_back(std::move(pair->key));
-                                                kwargElements.emplace_back(std::move(pair->value));
-                                            },
-                                            [&](parser::Node *node) { Exception::raise("Unhandled case"); });
-                                    }
-                                }
+                                parser::NodeVec kwargElements = flattenKwargs(send, hash, kwargsHashIndex);
 
                                 // Concat the flattened Hash elements on the end of the args list.
                                 send->args.insert(send->args.end(), make_move_iterator(kwargElements.begin()),

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -716,7 +716,14 @@ public:
 // If Kwargs Hash contains any splats, we skip the flattening.
 //
 // Returns nullopt if there was no Kwargs Hash
-optional<parser::NodeVec> flattenKwargs(parser::Send *send, parser::Hash *hash, int kwargsHashIndex, int &numPosArgs) {
+optional<parser::NodeVec> flattenKwargs(parser::Send *send, int kwargsHashIndex, int &numPosArgs) {
+    auto *hash = parser::NodeWithExpr::cast_node<parser::Hash>(send->args[kwargsHashIndex].get());
+
+    if (hash == nullptr) {
+        // Not a Hash, so nothing to flatten.
+        return nullopt;
+    }
+
     if (!hash->kwargs) {
         // This Hash was a regular Hash literal, not keyword arguments.
         return nullopt;
@@ -817,18 +824,15 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
 
                     // Deconstruct the kwargs hash if it's present.
                     if (!send->args.empty()) {
-                        if (auto *hash = parser::NodeWithExpr::cast_node<parser::Hash>(send->args.back().get())) {
-                            // If we have a Kwargs Hash, it will always be at the last position,
-                            // because we already popped off our `savedBlockPass` above.
-                            auto kwargsHashIndex = send->args.size() - 1;
+                        // If we have a Kwargs Hash, it will always be at the last position,
+                        // because we already popped off our `savedBlockPass` above.
+                        auto kwargsHashIndex = send->args.size() - 1;
 
-                            auto _numPosArgs = INT_MAX; // Dummy value, this code path doesn't use it.
+                        auto _numPosArgs = INT_MAX; // Dummy value, this code path doesn't use it.
 
-                            optional<parser::NodeVec> kwargElements =
-                                flattenKwargs(send, hash, kwargsHashIndex, _numPosArgs);
-                            if (kwargElements.has_value()) {
-                                kwArray = make_unique<parser::Array>(loc, std::move(*kwargElements));
-                            }
+                        optional<parser::NodeVec> kwargElements = flattenKwargs(send, kwargsHashIndex, _numPosArgs);
+                        if (kwargElements.has_value()) {
+                            kwArray = make_unique<parser::Array>(loc, std::move(*kwargElements));
                         }
                     }
 
@@ -965,16 +969,12 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         }
 
                         // Deconstruct the kwargs hash if it's present.
-                        if (auto *hash =
-                                parser::NodeWithExpr::cast_node<parser::Hash>(send->args[kwargsHashIndex].get())) {
-                            optional<parser::NodeVec> kwargElements =
-                                flattenKwargs(send, hash, kwargsHashIndex, numPosArgs);
+                        optional<parser::NodeVec> kwargElements = flattenKwargs(send, kwargsHashIndex, numPosArgs);
 
-                            if (kwargElements.has_value()) {
-                                // Concat the flattened Hash elements on the end of the args list.
-                                send->args.insert(send->args.end(), make_move_iterator(kwargElements->begin()),
-                                                  make_move_iterator(kwargElements->end()));
-                            }
+                        if (kwargElements.has_value()) {
+                            // Concat the flattened Hash elements on the end of the args list.
+                            send->args.insert(send->args.end(), make_move_iterator(kwargElements->begin()),
+                                              make_move_iterator(kwargElements->end()));
                         }
                     }
 

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -825,22 +825,20 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                                parser::NodeWithExpr::isa_node<parser::ForwardedArgs>(arg.get()) ||
                                parser::NodeWithExpr::isa_node<parser::ForwardedRestArg>(arg.get());
                     })) {
-                    // Build up an array that represents the keyword args for the send. When there is a Kwsplat, treat
-                    // all keyword arguments as a single argument.
-                    unique_ptr<parser::Node> kwArray;
-
                     int numPosArgs = send->args.size();
 
                     // Deconstruct the kwargs hash if it's present.
                     optional<parser::NodeVec> kwargElements = flattenKwargs(send, numPosArgs);
+
+                    // Build up an array that represents the keyword args for the send.
+                    // When there is a Kwsplat, treat all keyword arguments as a single argument.
+                    // If the kwargs hash is not present, make a `nil` to put in the place of that argument.
+                    // This will be used in the implementation of the intrinsic to tell the difference between keyword
+                    // args, keyword args with kw splats, and no keyword args at all.
+                    unique_ptr<parser::Node> kwArray;
                     if (kwargElements.has_value()) {
                         kwArray = make_unique<parser::Array>(loc, std::move(*kwargElements));
-                    }
-
-                    // If the kwargs hash is not present, make a `nil` to put in the place of that argument. This
-                    // will be used in the implementation of the intrinsic to tell the difference between keyword
-                    // args, keyword args with kw splats, and no keyword args at all.
-                    if (kwArray == nullptr) {
+                    } else {
                         kwArray = make_unique<parser::Nil>(loc);
                     }
 

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -853,8 +853,6 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 // Deconstruct the kwargs hash if it's present.
                 optional<parser::NodeVec> kwargElements = flattenKwargs(std::move(kwargsHash));
 
-                int numPosArgs = send->args.size();
-
                 if (hasFwdArgs || hasFwdRestArg || hasSplat) {
                     // If we have a splat anywhere in the argument list, desugar
                     // the argument list as a single Array node, and then
@@ -942,6 +940,9 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     }
                     result = std::move(res);
                 } else {
+                    // Count the arguments before we concat in the Kwarg key/value pairs
+                    int numPosArgs = send->args.size();
+
                     if (kwargElements.has_value()) {
                         // Concat the flattened Hash elements on the end of the args list.
                         send->args.insert(send->args.end(), make_move_iterator(kwargElements->begin()),

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -829,27 +829,12 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     // all keyword arguments as a single argument.
                     unique_ptr<parser::Node> kwArray;
 
-                    // If there's a &blk node in the last position, pop that off (we'll put it back later, but
-                    // subsequent logic for dealing with the kwargs hash is simpler this way).
-                    unique_ptr<parser::Node> savedBlockPass = nullptr;
-
-                    if (!send->args.empty() &&
-                        parser::NodeWithExpr::isa_node<parser::BlockPass>(send->args.back().get())) {
-                        savedBlockPass = std::move(send->args.back());
-                        send->args.pop_back();
-                    }
-
                     int numPosArgs = send->args.size();
 
                     // Deconstruct the kwargs hash if it's present.
                     optional<parser::NodeVec> kwargElements = flattenKwargs(send, numPosArgs);
                     if (kwargElements.has_value()) {
                         kwArray = make_unique<parser::Array>(loc, std::move(*kwargElements));
-                    }
-
-                    // Put the &blk arg back, if present.
-                    if (savedBlockPass) {
-                        send->args.emplace_back(std::move(savedBlockPass));
                     }
 
                     // If the kwargs hash is not present, make a `nil` to put in the place of that argument. This

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -859,7 +859,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     // If we have a splat anywhere in the argument list, desugar
                     // the argument list as a single Array node, and then
                     // synthesize a call to
-                    //   Magic.callWithSplat(receiver, method, argArray, [&blk])
+                    //   Magic.callWithSplat(receiver, method, argArray[, &blk])
                     // The callWithSplat implementation (in C++) will unpack a
                     // tuple type and call into the normal call mechanism.
 

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -831,45 +831,44 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     send->args.pop_back();
                 }
 
+                auto hasFwdArgs = false;
+                { // Pull out the ForwardedArgs (the `...` argument in a method call, like `foo(...)`)
+                    auto fwdIt = absl::c_find_if(send->args, [](auto &arg) {
+                        return parser::NodeWithExpr::isa_node<parser::ForwardedArgs>(arg.get());
+                    });
+                    if (fwdIt != send->args.end()) {
+                        block = make_unique<parser::LVar>(loc, core::Names::fwdBlock());
+                        hasFwdArgs = true;
+                        send->args.erase(fwdIt);
+                    }
+                }
+
+                auto hasFwdRestArg = false;
+                { // Pull out the ForwardedRestArg (an anonymous splat like `f(*)`)
+                    auto fwdRestIt = absl::c_find_if(send->args, [](auto &arg) {
+                        return parser::NodeWithExpr::isa_node<parser::ForwardedRestArg>(arg.get());
+                    });
+                    if (fwdRestIt != send->args.end()) {
+                        hasFwdRestArg = true;
+                        send->args.erase(fwdRestIt);
+                    }
+                }
+
                 int numPosArgs = send->args.size();
+
+                auto hasSplat = absl::c_any_of(
+                    send->args, [](auto &arg) { return parser::NodeWithExpr::isa_node<parser::Splat>(arg.get()); });
 
                 // Deconstruct the kwargs hash if it's present.
                 optional<parser::NodeVec> kwargElements = flattenKwargs(send, numPosArgs);
 
-                if (absl::c_any_of(send->args, [](auto &arg) {
-                        return parser::NodeWithExpr::isa_node<parser::Splat>(arg.get()) ||
-                               parser::NodeWithExpr::isa_node<parser::ForwardedArgs>(arg.get()) ||
-                               parser::NodeWithExpr::isa_node<parser::ForwardedRestArg>(arg.get());
-                    })) {
+                if (hasFwdArgs || hasFwdRestArg || hasSplat) {
                     // If we have a splat anywhere in the argument list, desugar
                     // the argument list as a single Array node, and then
                     // synthesize a call to
                     //   Magic.callWithSplat(receiver, method, argArray, [&blk])
                     // The callWithSplat implementation (in C++) will unpack a
                     // tuple type and call into the normal call mechanism.
-
-                    auto hasFwdArgs = false;
-                    { // Pull out the ForwardedArgs (the `...` argument in a method call, like `foo(...)`)
-                        auto fwdIt = absl::c_find_if(send->args, [](auto &arg) {
-                            return parser::NodeWithExpr::isa_node<parser::ForwardedArgs>(arg.get());
-                        });
-                        if (fwdIt != send->args.end()) {
-                            block = make_unique<parser::LVar>(loc, core::Names::fwdBlock());
-                            hasFwdArgs = true;
-                            send->args.erase(fwdIt);
-                        }
-                    }
-
-                    auto hasFwdRestArg = false;
-                    { // Pull out the ForwardedRestArg (an anonymous splat like `f(*)`)
-                        auto fwdRestIt = absl::c_find_if(send->args, [](auto &arg) {
-                            return parser::NodeWithExpr::isa_node<parser::ForwardedRestArg>(arg.get());
-                        });
-                        if (fwdRestIt != send->args.end()) {
-                            hasFwdRestArg = true;
-                            send->args.erase(fwdRestIt);
-                        }
-                    }
 
                     unique_ptr<parser::Node> array = make_unique<parser::Array>(locZeroLen, std::move(send->args));
                     auto args = node2TreeImpl(dctx, array);

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -829,11 +829,11 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         send->args.pop_back();
                     }
 
-                    // Deconstruct the kwargs hash if it's present.
-                    if (!send->args.empty()) {
-                        auto _numPosArgs = INT_MAX; // Dummy value, this code path doesn't use it.
+                    int numPosArgs = send->args.size();
 
-                        optional<parser::NodeVec> kwargElements = flattenKwargs(send, _numPosArgs);
+                    // Deconstruct the kwargs hash if it's present.
+                    if (numPosArgs > 0) {
+                        optional<parser::NodeVec> kwargElements = flattenKwargs(send, numPosArgs);
                         if (kwargElements.has_value()) {
                             kwArray = make_unique<parser::Array>(loc, std::move(*kwargElements));
                         }

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -716,41 +716,15 @@ public:
 // If Kwargs Hash contains any splats, we skip the flattening.
 //
 // Returns nullopt if there was no Kwargs Hash
-//
-// * Coming in, the numPosArgs is the *total* number of of arguments in the send node.
-// * Going out, the numPosArgs is decremented by 1 if there was a Kwargs Hash
-//   (it shouldn't be counted as a positional argument)
-optional<parser::NodeVec> flattenKwargs(parser::Send *send, int &numPosArgs) {
-    if (numPosArgs == 0) {
-        // There were no arguments, so there couldn't possibly by a Kwargs Hash.
+optional<parser::NodeVec> flattenKwargs(unique_ptr<parser::Hash> kwargsHash) {
+    if (kwargsHash == nullptr) {
         return nullopt;
     }
-
-    // If there is a Kwargs Hash, we know it will be in the last position,
-    // since we've already pulled out the BlockPass node before calling `flattenKwargs()`.
-    auto *hash = parser::NodeWithExpr::cast_node<parser::Hash>(send->args.back().get());
-
-    if (hash == nullptr) {
-        // Not a Hash, so nothing to flatten.
-        return nullopt;
-    }
-
-    if (!hash->kwargs) {
-        // This Hash was a regular Hash literal, not keyword arguments.
-        return nullopt;
-    }
-
-    // The send node's arguments includes a Kwargs Hash, which isn't a positional argument.
-    numPosArgs--;
-
-    // hold a reference to the node, and remove it from the back of the send list
-    auto hashNode = std::move(send->args.back());
-    send->args.pop_back();
 
     parser::NodeVec kwargElements;
 
     // skip inlining the kwargs if there are any kwsplat nodes present
-    if (absl::c_any_of(hash->pairs, [](auto &node) {
+    if (absl::c_any_of(kwargsHash->pairs, [](auto &node) {
             // the parser guarantees that if we see a kwargs hash it only contains pair,
             // kwsplat, or forwarded kwrest arg nodes
             ENFORCE(parser::NodeWithExpr::isa_node<parser::Kwsplat>(node.get()) ||
@@ -760,10 +734,10 @@ optional<parser::NodeVec> flattenKwargs(parser::Send *send, int &numPosArgs) {
             return parser::NodeWithExpr::isa_node<parser::Kwsplat>(node.get()) ||
                    parser::NodeWithExpr::isa_node<parser::ForwardedKwrestArg>(node.get());
         })) {
-        kwargElements.emplace_back(std::move(hashNode));
+        kwargElements.emplace_back(std::move(kwargsHash));
     } else {
         // inline the hash into the send args
-        for (auto &entry : hash->pairs) {
+        for (auto &entry : kwargsHash->pairs) {
             typecase(
                 entry.get(),
                 [&](parser::Pair *pair) {
@@ -831,6 +805,18 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     send->args.pop_back();
                 }
 
+                // Pop the Kwargs Hash off the end of the arguments, if there is one.
+                unique_ptr<parser::Hash> kwargsHash;
+                if (!send->args.empty()) {
+                    auto *hash = parser::NodeWithExpr::cast_node<parser::Hash>(send->args.back().get());
+
+                    // Only pop if it's a Hash, and if it's a kwargs Hash (as opposed to a regular Hash literal)
+                    if (hash != nullptr && hash->kwargs) {
+                        kwargsHash = unique_ptr<parser::Hash>(static_cast<parser::Hash *>(send->args.back().release()));
+                        send->args.pop_back();
+                    }
+                }
+
                 auto hasFwdArgs = false;
                 auto hasFwdRestArg = false;
                 auto hasSplat = false;
@@ -864,10 +850,10 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     }
                 }
 
-                int numPosArgs = send->args.size();
-
                 // Deconstruct the kwargs hash if it's present.
-                optional<parser::NodeVec> kwargElements = flattenKwargs(send, numPosArgs);
+                optional<parser::NodeVec> kwargElements = flattenKwargs(std::move(kwargsHash));
+
+                int numPosArgs = send->args.size();
 
                 if (hasFwdArgs || hasFwdRestArg || hasSplat) {
                     // If we have a splat anywhere in the argument list, desugar

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -811,14 +811,15 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     }
                 }
 
+                // Remove "special" arguments from the list, and keep track of what we found along the way.
                 auto hasFwdArgs = false;
                 auto hasFwdRestArg = false;
                 auto hasSplat = false;
-                for (auto it = send->args.begin(); it != send->args.end(); /* incremented below */) {
+                auto newEndIt = std::remove_if(send->args.begin(), send->args.end(), [&](auto &arg) {
                     bool eraseFromArgs = false;
 
                     typecase(
-                        it->get(),
+                        arg.get(),
                         [&](parser::ForwardedArgs *fwdArgs) {
                             // Pull out the ForwardedArgs (the `...` argument in a method call, like `foo(...)`)
                             hasFwdArgs = true;
@@ -831,18 +832,15 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                             eraseFromArgs = true;
                         },
                         [&](parser::Splat *splat) {
-                            // Detect if there's a splat in the argument list.
+                            // Detect if there's a splat in the argument list
                             hasSplat = true;
                             eraseFromArgs = false;
                         },
                         [&](parser::Node *node) { eraseFromArgs = false; });
 
-                    if (eraseFromArgs) {
-                        it = send->args.erase(it);
-                    } else {
-                        ++it;
-                    }
-                }
+                    return eraseFromArgs;
+                });
+                send->args.erase(newEndIt, send->args.end());
 
                 if (hasFwdArgs || hasFwdRestArg || hasSplat) {
                     // If we have a splat anywhere in the argument list, desugar

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -832,32 +832,39 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 }
 
                 auto hasFwdArgs = false;
-                { // Pull out the ForwardedArgs (the `...` argument in a method call, like `foo(...)`)
-                    auto fwdIt = absl::c_find_if(send->args, [](auto &arg) {
-                        return parser::NodeWithExpr::isa_node<parser::ForwardedArgs>(arg.get());
-                    });
-                    if (fwdIt != send->args.end()) {
-                        block = make_unique<parser::LVar>(loc, core::Names::fwdBlock());
-                        hasFwdArgs = true;
-                        send->args.erase(fwdIt);
-                    }
-                }
-
                 auto hasFwdRestArg = false;
-                { // Pull out the ForwardedRestArg (an anonymous splat like `f(*)`)
-                    auto fwdRestIt = absl::c_find_if(send->args, [](auto &arg) {
-                        return parser::NodeWithExpr::isa_node<parser::ForwardedRestArg>(arg.get());
-                    });
-                    if (fwdRestIt != send->args.end()) {
-                        hasFwdRestArg = true;
-                        send->args.erase(fwdRestIt);
+                auto hasSplat = false;
+                for (auto it = send->args.begin(); it != send->args.end(); /* incremented below */) {
+                    bool eraseFromArgs = false;
+
+                    typecase(
+                        it->get(),
+                        [&](parser::ForwardedArgs *fwdArgs) {
+                            // Pull out the ForwardedArgs (the `...` argument in a method call, like `foo(...)`)
+                            hasFwdArgs = true;
+                            block = make_unique<parser::LVar>(loc, core::Names::fwdBlock());
+                            eraseFromArgs = true;
+                        },
+                        [&](parser::ForwardedRestArg *fwdRestArg) {
+                            // Pull out the ForwardedRestArg (an anonymous splat like `f(*)`)
+                            hasFwdRestArg = true;
+                            eraseFromArgs = true;
+                        },
+                        [&](parser::Splat *splat) {
+                            // Detect if there's a splat in the argument list.
+                            hasSplat = true;
+                            eraseFromArgs = false;
+                        },
+                        [&](parser::Node *node) { eraseFromArgs = false; });
+
+                    if (eraseFromArgs) {
+                        it = send->args.erase(it);
+                    } else {
+                        ++it;
                     }
                 }
 
                 int numPosArgs = send->args.size();
-
-                auto hasSplat = absl::c_any_of(
-                    send->args, [](auto &arg) { return parser::NodeWithExpr::isa_node<parser::Splat>(arg.get()); });
 
                 // Deconstruct the kwargs hash if it's present.
                 optional<parser::NodeVec> kwargElements = flattenKwargs(send, numPosArgs);

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -774,7 +774,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         if (auto *hash = parser::NodeWithExpr::cast_node<parser::Hash>(send->args.back().get())) {
                             if (hash->kwargs) {
                                 // hold a reference to the node, and remove it from the back of the send list
-                                auto node = std::move(send->args.back());
+                                auto hashNode = std::move(send->args.back());
                                 send->args.pop_back();
 
                                 parser::NodeVec elts;
@@ -790,7 +790,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                                         return parser::NodeWithExpr::isa_node<parser::Kwsplat>(node.get()) ||
                                                parser::NodeWithExpr::isa_node<parser::ForwardedKwrestArg>(node.get());
                                     })) {
-                                    elts.emplace_back(std::move(node));
+                                    elts.emplace_back(std::move(hashNode));
                                 } else {
                                     // inline the hash into the send args
                                     for (auto &entry : hash->pairs) {
@@ -947,8 +947,12 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                             if (hash->kwargs) {
                                 numPosArgs--;
 
+                                // hold a reference to the node, and remove it from the back of the send list
+                                auto hashNode = std::move(send->args[kwargsHashIndex]);
+                                send->args.erase(send->args.begin() + kwargsHashIndex);
+
                                 // skip inlining the kwargs if there are any non-key/value pairs present
-                                if (!absl::c_any_of(hash->pairs, [](auto &node) {
+                                if (absl::c_any_of(hash->pairs, [](auto &node) {
                                         // the parser guarantees that if we see a kwargs hash it only contains pair,
                                         // kwsplat, or forwarded kwrest nodes
                                         ENFORCE(
@@ -958,10 +962,9 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                                         return parser::NodeWithExpr::isa_node<parser::Kwsplat>(node.get()) ||
                                                parser::NodeWithExpr::isa_node<parser::ForwardedKwrestArg>(node.get());
                                     })) {
-                                    // hold a reference to the node, and remove it from the back of the send list
-                                    auto node = std::move(send->args[kwargsHashIndex]);
-                                    send->args.erase(send->args.begin() + kwargsHashIndex);
-
+                                    // We pulled the Hash node out of the args list, so we need to put it back.
+                                    send->args.emplace_back(std::move(hashNode));
+                                } else {
                                     // inline the hash into the send args
                                     for (auto &entry : hash->pairs) {
                                         typecase(

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -723,7 +723,7 @@ optional<parser::NodeVec> flattenKwargs(unique_ptr<parser::Hash> kwargsHash) {
 
     parser::NodeVec kwargElements;
 
-    // skip inlining the kwargs if there are any kwsplat nodes present
+    // Skip inlining the kwargs if there are any kwsplat nodes present
     if (absl::c_any_of(kwargsHash->pairs, [](auto &node) {
             // the parser guarantees that if we see a kwargs hash it only contains pair,
             // kwsplat, or forwarded kwrest arg nodes
@@ -735,16 +735,16 @@ optional<parser::NodeVec> flattenKwargs(unique_ptr<parser::Hash> kwargsHash) {
                    parser::NodeWithExpr::isa_node<parser::ForwardedKwrestArg>(node.get());
         })) {
         kwargElements.emplace_back(std::move(kwargsHash));
-    } else {
-        // inline the hash into the send args
-        for (auto &entry : kwargsHash->pairs) {
-            typecase(
-                entry.get(),
-                [&](parser::Pair *pair) {
-                    kwargElements.emplace_back(std::move(pair->key));
-                    kwargElements.emplace_back(std::move(pair->value));
-                },
-                [&](parser::Node *node) { Exception::raise("Unhandled case"); });
+        return kwargElements;
+    }
+
+    // Flatten the key/value pairs into the result
+    for (auto &entry : kwargsHash->pairs) {
+        if (auto pair = parser::NodeWithExpr::cast_node<parser::Pair>(entry.get())) {
+            kwargElements.emplace_back(std::move(pair->key));
+            kwargElements.emplace_back(std::move(pair->value));
+        } else {
+            Exception::raise("Unhandled case");
         }
     }
 

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -711,7 +711,10 @@ public:
         }
     }
 };
-parser::NodeVec flattenKwargs(parser::Send *send, parser::Hash *hash, int kwargsHashIndex) {
+
+parser::NodeVec flattenKwargs(parser::Send *send, parser::Hash *hash, int kwargsHashIndex, int &numPosArgs) {
+    numPosArgs--;
+
     // hold a reference to the node, and remove it from the back of the send list
     auto hashNode = std::move(send->args[kwargsHashIndex]);
     send->args.erase(send->args.begin() + kwargsHashIndex);
@@ -811,8 +814,9 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                                 // because we already popped off our `savedBlockPass` above.
                                 auto kwargsHashIndex = send->args.size() - 1;
 
-                                parser::NodeVec kwargElements = flattenKwargs(send, hash, kwargsHashIndex);
+                                auto _numPosArgs = INT_MAX; // Dummy value, this code path doesn't use it.
 
+                                parser::NodeVec kwargElements = flattenKwargs(send, hash, kwargsHashIndex, _numPosArgs);
                                 kwArray = make_unique<parser::Array>(loc, std::move(kwargElements));
                             }
                         }
@@ -954,9 +958,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         if (auto *hash =
                                 parser::NodeWithExpr::cast_node<parser::Hash>(send->args[kwargsHashIndex].get())) {
                             if (hash->kwargs) {
-                                numPosArgs--;
-
-                                parser::NodeVec kwargElements = flattenKwargs(send, hash, kwargsHashIndex);
+                                parser::NodeVec kwargElements = flattenKwargs(send, hash, kwargsHashIndex, numPosArgs);
 
                                 // Concat the flattened Hash elements on the end of the args list.
                                 send->args.insert(send->args.end(), make_move_iterator(kwargElements.begin()),

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -712,16 +712,10 @@ public:
     }
 };
 
-// Returns the flattened key/value pairs from the Kwargs Hash, if there was one.
-// If Kwargs Hash contains any splats, we skip the flattening.
-//
-// Returns nullopt if there was no Kwargs Hash
-optional<parser::NodeVec> flattenKwargs(unique_ptr<parser::Hash> kwargsHash) {
-    if (kwargsHash == nullptr) {
-        return nullopt;
-    }
-
-    parser::NodeVec kwargElements;
+// Flattens the key/value pairs from the Kwargs Hash into the destination container.
+// If Kwargs Hash contains any splats, we skip the flattening and append the hash as-is.
+template <typename Container> void flattenKwargs(unique_ptr<parser::Hash> kwargsHash, Container &destination) {
+    ENFORCE(kwargsHash != nullptr);
 
     // Skip inlining the kwargs if there are any kwsplat nodes present
     if (absl::c_any_of(kwargsHash->pairs, [](auto &node) {
@@ -734,21 +728,21 @@ optional<parser::NodeVec> flattenKwargs(unique_ptr<parser::Hash> kwargsHash) {
             return parser::NodeWithExpr::isa_node<parser::Kwsplat>(node.get()) ||
                    parser::NodeWithExpr::isa_node<parser::ForwardedKwrestArg>(node.get());
         })) {
-        kwargElements.emplace_back(std::move(kwargsHash));
-        return kwargElements;
+        destination.emplace_back(std::move(kwargsHash));
+        return;
     }
 
-    // Flatten the key/value pairs into the result
+    // Flatten the key/value pairs into the destination
     for (auto &entry : kwargsHash->pairs) {
         if (auto pair = parser::NodeWithExpr::cast_node<parser::Pair>(entry.get())) {
-            kwargElements.emplace_back(std::move(pair->key));
-            kwargElements.emplace_back(std::move(pair->value));
+            destination.emplace_back(std::move(pair->key));
+            destination.emplace_back(std::move(pair->value));
         } else {
             Exception::raise("Unhandled case");
         }
     }
 
-    return kwargElements;
+    return;
 }
 
 [[noreturn]] void desugaredByPrismTranslator(parser::Node *node) {
@@ -850,9 +844,6 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     }
                 }
 
-                // Deconstruct the kwargs hash if it's present.
-                optional<parser::NodeVec> kwargElements = flattenKwargs(std::move(kwargsHash));
-
                 if (hasFwdArgs || hasFwdRestArg || hasSplat) {
                     // If we have a splat anywhere in the argument list, desugar
                     // the argument list as a single Array node, and then
@@ -898,8 +889,11 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     // This will be used in the implementation of the intrinsic to tell the difference between keyword
                     // args, keyword args with kw splats, and no keyword args at all.
                     ExpressionPtr kwargs;
-                    if (kwargElements.has_value()) {
-                        unique_ptr<parser::Node> kwArray = make_unique<parser::Array>(loc, std::move(*kwargElements));
+                    if (kwargsHash != nullptr) {
+                        parser::NodeVec kwargElements;
+                        flattenKwargs(std::move(kwargsHash), kwargElements);
+
+                        unique_ptr<parser::Node> kwArray = make_unique<parser::Array>(loc, std::move(kwargElements));
 
                         kwargs = node2TreeImpl(dctx, kwArray);
 
@@ -943,10 +937,10 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     // Count the arguments before we concat in the Kwarg key/value pairs
                     int numPosArgs = send->args.size();
 
-                    if (kwargElements.has_value()) {
-                        // Concat the flattened Hash elements on the end of the args list.
-                        send->args.insert(send->args.end(), make_move_iterator(kwargElements->begin()),
-                                          make_move_iterator(kwargElements->end()));
+                    if (kwargsHash != nullptr) {
+                        // Deconstruct the kwargs hash if it's present,
+                        // concating the key/value pairs to the end of the args list
+                        flattenKwargs(std::move(kwargsHash), send->args);
                     }
 
                     Send::ARGS_store args;


### PR DESCRIPTION
### Motivation

The desugaring logic for Send nodes has grown ... organically over time, and has gotten exceptionally complex. I did some refactoring to explore its behaviour (to migrate over to Prism), and found really valuable improvements that are worth upstreaming.

In general, there's two main code paths:

1. One which handles "splatty" method calls (whose which have `Splat`, `ForwardedArgs` or `ForwardedRestArg` arugments
2. One for everything else

These two code paths have really heavily duplication of nearly-identical-but-not-quite logic.

This PR pulls out the common parts, and makes a bunch of other improvements. The overall diff is going to be approximately useless, but it should be easy to review commit-by-commit. Each commit is self-contained and passes tests.

### Test plan

This is a pure refactor, which passes all existing tests.