### PR TITLE
Directly desugar some parameter nodes 

### DIFF
--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -1566,10 +1566,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 ExpressionPtr res = MK::RestArg(loc, MK::KeywordArg(loc, arg->name));
                 result = move(res);
             },
-            [&](parser::Kwarg *arg) {
-                ExpressionPtr res = MK::KeywordArg(loc, arg->name);
-                result = move(res);
-            },
+            [&](parser::Kwarg *arg) { desugaredByPrismTranslator(arg); },
             [&](parser::Blockarg *arg) {
                 ExpressionPtr res = MK::BlockArg(loc, MK::Local(loc, arg->name));
                 result = move(res);
@@ -1584,10 +1581,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     MK::OptionalArg(loc, MK::Local(arg->nameLoc, arg->name), node2TreeImpl(dctx, arg->default_));
                 result = move(res);
             },
-            [&](parser::Shadowarg *arg) {
-                ExpressionPtr res = MK::ShadowArg(loc, MK::Local(loc, arg->name));
-                result = move(res);
-            },
+            [&](parser::Shadowarg *arg) { desugaredByPrismTranslator(arg); },
             [&](parser::DefMethod *method) {
                 bool isSelf = false;
                 ExpressionPtr res = buildMethod(dctx, method->loc, method->declLoc, method->name, method->args.get(),

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -254,7 +254,8 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         case PM_BLOCK_LOCAL_VARIABLE_NODE: { // A named block local variable, like `baz` in `|bar; baz|`
             auto blockLocalNode = down_cast<pm_block_local_variable_node>(node);
             auto sorbetName = translateConstantName(blockLocalNode->name);
-            return make_unique<parser::Shadowarg>(location, sorbetName);
+            return make_node_with_expr<parser::Shadowarg>(MK::ShadowArg(location, MK::Local(location, sorbetName)),
+                                                          location, sorbetName);
         }
         case PM_BLOCK_PARAMETER_NODE: { // A block parameter declared at the top of a method, e.g. `def m(&block)`
             auto blockParamNode = down_cast<pm_block_parameter_node>(node);
@@ -270,7 +271,8 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
             auto blockLoc = core::LocOffsets{location.beginPos() + 1, location.endPos()};
 
-            return make_unique<parser::Blockarg>(blockLoc, sorbetName);
+            return make_node_with_expr<parser::Blockarg>(MK::BlockArg(blockLoc, MK::Local(blockLoc, sorbetName)),
+                                                         blockLoc, sorbetName);
         }
         case PM_BLOCK_PARAMETERS_NODE: { // The parameters declared at the top of a PM_BLOCK_NODE
             auto paramsNode = down_cast<pm_block_parameters_node>(node);
@@ -886,7 +888,8 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             }
 
             auto kwrestLoc = core::LocOffsets{location.beginPos() + 2, location.endPos()};
-            return make_unique<parser::Kwrestarg>(kwrestLoc, sorbetName);
+            return make_node_with_expr<parser::Kwrestarg>(MK::RestArg(kwrestLoc, MK::KeywordArg(kwrestLoc, sorbetName)),
+                                                          kwrestLoc, sorbetName);
         }
         case PM_LAMBDA_NODE: { // lambda literals, like `-> { 123 }`
             auto lambdaNode = down_cast<pm_lambda_node>(node);
@@ -1150,7 +1153,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             auto requiredKeywordParamNode = down_cast<pm_required_keyword_parameter_node>(node);
             auto name = translateConstantName(requiredKeywordParamNode->name);
 
-            return make_unique<parser::Kwarg>(location, name);
+            return make_node_with_expr<parser::Kwarg>(MK::KeywordArg(location, name), location, name);
         }
         case PM_REQUIRED_PARAMETER_NODE: { // A required positional parameter, like `def foo(a)`
             auto requiredParamNode = down_cast<pm_required_parameter_node>(node);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Directly desguar:
- Required keyword parameters (`PM_REQUIRED_KEYWORD_PARAMETER_NODE`)
- Block parameters (`PM_BLOCK_PARAMETER_NODE`) 
- Block local variables (`PM_BLOCK_LOCAL_VARIABLE_NODE`)
- Keyword rest parameters (`PM_KEYWORD_REST_PARAMETER_NODE`)

as part of integrating Prism into Sorbet


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests