### PR TITLE
Remove `FullyQualifiedName::loc`

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -478,7 +478,7 @@ public:
             }
             if (!importToInsertAfter.exists()) {
                 // Insert before the first import
-                core::Loc beforePackageName = {loc.file(), importedPackageNames.front().name.fullName.loc};
+                core::Loc beforePackageName = {loc.file(), importedPackageNames.front().loc};
                 auto [beforeImport, numWhitespace] = beforePackageName.findStartOfIndentation(gs);
                 auto endOfPrevLine = beforeImport.adjust(gs, -numWhitespace - 1, 0);
                 insertionLoc = endOfPrevLine.copyWithZeroLength();
@@ -1605,12 +1605,12 @@ void rewritePackageSpec(const core::GlobalState &gs, ast::ParsedFile &package, P
     ast::TreeWalk::apply(ctx, bodyWalk, package.tree);
     if (gs.packageDB().enforceLayering()) {
         if (!bodyWalk.foundLayerDeclaration) {
-            if (auto e = ctx.beginError(info.name.fullName.loc, core::errors::Packager::InvalidLayer)) {
+            if (auto e = gs.beginError(info.declLoc(), core::errors::Packager::InvalidLayer)) {
                 e.setHeader("This package does not declare a `{}`", "layer");
             }
         }
         if (!bodyWalk.foundStrictDependenciesDeclaration) {
-            if (auto e = ctx.beginError(info.name.fullName.loc, core::errors::Packager::InvalidStrictDependencies)) {
+            if (auto e = gs.beginError(info.declLoc(), core::errors::Packager::InvalidStrictDependencies)) {
                 e.setHeader("This package does not declare a `{}` level", "strict_dependencies");
             }
         }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1880,7 +1880,7 @@ void validateLayering(const core::Context &ctx, const Import &i) {
     auto otherPkgLayer = otherPkg.layer().value().first;
 
     if (thisPkg.causesLayeringViolation(packageDB, otherPkgLayer)) {
-        if (auto e = ctx.beginError(i.name.fullName.loc, core::errors::Packager::LayeringViolation)) {
+        if (auto e = ctx.beginError(i.loc, core::errors::Packager::LayeringViolation)) {
             e.setHeader("Layering violation: cannot import `{}` (in layer `{}`) from `{}` (in layer `{}`)",
                         otherPkg.show(ctx), otherPkgLayer.show(ctx), thisPkg.show(ctx), pkgLayer.show(ctx));
             e.addErrorLine(core::Loc(thisPkg.loc.file(), thisPkg.layer().value().second), "`{}`'s `{}` declared here",
@@ -1895,7 +1895,7 @@ void validateLayering(const core::Context &ctx, const Import &i) {
     core::packages::StrictDependenciesLevel otherPkgExpectedLevel = thisPkg.minimumStrictDependenciesLevel();
 
     if (otherPkg.strictDependenciesLevel().value().first < otherPkgExpectedLevel) {
-        if (auto e = ctx.beginError(i.name.fullName.loc, core::errors::Packager::StrictDependenciesViolation)) {
+        if (auto e = ctx.beginError(i.loc, core::errors::Packager::StrictDependenciesViolation)) {
             e.setHeader("Strict dependencies violation: All of `{}`'s `{}`s must be `{}` or higher", thisPkg.show(ctx),
                         "import", core::packages::strictDependenciesLevelToString(otherPkgExpectedLevel));
             e.addErrorLine(core::Loc(otherPkg.loc.file(), otherPkg.strictDependenciesLevel().value().second),
@@ -1909,7 +1909,7 @@ void validateLayering(const core::Context &ctx, const Import &i) {
 
     if (thisPkg.strictDependenciesLevel().value().first >= core::packages::StrictDependenciesLevel::LayeredDag) {
         if (thisPkg.sccID() == otherPkg.sccID()) {
-            if (auto e = ctx.beginError(i.name.fullName.loc, core::errors::Packager::StrictDependenciesViolation)) {
+            if (auto e = ctx.beginError(i.loc, core::errors::Packager::StrictDependenciesViolation)) {
                 auto level = fmt::format(
                     "strict_dependencies '{}'",
                     core::packages::strictDependenciesLevelToString(thisPkg.strictDependenciesLevel().value().first));
@@ -1945,7 +1945,7 @@ void validateVisibility(const core::Context &ctx, const PackageInfoImpl &absPkg,
         visibleTo, [&ctx, &absPkg](const auto &other) { return visibilityApplies(ctx, other, absPkg.mangledName()); });
 
     if (!allowed) {
-        if (auto e = ctx.beginError(i.name.fullName.loc, core::errors::Packager::ImportNotVisible)) {
+        if (auto e = ctx.beginError(i.loc, core::errors::Packager::ImportNotVisible)) {
             e.setHeader("Package `{}` includes explicit visibility modifiers and cannot be imported from `{}`",
                         otherPkg.show(ctx), absPkg.show(ctx));
             e.addErrorNote("Please consult with the owning team before adding a `{}` line to the package `{}`",
@@ -1996,7 +1996,7 @@ void validatePackage(core::Context ctx) {
         }
 
         if (i.name.mangledName == pkgInfo.name.mangledName) {
-            if (auto e = ctx.beginError(i.name.fullName.loc, core::errors::Packager::NoSelfImport)) {
+            if (auto e = ctx.beginError(i.loc, core::errors::Packager::NoSelfImport)) {
                 string import_;
                 switch (i.type) {
                     case core::packages::ImportType::Normal:

--- a/test/cli/package-strict-dependencies-show-cycle/test.out
+++ b/test/cli/package-strict-dependencies-show-cycle/test.out
@@ -1,6 +1,6 @@
 a/__package.rb:7: Strict dependencies violation: importing `B` will put `A` into a cycle, which is not valid at `strict_dependencies 'layered_dag'` https://srb.help/3727
      7 |  import B
-                 ^
+          ^^^^^^^^
   Note:
     Path from `B` to `A`:
     `B` →

--- a/test/testdata/packager/test_visibility/importers/allowed/__package.rb
+++ b/test/testdata/packager/test_visibility/importers/allowed/__package.rb
@@ -14,5 +14,5 @@ class Importers::Allowed < PackageSpec
 
   # not allowed---this package is NOT referenced using `visible_to`
   import Exporters::OnlyTestVisibleTo
-       # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: includes explicit visibility modifiers
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: includes explicit visibility modifiers
 end

--- a/test/testdata/packager/test_visibility/importers/disallowed/__package.rb
+++ b/test/testdata/packager/test_visibility/importers/disallowed/__package.rb
@@ -8,13 +8,13 @@ class Importers::Disallowed < PackageSpec
 
   # not allowed---this package is NOT referenced using `visible_to`
   import Exporters::ExplicitVisibleTo
-       # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: includes explicit visibility modifiers
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: includes explicit visibility modifiers
 
   # not allowed---this package is NOT referenced using `visible_to`
   import Exporters::TestVisibleTo
-       # ^^^^^^^^^^^^^^^^^^^^^^^^ error: includes explicit visibility modifiers
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: includes explicit visibility modifiers
 
   # not allowed---this package is NOT referenced using `visible_to`
   import Exporters::OnlyTestVisibleTo
-       # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: includes explicit visibility modifiers
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: includes explicit visibility modifiers
 end

--- a/test/testdata/packager/test_visibility/importers/disallowed_test/__package.rb
+++ b/test/testdata/packager/test_visibility/importers/disallowed_test/__package.rb
@@ -8,7 +8,7 @@ class Importers::DisallowedTest < PackageSpec
 
   # not allowed---this package is NOT referenced using `visible_to`
   test_import Exporters::ExplicitVisibleTo
-            # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: includes explicit visibility modifiers
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: includes explicit visibility modifiers
 
   # allowed---not mentioned, but `visible_to 'tests'` permits this
   test_import Exporters::TestVisibleTo


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Eventually I'm going to remove `FullyQualifiedName` because we should not be
tracking `vector<NameRef>` anymore, but this struct has a useful `LocOffsets`
field. Let's hoist that to the places that need it.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests