### PR TITLE
remove most uses of `Send::setBlock`

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -346,33 +346,33 @@ public:
     static ExpressionPtr Sig(core::LocOffsets loc, Send::ARGS_store args, ExpressionPtr ret) {
         auto params = Params(loc, Self(loc), std::move(args));
         auto returns = Send1(loc, std::move(params), core::Names::returns(), loc, std::move(ret));
-        auto sig = Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::sig(), loc,
-                         Constant(loc, core::Symbols::T_Sig_WithoutRuntime()));
-        auto sigSend = ast::cast_tree<ast::Send>(sig);
-        sigSend->setBlock(Block0(loc, std::move(returns)));
-        sigSend->flags.isRewriterSynthesized = true;
-        return sig;
+        Send::Flags flags;
+        flags.isRewriterSynthesized = true;
+        flags.hasBlock = true;
+        return Send(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::sig(), loc, 1,
+                    SendArgs(Constant(loc, core::Symbols::T_Sig_WithoutRuntime()), Block0(loc, std::move(returns))),
+                    flags);
     }
 
     static ExpressionPtr SigVoid(core::LocOffsets loc, Send::ARGS_store args) {
         auto params = Params(loc, Self(loc), std::move(args));
         auto void_ = Send0(loc, std::move(params), core::Names::void_(), loc);
-        auto sig = Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::sig(), loc,
-                         Constant(loc, core::Symbols::T_Sig_WithoutRuntime()));
-        auto sigSend = ast::cast_tree<ast::Send>(sig);
-        sigSend->setBlock(Block0(loc, std::move(void_)));
-        sigSend->flags.isRewriterSynthesized = true;
-        return sig;
+        Send::Flags flags;
+        flags.isRewriterSynthesized = true;
+        flags.hasBlock = true;
+        return Send(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::sig(), loc, 1,
+                    SendArgs(Constant(loc, core::Symbols::T_Sig_WithoutRuntime()), Block0(loc, std::move(void_))),
+                    flags);
     }
 
     static ExpressionPtr Sig0(core::LocOffsets loc, ExpressionPtr ret) {
         auto returns = Send1(loc, Self(loc), core::Names::returns(), loc, std::move(ret));
-        auto sig = Send1(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::sig(), loc,
-                         Constant(loc, core::Symbols::T_Sig_WithoutRuntime()));
-        auto sigSend = ast::cast_tree<ast::Send>(sig);
-        sigSend->setBlock(Block0(loc, std::move(returns)));
-        sigSend->flags.isRewriterSynthesized = true;
-        return sig;
+        Send::Flags flags;
+        flags.isRewriterSynthesized = true;
+        flags.hasBlock = true;
+        return Send(loc, Constant(loc, core::Symbols::Sorbet_Private_Static()), core::Names::sig(), loc, 1,
+                    SendArgs(Constant(loc, core::Symbols::T_Sig_WithoutRuntime()), Block0(loc, std::move(returns))),
+                    flags);
     }
 
     static ExpressionPtr Sig1(core::LocOffsets loc, ExpressionPtr key, ExpressionPtr value, ExpressionPtr ret) {

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -24,10 +24,10 @@ bool isKeywordInitKey(const core::GlobalState &gs, const ast::ExpressionPtr &nod
 
 // Elem = type_member {{fixed: T.untyped}}
 ast::ExpressionPtr elemFixedUntyped(core::LocOffsets loc) {
-    auto typeMember = ast::MK::Send0(loc, ast::MK::Self(loc), core::Names::typeMember(), loc.copyWithZeroLength());
-    ast::cast_tree_nonnull<ast::Send>(typeMember)
-        .setBlock(ast::MK::Block0(
-            loc, ast::MK::Hash1(loc, ast::MK::Symbol(loc, core::Names::fixed()), ast::MK::Untyped(loc))));
+    auto block =
+        ast::MK::Block0(loc, ast::MK::Hash1(loc, ast::MK::Symbol(loc, core::Names::fixed()), ast::MK::Untyped(loc)));
+    auto typeMember =
+        ast::MK::Send0Block(loc, ast::MK::Self(loc), core::Names::typeMember(), loc.copyWithZeroLength(), move(block));
     return ast::MK::Assign(loc, ast::MK::UnresolvedConstant(loc, ast::MK::EmptyTree(), core::Names::Constants::Elem()),
                            std::move(typeMember));
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I would like to get to the point where we never mutate the arguments of an `ast::Send` node once it has been constructed.  `setBlock` is currently an obstacle to that, as it will push the block onto the arguments list.

As @amomchilov demonstrated in #9226, we can construct the `Send` node properly by setting the relevant flags beforehand.

Once #9226 is merged, there are only a couple of remaining uses: `super` rewriting in local vars, which needs its own PR, and a tricky use in the resolver, which is also good to separate out into its own PR.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This should be a no-op; existing tests should confirm that.
