### PR TITLE
Desugar `PM_SINGLETON_CLASS` node 

### DIFF
--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -133,6 +133,9 @@ private:
                                                   std::unique_ptr<parser::Node> ifTrue,
                                                   std::unique_ptr<parser::Node> ifFalse);
 
+    // Extracts the desugared expressions out of a "scope" (class/sclass/module) body.
+    std::optional<ast::ClassDef::RHS_store> desugarScopeBodyToRHSStore(std::unique_ptr<parser::Node> &scopeBody);
+
     void reportError(core::LocOffsets loc, const std::string &message) const;
 
     // Context management helpers. These return a copy of `this` with some change to the context.


### PR DESCRIPTION
- Desugars `PM_SINGLETON_CLASS` node as part of the work integrating Prism into Sorbet. 
- Introduces a helper method `desugarScopeBodyToRHSStore` to extract the desugared expressions out of a "scope" (class/sclass/module) body. 


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests 