### PR TITLE
Directly desugar "statements" nodes

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -514,7 +514,15 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                         receiverExpr = receiver->takeDesugaredExpr();
                     }
 
-                    flags.isPrivateOk = PM_NODE_FLAG_P(callNode, PM_CALL_NODE_FLAGS_IGNORE_VISIBILITY);
+                    // Unsupported nodes are desugared to an empty tree.
+                    // Treat them as if they were `self` to match `Desugar.cc`.
+                    // TODO: Clean up after direct desugaring is complete. https://github.com/Shopify/sorbet/issues/671
+                    if (ast::isa_tree<ast::EmptyTree>(receiverExpr)) {
+                        receiverExpr = MK::Self(loc.copyWithZeroLength());
+                        flags.isPrivateOk = true;
+                    } else {
+                        flags.isPrivateOk = PM_NODE_FLAG_P(callNode, PM_CALL_NODE_FLAGS_IGNORE_VISIBILITY);
+                    }
 
                     int numPosArgs = args.size() - (hasKwargsHash ? 1 : 0) - (hasBlockArg ? 1 : 0);
 

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -780,12 +780,13 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             // Can be multiple statements separated by `;`.
             auto embeddedStmtsNode = down_cast<pm_embedded_statements_node>(node);
 
-            if (auto stmtsNode = embeddedStmtsNode->statements; stmtsNode != nullptr) {
-                auto inlineIfSingle = false;
-                return translateStatements(stmtsNode, inlineIfSingle);
-            } else {
-                return make_unique<parser::Begin>(location, NodeVec{});
+            auto stmtsNode = embeddedStmtsNode->statements;
+            if (stmtsNode == nullptr) {
+                return make_node_with_expr<parser::Begin>(MK::Nil(location), location, NodeVec{});
             }
+
+            auto inlineIfSingle = false;
+            return translateStatements(stmtsNode, inlineIfSingle);
         }
         case PM_EMBEDDED_VARIABLE_NODE: {
             auto embeddedVariableNode = down_cast<pm_embedded_variable_node>(node);
@@ -1330,14 +1331,16 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         case PM_PARENTHESES_NODE: { // A parethesized expression, e.g. `(a)`
             auto parensNode = down_cast<pm_parentheses_node>(node);
 
-            if (auto stmtsNode = parensNode->body; stmtsNode != nullptr) {
-                auto inlineIfSingle = false;
-                // Override the begin node location to be the parentheses location instead of the statements location
-                return translateStatements(down_cast<pm_statements_node>(stmtsNode), inlineIfSingle,
-                                           parensNode->base.location);
-            } else {
-                return make_unique<parser::Begin>(location, NodeVec{});
+            auto stmtsNode = parensNode->body;
+
+            if (stmtsNode == nullptr) {
+                return make_node_with_expr<parser::Begin>(MK::Nil(location), location, NodeVec{});
             }
+
+            auto inlineIfSingle = false;
+            // Override the begin node location to be the parentheses location instead of the statements location
+            return translateStatements(down_cast<pm_statements_node>(stmtsNode), inlineIfSingle,
+                                       parensNode->base.location);
         }
         case PM_PRE_EXECUTION_NODE: {
             auto preExecutionNode = down_cast<pm_pre_execution_node>(node);
@@ -1986,7 +1989,7 @@ unique_ptr<parser::Node> Translator::patternTranslate(pm_node_t *node) {
             // Sorbet's parser always wraps the pinned expression in a `Begin` node.
             NodeVec statements;
             statements.emplace_back(move(expr));
-            auto beginNode = make_unique<parser::Begin>(location, move(statements));
+            auto beginNode = make_node_with_expr<parser::Begin>(MK::Nil(location), location, move(statements));
 
             return make_unique<Pin>(location, move(beginNode));
         }
@@ -2333,8 +2336,29 @@ unique_ptr<parser::Node> Translator::translateStatements(pm_statements_node *stm
     // For multiple statements, convert each statement and add them to the body of a Begin node
     parser::NodeVec sorbetStmts = translateMulti(stmtsNode->body);
 
-    pm_location_t beginLocation = overrideLocation.value_or(stmtsNode->base.location);
-    return make_unique<parser::Begin>(translateLoc(beginLocation), move(sorbetStmts));
+    auto beginLoc = translateLoc(overrideLocation.value_or(stmtsNode->base.location));
+
+    if (sorbetStmts.empty()) {
+        return make_node_with_expr<parser::Begin>(MK::Nil(beginLoc), beginLoc, NodeVec{});
+    }
+
+    if (!directlyDesugar || !hasExpr(sorbetStmts)) {
+        return make_unique<parser::Begin>(beginLoc, move(sorbetStmts));
+    }
+
+    ast::InsSeq::STATS_store statements;
+    statements.reserve(sorbetStmts.size() - 1); // -1 because the `Begin` node stores the last element separately.
+
+    auto end = sorbetStmts.end();
+    --end; // Chop one off the end, so we iterate over all but the last element.
+    for (auto it = sorbetStmts.begin(); it != end; ++it) {
+        auto &statement = *it;
+        statements.emplace_back(statement->takeDesugaredExpr());
+    };
+    auto finalExpr = sorbetStmts.back()->takeDesugaredExpr(); // Process the last element separately.
+
+    auto instructionSequence = MK::InsSeq(beginLoc, move(statements), move(finalExpr));
+    return make_node_with_expr<parser::Begin>(move(instructionSequence), beginLoc, move(sorbetStmts));
 }
 
 // Helper function for creating if nodes with optional desugaring

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -604,7 +604,28 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                 declLoc = declLoc.join(superclass->loc);
             }
 
-            return make_unique<parser::Class>(location, declLoc, move(name), move(superclass), move(body));
+            if (!directlyDesugar || !hasExpr(name, superclass, body)) {
+                return make_unique<parser::Class>(location, declLoc, move(name), move(superclass), move(body));
+            }
+
+            auto bodyExprsOpt = desugarScopeBodyToRHSStore(body);
+            if (!bodyExprsOpt.has_value()) {
+                return make_unique<parser::Class>(location, declLoc, move(name), move(superclass), move(body));
+            }
+            auto bodyExprs = move(*bodyExprsOpt);
+
+            ast::ClassDef::ANCESTORS_store ancestors;
+            if (superclass == nullptr) {
+                ancestors.emplace_back(MK::Constant(location, core::Symbols::todo()));
+            } else {
+                ancestors.emplace_back(superclass->takeDesugaredExpr());
+            }
+
+            auto nameExpr = name->takeDesugaredExpr();
+            auto classDef = MK::Class(location, declLoc, move(nameExpr), move(ancestors), move(bodyExprs));
+
+            return make_node_with_expr<parser::Class>(move(classDef), location, declLoc, move(name), move(superclass),
+                                                      move(body));
         }
         case PM_CLASS_VARIABLE_AND_WRITE_NODE: { // And-assignment to a class variable, e.g. `@@a &&= 1`
             return translateOpAssignment<pm_class_variable_and_write_node, parser::AndAsgn, parser::CVarLhs>(node);


### PR DESCRIPTION
### Motivation

This includes the root `PM_PROGRAM_NODE` node, parenthesized expressions, and anywhere else multiple statements can occur. Basically, most things that used `MK::InsSeq`.

We can't delete this logic from `PrismDesugar.cc` though, because this direct desugar is only possible when all the statements have a directly desugared expr, which won't be guaranteed until we've completely handled all node types.

### Test plan

Covered by existing desugar tests