### PR TITLE
Directly desugar regular assignments

### DIFF
--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -110,7 +110,7 @@ private:
     template <typename PrismNode> std::unique_ptr<parser::Mlhs> translateMultiTargetLhs(PrismNode *);
 
     template <typename PrismAssignmentNode, typename SorbetLHSNode>
-    std::unique_ptr<parser::Assign> translateAssignment(pm_node_t *node);
+    std::unique_ptr<parser::Node> translateAssignment(pm_node_t *node);
 
     template <typename PrismAssignmentNode, typename SorbetAssignmentNode, typename SorbetLHSNode>
     std::unique_ptr<SorbetAssignmentNode> translateOpAssignment(pm_node_t *node);


### PR DESCRIPTION
### Motivation

Part of #9065 

This excludes more complicated assignments like `||=`, `&&=` and other operator assignments.

### Test plan

Covered by existing desugar tests