### PR TITLE
Some slight renamings in Import struct

### DIFF
--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -28,19 +28,6 @@ enum class ImportType {
     TestUnit,
 };
 
-struct Import {
-    MangledName name;
-    ImportType type;
-    core::LocOffsets loc;
-
-    Import(core::packages::MangledName &&name, core::packages::ImportType type, core::LocOffsets loc)
-        : name(std::move(name)), type(type), loc(loc) {}
-
-    bool isTestImport() const {
-        return type != core::packages::ImportType::Normal;
-    }
-};
-
 enum class VisibleToType {
     Normal,
     Wildcard,
@@ -54,6 +41,19 @@ enum class StrictDependenciesLevel {
 };
 
 std::string_view strictDependenciesLevelToString(core::packages::StrictDependenciesLevel level);
+
+struct Import {
+    MangledName mangledName;
+    ImportType type;
+    core::LocOffsets loc;
+
+    Import(MangledName mangledName, ImportType type, core::LocOffsets loc)
+        : mangledName(mangledName), type(type), loc(loc) {}
+
+    bool isTestImport() const {
+        return type != ImportType::Normal;
+    }
+};
 
 // TODO(jez) Why is this struct different from the `struct VisibleTo` defined in packager.cc?
 struct VisibleTo {

--- a/packager/ComputePackageSCCs.h
+++ b/packager/ComputePackageSCCs.h
@@ -66,13 +66,13 @@ class ComputePackageSCCs {
             }
             // We need to be careful with this; it's not valid after a call to `strongConnect`,
             // because our reference might disappear from underneath us during that call.
-            auto &importInfo = this->nodeMap[i.name];
+            auto &importInfo = this->nodeMap[i.mangledName];
             if (importInfo.index == NodeInfo::UNVISITED) {
                 // This is a tree edge (ie. a forward edge that we haven't visited yet).
-                this->strongConnect<EdgeType>(i.name, importInfo, packageGraph);
+                this->strongConnect<EdgeType>(i.mangledName, importInfo, packageGraph);
 
                 // Need to re-lookup for the reason above.
-                auto &importInfo = this->nodeMap[i.name];
+                auto &importInfo = this->nodeMap[i.mangledName];
                 if (importInfo.index == NodeInfo::UNVISITED) {
                     // This is to handle early return above.
                     continue;
@@ -138,14 +138,14 @@ class ComputePackageSCCs {
                     }
 
                     // The mangled name won't exist if the import was to a package that doesn't exist.
-                    if (!i.name.exists()) {
+                    if (!i.mangledName.exists()) {
                         continue;
                     }
 
                     // All of the imports of every member of the SCC will have been processed in the recursive step, so
                     // we can assume the scc id of the target exists. Additionally, all imports are to the original
                     // application code, which is why we don't consider using the `testSccID` here.
-                    auto impId = packageGraph.getSCCId(i.name);
+                    auto impId = packageGraph.getSCCId(i.mangledName);
                     if (impId == sccId) {
                         continue;
                     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I had made these changes in a stacked change of mine. It's a little
easier for me to use these names (fewer conflicts).

The one behavior change is that we don't need an rvalue reference for
MangledName, because it's trivially copyable.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests