### PR TITLE
Bump mimalloc to 2.2.4

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -123,10 +123,10 @@ def register_sorbet_dependencies():
 
     http_archive(
         name = "mimalloc",
-        url = "https://github.com/microsoft/mimalloc/archive/refs/tags/v2.1.2.zip",  # 2.1.2
-        sha256 = "86281c918921c1007945a8a31e5ad6ae9af77e510abfec20d000dd05d15123c7",
+        url = "https://github.com/microsoft/mimalloc/archive/refs/tags/v2.2.4.zip",  # 2.2.4
+        sha256 = "664667a48c9f101d979bbe4e41ee631da49d2024e30d66b7779b6ba4279af367",
         build_file = "@com_stripe_ruby_typer//third_party:mimalloc.BUILD",
-        strip_prefix = "mimalloc-2.1.2",
+        strip_prefix = "mimalloc-2.2.4",
     )
 
     http_archive(


### PR DESCRIPTION
Mimalloc 2.2.4 has been out since June, and lists some important bug fixes that we might want:

2025-06-09, v1.9.4, v2.2.4, v3.1.4 (beta) : Some important bug fixes, including a case where OS memory was not always fully released. Improved v3 performance, build on XBox, fix build on Android, support interpose for older macOS versions, use MADV_FREE_REUSABLE on macOS, always check commit success, better support for Windows fixed TLS offset, etc.

### Motivation
Pulling in potential allocator improvements.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a
