### PR TITLE
Desugar `PM_IMAGINARY_NODE`

### DIFF
--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -1708,14 +1708,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 ExpressionPtr res = MK::Float(loc, val);
                 result = move(res);
             },
-            [&](parser::Complex *complex) {
-                auto kernel = MK::Constant(loc, core::Symbols::Kernel());
-                core::NameRef complex_name = core::Names::Constants::Complex().dataCnst(dctx.ctx)->original;
-                core::NameRef value = dctx.ctx.state.enterNameUTF8(complex->value);
-                auto send =
-                    MK::Send2(loc, move(kernel), complex_name, locZeroLen, MK::Int(loc, 0), MK::String(loc, value));
-                result = move(send);
-            },
+            [&](parser::Complex *complex) { desugaredByPrismTranslator(complex); },
             [&](parser::Rational *rational) { desugaredByPrismTranslator(rational); },
             [&](parser::Array *array) {
                 Array::ENTRY_store elems;

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -803,22 +803,37 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
 
             ENFORCE(!value.empty());
 
-            char sign = value[0];
             // Check for optional leading '+' or '-'
-            if (sign == '+' || sign == '-') {
-                value.remove_prefix(1);
+            auto sign = value[0];
+            bool hasSign = (sign == '+' || sign == '-');
 
-                // Create the Complex node with the unsigned value
-                auto receiver = make_unique<parser::Complex>(location, string(value));
+            if (hasSign) {
+                value.remove_prefix(1); // Remove the sign
+            }
 
-                // Return the appropriate unary operation
+            // Create the desugared Complex call: `Kernel.Complex(0, unsigned_value)`
+            auto kernel = MK::Constant(location, core::Symbols::Kernel());
+            core::NameRef complexName = core::Names::Constants::Complex().dataCnst(ctx)->original;
+            core::NameRef valueName = ctx.state.enterNameUTF8(value);
+            auto complexCall = MK::Send2(location, move(kernel), complexName, location.copyWithZeroLength(),
+                                         MK::Int(location, 0), MK::String(location, valueName));
+
+            // If there was a sign, wrap in unary operation
+            // E.g. desugar `+42` to `42.+()`
+            if (hasSign) {
+                auto complexNode = make_unique<parser::Complex>(location, string(value));
                 core::NameRef unaryOp = (sign == '-') ? core::Names::unaryMinus() : core::Names::unaryPlus();
-                return make_unique<parser::Send>(location, move(receiver), unaryOp,
-                                                 core::LocOffsets{location.beginLoc, location.beginLoc + 1}, NodeVec{});
+
+                auto unarySend = MK::Send0(location, move(complexCall), unaryOp,
+                                           core::LocOffsets{location.beginLoc, location.beginLoc + 1});
+
+                return make_node_with_expr<parser::Send>(move(unarySend), location, move(complexNode), unaryOp,
+                                                         core::LocOffsets{location.beginLoc, location.beginLoc + 1},
+                                                         NodeVec{});
             }
 
             // No leading sign; return the Complex node directly
-            return make_unique<parser::Complex>(location, string(value));
+            return make_node_with_expr<parser::Complex>(move(complexCall), location, string(value));
         }
         case PM_IMPLICIT_NODE: { // A hash key without explicit value, like the `k4` in `{ k4: }`
             auto implicitNode = down_cast<pm_implicit_node>(node);


### PR DESCRIPTION
Desugar `PM_IMAGINARY_NODE` as part of the work to integrate Prism in Sorbet. 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests. 