### PR TITLE
Desugar `PM_ALIAS_METHOD_NODE`

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -191,7 +191,18 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             auto newName = translate(aliasMethodNode->new_name);
             auto oldName = translate(aliasMethodNode->old_name);
 
-            return make_unique<parser::Alias>(location, move(newName), move(oldName));
+            if (!directlyDesugar || !hasExpr(newName, oldName)) {
+                return make_unique<parser::Alias>(location, move(newName), move(oldName));
+            }
+
+            auto toExpr = newName->takeDesugaredExpr();
+            auto fromExpr = oldName->takeDesugaredExpr();
+
+            // Desugar methods: `alias new old` to `self.alias_method(new, old)`
+            auto expr = MK::Send2(location, MK::Self(location), core::Names::aliasMethod(),
+                                  location.copyWithZeroLength(), std::move(toExpr), std::move(fromExpr));
+
+            return make_node_with_expr<parser::Alias>(move(expr), location, move(newName), move(oldName));
         }
         case PM_AND_NODE: { // operator `&&` and `and`
             auto andNode = down_cast<pm_and_node>(node);


### PR DESCRIPTION
Desugar `PM_ALIAS_METHOD_NODE` as part of integrating Prism into Sorbet. 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests. 
