### PR TITLE
do fewer hashtable lookups when pretty-printing

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/pretty_printable.rb
+++ b/gems/sorbet-runtime/lib/types/props/pretty_printable.rb
@@ -12,8 +12,8 @@ module T::Props::PrettyPrintable
     pp.group(1, "<#{klass.inspect_class_with_decoration(self)}", ">") do
       klass.all_props.sort.each do |prop|
         pp.breakable
-        val = klass.get(self, prop)
         rules = klass.prop_rules(prop)
+        val = klass.get(self, prop, rules)
         pp.text("#{prop}=")
         if (custom_inspect = rules[:inspect])
           inspected = if T::Utils.arity(custom_inspect) == 1

--- a/gems/sorbet-runtime/lib/types/props/pretty_printable.rb
+++ b/gems/sorbet-runtime/lib/types/props/pretty_printable.rb
@@ -22,8 +22,8 @@ module T::Props::PrettyPrintable
             custom_inspect.call(val, {multiline: multiline})
           end
           pp.text(inspected.nil? ? "nil" : inspected)
-        elsif rules[:sensitivity] && !rules[:sensitivity].empty? && !val.nil?
-          pp.text("<REDACTED #{rules[:sensitivity].join(', ')}>")
+        elsif (sensitivity = rules[:sensitivity]) && !sensitivity.empty? && !val.nil?
+          pp.text("<REDACTED #{sensitivity.join(', ')}>")
         else
           val.pretty_print(pp)
         end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

A Stripe user ran into this code, and I noticed that it could be improved.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

We seem to have minimal coverage for pretty-printing, at least.
