### PR TITLE
Directly desugar `PM_RETRY_NODE`

### DIFF
--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -2016,10 +2016,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     result = move(res);
                 }
             },
-            [&](parser::Retry *ret) {
-                ExpressionPtr res = make_expression<Retry>(loc);
-                result = move(res);
-            },
+            [&](parser::Retry *ret) { desugaredByPrismTranslator(ret); },
             [&](parser::Yield *ret) {
                 Send::ARGS_store args;
                 args.reserve(ret->exprs.size());

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1195,7 +1195,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             return make_unique<parser::Return>(location, move(returnValues));
         }
         case PM_RETRY_NODE: { // The `retry` keyword
-            return make_unique<parser::Retry>(location);
+            return make_node_with_expr<parser::Retry>(ast::make_expression<ast::Retry>(location), location);
         }
         case PM_SELF_NODE: { // The `self` keyword
             return make_node_with_expr<parser::Self>(MK::Self(location), location);


### PR DESCRIPTION
Direct desugar `PM_RETRY_NODE`s as part of integrating Prism in Sorbet


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing desugar tests
