### PR TITLE
Use package references instead of mangled names

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1390,26 +1390,18 @@ public:
         return packageDB.getPackageInfo(packageName).importedPackageNames;
     }
 
-    void setSCCId(MangledName packageName, int sccID) {
-        auto *pkgInfoPtr = packageDB.getPackageInfoNonConst(packageName);
-        if (!pkgInfoPtr) {
-            return;
-        }
-        pkgInfoPtr->sccID_ = sccID;
+    void setSCCId(PackageInfo &info, int sccID) {
+        info.sccID_ = sccID;
     }
 
-    int getSCCId(MangledName packageName) const {
-        ENFORCE(packageDB.getPackageInfo(packageName).exists());
-        ENFORCE(packageDB.getPackageInfo(packageName).sccID().has_value());
-        return packageDB.getPackageInfo(packageName).sccID().value();
+    int getSCCId(const PackageInfo &info) const {
+        ENFORCE(info.exists());
+        ENFORCE(info.sccID().has_value());
+        return info.sccID().value();
     }
 
-    void setTestSCCId(MangledName packageName, int sccID) {
-        auto *pkgInfoPtr = packageDB.getPackageInfoNonConst(packageName);
-        if (!pkgInfoPtr) {
-            return;
-        }
-        pkgInfoPtr->testSccID_ = sccID;
+    void setTestSCCId(PackageInfo &info, int sccID) {
+        info.testSccID_ = sccID;
     }
 };
 


### PR DESCRIPTION
Pass in `PackageInfo &` values to the `packageGraph` argument's methods for interacting with SCC ids.

### Motivation
This avoids the need to lookup the info in the `packageGraph` implemetation, but still exposes the appropriate hooks into the SCC construction process.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
