### PR TITLE
Leak trees in autogen

### DIFF
--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -4,6 +4,7 @@
 #include "ast/ast.h"
 #include "ast/treemap/treemap.h"
 #include "common/common.h"
+#include "common/os/os.h"
 #include "common/strings/formatting.h"
 #include "main/autogen/crc_builder.h"
 
@@ -415,9 +416,15 @@ public:
 // Convert a Sorbet `ParsedFile` into an Autogen `ParsedFile` by walking it as above and also recording the checksum of
 // the current file
 ParsedFile Autogen::generate(core::Context ctx, ast::ParsedFile tree, const AutogenConfig &autogenCfg,
-                             const CRCBuilder &crcBuilder) {
+                             const CRCBuilder &crcBuilder, bool leakTrees) {
     AutogenWalk walk(autogenCfg);
     ast::ConstTreeWalk::apply(ctx, walk, tree.tree);
+
+    if (leakTrees) {
+        // Leak the tree, as we only run autogen in batch mode
+        intentionallyLeakMemory(tree.tree.release());
+    }
+
     auto pf = walk.parsedFile();
     pf.path = string(tree.file.data(ctx).path());
     auto src = tree.file.data(ctx).source();

--- a/main/autogen/autogen.h
+++ b/main/autogen/autogen.h
@@ -10,7 +10,7 @@ namespace sorbet::autogen {
 class Autogen final {
 public:
     static ParsedFile generate(core::Context ctx, ast::ParsedFile tree, const AutogenConfig &autogenCfg,
-                               const CRCBuilder &crcBuilder);
+                               const CRCBuilder &crcBuilder, bool leakTrees);
     Autogen() = delete;
 };
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -218,8 +218,8 @@ struct AutogenResult {
     vector<pair<int, Serialized>> prints;
 };
 
-vector<ast::ParsedFile> runAutogen(core::GlobalState &gs, options::Options &opts, WorkerPool &workers,
-                                   std::unique_ptr<const OwnedKeyValueStore> kvstore) {
+void runAutogen(core::GlobalState &gs, options::Options &opts, WorkerPool &workers,
+                std::unique_ptr<const OwnedKeyValueStore> kvstore) {
     if (!opts.inlineInput.empty()) {
         Exception::raise("Autogen ignores `-e`");
     }
@@ -293,7 +293,8 @@ vector<ast::ParsedFile> runAutogen(core::GlobalState &gs, options::Options &opts
                     }
 
                     core::Context ctx(gs, core::Symbols::root(), tree.file);
-                    auto pf = autogen::Autogen::generate(ctx, move(tree), autogenCfg, *crcBuilder);
+                    auto leakTrees = true;
+                    auto pf = autogen::Autogen::generate(ctx, move(tree), autogenCfg, *crcBuilder, leakTrees);
                     auto file = pf.file;
 
                     AutogenResult::Serialized serialized;
@@ -387,8 +388,6 @@ vector<ast::ParsedFile> runAutogen(core::GlobalState &gs, options::Options &opts
 
         opts.print.AutogenSubclasses.fmt("{}\n", fmt::join(serializedDescendantsMap, "\n"));
     }
-
-    return indexed;
 }
 
 #endif
@@ -571,7 +570,7 @@ int realmain(int argc, char *argv[]) {
         gs = loop.runLSP(make_shared<lsp::LSPFDInput>(logger, STDIN_FILENO)).value_or(nullptr);
     } else if (gs->cacheSensitiveOptions.runningUnderAutogen) {
         Timer timeall(logger, "wall_time");
-        auto indexed = runAutogen(*gs, opts, *workers, move(kvstore));
+        runAutogen(*gs, opts, *workers, move(kvstore));
 
         gs->errorQueue->flushAllErrors(*gs);
         if (!opts.noErrorCount) {

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -441,7 +441,9 @@ void autogen(core::GlobalState &gs, vector<core::FileRef> files, ExpectationHand
             auto crcBuilder = autogen::CRCBuilder::create();
             for (auto &tree : trees) {
                 core::Context ctx(gs, core::Symbols::root(), tree.file);
-                auto pf = autogen::Autogen::generate(ctx, move(tree), autogen::AutogenConfig{{}}, *crcBuilder);
+                auto leakTrees = false;
+                auto pf =
+                    autogen::Autogen::generate(ctx, move(tree), autogen::AutogenConfig{{}}, *crcBuilder, leakTrees);
                 payload << pf.toString(ctx, autogen::AutogenVersion::MAX_VERSION);
             }
             return payload.str();


### PR DESCRIPTION
I thought we used to do this, but it appears that we move ownership of trees into `Autogen::generate` and don't move them back out again. As a result, we'll free the trees in `Autogen::generate` instead of leaking the memory. This PR goes back to explicitly leaking the tree when we run autogen.

### Motivation
Performance.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
