### PR TITLE
Document block pass desugar logic

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -390,13 +390,14 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
     return mdef;
 }
 
+// Desugar a Symbol block pass like the `&foo` in `m(&:foo)` into a block literal.
+// `&:foo` => `{ |*temp| (temp[0]).foo(*temp[1, LONG_MAX]) }`
 ExpressionPtr symbol2Proc(DesugarContext dctx, ExpressionPtr expr) {
     auto loc = expr.loc();
     core::NameRef temp = dctx.freshNameUnique(core::Names::blockPassTemp());
     auto lit = cast_tree<Literal>(expr);
     ENFORCE(lit && lit->isSymbol());
 
-    // &:foo => {|*temp| (temp[0]).foo(*tmp[1, LONG_MAX]) }
     core::NameRef name = core::cast_type_nonnull<core::NamedLiteralType>(lit->value).asName();
     // `temp` does not refer to any specific source text, so give it a 0-length Loc so LSP ignores it.
     auto zeroLengthLoc = loc.copyWithZeroLength();
@@ -773,7 +774,9 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
 
                 auto methodName = MK::Symbol(locZeroLen, send->method);
 
-                // Pop the BlockPass off the end of the arguments, if there is one.
+                // Pop the BlockPass off the end of the arguments, if there is one. (e.g. the `&:b` in `foo(&:b)`)
+                // Note: this does *not* handle regular block arguments (e.g. `foo { }`),
+                //       which are handled separately in the`parser::Block *` case.
                 ExpressionPtr block;
                 if (!send->args.empty() && parser::isa_node<parser::BlockPass>(send->args.back().get())) {
                     auto *bp = parser::cast_node<parser::BlockPass>(send->args.back().get());
@@ -895,15 +898,25 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     sendargs.emplace_back(move(args));
                     sendargs.emplace_back(move(kwargs));
                     ExpressionPtr res;
+
                     if (block == nullptr) {
+                        // Desugar any call with a splat and without a block pass argument.
+                        // If there's a literal block argument, that's handled here, too.
+                        // E.g. `foo(*splat)` or `foo(*splat) { |x| puts(x) }`
                         res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplat(), send->methodLoc, 4,
                                        move(sendargs), flags);
                     } else {
                         if (auto lit = cast_tree<Literal>(block); lit && lit->isSymbol()) {
+                            // Desugar a call with a splat and a Symbol block pass argument.
+                            // E.g. `foo(*splat, &:to_s)`
+
                             res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplat(), send->methodLoc, 4,
                                            move(sendargs), flags);
                             ast::cast_tree_nonnull<ast::Send>(res).setBlock(symbol2Proc(dctx, move(block)));
                         } else {
+                            // Desugar a call with a splat, and any other expression as a block pass argument.
+                            // E.g. `foo(*splat, &block)`
+
                             sendargs.emplace_back(move(block));
                             res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplatAndBlock(), send->methodLoc,
                                            5, move(sendargs), flags);
@@ -930,13 +943,22 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
 
                     ExpressionPtr res;
                     if (block == nullptr) {
+                        // Desugar any call without a splat and without a block pass argument.
+                        // If there's a literal block argument, that's handled here, too.
+                        // E.g. `a.each` or `a.each { |x| puts(x) }`
                         res = MK::Send(loc, move(rec), send->method, send->methodLoc, numPosArgs, move(args), flags);
                     } else {
                         if (auto lit = cast_tree<Literal>(block); lit && lit->isSymbol()) {
+                            // Desugar a call without a splat and a Symbol block pass argument.
+                            // E.g. `a.map(:to_s)`
+
                             res =
                                 MK::Send(loc, move(rec), send->method, send->methodLoc, numPosArgs, move(args), flags);
                             ast::cast_tree_nonnull<ast::Send>(res).setBlock(symbol2Proc(dctx, move(block)));
                         } else {
+                            // Desugar a call without a splat, and any other expression as a block pass argument.
+                            // E.g. `a.each(&block)`
+
                             Send::ARGS_store sendargs;
                             sendargs.reserve(3 + args.size());
                             sendargs.emplace_back(move(rec));

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -912,9 +912,12 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                             // Desugar a call with a splat and a Symbol block pass argument.
                             // E.g. `foo(*splat, &:to_s)`
 
+                            auto desugaredBlockLiteral = symbol2Proc(dctx, move(blockPassArg));
+                            sendargs.emplace_back(move(desugaredBlockLiteral));
+                            flags.hasBlock = true;
+
                             res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplat(), send->methodLoc, 4,
                                            move(sendargs), flags);
-                            ast::cast_tree_nonnull<ast::Send>(res).setBlock(symbol2Proc(dctx, move(blockPassArg)));
                         } else {
                             // Desugar a call with a splat, and any other expression as a block pass argument.
                             // E.g. `foo(*splat, &block)`
@@ -953,6 +956,10 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         if (auto lit = cast_tree<Literal>(blockPassArg); lit && lit->isSymbol()) {
                             // Desugar a call without a splat and a Symbol block pass argument.
                             // E.g. `a.map(:to_s)`
+
+                            auto desugaredBlockLiteral = symbol2Proc(dctx, move(blockPassArg));
+                            args.emplace_back(move(desugaredBlockLiteral));
+                            flags.hasBlock = true;
 
                             res =
                                 MK::Send(loc, move(rec), send->method, send->methodLoc, numPosArgs, move(args), flags);

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -875,9 +875,12 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                             // Desugar a call with a splat and a Symbol block pass argument.
                             // E.g. `foo(*splat, &:to_s)`
 
+                            auto desugaredBlockLiteral = symbol2Proc(dctx, move(blockPassArg));
+                            sendargs.emplace_back(move(desugaredBlockLiteral));
+                            flags.hasBlock = true;
+
                             res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplat(), send->methodLoc, 4,
                                            move(sendargs), flags);
-                            ast::cast_tree_nonnull<ast::Send>(res).setBlock(symbol2Proc(dctx, move(blockPassArg)));
                         } else {
                             // Desugar a call with a splat, and any other expression as a block pass argument.
                             // E.g. `foo(*splat, &block)`
@@ -917,9 +920,12 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                             // Desugar a call without a splat and a Symbol block pass argument.
                             // E.g. `a.map(:to_s)`
 
+                            auto desugaredBlockLiteral = symbol2Proc(dctx, move(blockPassArg));
+                            args.emplace_back(move(desugaredBlockLiteral));
+                            flags.hasBlock = true;
+
                             res =
                                 MK::Send(loc, move(rec), send->method, send->methodLoc, numPosArgs, move(args), flags);
-                            ast::cast_tree_nonnull<ast::Send>(res).setBlock(symbol2Proc(dctx, move(blockPassArg)));
                         } else {
                             // Desugar a call without a splat, and any other expression as a block pass argument.
                             // E.g. `a.each(&block)`

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -741,14 +741,14 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 // Pop the BlockPass off the end of the arguments, if there is one. (e.g. the `&:b` in `foo(&:b)`)
                 // Note: this does *not* handle regular block arguments (e.g. `foo { }`),
                 //       which are handled separately in the`parser::Block *` case.
-                ExpressionPtr block;
+                ExpressionPtr blockPassArg;
                 if (!send->args.empty() && parser::NodeWithExpr::isa_node<parser::BlockPass>(send->args.back().get())) {
                     auto *bp = parser::NodeWithExpr::cast_node<parser::BlockPass>(send->args.back().get());
                     if (bp->block == nullptr) {
                         // Replace an anonymous block pass like `f(&)` with a local variable reference, like `f(&&)`.
-                        block = MK::Local(bp->loc, core::Names::ampersand());
+                        blockPassArg = MK::Local(bp->loc, core::Names::ampersand());
                     } else {
-                        block = node2TreeImpl(dctx, bp->block);
+                        blockPassArg = node2TreeImpl(dctx, bp->block);
                     }
 
                     send->args.pop_back();
@@ -778,9 +778,9 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         [&](parser::ForwardedArgs *fwdArgs) {
                             // Pull out the ForwardedArgs (the `...` argument in a method call, like `foo(...)`)
 
-                            ENFORCE(block == nullptr, "The parser should have rejected `foo(&, ...)`");
+                            ENFORCE(blockPassArg == nullptr, "The parser should have rejected `foo(&, ...)`");
                             // Desugar a call like `foo(...)` so it has a block argument like `foo(..., &<fwd-block>)`.
-                            block = MK::Local(loc, core::Names::fwdBlock());
+                            blockPassArg = MK::Local(loc, core::Names::fwdBlock());
 
                             hasFwdArgs = true;
                             eraseFromArgs = true;
@@ -864,25 +864,25 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     sendargs.emplace_back(move(args));
                     sendargs.emplace_back(move(kwargs));
                     ExpressionPtr res;
-                    if (block == nullptr) {
+                    if (blockPassArg == nullptr) {
                         // Desugar any call with a splat and without a block pass argument.
                         // If there's a literal block argument, that's handled here, too.
                         // E.g. `foo(*splat)` or `foo(*splat) { |x| puts(x) }`
                         res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplat(), send->methodLoc, 4,
                                        move(sendargs), flags);
                     } else {
-                        if (auto lit = cast_tree<Literal>(block); lit && lit->isSymbol()) {
+                        if (auto lit = cast_tree<Literal>(blockPassArg); lit && lit->isSymbol()) {
                             // Desugar a call with a splat and a Symbol block pass argument.
                             // E.g. `foo(*splat, &:to_s)`
 
                             res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplat(), send->methodLoc, 4,
                                            move(sendargs), flags);
-                            ast::cast_tree_nonnull<ast::Send>(res).setBlock(symbol2Proc(dctx, move(block)));
+                            ast::cast_tree_nonnull<ast::Send>(res).setBlock(symbol2Proc(dctx, move(blockPassArg)));
                         } else {
                             // Desugar a call with a splat, and any other expression as a block pass argument.
                             // E.g. `foo(*splat, &block)`
 
-                            sendargs.emplace_back(move(block));
+                            sendargs.emplace_back(move(blockPassArg));
                             res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplatAndBlock(), send->methodLoc,
                                            5, move(sendargs), flags);
                         }
@@ -907,19 +907,19 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     DuplicateHashKeyCheck::checkSendArgs(dctx, numPosArgs, args);
 
                     ExpressionPtr res;
-                    if (block == nullptr) {
+                    if (blockPassArg == nullptr) {
                         // Desugar any call without a splat and without a block pass argument.
                         // If there's a literal block argument, that's handled here, too.
                         // E.g. `a.each` or `a.each { |x| puts(x) }`
                         res = MK::Send(loc, move(rec), send->method, send->methodLoc, numPosArgs, move(args), flags);
                     } else {
-                        if (auto lit = cast_tree<Literal>(block); lit && lit->isSymbol()) {
+                        if (auto lit = cast_tree<Literal>(blockPassArg); lit && lit->isSymbol()) {
                             // Desugar a call without a splat and a Symbol block pass argument.
                             // E.g. `a.map(:to_s)`
 
                             res =
                                 MK::Send(loc, move(rec), send->method, send->methodLoc, numPosArgs, move(args), flags);
-                            ast::cast_tree_nonnull<ast::Send>(res).setBlock(symbol2Proc(dctx, move(block)));
+                            ast::cast_tree_nonnull<ast::Send>(res).setBlock(symbol2Proc(dctx, move(blockPassArg)));
                         } else {
                             // Desugar a call without a splat, and any other expression as a block pass argument.
                             // E.g. `a.each(&block)`
@@ -928,7 +928,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                             sendargs.reserve(3 + args.size());
                             sendargs.emplace_back(move(rec));
                             sendargs.emplace_back(move(methodName));
-                            sendargs.emplace_back(move(block));
+                            sendargs.emplace_back(move(blockPassArg));
 
                             numPosArgs += 3;
 


### PR DESCRIPTION
### Motivation

The code that handles block passes within Send nodes is pretty tricky. I wrote myself some notes while working through it, and figured it'd be useful to others.

### Test plan

Pure refactor, covered by existing tests.
