### PR TITLE
Move `renderPath` helper out of `PackageInfo`

### DIFF
--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -390,7 +390,7 @@ StrictDependenciesLevel PackageInfo::minimumStrictDependenciesLevel() const {
     }
 }
 
-string PackageInfo::renderPath(const core::GlobalState &gs, const vector<MangledName> &path) const {
+string renderPath(const core::GlobalState &gs, const vector<MangledName> &path) {
     // TODO(neil): if the cycle has a large number of nodes (10?), show partial path (first 5, ... (n omitted), last
     // 5) to prevent error being too long
     // Note: This function iterates through path in reverse order because pathTo generates it in that order, so

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -241,8 +241,6 @@ public:
     // What is the minimum strict dependencies level that this package's imports must have?
     StrictDependenciesLevel minimumStrictDependenciesLevel() const;
 
-    std::string renderPath(const core::GlobalState &gs, const std::vector<MangledName> &path) const;
-
     // Returns a string representing the path to the given package from this package, if it exists. Note: this only
     // looks at non-test imports.
     std::optional<std::string> pathTo(const core::GlobalState &gs, const MangledName dest) const;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Not used anywhere else.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
