### PR TITLE
type `Enumerable#to_set`

### DIFF
--- a/rbi/stdlib/set.rbi
+++ b/rbi/stdlib/set.rbi
@@ -2045,5 +2045,13 @@ module Enumerable
   # arguments.
   # Needs
   # to `require "set"` to use this method.
-  def to_set(klass = _, *args, &block); end
+  sig do
+    returns(T::Set[Elem])
+  end
+  sig do
+    type_parameters(:Return)
+    .params(blk: T.nilable(T.proc.params(arg0: Elem).returns(T.type_parameter(:Return))))
+    .returns(T::Set[T.type_parameter(:Return)])
+  end
+  def to_set(&blk); end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Rubocop's `Style/MapToSet` doesn't like `.map(&:foo).to_set` and wants you to write `to_set(&:foo)` instead, but for non-array things, the former expression is properly typed whereas the latter is not.

As the changes to the definition show, this is not strictly correct with respect to what the function actually takes, but we have gotten away with the wrong signature on `Array#to_set` earlier in this file for a long time.  I'm not 100% sure we could actually write the correct type for the full signature?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The usual testing regimen.