### PR TITLE
Directly desugar constant reads

### DIFF
--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -1526,10 +1526,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 ExpressionPtr res = MK::UnresolvedConstant(loc, move(scope), constLhs->name);
                 result = move(res);
             },
-            [&](parser::Cbase *cbase) {
-                ExpressionPtr res = MK::Constant(loc, core::Symbols::root());
-                result = move(res);
-            },
+            [&](parser::Cbase *cbase) { desugaredByPrismTranslator(cbase); },
             [&](parser::Kwbegin *kwbegin) { result = desugarBegin(dctx, loc, kwbegin->stmts); },
             [&](parser::Module *module) {
                 DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1860,11 +1860,15 @@ unique_ptr<parser::Node> Translator::translateConst(PrismLhsNode *node, bool rep
         return make_unique<LVarLhs>(location, core::Names::dynamicConstAssign());
     }
 
+    auto constantName = ctx.state.enterNameConstant(name);
+
     auto constexpr isConstantPath = is_same_v<PrismLhsNode, pm_constant_path_target_node> ||
                                     is_same_v<PrismLhsNode, pm_constant_path_write_node> ||
                                     is_same_v<PrismLhsNode, pm_constant_path_node>;
 
     unique_ptr<parser::Node> parent;
+    ast::ExpressionPtr parentExpr = nullptr;
+
     if constexpr (isConstantPath) { // Handle constant paths, has a parent node that needs translation.
         if (auto prismParentNode = node->parent; prismParentNode != nullptr) {
             // This constant reference is chained onto another constant reference.
@@ -1875,9 +1879,11 @@ unique_ptr<parser::Node> Translator::translateConst(PrismLhsNode *node, bool rep
             //  /  \
             // A   ::B
             parent = translate(prismParentNode);
+            parentExpr = parent ? parent->takeDesugaredExpr() : nullptr;
         } else { // This is the root of a fully qualified constant reference, like `::A`.
             auto delimiterLoc = translateLoc(node->delimiter_loc); // The location of the `::`
             parent = make_unique<parser::Cbase>(delimiterLoc);
+            parentExpr = MK::Constant(delimiterLoc, core::Symbols::root());
         }
     } else { // Handle plain constants like `A`, that aren't part of a constant path.
         static_assert(
@@ -1894,9 +1900,15 @@ unique_ptr<parser::Node> Translator::translateConst(PrismLhsNode *node, bool rep
             location = translateLoc(node->name_loc);
         }
         parent = nullptr;
+        parentExpr = MK::EmptyTree();
     }
 
-    return make_unique<SorbetLHSNode>(location, move(parent), ctx.state.enterNameConstant(name));
+    if (parentExpr != nullptr) {
+        ast::ExpressionPtr desugaredExpr = MK::UnresolvedConstant(location, move(parentExpr), constantName);
+        return make_node_with_expr<SorbetLHSNode>(move(desugaredExpr), location, move(parent), constantName);
+    } else {
+        return make_unique<SorbetLHSNode>(location, move(parent), constantName);
+    }
 }
 
 core::NameRef Translator::translateConstantName(pm_constant_id_t constant_id) {


### PR DESCRIPTION
### Motivation

Directly desugar constant reads, such as in `_ = X`, `X.new`, `class X; end`, `class << X; end`, etc.

Part of #9065

### Test plan

Covered by existing desugar tests