### PR TITLE
Fix packager import SCC ID crash differently

### DIFF
--- a/packager/ComputePackageSCCs.h
+++ b/packager/ComputePackageSCCs.h
@@ -138,23 +138,20 @@ class ComputePackageSCCs {
                         }
                     }
 
-                    // Only process valid imports (this is the same check as in the early return at the beginning of
-                    // this function)
-                    auto &importedPkg = packageDB.getPackageInfo(i.mangledName);
-                    if (!importedPkg.exists()) {
+                    // The mangled name won't exist if the import was to a package that doesn't exist.
+                    if (!i.mangledName.exists()) {
                         continue;
                     }
 
                     // All of the imports of every member of the SCC will have been processed in the recursive step, so
                     // we can assume the scc id of the target exists. Additionally, all imports are to the original
                     // application code, which is why we don't consider using the `testSccID` here.
-                    auto impId = importedPkg.sccID();
-                    ENFORCE(impId.has_value());
-                    if (*impId == sccId) {
+                    auto impId = packageGraph.getSCCId(i.mangledName);
+                    if (impId == sccId) {
                         continue;
                     }
 
-                    condensationNode.imports.insert(*impId);
+                    condensationNode.imports.insert(impId);
                 }
             }
         }

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -669,7 +669,7 @@ struct PackageSpecBodyWalk {
                         auto &posArg = send.getPosArg(0);
                         auto importArg = move(target->recv);
                         posArg = ast::packager::prependRegistry(move(importArg));
-                        // Allow namespaces to allow wildcard visible_to of namespaces, not just rooted packages.
+                        // Allow namespaces to enable wildcard visible_to of namespaces, not just rooted packages.
                         auto allowNamespace = true;
                         info.visibleTo_.emplace_back(resolvePackageName(ctx, recv, allowNamespace),
                                                      VisibleToType::Wildcard);

--- a/test/testdata/packager/dag/c/__package.rb
+++ b/test/testdata/packager/dag/c/__package.rb
@@ -7,5 +7,6 @@ class C < PackageSpec
 
   import A # error: All of `C`'s `import`s must be `dag` or higher
   import Nested
+  #      ^^^^^^ error: Expected `T.class_of(Sorbet::Private::Static::PackageSpec)` but found `T.class_of(Nested)`
   test_import B
 end

--- a/test/testdata/packager/dag/c/__package.rb
+++ b/test/testdata/packager/dag/c/__package.rb
@@ -6,5 +6,6 @@ class C < PackageSpec
   layer 'business'
 
   import A # error: All of `C`'s `import`s must be `dag` or higher
+  import Nested
   test_import B
 end

--- a/test/testdata/packager/dag/nested/some_package/__package.rb
+++ b/test/testdata/packager/dag/nested/some_package/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Nested::SomePackage < PackageSpec
+  strict_dependencies 'dag'
+  layer 'utility'
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Reverts #9202
cc @elliottt

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Thanks to @elliottt for finding the source of the crash that we were looking at
today.

I wanted to get thoughts on fixing the cause of the crash differently, by
establishing an invariant that a package's import list in the PackageDB says
that if the `MangledName` exists, then the imported package exists.

This is a better invariant, because soon we will want the `import` list to be a
`vector<core::PackageRef>`, and we won't be able to make a `PackageRef` that
corresponds to something that is not a package.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

Regardless of whether we go with this alternative fix, I've included a test case
that crashes in the manner observed before #9202, and is both fixed by #9202 and
the changes in this PR.