### PR TITLE
Add runtime checks for necessary override sigils on props

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -330,13 +330,25 @@ class T::Props::Decorator
 
     return if rules[:without_accessors]
 
+    if method_defined_on_ancestor?(name) && props.include?(name) && !override[:reader]
+      raise ArgumentError.new("The reader for prop #{name.inspect} overrides the method `#{name}`, but is not marked as `override: :reader`.")
+    end
+
     if override[:reader] && !method_defined_on_ancestor?(name) && !props.include?(name)
-      raise ArgumentError.new("You marked the getter for prop #{name.inspect} as `override`, but the method `#{name}` doesn't exist to be overridden.")
+      raise ArgumentError.new("You marked the reader for prop #{name.inspect} as `override`, but the method `#{name}` doesn't exist to be overridden.")
     end
 
     # Properly, we should also check whether `props[name]` is immutable, but the old code didn't either.
-    if !rules[:immutable] && override[:writer] && !method_defined_on_ancestor?("#{name}=".to_sym) && !props.include?(name)
-      raise ArgumentError.new("You marked the setter for prop #{name.inspect} as `override`, but the method `#{name}=` doesn't exist to be overridden.")
+    if !rules[:immutable]
+      wname = "#{name}=".to_sym
+
+      if method_defined_on_ancestor?(wname) && props.include?(wname) && !override[:writer]
+        raise ArgumentError.new("The writer for prop #{name.inspect} overrides the method `#{name}=`, but is not marked as `override: :writer`.")
+      end
+
+      if override[:writer] && !method_defined_on_ancestor?(wname) && !props.include?(wname)
+        raise ArgumentError.new("You marked the writer for prop #{name.inspect} as `override`, but the method `#{name}=` doesn't exist to be overridden.")
+      end
     end
   end
 

--- a/gems/sorbet-runtime/test/types/props/_props.rb
+++ b/gems/sorbet-runtime/test/types/props/_props.rb
@@ -505,4 +505,24 @@ class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest
 
     assert(err.message.include?("doesn't exist to be overridden"))
   end
+
+  it "errors if override isn't specified" do
+    err = assert_raises(ArgumentError) do
+      module Parent
+        extend T::Sig
+        extend T::Helpers
+        abstract!
+        sig { abstract.returns(Integer) }
+        def foo
+        end
+      end
+
+      class Child < T::Struct
+        include Parent
+        const :foo, Integer
+      end
+    end
+
+    assert(err.message.include?("not marked as `override: :reader`"))
+  end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
This is the corresponding runtime check to #9085, causing a runtime error if a `prop` is declared that overrides without an `override` sigil.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
