### PR TITLE
Directly desugar method definitions (including parameters)

### DIFF
--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -92,6 +92,9 @@ private:
     std::pair<std::unique_ptr<parser::Args>, core::NameRef /* enclosingBlockParamName */>
     translateParametersNode(pm_parameters_node *paramsNode);
 
+    std::tuple<ast::MethodDef::ARGS_store, ast::InsSeq::STATS_store, bool>
+    desugarParametersNode(parser::Args *paramsNode, bool attemptToDesugarParams);
+
     NodeVec translateArguments(pm_arguments_node *node, pm_node *blockArgumentNode = nullptr);
     parser::NodeVec translateKeyValuePairs(pm_node_list_t elements);
     static bool isKeywordHashElement(sorbet::parser::Node *node);

--- a/test/prism_regression/def.parse-tree.exp
+++ b/test/prism_regression/def.parse-tree.exp
@@ -7,34 +7,6 @@ Begin {
     }
     DefMethod {
       name = <U bar>
-      args = NULL
-      body = Begin {
-        stmts = [
-          String {
-            val = <U string1>
-          }
-          String {
-            val = <U string2>
-          }
-        ]
-      }
-    }
-    DefMethod {
-      name = <U baz>
-      args = NULL
-      body = Kwbegin {
-        stmts = [
-          String {
-            val = <U string1>
-          }
-          String {
-            val = <U string2>
-          }
-        ]
-      }
-    }
-    DefMethod {
-      name = <U qux>
       args = Args {
         args = [
         ]

--- a/test/prism_regression/def.rb
+++ b/test/prism_regression/def.rb
@@ -2,16 +2,4 @@
 
 def foo; end
 
-def bar
-  "string1"
-  "string2"
-end
-
-def baz
-  begin
-  "string1"
-  "string2"
-  end
-end
-
-def qux(); end
+def bar(); end

--- a/test/prism_regression/def_block_param.parse-tree.exp
+++ b/test/prism_regression/def_block_param.parse-tree.exp
@@ -5,7 +5,7 @@ Begin {
       args = Args {
         args = [
           Blockarg {
-            name = <U blk>
+            name = <U my_block_param>
           }
         ]
       }
@@ -21,25 +21,6 @@ Begin {
         ]
       }
       body = NULL
-    }
-    DefMethod {
-      name = <U foo>
-      args = Args {
-        args = [
-          Blockarg {
-            name = <U blk>
-          }
-        ]
-      }
-      body = Super {
-        args = [
-          BlockPass {
-            block = LVar {
-              name = <U blk>
-            }
-          }
-        ]
-      }
     }
   ]
 }

--- a/test/prism_regression/def_block_param.rb
+++ b/test/prism_regression/def_block_param.rb
@@ -1,9 +1,5 @@
 # typed: false
 
-def foo(&blk); end
+def foo(&my_block_param); end
 
 def foo(&); end
-
-def foo(&blk)
-  super(&blk)
-end

--- a/test/prism_regression/def_with_body.parse-tree.exp
+++ b/test/prism_regression/def_with_body.parse-tree.exp
@@ -1,7 +1,59 @@
-DefMethod {
-  name = <U foo>
-  args = NULL
-  body = Integer {
-    val = "5"
-  }
+Begin {
+  stmts = [
+    DefMethod {
+      name = <U one_statement>
+      args = NULL
+      body = Integer {
+        val = "1"
+      }
+    }
+    DefMethod {
+      name = <U two_statements>
+      args = NULL
+      body = Begin {
+        stmts = [
+          Integer {
+            val = "2"
+          }
+          Integer {
+            val = "3"
+          }
+        ]
+      }
+    }
+    DefMethod {
+      name = <U three_statements>
+      args = NULL
+      body = Begin {
+        stmts = [
+          Integer {
+            val = "4"
+          }
+          Integer {
+            val = "5"
+          }
+          Integer {
+            val = "6"
+          }
+        ]
+      }
+    }
+    DefMethod {
+      name = <U begin_block>
+      args = NULL
+      body = Kwbegin {
+        stmts = [
+          Integer {
+            val = "7"
+          }
+          Integer {
+            val = "8"
+          }
+          Integer {
+            val = "9"
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/test/prism_regression/def_with_body.rb
+++ b/test/prism_regression/def_with_body.rb
@@ -1,5 +1,24 @@
 # typed: false
 
-def foo
+def one_statement
+  1
+end
+
+def two_statements
+  2
+  3
+end
+
+def three_statements
+  4
   5
+  6
+end
+
+def begin_block
+  begin
+    7
+    8
+    9
+  end
 end


### PR DESCRIPTION
### Motivation

Part of #9065

This PR adds direct desugaring for `PM_DEF_NODE`, and several other node types that don't have their own desugar tree representation (`PM_PARAMETERS_NODE`, `PM_FORWARDING_PARAMETER_NODE`, `PM_NO_KEYWORDS_PARAMETER_NODE`).

### Test plan

There's tons of method definitions in the tests already, which cover this. I also improved the Prism-specific tests to cover more cases (like bodies of single statements, vs bodies of multiple statements)
