### PR TITLE
Two more minitest memory improvements

### DIFF
--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -108,7 +108,7 @@ public:
 };
 
 ast::ExpressionPtr addSigVoid(core::Context ctx, ast::ExpressionPtr expr) {
-    if (ctx.file.data(ctx).strictLevel >= core::StrictLevel::Strict) {
+    if (ctx.file.data(ctx).strictLevel < core::StrictLevel::Strict) {
         // Only add a dummy sig if it would be required (because the file is `# typed: strict`).
         // This is to save memory (and possibly also typechecking runtime).
         //

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -107,7 +107,19 @@ public:
     }
 };
 
-ast::ExpressionPtr addSigVoid(ast::ExpressionPtr expr) {
+ast::ExpressionPtr addSigVoid(core::Context ctx, ast::ExpressionPtr expr) {
+    if (ctx.file.data(ctx).strictLevel >= core::StrictLevel::Strict) {
+        // Only add a dummy sig if it would be required (because the file is `# typed: strict`).
+        // This is to save memory (and possibly also typechecking runtime).
+        //
+        // Another alternative if this approach becomes problematic would be to set some sort of
+        // flag on MethodDef that says to suppress the "missing sig" error, or to implicitly assume
+        // a sig of `sig { void }` or something.
+        //
+        // For example, in a world where all tests are `# typed: strict`, this approach saves no memory.
+        return expr;
+    }
+
     core::LocOffsets declLoc;
     if (auto mdef = ast::cast_tree<ast::MethodDef>(expr)) {
         declLoc = mdef->declLoc;
@@ -264,7 +276,7 @@ ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName
                                             send->loc.copyWithZeroLength(), move(blk));
             // put that into a method def named the appropriate thing
             auto declLoc = declLocForSendWithBlock(*send);
-            auto method = addSigVoid(ast::MK::SyntheticMethod0(send->loc, declLoc, move(name), move(each)));
+            auto method = addSigVoid(ctx, ast::MK::SyntheticMethod0(send->loc, declLoc, move(name), move(each)));
             // add back any moved constants
             return constantMover.addConstantsToExpression(send->loc, move(method));
         } else if (send->fun == core::Names::describe() && send->numPosArgs() == 1 && correctBlockArity) {
@@ -415,8 +427,9 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
         ConstantMover constantMover;
         ast::TreeWalk::apply(ctx, constantMover, block->body);
         auto declLoc = declLocForSendWithBlock(*send);
-        auto method = addSigVoid(ast::MK::SyntheticMethod0(
-            send->loc, declLoc, name, prepareBody(ctx, isClass, std::move(block->body), insideDescribe)));
+        auto method = addSigVoid(
+            ctx, ast::MK::SyntheticMethod0(send->loc, declLoc, name,
+                                           prepareBody(ctx, isClass, std::move(block->body), insideDescribe)));
         return constantMover.addConstantsToExpression(send->loc, move(method));
     }
 
@@ -465,7 +478,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
         // defined methods, we don't actually need to care about the RuntimeMethodDefinition, and
         // omitting it saves memory.
         ast::cast_tree_nonnull<ast::MethodDef>(method).flags.discardDef = true;
-        method = addSigVoid(move(method));
+        method = addSigVoid(ctx, move(method));
         if (!ast::isa_tree<ast::Literal>(arg)) {
             method = ast::MK::InsSeq1(send->loc, send->getPosArg(0).deepCopy(), move(method));
         }

--- a/test/testdata/rewriter/before_do.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/before_do.rb.rewrite-tree.exp
@@ -16,10 +16,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C MyTestParent><<C <todo sym>>> < (<emptyTree>::<C MyTestGrandParent>)
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <before><<todo method>>(&<blk>)
       @x = <cast:let>(1, <todo sym>, <emptyTree>::<C Integer>)
     end
@@ -39,10 +35,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <runtime method definition of initialize>
 
     class <emptyTree>::<C <describe 'example'>><<C <todo sym>>> < (<self>)
-      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-        <self>.void()
-      end
-
       def <it 'does thing'><<todo method>>(&<blk>)
         <emptyTree>::<C T>.reveal_type(@x)
       end

--- a/test/testdata/rewriter/before_do.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/before_do.rb.rewrite-tree.exp
@@ -16,6 +16,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C MyTestParent><<C <todo sym>>> < (<emptyTree>::<C MyTestGrandParent>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
     def <before><<todo method>>(&<blk>)
       @x = <cast:let>(1, <todo sym>, <emptyTree>::<C Integer>)
     end
@@ -35,6 +39,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <runtime method definition of initialize>
 
     class <emptyTree>::<C <describe 'example'>><<C <todo sym>>> < (<self>)
+      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+        <self>.void()
+      end
+
       def <it 'does thing'><<todo method>>(&<blk>)
         <emptyTree>::<C T>.reveal_type(@x)
       end

--- a/test/testdata/rewriter/before_do.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/before_do.rb.rewrite-tree.exp
@@ -46,8 +46,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       def <it 'does thing'><<todo method>>(&<blk>)
         <emptyTree>::<C T>.reveal_type(@x)
       end
-
-      <runtime method definition of <it 'does thing'>>
     end
   end
 end

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -8,40 +8,20 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it 'works outside'><<todo method>>(&<blk>)
       <self>.outside_method()
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
     end
 
     def <it 'allows constants inside of IT'><<todo method>>(&<blk>)
       ::Module.const_set(:CONST, 10)
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it 'allows let-ed constants inside of IT'><<todo method>>(&<blk>)
       ::Module.const_set(:C2, <cast:let>(10, <todo sym>, <emptyTree>::<C Integer>))
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it 'allows path constants inside of IT'><<todo method>>(&<blk>)
       <emptyTree>::<C C3>.new()
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
     end
 
     def <it '::<Magic>.<string-interpolate>("finds errors in the test name: ", <self>.bad_variable())'><<todo method>>(&<blk>)
@@ -52,10 +32,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <before><<todo method>>(&<blk>)
       begin
         @foo = <cast:let>(3, <todo sym>, <emptyTree>::<C Integer>)
@@ -63,19 +39,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <after><<todo method>>(&<blk>)
       begin
         @foo = nil
         <self>.instance_helper()
       end
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
     end
 
     def <it 'can read foo'><<todo method>>(&<blk>)
@@ -120,10 +88,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <emptyTree>
       end
 
-      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-        <self>.void()
-      end
-
       def <it 'works inside'><<todo method>>(&<blk>)
         begin
           <self>.outside_method()
@@ -147,16 +111,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C <describe 'Object'>><<C <todo sym>>> < (<self>)
-      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-        <self>.void()
-      end
-
       def <it 'Object'><<todo method>>(&<blk>)
         <emptyTree>
-      end
-
-      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-        <self>.void()
       end
 
       def <it 'Object'><<todo method>>(&<blk>)
@@ -183,10 +139,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C <describe 'a non-ideal situation'>><<C <todo sym>>> < (<self>)
-      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-        <self>.void()
-      end
-
       def <it 'contains nested describes'><<todo method>>(&<blk>)
         <emptyTree>
       end
@@ -203,10 +155,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def example<<todo method>>(&<blk>)
       0
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
     end
 
     def <it 'calls example'><<todo method>>(&<blk>)

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -95,26 +95,24 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of outside_method>
 
-    <runtime method definition of <it 'works outside'>>
-
     begin
       <emptyTree>::<C CONST> = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-      <runtime method definition of <it 'allows constants inside of IT'>>
+      <emptyTree>
     end
 
     begin
       <emptyTree>::<C C2> = <cast:let>(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented"), <todo sym>, <emptyTree>::<C Integer>)
-      <runtime method definition of <it 'allows let-ed constants inside of IT'>>
+      <emptyTree>
     end
 
     begin
       <emptyTree>::<C C3> = <emptyTree>::<C Mod>::<C C>
-      <runtime method definition of <it 'allows path constants inside of IT'>>
+      <emptyTree>
     end
 
     begin
       ::<Magic>.<string-interpolate>("finds errors in the test name: ", <self>.bad_variable())
-      <runtime method definition of <it '::<Magic>.<string-interpolate>("finds errors in the test name: ", <self>.bad_variable())'>>
+      <emptyTree>
     end
 
     class <emptyTree>::<C <describe 'some inner tests'>><<C <todo sym>>> < (<self>)
@@ -134,8 +132,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       <runtime method definition of inside_method>
-
-      <runtime method definition of <it 'works inside'>>
     end
 
     <runtime method definition of instance_helper>
@@ -143,8 +139,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <runtime method definition of <before>>
 
     <runtime method definition of <after>>
-
-    <runtime method definition of <it 'can read foo'>>
 
     <runtime method definition of self.random_method>
 
@@ -171,12 +165,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
       begin
         <emptyTree>::<C Object>
-        <runtime method definition of <it 'Object'>>
+        <emptyTree>
       end
 
       begin
         <emptyTree>::<C Object>
-        <runtime method definition of <it 'Object'>>
+        <emptyTree>
       end
     end
 
@@ -199,8 +193,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
       class <emptyTree>::<C <describe 'nobody should write this but we should still parse it'>><<C <todo sym>>> < (<self>)
       end
-
-      <runtime method definition of <it 'contains nested describes'>>
     end
   end
 
@@ -227,8 +219,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.extend(<emptyTree>::<C T>::<C Sig>)
 
     <runtime method definition of example>
-
-    <runtime method definition of <it 'calls example'>>
   end
 
   <runtime method definition of junk>

--- a/test/testdata/rewriter/minitest_empty_test_each.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_empty_test_each.rb.rewrite-tree.exp
@@ -22,18 +22,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C Foo><<C <todo sym>>> < (<emptyTree>::<C Test>)
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it 'it block 1'><<todo method>>(&<blk>)
       [[1, 2], [3, 4]].each() do |<destructure>$2|
         <emptyTree>
       end
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
     end
 
     def <it 'it block 2'><<todo method>>(&<blk>)

--- a/test/testdata/rewriter/minitest_hover.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_hover.rb.rewrite-tree.exp
@@ -76,17 +76,17 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     begin
       ::<Magic>.<string-interpolate>("outside test_each ", x)
-      <runtime method definition of <it '::<Magic>.<string-interpolate>("outside test_each ", x)'>>
+      <emptyTree>
     end
 
     begin
       ::<Magic>.<string-interpolate>("outside test_each ", <self>.y())
-      <runtime method definition of <it '::<Magic>.<string-interpolate>("outside test_each ", <self>.y())'>>
+      <emptyTree>
     end
 
     begin
       ::<Magic>.<string-interpolate>("outside test_each ", <emptyTree>::<C X>)
-      <runtime method definition of <it '::<Magic>.<string-interpolate>("outside test_each ", <emptyTree>::<C X>)'>>
+      <emptyTree>
     end
 
     <self>.test_each(["foo"]) do |x|

--- a/test/testdata/rewriter/minitest_hover.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_hover.rb.rewrite-tree.exp
@@ -38,32 +38,16 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C X> = "hello"
 
   class <emptyTree>::<C <describe 'example'>><<C <todo sym>>> < (<self>)
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it '::<Magic>.<string-interpolate>("outside test_each ", x)'><<todo method>>(&<blk>)
       <emptyTree>
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
     end
 
     def <it '::<Magic>.<string-interpolate>("outside test_each ", <self>.y())'><<todo method>>(&<blk>)
       <emptyTree>
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it '::<Magic>.<string-interpolate>("outside test_each ", <emptyTree>::<C X>)'><<todo method>>(&<blk>)
       <emptyTree>
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
     end
 
     def <it '::<Magic>.<string-interpolate>("bar ", x)'><<todo method>>(&<blk>)

--- a/test/testdata/rewriter/minitest_module_context.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_module_context.rb.rewrite-tree.exp
@@ -17,8 +17,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <emptyTree>
       end
 
-      <runtime method definition of <it 'adds a method'>>
-
       class <emptyTree>::<C <describe 'inner'>><<C <todo sym>>> < (<self>)
         ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
           <self>.void()
@@ -27,8 +25,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         def <it 'inner test'><<todo method>>(&<blk>)
           <emptyTree>
         end
-
-        <runtime method definition of <it 'inner test'>>
       end
     end
 
@@ -42,8 +38,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       <self>.include(<emptyTree>::<C Helper>)
-
-      <runtime method definition of <it 'something'>>
     end
   end
 
@@ -62,8 +56,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       def <it 'adds a method'><<todo method>>(&<blk>)
         <self>.test_method()
       end
-
-      <runtime method definition of <it 'adds a method'>>
     end
   end
 end

--- a/test/testdata/rewriter/minitest_module_context.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_module_context.rb.rewrite-tree.exp
@@ -9,19 +9,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   module <emptyTree>::<C M><<C <todo sym>>> < ()
     class <emptyTree>::<C <describe 'describe'>><<C <todo sym>>> < (::<todo sym>)
-      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-        <self>.void()
-      end
-
       def <it 'adds a method'><<todo method>>(&<blk>)
         <emptyTree>
       end
 
       class <emptyTree>::<C <describe 'inner'>><<C <todo sym>>> < (<self>)
-        ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-          <self>.void()
-        end
-
         def <it 'inner test'><<todo method>>(&<blk>)
           <emptyTree>
         end
@@ -29,10 +21,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C <describe 'another'>><<C <todo sym>>> < (::<todo sym>)
-      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-        <self>.void()
-      end
-
       def <it 'something'><<todo method>>(&<blk>)
         <self>.foo()
       end
@@ -49,10 +37,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <runtime method definition of test_method>
 
     class <emptyTree>::<C <describe 'describe'>><<C <todo sym>>> < (<self>)
-      ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-        <self>.void()
-      end
-
       def <it 'adds a method'><<todo method>>(&<blk>)
         <self>.test_method()
       end

--- a/test/testdata/rewriter/minitest_strict_constants.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_strict_constants.rb.rewrite-tree.exp
@@ -1,9 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C MyTest><<C <todo sym>>> < (::<todo sym>)
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it 'allows let-ed constants inside of IT'><<todo method>>(&<blk>)
       ::Module.const_set(:C2, <cast:let>(10, <todo sym>, <emptyTree>::<C Integer>))
     end

--- a/test/testdata/rewriter/minitest_strict_constants.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_strict_constants.rb.rewrite-tree.exp
@@ -1,5 +1,9 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C MyTest><<C <todo sym>>> < (::<todo sym>)
+    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
+      <self>.void()
+    end
+
     def <it 'allows let-ed constants inside of IT'><<todo method>>(&<blk>)
       ::Module.const_set(:C2, <cast:let>(10, <todo sym>, <emptyTree>::<C Integer>))
     end

--- a/test/testdata/rewriter/minitest_strict_constants.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_strict_constants.rb.rewrite-tree.exp
@@ -10,7 +10,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     begin
       <emptyTree>::<C C2> = <cast:let>(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented"), <todo sym>, <emptyTree>::<C Integer>)
-      <runtime method definition of <it 'allows let-ed constants inside of IT'>>
+      <emptyTree>
     end
   end
 end

--- a/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
@@ -42,10 +42,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it 'works with instance methods'><<todo method>>(&<blk>)
       [<emptyTree>::<C Parent>.new(), <emptyTree>::<C Child>.new()].each() do |value|
         begin
@@ -54,10 +50,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           <emptyTree>::<C T>.reveal_type(value)
         end
       end
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
     end
 
     def <it 'succeeds with a constant list'><<todo method>>(&<blk>)
@@ -69,10 +61,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it 'succeeds with a typed constant list'><<todo method>>(&<blk>)
       <emptyTree>::<C ANOTHER_CONST_LIST>.each() do |value|
         begin
@@ -80,10 +68,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           <emptyTree>::<C T>.reveal_type(value)
         end
       end
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
     end
 
     def <it 'succeed with a local variable but cannot type it'><<todo method>>(&<blk>)
@@ -95,28 +79,16 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it 'fails with non-it statements'><<todo method>>(&<blk>)
       <emptyTree>::<C CONST_LIST>.each() do |value|
         <self>.puts(x)
       end
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it 'handles lists with several types'><<todo method>>(&<blk>)
       ["foo", 5, {:x => false}].each() do |v|
         <emptyTree>::<C T>.reveal_type(v)
       end
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
     end
 
     def <it 'blocks get padded with NilClass arguments'><<todo method>>(&<blk>)
@@ -128,10 +100,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it 'multiple it blocks are ok with multiple arguments'><<todo method>>(&<blk>)
       [1, 2, 3].each() do |k, v|
         begin
@@ -139,10 +107,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           <emptyTree>::<C T>.reveal_type(v)
         end
       end
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
     end
 
     def <it 'destructured blocks get padded with NilClass arguments'><<todo method>>(&<blk>)
@@ -163,10 +127,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it 'multiple it blocks are ok with multiple destructured arguments'><<todo method>>(&<blk>)
       [1, 2, 3].each() do |<destructure>$4|
         begin
@@ -183,10 +143,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           end
         end
       end
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
     end
 
     def <it 'handles mixed destructuring and positional arguments'><<todo method>>(&<blk>)
@@ -217,10 +173,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it 'multiple it blocks are ok with mixed argument styles'><<todo method>>(&<blk>)
       [[1, ["hi", false]], [2, ["bye", true]]].each() do |i, <destructure>$7, <destructure>$10|
         begin
@@ -247,10 +199,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it 'succeeds with a constant list of tuples'><<todo method>>(&<blk>)
       <emptyTree>::<C CONST_LIST_TUPLE>.each() do |i, s|
         begin
@@ -258,10 +206,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           <emptyTree>::<C T>.reveal_type(s)
         end
       end
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
     end
 
     def <it 'succeeds with a constant list of tuples and destructuring'><<todo method>>(&<blk>)
@@ -282,10 +226,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it 'succeeds with a typed constant tuple list'><<todo method>>(&<blk>)
       <emptyTree>::<C ANOTHER_CONST_LIST_TUPLE>.each() do |i, s|
         begin
@@ -293,10 +233,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           <emptyTree>::<C T>.reveal_type(s)
         end
       end
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
     end
 
     def <it 'succeeds with a typed constant tuple list with destructuring'><<todo method>>(&<blk>)
@@ -317,10 +253,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it 'succeed with local variables but cannot type them'><<todo method>>(&<blk>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented").each() do |i, s|
         begin
@@ -328,10 +260,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           <emptyTree>::<C T>.reveal_type(s)
         end
       end
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
     end
 
     def <it 'succeed with destructured local variables but cannot type them'><<todo method>>(&<blk>)
@@ -352,10 +280,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it 'rejects manual destructuring of the list argument'><<todo method>>(&<blk>)
       [[1, "a"], [2, "b"]].each() do |value|
         begin
@@ -363,10 +287,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           <emptyTree>::<C T>.reveal_type(s)
         end
       end
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
     end
 
     def <it '::<Magic>.<string-interpolate>("color ", color, " which is not purple is not number 1 ", ns)'><<todo method>>(&<blk>)
@@ -387,10 +307,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it 'handles lists with several types'><<todo method>>(&<blk>)
       {:foo => 1, :bar => 2, :baz => 3}.each() do |k, v|
         begin
@@ -398,10 +314,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           <emptyTree>::<C T>.reveal_type(v)
         end
       end
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
     end
 
     def <it 'fails to typecheck with non-hash arguments to `test_each-hash`'><<todo method>>(&<blk>)

--- a/test/testdata/rewriter/minitest_test_each_describe_and_it.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_test_each_describe_and_it.rb.rewrite-tree.exp
@@ -14,10 +14,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it 'b'><<todo method>>(&<blk>)
       [[1, 2], [3, 4]].each() do |<destructure>$2|
         begin
@@ -31,10 +27,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           <emptyTree>::<C T>.reveal_type(a)
         end
       end
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
     end
 
     def <it 'a'><<todo method>>(&<blk>)

--- a/test/testdata/rewriter/test_each_describe.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/test_each_describe.rb.rewrite-tree.exp
@@ -22,10 +22,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C MyTest><<C <todo sym>>> < (<emptyTree>::<C Minitest>::<C Spec>)
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <before><<todo method>>(&<blk>)
       [true, false].each() do |flag_enabled|
         begin
@@ -36,18 +32,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <after><<todo method>>(&<blk>)
       [true, false].each() do |flag_enabled|
         @enabled = false
       end
-    end
-
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
     end
 
     def <it 'do this thing'><<todo method>>(&<blk>)
@@ -79,10 +67,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C MyTestBad2><<C <todo sym>>> < (<emptyTree>::<C Minitest>::<C Spec>)
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it ''><<todo method>>(&<blk>)
       [true, false].each() do |flag_enabled|
         <emptyTree>
@@ -102,10 +86,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C MyTestBad3><<C <todo sym>>> < (<emptyTree>::<C Minitest>::<C Spec>)
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it ''><<todo method>>(&<blk>)
       [true, false].each() do |flag_enabled|
         <emptyTree>
@@ -125,10 +105,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C MyTestBad4><<C <todo sym>>> < (<emptyTree>::<C Minitest>::<C Spec>)
-    ::Sorbet::Private::Static.sig(::T::Sig::WithoutRuntime) do ||
-      <self>.void()
-    end
-
     def <it ''><<todo method>>(&<blk>)
       [true, false].each() do |flag_enabled|
         <emptyTree>


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

See also: #9198

This saves even more memory by omitting nodes in the minitest rewriter if
they're not actually required.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.