### PR TITLE
Directly desugar Strings and Symbols

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1243,10 +1243,9 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             auto strNode = down_cast<pm_string_node>(node);
 
             auto unescaped = &strNode->unescaped;
-            auto source = parser.extractString(unescaped);
+            auto content = ctx.state.enterNameUTF8(parser.extractString(unescaped));
 
-            // TODO: handle different string encodings
-            return make_unique<parser::String>(location, ctx.state.enterNameUTF8(source));
+            return make_node_with_expr<parser::String>(MK::String(location, content), location, content);
         }
         case PM_SUPER_NODE: { // The `super` keyword, like `super`, `super(a, b)`
             auto superNode = down_cast<pm_super_node>(node);

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1266,8 +1266,8 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             auto symNode = down_cast<pm_symbol_node>(node);
 
             auto unescaped = &symNode->unescaped;
-
-            auto source = parser.extractString(unescaped);
+            // TODO: can these have different encodings?
+            auto content = ctx.state.enterNameUTF8(parser.extractString(unescaped));
 
             // If the opening location is null, the symbol is used as a key with a colon postfix, like `{a: 1}`
             // In those cases, the location should not include the colon.
@@ -1275,8 +1275,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                 location = translateLoc(symNode->value_loc);
             }
 
-            // TODO: can these have different encodings?
-            return make_unique<parser::Symbol>(location, ctx.state.enterNameUTF8(source));
+            return make_node_with_expr<parser::Symbol>(MK::Symbol(location, content), location, content);
         }
         case PM_TRUE_NODE: { // The `true` keyword
             return make_node_with_expr<parser::True>(MK::True(location), location);


### PR DESCRIPTION
This PR updates the translation of `PM_STRING_NODE` and `PM_SYMBOL_NODE` from Prism AST to directly build the expression tree Sorbet can use.

### Test plan
Existing tests pass with both the prism and whitequark parsers