### PR TITLE
Remove references from ctx parameters

### DIFF
--- a/ast/desugar/DuplicateHashKeyCheck.h
+++ b/ast/desugar/DuplicateHashKeyCheck.h
@@ -12,7 +12,7 @@ class DuplicateHashKeyCheck {
     UnorderedMap<core::NameRef, core::LocOffsets> hashKeyStrings;
 
 public:
-    DuplicateHashKeyCheck(const core::MutableContext &ctx) : ctx{ctx}, hashKeySymbols(), hashKeyStrings() {}
+    DuplicateHashKeyCheck(core::MutableContext ctx) : ctx{ctx}, hashKeySymbols(), hashKeyStrings() {}
 
     void check(const ExpressionPtr &key);
 

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -568,9 +568,9 @@ public:
     // Returns the locations that are allowed to subclass the sealed class.
     absl::Span<const Loc> sealedLocs(const GlobalState &gs) const;
 
-    TypePtr sealedSubclassesToUnion(const GlobalState &ctx) const;
+    TypePtr sealedSubclassesToUnion(const GlobalState &gs) const;
 
-    bool hasSingleSealedSubclass(const GlobalState &ctx) const;
+    bool hasSingleSealedSubclass(const GlobalState &gs) const;
 
     // Record a required ancestor for this class of module
     void recordRequiredAncestor(GlobalState &gs, ClassOrModuleRef ancestor, Loc loc);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1910,7 +1910,7 @@ void Environment::initializeBasicBlockArgs(const cfg::BasicBlock &bb) {
     }
 }
 
-void Environment::setUninitializedVarsToNil(const core::Context &ctx, core::Loc origin) {
+void Environment::setUninitializedVarsToNil(core::Context ctx, core::Loc origin) {
     for (auto &uninitialized : _vars) {
         if (uninitialized.second.typeAndOrigins.type == nullptr) {
             uninitialized.second.typeAndOrigins.type = core::Types::nilClass();

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -209,7 +209,7 @@ public:
 
     void initializeBasicBlockArgs(const cfg::BasicBlock &bb);
 
-    void setUninitializedVarsToNil(const core::Context &ctx, core::Loc origin);
+    void setUninitializedVarsToNil(core::Context ctx, core::Loc origin);
 
     std::string toString(const core::GlobalState &gs, const cfg::CFG &cfg) const;
 

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -62,7 +62,7 @@ class PropagateVisibility final {
         }
     }
 
-    bool ignoreRBIExportEnforcement(core::MutableContext &ctx, core::FileRef file) {
+    bool ignoreRBIExportEnforcement(core::MutableContext ctx, core::FileRef file) {
         const auto path = file.data(ctx).path();
 
         return absl::c_any_of(ctx.state.packageDB().skipRBIExportEnforcementDirs(),
@@ -70,7 +70,7 @@ class PropagateVisibility final {
     }
 
     // Checks that the package that a symbol is defined in can be exported from the package we're currently checking.
-    void checkExportPackage(core::MutableContext &ctx, core::LocOffsets loc, core::SymbolRef sym) {
+    void checkExportPackage(core::MutableContext ctx, core::LocOffsets loc, core::SymbolRef sym) {
         ENFORCE(!sym.locs(ctx).empty()); // Can't be empty
 
         bool allRBI = absl::c_all_of(sym.locs(ctx), [&](const core::Loc &loc) {

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1086,7 +1086,7 @@ void populatePackagePathPrefixes(core::GlobalState &gs, ast::ParsedFile &package
     }
 }
 
-void validateLayering(const core::Context &ctx, const Import &i) {
+void validateLayering(core::Context ctx, const Import &i) {
     if (i.isTestImport()) {
         return;
     }
@@ -1159,7 +1159,7 @@ void validateLayering(const core::Context &ctx, const Import &i) {
     }
 }
 
-void validateVisibility(const core::Context &ctx, const PackageInfo &absPkg, const Import i) {
+void validateVisibility(core::Context ctx, const PackageInfo &absPkg, const Import i) {
     ENFORCE(ctx.state.packageDB().getPackageInfo(i.mangledName).exists())
     ENFORCE(ctx.state.packageDB().getPackageNameForFile(ctx.file).exists())
     auto &otherPkg = ctx.state.packageDB().getPackageInfo(i.mangledName);

--- a/parser/prism/Parser.cc
+++ b/parser/prism/Parser.cc
@@ -7,7 +7,7 @@ using namespace std;
 
 namespace sorbet::parser::Prism {
 
-parser::ParseResult Parser::run(core::MutableContext &ctx, bool directlyDesugar, bool preserveConcreteSyntax) {
+parser::ParseResult Parser::run(core::MutableContext ctx, bool directlyDesugar, bool preserveConcreteSyntax) {
     auto file = ctx.file;
     auto source = file.data(ctx).source();
     Prism::Parser parser{source};

--- a/parser/prism/Parser.h
+++ b/parser/prism/Parser.h
@@ -55,7 +55,7 @@ public:
     Parser(Parser &&) = delete;
     Parser &operator=(Parser &&) = delete;
 
-    static parser::ParseResult run(core::MutableContext &ctx, bool directlyDesugar = true,
+    static parser::ParseResult run(core::MutableContext ctx, bool directlyDesugar = true,
                                    bool preserveConcreteSyntax = false);
 
     ParseResult parse(bool collectComments = false);

--- a/rewriter/SigRewriter.cc
+++ b/rewriter/SigRewriter.cc
@@ -24,7 +24,7 @@ bool isTSigWithoutRuntime(ast::ExpressionPtr &expr) {
 } // namespace
 
 // Rewrite all sig usage into uses of `Sorbet::Private::Static.<sig>`, and mark them as being dsl synthesized.
-bool SigRewriter::run(core::MutableContext &ctx, ast::Send *send) {
+bool SigRewriter::run(core::MutableContext ctx, ast::Send *send) {
     if (send->fun != core::Names::sig()) {
         return false;
     }

--- a/rewriter/SigRewriter.h
+++ b/rewriter/SigRewriter.h
@@ -6,7 +6,7 @@
 namespace sorbet::rewriter {
 class SigRewriter {
 public:
-    static bool run(core::MutableContext &ctx, ast::Send *send);
+    static bool run(core::MutableContext ctx, ast::Send *send);
 };
 } // namespace sorbet::rewriter
 #endif


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Contexts are always passed by value. They contain a `GlobalState &`
inside them so that they do not need to copy the full GlobalState.
Accepting a `{Mutable,}Context &` means that a method can do something
like:

```cpp
ctx = compute_new_context();
```

and overwrite the caller's context. That's ~never what we want.
Technically we can do something similar with

```cpp
ctx.state = compute_new_gs();
```

But I don't know how to avoid that. At least you can't ovewrite the
context, or mutate the `ctx.file` field.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests