### PR TITLE
Directly desugar parameter and rest nodes

### DIFF
--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -1554,10 +1554,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                                               move(ancestors), move(body));
                 result = move(res);
             },
-            [&](parser::Arg *arg) {
-                ExpressionPtr res = MK::Local(loc, arg->name);
-                result = move(res);
-            },
+            [&](parser::Arg *arg) { desugaredByPrismTranslator(arg); },
             [&](parser::Restarg *arg) {
                 ExpressionPtr res = MK::RestArg(loc, MK::Local(arg->nameLoc, arg->name));
                 result = move(res);

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -716,7 +716,10 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         }
         case PM_IMPLICIT_REST_NODE: { // An implicit splat, like the `,` in `a, = 1, 2, 3`
             auto restLoc = core::LocOffsets{location.beginLoc + 1, location.beginLoc + 1};
-            return make_unique<parser::Restarg>(restLoc, core::Names::restargs(), restLoc);
+            core::NameRef sorbetName = core::Names::restargs();
+            auto expr = MK::RestArg(restLoc, MK::Local(restLoc, sorbetName));
+
+            return make_node_with_expr<parser::Restarg>(move(expr), restLoc, sorbetName, restLoc);
         }
         case PM_INDEX_AND_WRITE_NODE: { // And-assignment to an index, e.g. `a[i] &&= false`
             return translateOpAssignment<pm_index_and_write_node, parser::AndAsgn, void>(node);
@@ -1155,8 +1158,9 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
         case PM_REQUIRED_PARAMETER_NODE: { // A required positional parameter, like `def foo(a)`
             auto requiredParamNode = down_cast<pm_required_parameter_node>(node);
             auto name = translateConstantName(requiredParamNode->name);
+            auto expr = MK::Local(location, name);
 
-            return make_unique<parser::Arg>(location, name);
+            return make_node_with_expr<parser::Arg>(move(expr), location, name);
         }
         case PM_RESCUE_MODIFIER_NODE: {
             auto rescueModifierNode = down_cast<pm_rescue_modifier_node>(node);
@@ -1185,7 +1189,8 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                 nameLoc = location;
             }
 
-            return make_unique<parser::Restarg>(location, sorbetName, nameLoc);
+            auto expr = MK::RestArg(location, MK::Local(nameLoc, sorbetName));
+            return make_node_with_expr<parser::Restarg>(move(expr), location, sorbetName, nameLoc);
         }
         case PM_RETURN_NODE: { // A `return` statement, like `return 1, 2, 3`
             auto returnNode = down_cast<pm_return_node>(node);


### PR DESCRIPTION
This PR adds desugaring support for three Prism node types:

- `PM_REQUIRED_PARAMETER_NODE`
- `PM_REST_PARAMETER_NODE`
- `PM_IMPLICIT_REST_NODE`

as part of integrating Prism in Sorbet

`PM_SPLAT_NODE` creates `parser::Restarg` nodes which is why the `parser::Restarg` case cannot be changed in `PrismDesugar.cc` yet. 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests 