### PR TITLE
Move Prism desugar tests earlier in the test pipline

### DIFF
--- a/core/Unfreeze.cc
+++ b/core/Unfreeze.cc
@@ -4,7 +4,7 @@ namespace sorbet::core {
 
 UnfreezeSymbolTable::UnfreezeSymbolTable(GlobalState &gs) : gs(gs) {
     auto oldState = gs.unfreezeSymbolTable();
-    ENFORCE(oldState);
+    ENFORCE(oldState, "The symbol table was already unfrozen. Remove the excess call to UnfreezeSymbolTable.");
 }
 
 UnfreezeSymbolTable::~UnfreezeSymbolTable() {
@@ -13,7 +13,7 @@ UnfreezeSymbolTable::~UnfreezeSymbolTable() {
 
 UnfreezeNameTable::UnfreezeNameTable(GlobalState &gs) : gs(gs) {
     auto oldState = gs.unfreezeNameTable();
-    ENFORCE(oldState);
+    ENFORCE(oldState, "The name table was already unfrozen. Remove the excess call to UnfreezeNameTable.");
 }
 
 UnfreezeNameTable::~UnfreezeNameTable() {
@@ -22,7 +22,7 @@ UnfreezeNameTable::~UnfreezeNameTable() {
 
 UnfreezeFileTable::UnfreezeFileTable(GlobalState &gs) : gs(gs) {
     auto oldState = gs.unfreezeFileTable();
-    ENFORCE(oldState);
+    ENFORCE(oldState, "The file table was already unfrozen. Remove the excess call to UnfreezeFileTable.");
 }
 
 UnfreezeFileTable::~UnfreezeFileTable() {


### PR DESCRIPTION
### Motivation

The incremental resolver runs over a modified version of the test file, that's been prepending with a bunch of new lines:

https://github.com/sorbet/sorbet/blob/bb79ad419b06e1a0c3a67839724244e23fd3ec1f/test/pipeline_test_runner.cc#L702-L706

I made the mistake of putting our desugar location tests on this incremental resolver test stage, where all the new lines ruin our location information, and make test debugging difficult.

This PR moves our desugar location testing to happen during the initial indexing, so that we get correct location information.