### PR TITLE
Directly Desugar PM_BLOCK_ARGUMENT_NODE

### DIFF
--- a/parser/Node.h
+++ b/parser/Node.h
@@ -30,6 +30,10 @@ public:
         return nullptr;
     }
 
+    virtual ast::ExpressionPtr copyDesugaredExpr() {
+        return nullptr;
+    }
+
     virtual bool hasDesugaredExpr() {
         return false;
     }
@@ -104,6 +108,10 @@ public:
         // Because of this, we don't need to make any copies here. Just move this value out,
         // and hand exclusive ownership to the caller.
         return std::move(this->desugaredExpr);
+    }
+
+    virtual ast::ExpressionPtr copyDesugaredExpr() final {
+        return this->desugaredExpr.deepCopy();
     }
 
     virtual bool hasDesugaredExpr() final {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

- Part of #9065 
- includes TODO related to having to copy desugared expression from block argument node

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
