### PR TITLE
remove `setBlock` usage from `local_vars`

### DIFF
--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -305,6 +305,7 @@ class LocalNameInserter {
         ast::ExpressionPtr blockArg;
 
         core::NameRef newFun = original.fun;
+        ast::Send::Flags newFlags = original.flags;
 
         for (const auto &arg : enclosingMethodScopeStack.args) {
             ENFORCE(blockArg == nullptr, "Block arg was not in final position");
@@ -421,6 +422,7 @@ class LocalNameInserter {
                 // <call-with-splat> and "do"
                 newFun = core::Names::callWithSplat();
                 // Re-add block argument
+                newFlags.hasBlock = true;
                 original.setBlock(std::move(originalBlock));
             } else if (shouldForwardBlockArg) {
                 // <call-with-splat-and-block>(..., &blk)
@@ -476,6 +478,7 @@ class LocalNameInserter {
             }
             // Re-add original block
             if (originalBlock) {
+                newFlags.hasBlock = true;
                 original.setBlock(std::move(originalBlock));
             }
             kwArgKeyEntries.clear();
@@ -483,6 +486,7 @@ class LocalNameInserter {
         }
 
         original.fun = newFun;
+        original.flags = newFlags;
         return tree;
     }
 

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -466,8 +466,10 @@ class LocalNameInserter {
             newFun = core::Names::callWithBlock();
         } else {
             // No positional splat and we have a "do", so we can synthesize an ordinary send.
-            newArgs.reserve(posArgsEntries.size() + kwArgKeyEntries.size() * 2
-                            /* hasKwSplat */ + int(kwArgsHash != nullptr) + /* hasBlock */ int(originalBlock != nullptr));
+            newArgs.reserve(posArgsEntries.size() +
+                            kwArgKeyEntries.size() * 2
+                            /* hasKwSplat */
+                            + int(kwArgsHash != nullptr) + /* hasBlock */ int(originalBlock != nullptr));
 
             absl::c_move(std::move(posArgsEntries), std::back_inserter(newArgs));
             posArgsEntries.clear();
@@ -492,7 +494,8 @@ class LocalNameInserter {
             kwArgValueEntries.clear();
         }
 
-        return ast::make_expression<ast::Send>(original.loc, std::move(newRecv), newFun, original.funLoc, newNumPosArgs, std::move(newArgs), newFlags);
+        return ast::make_expression<ast::Send>(original.loc, std::move(newRecv), newFun, original.funLoc, newNumPosArgs,
+                                               std::move(newArgs), newFlags);
     }
 
     void walkConstantLit(core::MutableContext ctx, ast::ExpressionPtr &tree) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I would like to get to a world where we never modify the arguments of an `ast::Send` node after it is created.  `Send::setBlock` is an impediment to doing this, so I would like to remove it.

This PR takes care of all the uses in `local_vars`.

We do have to construct an entirely new `ast::Send` node as a result, so there is some memory churn associated with this, but `super` nodes are uncommon, so this performance hit should be in the noise.  I think constructing the arguments for the new send in a more straightforward way might balance out the memory churn.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests -- this should be validated by the `z_super_args.rb` AST test that we have, at a minimum.
