### PR TITLE
Desugar `PM_FLOAT_NODE`

### DIFF
--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -1690,24 +1690,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 ExpressionPtr res = desugarDString(dctx, loc, move(dstring->nodes));
                 result = move(res);
             },
-            [&](parser::Float *floatNode) {
-                double val;
-                auto underscorePos = floatNode->val.find("_");
-
-                const string &withoutUnderscores =
-                    (underscorePos == string::npos) ? floatNode->val : absl::StrReplaceAll(floatNode->val, {{"_", ""}});
-                if (!absl::SimpleAtod(withoutUnderscores, &val)) {
-                    val = numeric_limits<double>::quiet_NaN();
-                    if (auto e = dctx.ctx.beginIndexerError(loc, core::errors::Desugar::FloatOutOfRange)) {
-                        e.setHeader("Unsupported float literal: `{}`", floatNode->val);
-                        e.addErrorNote("This likely represents a bug in Sorbet. Please report an issue:\n"
-                                       "    https://github.com/sorbet/sorbet/issues");
-                    }
-                }
-
-                ExpressionPtr res = MK::Float(loc, val);
-                result = move(res);
-            },
+            [&](parser::Float *floatNode) { desugaredByPrismTranslator(floatNode); },
             [&](parser::Complex *complex) { desugaredByPrismTranslator(complex); },
             [&](parser::Rational *rational) { desugaredByPrismTranslator(rational); },
             [&](parser::Array *array) {


### PR DESCRIPTION
Desugars `PM_FLOAT_NODE` as part of the work to integrate Prism in Sorbet. 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
