### PR TITLE
Escape `srb`'s `exec` call

### DIFF
--- a/gems/sorbet/bin/srb
+++ b/gems/sorbet/bin/srb
@@ -52,7 +52,7 @@ typecheck() {
     cache_hash=$(compute_md5 Gemfile.lock | awk '{ print $1 }')
     cache_file="${cache_dir}/${cache_hash}"
     if [ ! -f "$cache_file" ]; then
-      $0 rbi find-gem-rbis > /dev/null
+      "$0" rbi find-gem-rbis > /dev/null
     fi
     args+=("@$cache_file")
   fi


### PR DESCRIPTION
If the path to `srb` contains strings that need to be escaped, calls to `srb` will fail. This ensures `srb` is always executable regardless of the path

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
I was setting up a project and I realized invoking `srb` was returning the following error:

```
/home/vraiment/Desktop/1. Projects/ruby_project_template/tmp/vendor/bundle/ruby/3.2.0/gems/sorbet-0.5.12388/bin/srb:150:in `exec': No such file or directory - /home/vraiment/Desktop/1. (Errno::ENOENT)
        from /home/vraiment/Desktop/1. Projects/ruby_project_template/tmp/vendor/bundle/ruby/3.2.0/gems/sorbet-0.5.12388/bin/srb:150:in `<top (required)>'
        from bin/srb:27:in `load'
        from bin/srb:27:in `<main>'
```


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I applied the patch to my `srb` file and it worked, not sure if you have tests specifically for this code path
