### PR TITLE
Fix parameter order in Translator constructor calls

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -2764,15 +2764,15 @@ Translator Translator::enterMethodDef(bool isSingletonMethod, core::LocOffsets m
                                       core::NameRef enclosingBlockParamName) const {
     auto resetDesugarUniqueCounter = true;
     auto isInModule = this->isInModule && !isSingletonMethod;
-    return Translator(*this, resetDesugarUniqueCounter, methodLoc, methodName, enclosingBlockParamName,
-                      this->isInAnyBlock, isInModule);
+    return Translator(*this, resetDesugarUniqueCounter, methodLoc, methodName, enclosingBlockParamName, isInModule,
+                      this->isInAnyBlock);
 }
 
 Translator Translator::enterBlockContext() const {
     auto resetDesugarUniqueCounter = false; // Blocks inherit their parent's numbering
     auto isInAnyBlock = true;
     return Translator(*this, resetDesugarUniqueCounter, this->enclosingMethodLoc, this->enclosingMethodName,
-                      this->enclosingBlockParamName, isInAnyBlock, this->isInModule);
+                      this->enclosingBlockParamName, this->isInModule, isInAnyBlock);
 }
 
 Translator Translator::enterModuleContext() const {
@@ -2780,7 +2780,7 @@ Translator Translator::enterModuleContext() const {
     auto isInModule = true;
     auto isInAnyBlock = false; // Blocks never persist across a class/module boundary
     return Translator(*this, resetDesugarUniqueCounter, this->enclosingMethodLoc, this->enclosingMethodName,
-                      this->enclosingBlockParamName, isInAnyBlock, isInModule);
+                      this->enclosingBlockParamName, isInModule, isInAnyBlock);
 }
 
 Translator Translator::enterClassContext() const {
@@ -2788,7 +2788,7 @@ Translator Translator::enterClassContext() const {
     auto isInModule = false;
     auto isInAnyBlock = false; // Blocks never persist across a class/module boundary
     return Translator(*this, resetDesugarUniqueCounter, this->enclosingMethodLoc, this->enclosingMethodName,
-                      this->enclosingBlockParamName, isInAnyBlock, isInModule);
+                      this->enclosingBlockParamName, isInModule, isInAnyBlock);
 }
 
 void Translator::reportError(core::LocOffsets loc, const string &message) const {


### PR DESCRIPTION
Follow-up to https://github.com/sorbet/sorbet/pull/9233
Part of https://github.com/sorbet/sorbet/issues/9065

Swaps `isInModule` and `isInAnyBlock` arguments to match the `Translator` constructor definition: https://github.com/sorbet/sorbet/blob/8a98ff8ed44b467745ff0876626e6af940707e45/parser/prism/Translator.h#L68-L70

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This is supporting infrastructure that will be tested in the upcoming PRs that use it