### PR TITLE
Delete `_prism` suffix from test targets

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,7 +39,7 @@
             "type": "lldb",
             "request": "launch",
             "name": "Debug Prism test in LLDB",
-            "program": "${workspaceFolder}/bazel-bin/test/test_PosTests/prism_regression/${input:prism_regression_test_name}_prism.runfiles/com_stripe_ruby_typer/test/pipeline_test_runner",
+            "program": "${workspaceFolder}/bazel-bin/test/test_PrismPosTests/prism_regression/${input:prism_regression_test_name}.runfiles/com_stripe_ruby_typer/test/pipeline_test_runner",
             "args": ["--single_test=${workspaceFolder}/test/prism_regression/${input:prism_regression_test_name}.rb", "--parser=prism"],
             // We need to run all tests to generate the pipeline_test_runner files, which are needed by the LLDB debugger to execute the tests.
             "preLaunchTask": "Run all Prism regression tests",

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -92,13 +92,6 @@ def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_files = [], ta
                         "isPackage": True,
                     }
 
-                    # Tests that run with Prism parser need to have "_prism" appended to their name
-                    # to differentiate them from the tests that run with Sorbet parser.
-                    # The condition here is only for the packager tests
-                    # Other tests are handled below.
-                    if parser == "prism":
-                        test_name = test_name + "_prism"
-
                     tests[test_name] = data
                 continue
 
@@ -106,11 +99,6 @@ def pipeline_tests(suite_name, all_paths, test_name_prefix, extra_files = [], ta
         prefix = dropExtension(basename(path).partition("__")[0])
 
         test_name = dirname(path) + "/" + prefix
-
-        # Tests that run with Prism parser need to have "_prism" appended to their name
-        # to differentiate them from the tests that run with Sorbet parser.
-        if parser == "prism":
-            test_name = test_name + "_prism"
 
         current = tests.get(test_name)
         if None == current:


### PR DESCRIPTION
### Motivation

The Prism-related test targets have similar names to their non-Prism counterparts, except they include "prism" twice in their names:

```
//test:test_PrismPosTests/testdata/parser/invalid_def_forward_prism
            ^^^^^                                            ^^^^^^
```

This makes it cumbersome to switch back and forth between the Prism and non-Prism variants of the same test.

Part of #9065, supersedes #9209.

### Test plan

Just renames existing test targets
