### PR TITLE
eschew runtime typechecking for pretty-printing hooks

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/pretty_printable.rb
+++ b/gems/sorbet-runtime/lib/types/props/pretty_printable.rb
@@ -56,14 +56,14 @@ module T::Props::PrettyPrintable
 
     # Overridable method to specify how the first part of a `pretty_print`d object's class should look like
     # NOTE: This is just to support Stripe's `PrettyPrintableModel` case, and not recommended to be overridden
-    sig { params(instance: T::Props::PrettyPrintable).returns(String) }
+    sig { params(instance: T::Props::PrettyPrintable).returns(String).checked(:never) }
     def inspect_class_with_decoration(instance)
       T.unsafe(instance).class.to_s
     end
 
     # Overridable method to add anything that is not a prop
     # NOTE: This is to support cases like Serializable's `@_extra_props`, and Stripe's `PrettyPrintableModel#@_deleted`
-    sig { params(instance: T::Props::PrettyPrintable, pp: T.any(PrettyPrint, PP::SingleLine)).void }
+    sig { params(instance: T::Props::PrettyPrintable, pp: T.any(PrettyPrint, PP::SingleLine)).void.checked(:never) }
     def pretty_print_extra(instance, pp); end
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We already `.checked(:never)` some functions in this file, let's not check these as well.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
