### PR TITLE
RFC: Allow using `attr_reader` et al. to define abstract methods

### DIFF
--- a/test/testdata/rewriter/attr_abstract.rb
+++ b/test/testdata/rewriter/attr_abstract.rb
@@ -5,11 +5,11 @@ module IFoo
   abstract!
 
   sig { abstract.returns(String) }
-  attr_reader :foo # error: Abstract methods must not contain any code in their body
+  attr_reader :foo
 
   sig { abstract.params(bar: String).returns(String) }
-  attr_writer :bar # error: Abstract methods must not contain any code in their body
+  attr_writer :bar
 
   sig { abstract.returns(String) }
-  attr_accessor :qux # error: Abstract methods must not contain any code in their body
+  attr_accessor :qux
 end

--- a/test/testdata/rewriter/attr_abstract.rb
+++ b/test/testdata/rewriter/attr_abstract.rb
@@ -1,0 +1,15 @@
+# typed: strict
+
+module IFoo
+  extend T::Sig, T::Helpers
+  abstract!
+
+  sig { abstract.returns(String) }
+  attr_reader :foo # error: Abstract methods must not contain any code in their body
+
+  sig { abstract.params(bar: String).returns(String) }
+  attr_writer :bar # error: Abstract methods must not contain any code in their body
+
+  sig { abstract.returns(String) }
+  attr_accessor :qux # error: Abstract methods must not contain any code in their body
+end

--- a/test/testdata/rewriter/attr_abstract.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/attr_abstract.rb.rewrite-tree.exp
@@ -1,0 +1,47 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C IFoo><<C <todo sym>>> < ()
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.abstract().returns(<emptyTree>::<C String>)
+    end
+
+    def foo<<todo method>>(&<blk>)
+      @foo
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.abstract().params(:bar, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
+    end
+
+    def bar=<<todo method>>(bar, &<blk>)
+      @bar = bar
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.abstract().returns(<emptyTree>::<C String>)
+    end
+
+    def qux<<todo method>>(&<blk>)
+      @qux
+    end
+
+    ::Sorbet::Private::Static.sig(<self>) do ||
+      <self>.params(:qux, <emptyTree>::<C String>).abstract().returns(<emptyTree>::<C String>)
+    end
+
+    def qux=<<todo method>>(qux, &<blk>)
+      @qux = qux
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>, <emptyTree>::<C T>::<C Helpers>)
+
+    <self>.abstract!()
+
+    <runtime method definition of foo>
+
+    <runtime method definition of bar=>
+
+    <runtime method definition of qux>
+
+    <runtime method definition of qux=>
+  end
+end

--- a/test/testdata/rewriter/attr_abstract.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/attr_abstract.rb.rewrite-tree.exp
@@ -5,7 +5,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<todo method>>(&<blk>)
-      @foo
+      <emptyTree>
     end
 
     ::Sorbet::Private::Static.sig(<self>) do ||
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def bar=<<todo method>>(bar, &<blk>)
-      @bar = bar
+      <emptyTree>
     end
 
     ::Sorbet::Private::Static.sig(<self>) do ||
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def qux<<todo method>>(&<blk>)
-      @qux
+      <emptyTree>
     end
 
     ::Sorbet::Private::Static.sig(<self>) do ||
@@ -29,7 +29,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def qux=<<todo method>>(qux, &<blk>)
-      @qux = qux
+      <emptyTree>
     end
 
     <self>.extend(<emptyTree>::<C T>::<C Sig>, <emptyTree>::<C T>::<C Helpers>)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Less boilerplate when defining abstract methods.

At runtime, this will still behave the same way as always: the `sig` will
evaluate, notice that it's abstract, and replace the method with something that
either raises or calls `super`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.