### PR TITLE
Deduplicate block desugar logic

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -771,17 +771,17 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     flags.isPrivateOk = true;
                 }
 
+                auto methodName = MK::Symbol(locZeroLen, send->method);
+
                 // Pop the BlockPass off the end of the arguments, if there is one.
-                unique_ptr<parser::Node> block;
-                bool anonymousBlockPass = false;
-                core::LocOffsets bpLoc;
+                ExpressionPtr block;
                 if (!send->args.empty() && parser::isa_node<parser::BlockPass>(send->args.back().get())) {
                     auto *bp = parser::cast_node<parser::BlockPass>(send->args.back().get());
                     if (bp->block == nullptr) {
-                        anonymousBlockPass = true;
-                        bpLoc = bp->loc;
+                        // Replace an anonymous block pass like `f(&)` with a local variable reference, like `f(&&)`.
+                        block = MK::Local(bp->loc, core::Names::ampersand());
                     } else {
-                        block = move(bp->block);
+                        block = node2TreeImpl(dctx, bp->block);
                     }
 
                     send->args.pop_back();
@@ -811,7 +811,9 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         [&](parser::ForwardedArgs *fwdArgs) {
                             // Pull out the ForwardedArgs (the `...` argument in a method call, like `foo(...)`)
                             hasFwdArgs = true;
-                            block = make_unique<parser::LVar>(loc, core::Names::fwdBlock());
+                            ENFORCE(block == nullptr, "The parser should have rejected `foo(&, ...)`");
+                            // Desugar a call like `foo(...)` so it has a block argument like `foo(..., &<fwd-block>)`.
+                            block = MK::Local(loc, core::Names::fwdBlock());
                             eraseFromArgs = true;
                         },
                         [&](parser::ForwardedRestArg *fwdRestArg) {
@@ -887,31 +889,22 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         kwargs = MK::Nil(loc);
                     }
 
-                    auto method = MK::Symbol(locZeroLen, send->method);
-
                     Send::ARGS_store sendargs;
                     sendargs.emplace_back(move(rec));
-                    sendargs.emplace_back(move(method));
+                    sendargs.emplace_back(move(methodName));
                     sendargs.emplace_back(move(args));
                     sendargs.emplace_back(move(kwargs));
                     ExpressionPtr res;
-                    if (block == nullptr && !anonymousBlockPass) {
+                    if (block == nullptr) {
                         res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplat(), send->methodLoc, 4,
                                        move(sendargs), flags);
                     } else {
-                        ExpressionPtr convertedBlock;
-                        if (anonymousBlockPass) {
-                            ENFORCE(block == nullptr, "encountered a block while processing an anonymous block pass");
-                            convertedBlock = MK::Local(bpLoc, core::Names::ampersand());
-                        } else {
-                            convertedBlock = node2TreeImpl(dctx, block);
-                        }
-                        if (auto lit = cast_tree<Literal>(convertedBlock); lit && lit->isSymbol()) {
+                        if (auto lit = cast_tree<Literal>(block); lit && lit->isSymbol()) {
                             res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplat(), send->methodLoc, 4,
                                            move(sendargs), flags);
-                            ast::cast_tree_nonnull<ast::Send>(res).setBlock(symbol2Proc(dctx, move(convertedBlock)));
+                            ast::cast_tree_nonnull<ast::Send>(res).setBlock(symbol2Proc(dctx, move(block)));
                         } else {
-                            sendargs.emplace_back(move(convertedBlock));
+                            sendargs.emplace_back(move(block));
                             res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplatAndBlock(), send->methodLoc,
                                            5, move(sendargs), flags);
                         }
@@ -936,27 +929,19 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     DuplicateHashKeyCheck::checkSendArgs(dctx, numPosArgs, args);
 
                     ExpressionPtr res;
-                    if (block == nullptr && !anonymousBlockPass) {
+                    if (block == nullptr) {
                         res = MK::Send(loc, move(rec), send->method, send->methodLoc, numPosArgs, move(args), flags);
                     } else {
-                        auto method = MK::Symbol(locZeroLen, send->method);
-                        ExpressionPtr convertedBlock;
-                        if (anonymousBlockPass) {
-                            ENFORCE(block == nullptr, "encountered a block while processing an anonymous block pass");
-                            convertedBlock = MK::Local(bpLoc, core::Names::ampersand());
-                        } else {
-                            convertedBlock = node2TreeImpl(dctx, block);
-                        }
-                        if (auto lit = cast_tree<Literal>(convertedBlock); lit && lit->isSymbol()) {
+                        if (auto lit = cast_tree<Literal>(block); lit && lit->isSymbol()) {
                             res =
                                 MK::Send(loc, move(rec), send->method, send->methodLoc, numPosArgs, move(args), flags);
-                            ast::cast_tree_nonnull<ast::Send>(res).setBlock(symbol2Proc(dctx, move(convertedBlock)));
+                            ast::cast_tree_nonnull<ast::Send>(res).setBlock(symbol2Proc(dctx, move(block)));
                         } else {
                             Send::ARGS_store sendargs;
                             sendargs.reserve(3 + args.size());
                             sendargs.emplace_back(move(rec));
-                            sendargs.emplace_back(move(method));
-                            sendargs.emplace_back(move(convertedBlock));
+                            sendargs.emplace_back(move(methodName));
+                            sendargs.emplace_back(move(block));
 
                             numPosArgs += 3;
 

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -775,17 +775,17 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     flags.isPrivateOk = true;
                 }
 
+                auto methodName = MK::Symbol(locZeroLen, send->method);
+
                 // Pop the BlockPass off the end of the arguments, if there is one.
-                unique_ptr<parser::Node> block;
-                bool anonymousBlockPass = false;
-                core::LocOffsets bpLoc;
+                ExpressionPtr block;
                 if (!send->args.empty() && parser::NodeWithExpr::isa_node<parser::BlockPass>(send->args.back().get())) {
                     auto *bp = parser::NodeWithExpr::cast_node<parser::BlockPass>(send->args.back().get());
                     if (bp->block == nullptr) {
-                        anonymousBlockPass = true;
-                        bpLoc = bp->loc;
+                        // Replace an anonymous block pass like `f(&)` with a local variable reference, like `f(&&)`.
+                        block = MK::Local(bp->loc, core::Names::ampersand());
                     } else {
-                        block = move(bp->block);
+                        block = node2TreeImpl(dctx, bp->block);
                     }
 
                     send->args.pop_back();
@@ -814,8 +814,12 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         arg.get(),
                         [&](parser::ForwardedArgs *fwdArgs) {
                             // Pull out the ForwardedArgs (the `...` argument in a method call, like `foo(...)`)
+
+                            ENFORCE(block == nullptr, "The parser should have rejected `foo(&, ...)`");
+                            // Desugar a call like `foo(...)` so it has a block argument like `foo(..., &<fwd-block>)`.
+                            block = MK::Local(loc, core::Names::fwdBlock());
+
                             hasFwdArgs = true;
-                            block = make_unique<parser::LVar>(loc, core::Names::fwdBlock());
                             eraseFromArgs = true;
                         },
                         [&](parser::ForwardedRestArg *fwdRestArg) {
@@ -891,31 +895,22 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         kwargs = MK::Nil(loc);
                     }
 
-                    auto method = MK::Symbol(locZeroLen, send->method);
-
                     Send::ARGS_store sendargs;
                     sendargs.emplace_back(move(rec));
-                    sendargs.emplace_back(move(method));
+                    sendargs.emplace_back(move(methodName));
                     sendargs.emplace_back(move(args));
                     sendargs.emplace_back(move(kwargs));
                     ExpressionPtr res;
-                    if (block == nullptr && !anonymousBlockPass) {
+                    if (block == nullptr) {
                         res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplat(), send->methodLoc, 4,
                                        move(sendargs), flags);
                     } else {
-                        ExpressionPtr convertedBlock;
-                        if (anonymousBlockPass) {
-                            ENFORCE(block == nullptr, "encountered a block while processing an anonymous block pass");
-                            convertedBlock = MK::Local(bpLoc, core::Names::ampersand());
-                        } else {
-                            convertedBlock = node2TreeImpl(dctx, block);
-                        }
-                        if (auto lit = cast_tree<Literal>(convertedBlock); lit && lit->isSymbol()) {
+                        if (auto lit = cast_tree<Literal>(block); lit && lit->isSymbol()) {
                             res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplat(), send->methodLoc, 4,
                                            move(sendargs), flags);
-                            ast::cast_tree_nonnull<ast::Send>(res).setBlock(symbol2Proc(dctx, move(convertedBlock)));
+                            ast::cast_tree_nonnull<ast::Send>(res).setBlock(symbol2Proc(dctx, move(block)));
                         } else {
-                            sendargs.emplace_back(move(convertedBlock));
+                            sendargs.emplace_back(move(block));
                             res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplatAndBlock(), send->methodLoc,
                                            5, move(sendargs), flags);
                         }
@@ -940,27 +935,19 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     DuplicateHashKeyCheck::checkSendArgs(dctx, numPosArgs, args);
 
                     ExpressionPtr res;
-                    if (block == nullptr && !anonymousBlockPass) {
+                    if (block == nullptr) {
                         res = MK::Send(loc, move(rec), send->method, send->methodLoc, numPosArgs, move(args), flags);
                     } else {
-                        auto method = MK::Symbol(locZeroLen, send->method);
-                        ExpressionPtr convertedBlock;
-                        if (anonymousBlockPass) {
-                            ENFORCE(block == nullptr, "encountered a block while processing an anonymous block pass");
-                            convertedBlock = MK::Local(bpLoc, core::Names::ampersand());
-                        } else {
-                            convertedBlock = node2TreeImpl(dctx, block);
-                        }
-                        if (auto lit = cast_tree<Literal>(convertedBlock); lit && lit->isSymbol()) {
+                        if (auto lit = cast_tree<Literal>(block); lit && lit->isSymbol()) {
                             res =
                                 MK::Send(loc, move(rec), send->method, send->methodLoc, numPosArgs, move(args), flags);
-                            ast::cast_tree_nonnull<ast::Send>(res).setBlock(symbol2Proc(dctx, move(convertedBlock)));
+                            ast::cast_tree_nonnull<ast::Send>(res).setBlock(symbol2Proc(dctx, move(block)));
                         } else {
                             Send::ARGS_store sendargs;
                             sendargs.reserve(3 + args.size());
                             sendargs.emplace_back(move(rec));
-                            sendargs.emplace_back(move(method));
-                            sendargs.emplace_back(move(convertedBlock));
+                            sendargs.emplace_back(move(methodName));
+                            sendargs.emplace_back(move(block));
 
                             numPosArgs += 3;
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -324,6 +324,8 @@ pipeline_tests(
             "testdata/deviations/keyword_method_names.rb",
             "testdata/rewriter/minitest_empty_test_each.rb",
             "testdata/infer/crash_after_parse_errors.rb",
+            "testdata/parser/invalid_def_block_param_after_forward.rb",
+            "testdata/parser/invalid_def_forward_after_block_param.rb",
 
             # Sorbets' parser incorrectly accepts invalid syntax
             "testdata/desugar/pattern_matching_hash.rb",  # See https://github.com/Shopify/sorbet/issues/362

--- a/test/testdata/parser/invalid_def_block_param_after_forward.parse-tree.exp
+++ b/test/testdata/parser/invalid_def_block_param_after_forward.parse-tree.exp
@@ -1,0 +1,3 @@
+String {
+  val = <U The body of the invalid method>
+}

--- a/test/testdata/parser/invalid_def_block_param_after_forward.rb
+++ b/test/testdata/parser/invalid_def_block_param_after_forward.rb
@@ -1,0 +1,10 @@
+# typed: true
+
+# This parser behaviour is really bizarre, and depends on whether `#invalid` has an empty body or not.
+# It seems to replace the entire `def invalid` node with whatever comes after that line.
+# If `#invalid` has an empty body, then it would take the next method.
+
+def invalid(&, ...)
+  #          ^ error: unexpected token ","
+  "The body of the invalid method"
+end

--- a/test/testdata/parser/invalid_def_forward_after_block_param.parse-tree.exp
+++ b/test/testdata/parser/invalid_def_forward_after_block_param.parse-tree.exp
@@ -1,0 +1,3 @@
+String {
+  val = <U The body of the invalid method>
+}

--- a/test/testdata/parser/invalid_def_forward_after_block_param.rb
+++ b/test/testdata/parser/invalid_def_forward_after_block_param.rb
@@ -1,0 +1,10 @@
+# typed: true
+
+# This parser behaviour is really bizarre, and depends on whether `#invalid` has an empty body or not.
+# It seems to replace the entire `def invalid` node with whatever comes after that line.
+# If `#invalid` has an empty body, then it would take the next method.
+
+def invalid(&, ...)
+  #          ^ error: unexpected token ","
+  "The body of the invalid method"
+end


### PR DESCRIPTION
### Motivation

Rather than tracking state like `bool anonymousBlockPass` and `core::LocOffsets bpLoc` to act on it later (twice), just desugar the block immediately. This lets us clean up the two copies of the same logic.

Follow-up to #9141

### Test plan

Pure refactor, covered by existing tests.