### PR TITLE
Drop support for Ruby 2.7

### DIFF
--- a/.buildkite/build-sorbet-runtime.sh
+++ b/.buildkite/build-sorbet-runtime.sh
@@ -7,7 +7,7 @@ pushd gems/sorbet-runtime
 echo "--- setup :ruby:"
 eval "$(rbenv init -)"
 
-runtime_versions=(3.1.2 3.3.0 3.4.5)
+runtime_versions=(3.1.2 3.3.0)
 
 for runtime_version in "${runtime_versions[@]}"; do
   rbenv install --skip-existing "$runtime_version"

--- a/.buildkite/build-sorbet-runtime.sh
+++ b/.buildkite/build-sorbet-runtime.sh
@@ -7,7 +7,7 @@ pushd gems/sorbet-runtime
 echo "--- setup :ruby:"
 eval "$(rbenv init -)"
 
-runtime_versions=(2.7.7 3.1.2 3.3.0)
+runtime_versions=(3.1.2 3.3.0 3.4.5)
 
 for runtime_version in "${runtime_versions[@]}"; do
   rbenv install --skip-existing "$runtime_version"
@@ -22,14 +22,6 @@ for runtime_version in "${runtime_versions[@]}"; do
   rbenv exec ruby --version
 
   failed=
-
-  if [ "$runtime_version" = "2.7.7" ]; then
-    # Our Rubocop version doesn't understand Ruby 3.1 as a valid Ruby version
-    echo "+++ rubocop ($runtime_version)"
-    if ! rbenv exec bundle exec rake rubocop; then
-      failed=1
-    fi
-  fi
 
   echo "+++ tests ($runtime_version)"
   if ! rbenv exec bundle exec rake test; then
@@ -54,7 +46,7 @@ done
 
 echo "--- build"
 git_commit_count=$(git rev-list --count HEAD)
-release_version="0.5.${git_commit_count}"
+release_version="0.6.${git_commit_count}"
 sed -i.bak "s/0\\.0\\.0/${release_version}/" sorbet-runtime.gemspec
 gem build sorbet-runtime.gemspec
 popd

--- a/.buildkite/build-sorbet-static-and-runtime.sh
+++ b/.buildkite/build-sorbet-static-and-runtime.sh
@@ -13,7 +13,7 @@ ruby --version
 
 echo "--- build"
 git_commit_count=$(git rev-list --count HEAD)
-release_version="0.5.${git_commit_count}"
+release_version="0.6.${git_commit_count}"
 sed -i.bak "s/0\\.0\\.0/${release_version}/" sorbet-static-and-runtime.gemspec
 gem build sorbet-static-and-runtime.gemspec
 

--- a/.buildkite/build-static-release-java.sh
+++ b/.buildkite/build-static-release-java.sh
@@ -15,7 +15,7 @@ buildkite-agent artifact download "_out_/**/*.gem" .
 mkdir -p gems/sorbet-static/libexec
 
 git_commit_count=$(git rev-list --count HEAD)
-prefix="0.5"
+prefix="0.6"
 release_version="$prefix.${git_commit_count}"
 
 rbenv install --skip-existing

--- a/.buildkite/build-static-release.sh
+++ b/.buildkite/build-static-release.sh
@@ -56,7 +56,7 @@ rbenv install --skip-existing
 
 pushd gems/sorbet-static
 git_commit_count=$(git rev-list --count HEAD)
-release_version="0.5.${git_commit_count}"
+release_version="0.6.${git_commit_count}"
 sed -i.bak "s/0\\.0\\.0/${release_version}/" sorbet-static.gemspec
 if [[ "darwin" == "$kernel_name" ]]; then
     sed -i.bak "s/Gem::Platform::CURRENT/'universal-darwin'/" sorbet-static.gemspec

--- a/.buildkite/publish-ruby-gems.sh
+++ b/.buildkite/publish-ruby-gems.sh
@@ -8,7 +8,7 @@ if [ "${PUBLISH_TO_RUBYGEMS:-}" == "" ]; then
 fi
 
 git_commit_count=$(git rev-list --count HEAD)
-prefix="0.5"
+prefix="0.6"
 release_version="$prefix.${git_commit_count}"
 
 echo "--- Dowloading artifacts"

--- a/gems/sorbet-runtime/sorbet-runtime.gemspec
+++ b/gems/sorbet-runtime/sorbet-runtime.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/sorbet/sorbet",
   }
 
-  s.required_ruby_version = ['>= 2.7.0']
+  s.required_ruby_version = ['>= 3.0.0']
 
   s.add_development_dependency 'minitest', '~> 5.11'
   s.add_development_dependency 'mocha', '~> 2.1'

--- a/gems/sorbet-static-and-runtime/sorbet-static-and-runtime.gemspec
+++ b/gems/sorbet-static-and-runtime/sorbet-static-and-runtime.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'sorbet', '0.0.0'
   s.add_dependency 'sorbet-runtime', '0.0.0'
 
-  s.required_ruby_version = ['>= 2.7.0']
+  s.required_ruby_version = ['>= 3.0.0']
 end

--- a/gems/sorbet-static/sorbet-static.gemspec
+++ b/gems/sorbet-static/sorbet-static.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   # We include a pre-built binary (in libexec/), making us platform dependent.
   s.platform = Gem::Platform::CURRENT
 
-  s.required_ruby_version = ['>= 2.7.0']
+  s.required_ruby_version = ['>= 3.0.0']
 end

--- a/gems/sorbet/sorbet.gemspec
+++ b/gems/sorbet/sorbet.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'sorbet-static', '0.0.0'
 
-  s.required_ruby_version = ['>= 2.7.0']
+  s.required_ruby_version = ['>= 3.0.0']
 
   s.add_development_dependency 'minitest', '~> 5.11'
   s.add_development_dependency 'mocha', '~> 1.7'


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Solving #9213 requires an API that is only available in Ruby 3.0 and
later. We're going to drop support for Ruby 2.7, which went EOL in March
2023, and then make sorbet-runtime use that new standard library method
to solve the bug.

cc @CT075

See also #9214


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This is tricky to test, I have not tested it.