### PR TITLE
Directly Prism Desugar PM_AND_NODE

### DIFF
--- a/parser/Node.h
+++ b/parser/Node.h
@@ -34,6 +34,10 @@ public:
         return false;
     }
 
+    virtual bool desugaredExprIsReference() {
+        return false;
+    }
+
 protected:
     void printTabs(fmt::memory_buffer &to, int count) const;
     void printNode(fmt::memory_buffer &to, const std::unique_ptr<Node> &node, const core::GlobalState &gs,
@@ -108,6 +112,10 @@ public:
 
     virtual bool hasDesugaredExpr() final {
         return this->desugaredExpr != nullptr;
+    }
+
+    virtual bool desugaredExprIsReference() final {
+        return hasDesugaredExpr() && isa_reference(this->desugaredExpr);
     }
 
     // Like `parser::cast_node`, but can cast a `NodeWithExpr` *as if* it was its wrapped node.

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -60,7 +60,7 @@ public:
           desugarUniqueCounter(this->desugarUniqueCounterStorage) {}
 
     // Translates the given AST from Prism's node types into the equivalent AST in Sorbet's legacy parser node types.
-    std::unique_ptr<parser::Node> translate(pm_node_t *node);
+    std::unique_ptr<parser::Node> translate(pm_node_t *node, bool preserveConcreteSyntax = false);
 
 private:
     // This private constructor is used for creating child translators with modified context.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

- Part of #9065 
- Remaining issue: nextUniqueDesugarName will lead to temporary variable names being different and thus tests failing. One possible solution is to ignore these differences as they are not user facing. The current solution is to fallback when the left hand side node is not a reference.
- Depends on #9257 


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
