### PR TITLE
Rename `test_PrismPosTests` → `test_PosTests`

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -334,7 +334,7 @@ pipeline_tests(
             "testdata/rbs/**/*.rb",
         ],
     ),
-    "PrismPosTests",
+    "PosTests",
     parser = "prism",
 )
 
@@ -366,7 +366,7 @@ pipeline_tests(
         "prism_regression/**/*.rb",
         "prism_regression/**/*.exp",
     ]),
-    "PrismPosTests",
+    "PosTests",
     parser = "prism",
 )
 

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -57,7 +57,6 @@ exp_test = rule(
 
 _TEST_RUNNERS = {
     "PosTests": ":pipeline_test_runner",
-    "PrismPosTests": ":pipeline_test_runner",
     "LSPTests": ":lsp_test_runner",
     "WhitequarkParserTests": ":parser_test_runner",
     "PackagerTests": ":pipeline_test_runner",


### PR DESCRIPTION
### Motivation

The Prism-related test targets have similar names to their non-Prism counterparts, except they include "prism" twice in their names:

```
//test:test_PrismPosTests/testdata/parser/invalid_def_forward_prism
            ^^^^^                                            ^^^^^^
```

This makes it cumbersome to switch back and forth between the Prism and non-Prism variants of the same test. Alternatively, we can delete the `_prism` suffix instead.

Part of #9065. Undoes https://github.com/sorbet/sorbet/pull/8122#discussion_r1765442564

### Test plan

Just renames existing tests.
