### PR TITLE
Nearly entirely remove FullyQualifiedName

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -17,11 +17,6 @@ public:
         return MangledName();
     }
 
-    absl::Span<const core::NameRef> fullName() const {
-        notImplemented();
-        return absl::Span<const core::NameRef>();
-    }
-
     absl::Span<const string> pathPrefixes() const {
         notImplemented();
         return absl::Span<const string>();

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -37,41 +37,4 @@ string PackageInfo::show(const core::GlobalState &gs) const {
     return this->mangledName().owner.show(gs);
 }
 
-namespace {
-
-core::ClassOrModuleRef lookupNameOn(const core::GlobalState &gs, const core::ClassOrModuleRef root,
-                                    absl::Span<const core::NameRef> name) {
-    auto curSym = root;
-    if (!curSym.exists()) {
-        return {};
-    }
-
-    for (const auto part : name) {
-        auto member = curSym.data(gs)->findMember(gs, part);
-        if (!member.exists() || !member.isClassOrModule()) {
-            return {};
-        }
-        curSym = member.asClassOrModuleRef();
-    }
-
-    return curSym;
-}
-
-} // namespace
-
-core::ClassOrModuleRef PackageInfo::getPackageScope(const core::GlobalState &gs) const {
-    // return lookupNameOn(gs, core::Symbols::root(), fullName());
-    Exception::notImplemented();
-}
-
-core::ClassOrModuleRef PackageInfo::getPackageTestScope(const core::GlobalState &gs) const {
-    auto testSym = core::Symbols::root().data(gs)->findMember(gs, core::Names::Constants::Test());
-    if (!testSym.isClassOrModule()) {
-        return {};
-    }
-
-    // return lookupNameOn(gs, testSym.asClassOrModuleRef(), fullName());
-    Exception::notImplemented();
-}
-
 } // namespace sorbet::core::packages

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -34,8 +34,7 @@ PackageInfo::~PackageInfo() {
 }
 
 string PackageInfo::show(const core::GlobalState &gs) const {
-    return absl::StrJoin(fullName(),
-                         "::", [&](string *out, core::NameRef name) { absl::StrAppend(out, name.show(gs)); });
+    return this->mangledName().owner.show(gs);
 }
 
 namespace {
@@ -61,7 +60,8 @@ core::ClassOrModuleRef lookupNameOn(const core::GlobalState &gs, const core::Cla
 } // namespace
 
 core::ClassOrModuleRef PackageInfo::getPackageScope(const core::GlobalState &gs) const {
-    return lookupNameOn(gs, core::Symbols::root(), fullName());
+    // return lookupNameOn(gs, core::Symbols::root(), fullName());
+    Exception::notImplemented();
 }
 
 core::ClassOrModuleRef PackageInfo::getPackageTestScope(const core::GlobalState &gs) const {
@@ -70,7 +70,8 @@ core::ClassOrModuleRef PackageInfo::getPackageTestScope(const core::GlobalState 
         return {};
     }
 
-    return lookupNameOn(gs, testSym.asClassOrModuleRef(), fullName());
+    // return lookupNameOn(gs, testSym.asClassOrModuleRef(), fullName());
+    Exception::notImplemented();
 }
 
 } // namespace sorbet::core::packages

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -92,9 +92,6 @@ public:
     virtual bool exists() const final;
     std::string show(const core::GlobalState &gs) const;
 
-    core::ClassOrModuleRef getPackageScope(const core::GlobalState &gs) const;
-    core::ClassOrModuleRef getPackageTestScope(const core::GlobalState &gs) const;
-
     virtual std::optional<ImportType> importsPackage(MangledName mangledName) const = 0;
 
     // Is it a layering violation to import otherPkg from this package?

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -67,7 +67,6 @@ struct VisibleTo {
 class PackageInfo {
 public:
     virtual MangledName mangledName() const = 0;
-    virtual absl::Span<const core::NameRef> fullName() const = 0;
     virtual absl::Span<const std::string> pathPrefixes() const = 0;
     virtual std::vector<VisibleTo> visibleTo() const = 0;
     virtual std::unique_ptr<PackageInfo> deepCopy() const = 0;

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -346,11 +346,11 @@ public:
 
         bool isExported = pkg.exportAll();
         if (litSymbol.isClassOrModule()) {
-            isExported |= litSymbol.asClassOrModuleRef().data(ctx)->flags.isExported;
+            isExported = isExported || litSymbol.asClassOrModuleRef().data(ctx)->flags.isExported;
         } else if (litSymbol.isFieldOrStaticField()) {
-            isExported |= litSymbol.asFieldRef().data(ctx)->flags.isExported;
+            isExported = isExported || litSymbol.asFieldRef().data(ctx)->flags.isExported;
         }
-        isExported |= db.allowRelaxedPackagerChecksFor(this->package.mangledName());
+        isExported = isExported || db.allowRelaxedPackagerChecksFor(this->package.mangledName());
         bool definesBehavior =
             !litSymbol.isClassOrModule() || litSymbol.asClassOrModuleRef().data(ctx)->flags.isBehaviorDefining;
         auto currentImportType = this->package.importsPackage(otherPackage);

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -73,22 +73,6 @@ struct FullyQualifiedName {
     FullyQualifiedName &operator=(const FullyQualifiedName &) = delete;
     FullyQualifiedName &operator=(FullyQualifiedName &&) = default;
 
-    FullyQualifiedName withPrefix(core::NameRef prefix) const {
-        vector<core::NameRef> prefixed(parts.size() + 1);
-        prefixed[0] = prefix;
-        std::copy(parts.begin(), parts.end(), prefixed.begin() + 1);
-        ENFORCE(prefixed.size() == parts.size() + 1);
-        return move(prefixed);
-    }
-
-    bool isSuffix(const FullyQualifiedName &prefix) const {
-        if (prefix.parts.size() >= parts.size()) {
-            return false;
-        }
-
-        return std::equal(prefix.parts.begin(), prefix.parts.end(), parts.begin());
-    }
-
     string show(const core::GlobalState &gs) const {
         return absl::StrJoin(parts, "::", core::packages::NameFormatter(gs));
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

As we move towards having the package database in the symbol table, we want to
get rid of all the `vector<NameRef>` structures, and instead track simple
SymbolRefs.

This PR removes `FullyQualifiedName` everywhere but `Export`.

I also have some work in progress to remove them from Export, but involves a
slightly more involved refactor, so I will do that another time.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests