### PR TITLE
minor tweaks to the `T.must_because` docs

### DIFF
--- a/website/docs/type-assertions.md
+++ b/website/docs/type-assertions.md
@@ -125,7 +125,9 @@ end
   → View on sorbet.run
 </a>
 
-Here's the same example with `T.must_because`, showing the user of custom reasons. The reason is provided as a block that returns a `String`, so that the reason is only computed if the exception would be raised.
+### `T.must_because`
+
+Here's the same example with `T.must_because`, showing the use of custom reasons. The reason is provided as a block that returns a `String`, so that the reason is only computed if the exception would be raised.
 
 ```ruby
 class A


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The textual change is a very minor one.

I think it's mildly useful to have `T.must_because` as a heading so it shows up in the outline on the RHS of the doc page, but I can be convinced that this is a bad idea.  (Note that it's one lever deeper than the `T.must` one, because I think it's a related concept, not a separate one.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
