### PR TITLE
Add loc detals to VisibleTo

### DIFF
--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -86,8 +86,10 @@ struct Export {
 struct VisibleTo {
     MangledName mangledName;
     VisibleToType type;
+    core::LocOffsets loc;
 
-    VisibleTo(MangledName mangledName, VisibleToType type) : mangledName(mangledName), type(type){};
+    VisibleTo(MangledName mangledName, VisibleToType type, core::LocOffsets loc)
+        : mangledName(mangledName), type(type), loc(loc){};
 };
 
 class PackageInfo {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -672,7 +672,7 @@ struct PackageSpecBodyWalk {
                         // Allow namespaces to enable wildcard visible_to of namespaces, not just rooted packages.
                         auto allowNamespace = true;
                         info.visibleTo_.emplace_back(resolvePackageName(ctx, recv, allowNamespace),
-                                                     VisibleToType::Wildcard);
+                                                     VisibleToType::Wildcard, send.loc);
                     } else {
                         if (auto e = ctx.beginError(target->loc, core::errors::Packager::InvalidConfiguration)) {
                             e.setHeader("Argument to `{}` must be a constant or the string literal `{}`",
@@ -686,8 +686,8 @@ struct PackageSpecBodyWalk {
                     posArg = ast::packager::prependRegistry(move(importArg));
 
                     auto allowNamespace = false;
-                    info.visibleTo_.emplace_back(resolvePackageName(ctx, target, allowNamespace),
-                                                 VisibleToType::Normal);
+                    info.visibleTo_.emplace_back(resolvePackageName(ctx, target, allowNamespace), VisibleToType::Normal,
+                                                 send.loc);
                 }
             }
         } else if (send.fun == core::Names::strictDependencies()) {


### PR DESCRIPTION
To raise errors for `visible_to` uses in prelude packages, I need a location to point to. As we may not have seen the `prelude_package` annotation yet, it's not possible to reliably catch this error while processing the `visible_to` declaration, so this PR avoids the issue by adding a loc to `VisibleTo` so that there's context when raising errors later.

### Motivation
Making it easier to raise errors when processing prelude packages.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
