### PR TITLE
Desugar `PM_RANGE_NODE`

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1325,10 +1325,32 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             auto left = translate(rangeNode->left);
             auto right = translate(rangeNode->right);
 
-            if (PM_NODE_FLAG_P(rangeNode, PM_RANGE_FLAGS_EXCLUDE_END)) { // `...`
-                return make_unique<parser::ERange>(location, move(left), move(right));
+            bool isExclusive = PM_NODE_FLAG_P(rangeNode, PM_RANGE_FLAGS_EXCLUDE_END);
+
+            if (!directlyDesugar || !hasExpr(left, right)) {
+                if (isExclusive) { // `...`
+                    return make_unique<parser::ERange>(location, move(left), move(right));
+                } else { // `..`
+                    return make_unique<parser::IRange>(location, move(left), move(right));
+                }
+            }
+
+            auto recv = MK::Magic(location);
+            auto locZeroLen = core::LocOffsets{location.beginPos(), location.beginPos()};
+
+            auto fromExpr = left ? left->takeDesugaredExpr() : MK::EmptyTree();
+            auto toExpr = right ? right->takeDesugaredExpr() : MK::EmptyTree();
+
+            auto excludeEndExpr = isExclusive ? MK::True(location) : MK::False(location);
+
+            // Desugar to `::Kernel.<buildRange>(from, to, excludeEnd)`
+            auto desugaredExpr = MK::Send3(location, move(recv), core::Names::buildRange(), locZeroLen, move(fromExpr),
+                                           move(toExpr), move(excludeEndExpr));
+
+            if (isExclusive) { // `...`
+                return make_node_with_expr<parser::ERange>(move(desugaredExpr), location, move(left), move(right));
             } else { // `..`
-                return make_unique<parser::IRange>(location, move(left), move(right));
+                return make_node_with_expr<parser::IRange>(move(desugaredExpr), location, move(left), move(right));
             }
         }
         case PM_RATIONAL_NODE: { // A rational number literal, e.g. `1r`


### PR DESCRIPTION
Part of #9065 
- Desugar `PM_RANGE_NODE` as part of Prism in Sorbet work
- Properly handle nil values for beginless/endless ranges (e.g., ..5, 1..)
- Only desugar when all children have been desugared

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests