### PR TITLE
Fix puts / p param types

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -1920,7 +1920,7 @@ module Kernel
   # ```
   sig do
     params(
-        arg0: BasicObject,
+        arg0: Object,
     )
     .returns(NilClass)
   end
@@ -1954,7 +1954,7 @@ module Kernel
   # ```
   sig do
     params(
-        arg0: BasicObject,
+        arg0: Object,
     )
     .returns(NilClass)
   end

--- a/test/cli/track-untyped/test.out
+++ b/test/cli/track-untyped/test.out
@@ -28,9 +28,9 @@ a.rb:8: Conditional branch on `T.untyped` https://srb.help/7018
 a.rb:9: Argument passed to parameter `arg0` is `T.untyped` https://srb.help/7018
      9 |    puts(result)
                  ^^^^^^
-  Expected `BasicObject` for argument `arg0` of method `Kernel#puts`:
+  Expected `Object` for argument `arg0` of method `Kernel#puts`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED:
-      NN |        arg0: BasicObject,
+      NN |        arg0: Object,
                   ^^^^
   Got `T.untyped` originating from:
     a.rb:6:
@@ -128,9 +128,9 @@ a.rb:8: Conditional branch on `T.untyped` https://srb.help/7018
 a.rb:9: Argument passed to parameter `arg0` is `T.untyped` https://srb.help/7018
      9 |    puts(result)
                  ^^^^^^
-  Expected `BasicObject` for argument `arg0` of method `Kernel#puts`:
+  Expected `Object` for argument `arg0` of method `Kernel#puts`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED:
-      NN |        arg0: BasicObject,
+      NN |        arg0: Object,
                   ^^^^
   Got `T.untyped` originating from:
     a.rb:6:
@@ -226,9 +226,9 @@ a.rb:8: Conditional branch on `T.untyped` https://srb.help/7018
 a.rb:9: Argument passed to parameter `arg0` is `T.untyped` https://srb.help/7018
      9 |    puts(result)
                  ^^^^^^
-  Expected `BasicObject` for argument `arg0` of method `Kernel#puts`:
+  Expected `Object` for argument `arg0` of method `Kernel#puts`:
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED:
-      NN |        arg0: BasicObject,
+      NN |        arg0: Object,
                   ^^^^
   Got `T.untyped` originating from:
     a.rb:6:

--- a/test/testdata/compiler/t_enum_type_test.rb
+++ b/test/testdata/compiler/t_enum_type_test.rb
@@ -34,10 +34,8 @@ class Main
   end
 end
 
-p Main.takes_a_or_b(T.unsafe(MyEnum::A))
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Object` but found `BasicObject` for argument `arg0`
-p Main.takes_a_or_b(T.unsafe(MyEnum::B))
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Object` but found `BasicObject` for argument `arg0`
+Main.takes_a_or_b(T.unsafe(MyEnum::A))
+Main.takes_a_or_b(T.unsafe(MyEnum::B))
 begin
   Main.takes_a_or_b(T.unsafe(MyEnum::C))
 rescue TypeError => exn
@@ -45,19 +43,13 @@ rescue TypeError => exn
 end
 
 begin
-  p Main.takes_c(T.unsafe(MyEnum::A))
-  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Object` but found `BasicObject` for argument `arg0`
+  Main.takes_c(T.unsafe(MyEnum::A))
 rescue TypeError => exn
   puts exn.message.match(/Expected.*/).to_s
 end
-p Main.takes_c(T.unsafe(MyEnum::C))
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Object` but found `BasicObject` for argument `arg0`
+Main.takes_c(T.unsafe(MyEnum::C))
 
-p Main.some_common_cases(T.unsafe(MyEnum::A))
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Object` but found `BasicObject` for argument `arg0`
-p Main.some_common_cases(T.unsafe(MyEnum::B))
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Object` but found `BasicObject` for argument `arg0`
-p Main.some_common_cases(T.unsafe(MyEnum::C))
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Object` but found `BasicObject` for argument `arg0`
-p Main.some_common_cases(T.unsafe(MyEnum::D))
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Object` but found `BasicObject` for argument `arg0`
+Main.some_common_cases(T.unsafe(MyEnum::A))
+Main.some_common_cases(T.unsafe(MyEnum::B))
+Main.some_common_cases(T.unsafe(MyEnum::C))
+Main.some_common_cases(T.unsafe(MyEnum::D))

--- a/test/testdata/compiler/t_enum_type_test.rb
+++ b/test/testdata/compiler/t_enum_type_test.rb
@@ -35,7 +35,9 @@ class Main
 end
 
 p Main.takes_a_or_b(T.unsafe(MyEnum::A))
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Object` but found `BasicObject` for argument `arg0`
 p Main.takes_a_or_b(T.unsafe(MyEnum::B))
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Object` but found `BasicObject` for argument `arg0`
 begin
   Main.takes_a_or_b(T.unsafe(MyEnum::C))
 rescue TypeError => exn
@@ -44,12 +46,18 @@ end
 
 begin
   p Main.takes_c(T.unsafe(MyEnum::A))
+  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Object` but found `BasicObject` for argument `arg0`
 rescue TypeError => exn
   puts exn.message.match(/Expected.*/).to_s
 end
 p Main.takes_c(T.unsafe(MyEnum::C))
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Object` but found `BasicObject` for argument `arg0`
 
 p Main.some_common_cases(T.unsafe(MyEnum::A))
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Object` but found `BasicObject` for argument `arg0`
 p Main.some_common_cases(T.unsafe(MyEnum::B))
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Object` but found `BasicObject` for argument `arg0`
 p Main.some_common_cases(T.unsafe(MyEnum::C))
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Object` but found `BasicObject` for argument `arg0`
 p Main.some_common_cases(T.unsafe(MyEnum::D))
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `Object` but found `BasicObject` for argument `arg0`

--- a/test/testdata/lsp/go_to_type_definition.rb
+++ b/test/testdata/lsp/go_to_type_definition.rb
@@ -42,12 +42,12 @@ class TestClass
   #    ^ type: AB
 
   m_or_n = T.cast(nil, T.all(M, N))
-  puts m_or_n
-  #    ^^^^^^ error: Expected `Object` but found `T.all(M, N)` for argument `arg0`
+  m_or_n
+# ^ type: MN
 
   a_or_b_or_mn = T.let(A.new, T.any(A, B, T.all(M, N)))
-  puts a_or_b_or_mn
-  #    ^^^^^^^^^^^^ error: Expected `Object` but found `T.any(A, B, T.all(M, N))` for argument `arg0`
+  a_or_b_or_mn
+# ^ type: ABMN
 
   def example(x)
     #         ^ type: (nothing)

--- a/test/testdata/lsp/go_to_type_definition.rb
+++ b/test/testdata/lsp/go_to_type_definition.rb
@@ -43,11 +43,11 @@ class TestClass
 
   m_or_n = T.cast(nil, T.all(M, N))
   puts m_or_n
-  #    ^ type: MN
+  #    ^^^^^^ error: Expected `Object` but found `T.all(M, N)` for argument `arg0`
 
   a_or_b_or_mn = T.let(A.new, T.any(A, B, T.all(M, N)))
   puts a_or_b_or_mn
-  #    ^ type: ABMN
+  #    ^^^^^^^^^^^^ error: Expected `Object` but found `T.any(A, B, T.all(M, N))` for argument `arg0`
 
   def example(x)
     #         ^ type: (nothing)


### PR DESCRIPTION
```
[1] pry(main)> puts BasicObject.new
NoMethodError: undefined method `to_s' for an instance of BasicObject (NoMethodError)
from (pry):1:in `puts'
[2] pry(main)> puts Object.new
#<Object:0x000000011f83a458>
=> nil
[3] pry(main)> p BasicObject.new
NoMethodError: undefined method `inspect' for an instance of BasicObject (NoMethodError)
from (pry):3:in `p'
[4] pry(main)> p Object.new
#<Object:0x000000011e33ad78>
=> #<Object:0x000000011e33ad78>
```

(Note that the return type of `p` is incorrect, but that is left for a future PR.)