### PR TITLE
Add rbi entry for `Timeout::ExitException`

### DIFF
--- a/rbi/stdlib/timeout.rbi
+++ b/rbi/stdlib/timeout.rbi
@@ -77,6 +77,10 @@ module Timeout
   def self.timeout(sec, klass = nil, message = nil, &blk); end
 end
 
+class Timeout::ExitException < Exception
+  def exception(*); end
+end
+
 # Raised by
 # [`Timeout.timeout`](https://docs.ruby-lang.org/en/2.7.0/Timeout.html#method-c-timeout)
 # when the block times out.


### PR DESCRIPTION
See https://github.com/ruby/timeout/blob/99bf1dd3e9720fc6cc0fd6b7bcca86fe2bd6e420/lib/timeout.rb#L26-L30

(Despite being an internal error, this shows up in https://github.com/brianmario/mysql2/blob/0f38974ead068daa5388013cd01f49f74e439805/lib/mysql2.rb#L82 )