### PR TITLE
Implement single-line string recovery strategy

### DIFF
--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -1300,7 +1300,12 @@ void lexer::set_state_expr_value() {
     } else {
       // Try ending the literal with a newline.
       auto str = tok_view();
-      if (current_literal.nest_and_try_closing(str, ts, te)) {
+      if (current_literal.nest_and_try_closing(str, ts, te, "", this->singleLineStrings)) {
+        if (this->singleLineStrings) {
+          // `fhold` to ensure that the tNL gets emitted as an actual tNL token
+          // (statement delimiter) and not consumed as the end token of the string literal.
+          fhold;
+        }
         fnext *pop_literal(); fbreak;
       }
 

--- a/parser/parser/codegen/generate_diagnostics.cc
+++ b/parser/parser/codegen/generate_diagnostics.cc
@@ -85,6 +85,7 @@ tuple<string, string> MESSAGES[] = {
     {"BlockArgsUnexpectedNewline", "Hint: expected \\\"|\\\" token here"},
     {"EOFInsteadOfEnd", "Hint: this {} token is not closed before the end of the file"},
     {"DefMissingName", "Hint: this {} token might not be followed by a method name"},
+    {"EscapeEofHint", "Hint: this string literal might be missing a closing `{}` at the end of the line"},
 
     // Parser warnings
     {"UselessElse", "else without rescue is useless"},

--- a/parser/parser/include/ruby_parser/lexer.hh
+++ b/parser/parser/include/ruby_parser/lexer.hh
@@ -193,6 +193,11 @@ public:
     Context context;
 
     bool collect_comments = false;
+
+    // Whether to run in a mode where string literals are only allowed to span a single line,
+    // for better error recovery.
+    bool singleLineStrings = false;
+
     std::vector<std::pair<size_t, size_t>> comment_locations;
 
     lexer(diagnostics_t &diag, ruby_version version, std::string_view source_buffer,

--- a/parser/parser/include/ruby_parser/literal.hh
+++ b/parser/parser/include/ruby_parser/literal.hh
@@ -84,7 +84,7 @@ public:
     bool end_interp_brace_and_try_closing();
 
     bool nest_and_try_closing(std::string_view delimiter, const char *ts, const char *te,
-                              std::string_view lookahead = "");
+                              std::string_view lookahead = "", bool singleLineLiteral = false);
 
     void extend_space(const char *ts, const char *te);
     void extend_string(std::string_view str, const char *ts, const char *te);

--- a/test/cli/unclosed-quote/test.out
+++ b/test/cli/unclosed-quote/test.out
@@ -59,9 +59,9 @@ end
     11 |
     12 |
 
-./unclosed_quote_2.rb:5: Hint: this "def" token is not closed before the end of the file https://srb.help/2003
-     5 |def foo
-        ^^^
+./unclosed_quote_2.rb:6: Hint: this string literal might be missing a closing `"` at the end of the line https://srb.help/2003
+     6 |  x = "some string
+                          ^
 Errors: 3
 class <emptyTree><<C <root>>> < (::<todo sym>)
   def before<<todo method>>(&<blk>)
@@ -69,7 +69,11 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   def foo<<todo method>>(&<blk>)
-    x = <emptyTree>::<C <ErrorNode>>
+    x = "some string"
+  end
+
+  def after<<todo method>>(&<blk>)
+    <emptyTree>
   end
 end
 
@@ -97,17 +101,35 @@ end
     12 |
     13 |
 
-./unclosed_quote_3.rb:5: Hint: this "def" token is not closed before the end of the file https://srb.help/2003
-     5 |def foo
+./unclosed_quote_3.rb:6: Hint: this string literal might be missing a closing `"` at the end of the line https://srb.help/2003
+     6 |  x = "valid
+                    ^
+
+./unclosed_quote_3.rb:7: Hint: this "if" token might not be properly closed https://srb.help/2003
+     7 |  if x
+          ^^
+    ./unclosed_quote_3.rb:8: Matching `end` found here but is not indented as far
+     8 |end
         ^^^
-Errors: 3
+Errors: 4
 class <emptyTree><<C <root>>> < (::<todo sym>)
   def before<<todo method>>(&<blk>)
     <emptyTree>
   end
 
   def foo<<todo method>>(&<blk>)
-    x = <emptyTree>::<C <ErrorNode>>
+    begin
+      x = "valid"
+      if x
+        <emptyTree>
+      else
+        <emptyTree>
+      end
+    end
+  end
+
+  def after<<todo method>>(&<blk>)
+    <emptyTree>
   end
 end
 
@@ -136,13 +158,20 @@ end
     15 |end
     16 |
 
-./unclosed_quote_4.rb:6: Hint: this "def" token is not closed before the end of the file https://srb.help/2003
-     6 |  def foo
-          ^^^
+./unclosed_quote_4.rb:7: Hint: this string literal might be missing a closing `"` at the end of the line https://srb.help/2003
+     7 |    xyz = "
+                   ^
 
-./unclosed_quote_4.rb:5: Hint: this "class" token is not closed before the end of the file https://srb.help/2003
-     5 |class A
-        ^^^^^
+./unclosed_quote_4.rb:9: Changing the type of a variable is not permitted in loops and blocks https://srb.help/7001
+     9 |      xyz = nil
+                    ^^^
+  Existing variable has type: `String("")`
+  Attempting to change type to: `NilClass`
+
+  Autocorrect: Done
+    ./unclosed_quote_4.rb:7: Replaced with `T.let(", T.nilable(String))`
+     7 |    xyz = "
+                  ^
 Errors: 4
 class <emptyTree><<C <root>>> < (::<todo sym>)
   def before<<todo method>>(&<blk>)
@@ -151,8 +180,17 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
     def foo<<todo method>>(&<blk>)
-      xyz = <emptyTree>::<C <ErrorNode>>
+      begin
+        xyz = ""
+        1.times() do ||
+          xyz = nil
+        end
+      end
     end
+  end
+
+  def after<<todo method>>(&<blk>)
+    <emptyTree>
   end
 end
 
@@ -164,7 +202,7 @@ def before; end
 
 class A
   def foo
-    xyz = "
+    xyz = T.let(", T.nilable(String))
     1.times do
       xyz = nil
     end
@@ -184,16 +222,32 @@ end
     16 |
     17 |
 
-./unclosed_quote_5.rb:5: Hint: this "def" token is not closed before the end of the file https://srb.help/2003
-     5 |def main
-        ^^^
-Errors: 3
+./unclosed_quote_5.rb:6: Hint: this string literal might be missing a closing `)` at the end of the line https://srb.help/2003
+     6 |  %w(we are the people
+                              ^
+
+./unclosed_quote_5.rb:8: Hint: this string literal might be missing a closing `'` at the end of the line https://srb.help/2003
+     8 |  'foo
+              ^
+
+./unclosed_quote_5.rb:10: Hint: this string literal might be missing a closing `)` at the end of the line https://srb.help/2003
+    10 |  %r(foo
+                ^
+Errors: 5
 class <emptyTree><<C <root>>> < (::<todo sym>)
   def before<<todo method>>(&<blk>)
     <emptyTree>
   end
 
   def main<<todo method>>(&<blk>)
+    begin
+      ["we", "are", "the"]
+      "foo"
+      ::Regexp.new("", 0)
+    end
+  end
+
+  def after<<todo method>>(&<blk>)
     <emptyTree>
   end
 end
@@ -227,13 +281,20 @@ end
     16 |
     17 |
 
-./unclosed_quote_6.rb:6: Hint: this "def" token is not closed before the end of the file https://srb.help/2003
-     6 |  def foo
-          ^^^
+./unclosed_quote_6.rb:7: Hint: this string literal might be missing a closing `"` at the end of the line https://srb.help/2003
+     7 |    xyz = "#{}
+                      ^
 
-./unclosed_quote_6.rb:5: Hint: this "class" token is not closed before the end of the file https://srb.help/2003
-     5 |class A
-        ^^^^^
+./unclosed_quote_6.rb:9: Changing the type of a variable is not permitted in loops and blocks https://srb.help/7001
+     9 |      xyz = nil
+                    ^^^
+  Existing variable has type: `String`
+  Attempting to change type to: `NilClass`
+
+  Autocorrect: Done
+    ./unclosed_quote_6.rb:7: Replaced with `T.let("#{}, T.nilable(String))`
+     7 |    xyz = "#{}
+                  ^^^^
 Errors: 4
 class <emptyTree><<C <root>>> < (::<todo sym>)
   def before<<todo method>>(&<blk>)
@@ -242,8 +303,17 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
     def foo<<todo method>>(&<blk>)
-      xyz = <emptyTree>::<C <ErrorNode>>
+      begin
+        xyz = ::<Magic>.<string-interpolate>(nil)
+        1.times() do ||
+          xyz = nil
+        end
+      end
     end
+  end
+
+  def after<<todo method>>(&<blk>)
+    <emptyTree>
   end
 end
 
@@ -255,7 +325,7 @@ def before; end
 
 class A
   def foo
-    xyz = "#{}
+    xyz = T.let("#{}, T.nilable(String))
     1.times do
       xyz = nil
     end
@@ -276,10 +346,18 @@ end
     12 |def after; end
     13 |
 
-./unclosed_quote_7.rb:5: Hint: this "def" token is not closed before the end of the file https://srb.help/2003
-     5 |def foo
-        ^^^
-Errors: 3
+./unclosed_quote_7.rb:6: Hint: this string literal might be missing a closing `"` at the end of the line https://srb.help/2003
+     6 |  x = "first line
+                         ^
+
+./unclosed_quote_7.rb:7: Hint: this string literal might be missing a closing `"` at the end of the line https://srb.help/2003
+     7 |  second line"
+                      ^
+
+./unclosed_quote_7.rb:9: Hint: this string literal might be missing a closing `"` at the end of the line https://srb.help/2003
+     9 |  x = "unclosed string
+                              ^
+Errors: 5
 class <emptyTree><<C <root>>> < (::<todo sym>)
   def before<<todo method>>(&<blk>)
     <emptyTree>
@@ -287,9 +365,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   def foo<<todo method>>(&<blk>)
     begin
-      x = "first line\n  second line"
-      x = <emptyTree>::<C <ErrorNode>>
+      x = "first line"
+      <self>.second(<self>.line(""))
+      x = "unclosed string"
     end
+  end
+
+  def after<<todo method>>(&<blk>)
+    <emptyTree>
   end
 end
 

--- a/test/cli/unclosed-quote/test.out
+++ b/test/cli/unclosed-quote/test.out
@@ -1,0 +1,309 @@
+
+----- ./unclosed_quote_1.rb ---------------------------------------
+
+./unclosed_quote_1.rb:13: unexpected token "end of file" https://srb.help/2001
+    13 |end
+    14 |
+
+./unclosed_quote_1.rb:8: Hint: this "if" token might not be properly closed https://srb.help/2003
+     8 |  if x
+          ^^
+    ./unclosed_quote_1.rb:9: Matching `end` found here but is not indented as far
+     9 |end
+        ^^^
+Errors: 2
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def before<<todo method>>(&<blk>)
+    <emptyTree>
+  end
+
+  def foo<<todo method>>(&<blk>)
+    begin
+      x = "\n    valid"
+      if x
+        <emptyTree>
+      else
+        <emptyTree>
+      end
+    end
+  end
+
+  def after<<todo method>>(&<blk>)
+    <emptyTree>
+  end
+end
+
+--------------------------------------------------------------------------
+
+# typed: false
+
+def before; end
+
+def foo
+  x = "
+    valid"
+  if x
+end
+
+
+def after
+end
+
+----- ./unclosed_quote_2.rb ---------------------------------------
+
+./unclosed_quote_2.rb:6: escape sequence meets end of file https://srb.help/2001
+     6 |  x = "some string
+              ^
+
+./unclosed_quote_2.rb:11: unexpected token "end of file" https://srb.help/2001
+    11 |
+    12 |
+
+./unclosed_quote_2.rb:5: Hint: this "def" token is not closed before the end of the file https://srb.help/2003
+     5 |def foo
+        ^^^
+Errors: 3
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def before<<todo method>>(&<blk>)
+    <emptyTree>
+  end
+
+  def foo<<todo method>>(&<blk>)
+    x = <emptyTree>::<C <ErrorNode>>
+  end
+end
+
+--------------------------------------------------------------------------
+
+# typed: false
+
+def before; end
+
+def foo
+  x = "some string
+end
+
+def after
+end
+
+
+----- ./unclosed_quote_3.rb ---------------------------------------
+
+./unclosed_quote_3.rb:6: escape sequence meets end of file https://srb.help/2001
+     6 |  x = "valid
+              ^
+
+./unclosed_quote_3.rb:12: unexpected token "end of file" https://srb.help/2001
+    12 |
+    13 |
+
+./unclosed_quote_3.rb:5: Hint: this "def" token is not closed before the end of the file https://srb.help/2003
+     5 |def foo
+        ^^^
+Errors: 3
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def before<<todo method>>(&<blk>)
+    <emptyTree>
+  end
+
+  def foo<<todo method>>(&<blk>)
+    x = <emptyTree>::<C <ErrorNode>>
+  end
+end
+
+--------------------------------------------------------------------------
+
+# typed: false
+
+def before; end
+
+def foo
+  x = "valid
+  if x
+end
+
+def after
+end
+
+
+----- ./unclosed_quote_4.rb ---------------------------------------
+
+./unclosed_quote_4.rb:7: escape sequence meets end of file https://srb.help/2001
+     7 |    xyz = "
+                  ^
+
+./unclosed_quote_4.rb:15: unexpected token "end of file" https://srb.help/2001
+    15 |end
+    16 |
+
+./unclosed_quote_4.rb:6: Hint: this "def" token is not closed before the end of the file https://srb.help/2003
+     6 |  def foo
+          ^^^
+
+./unclosed_quote_4.rb:5: Hint: this "class" token is not closed before the end of the file https://srb.help/2003
+     5 |class A
+        ^^^^^
+Errors: 4
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def before<<todo method>>(&<blk>)
+    <emptyTree>
+  end
+
+  class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
+    def foo<<todo method>>(&<blk>)
+      xyz = <emptyTree>::<C <ErrorNode>>
+    end
+  end
+end
+
+--------------------------------------------------------------------------
+
+# typed: true
+
+def before; end
+
+class A
+  def foo
+    xyz = "
+    1.times do
+      xyz = nil
+    end
+  end
+end
+
+def after
+end
+
+----- ./unclosed_quote_5.rb ---------------------------------------
+
+./unclosed_quote_5.rb:6: escape sequence meets end of file https://srb.help/2001
+     6 |  %w(we are the people
+          ^
+
+./unclosed_quote_5.rb:16: unexpected token tSTRING_CONTENT https://srb.help/2001
+    16 |
+    17 |
+
+./unclosed_quote_5.rb:5: Hint: this "def" token is not closed before the end of the file https://srb.help/2003
+     5 |def main
+        ^^^
+Errors: 3
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def before<<todo method>>(&<blk>)
+    <emptyTree>
+  end
+
+  def main<<todo method>>(&<blk>)
+    <emptyTree>
+  end
+end
+
+--------------------------------------------------------------------------
+
+# typed: false
+
+def before; end
+
+def main
+  %w(we are the people
+
+  'foo
+
+  %r(foo
+
+end
+
+def after
+end
+
+
+----- ./unclosed_quote_6.rb ---------------------------------------
+
+./unclosed_quote_6.rb:7: escape sequence meets end of file https://srb.help/2001
+     7 |    xyz = "#{}
+                  ^
+
+./unclosed_quote_6.rb:16: unexpected token "end of file" https://srb.help/2001
+    16 |
+    17 |
+
+./unclosed_quote_6.rb:6: Hint: this "def" token is not closed before the end of the file https://srb.help/2003
+     6 |  def foo
+          ^^^
+
+./unclosed_quote_6.rb:5: Hint: this "class" token is not closed before the end of the file https://srb.help/2003
+     5 |class A
+        ^^^^^
+Errors: 4
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def before<<todo method>>(&<blk>)
+    <emptyTree>
+  end
+
+  class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
+    def foo<<todo method>>(&<blk>)
+      xyz = <emptyTree>::<C <ErrorNode>>
+    end
+  end
+end
+
+--------------------------------------------------------------------------
+
+# typed: true
+
+def before; end
+
+class A
+  def foo
+    xyz = "#{}
+    1.times do
+      xyz = nil
+    end
+  end
+end
+
+def after
+end
+
+
+----- ./unclosed_quote_7.rb ---------------------------------------
+
+./unclosed_quote_7.rb:9: escape sequence meets end of file https://srb.help/2001
+     9 |  x = "unclosed string
+              ^
+
+./unclosed_quote_7.rb:12: unexpected token "end of file" https://srb.help/2001
+    12 |def after; end
+    13 |
+
+./unclosed_quote_7.rb:5: Hint: this "def" token is not closed before the end of the file https://srb.help/2003
+     5 |def foo
+        ^^^
+Errors: 3
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def before<<todo method>>(&<blk>)
+    <emptyTree>
+  end
+
+  def foo<<todo method>>(&<blk>)
+    begin
+      x = "first line\n  second line"
+      x = <emptyTree>::<C <ErrorNode>>
+    end
+  end
+end
+
+--------------------------------------------------------------------------
+
+# typed: false
+
+def before; end
+
+def foo
+  x = "first line
+  second line"
+
+  x = "unclosed string
+end
+
+def after; end

--- a/test/cli/unclosed-quote/test.sh
+++ b/test/cli/unclosed-quote/test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+tmp="$(mktemp -d)"
+cp test/cli/unclosed-quote/*.rb "$tmp"
+
+cwd="$(pwd)"
+cd "$tmp" || exit 1
+
+# Using bash range here because sometimes the glob order sorting is OS/shell dependent.
+for file in ./unclosed_quote_{1..7}.rb; do
+  echo
+  echo ----- "$file" ---------------------------------------
+  echo
+
+  if "$cwd/main/sorbet" --silence-dev-message --print=desugar-tree -a "$file" 2>&1; then
+    echo "Expected to fail, but didn't"
+    exit 1
+  fi
+
+  echo
+  echo --------------------------------------------------------------------------
+  echo
+
+  # Also cat the file, to make sure that 'extend' is only added once per class.
+  cat "$file"
+done
+
+cd - &> /dev/null
+rm -rf "$tmp"

--- a/test/cli/unclosed-quote/unclosed_quote_1.rb
+++ b/test/cli/unclosed-quote/unclosed_quote_1.rb
@@ -1,0 +1,13 @@
+# typed: false
+
+def before; end
+
+def foo
+  x = "
+    valid"
+  if x
+end
+
+
+def after
+end

--- a/test/cli/unclosed-quote/unclosed_quote_2.rb
+++ b/test/cli/unclosed-quote/unclosed_quote_2.rb
@@ -1,0 +1,11 @@
+# typed: false
+
+def before; end
+
+def foo
+  x = "some string
+end
+
+def after
+end
+

--- a/test/cli/unclosed-quote/unclosed_quote_3.rb
+++ b/test/cli/unclosed-quote/unclosed_quote_3.rb
@@ -1,0 +1,12 @@
+# typed: false
+
+def before; end
+
+def foo
+  x = "valid
+  if x
+end
+
+def after
+end
+

--- a/test/cli/unclosed-quote/unclosed_quote_4.rb
+++ b/test/cli/unclosed-quote/unclosed_quote_4.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+def before; end
+
+class A
+  def foo
+    xyz = "
+    1.times do
+      xyz = nil
+    end
+  end
+end
+
+def after
+end

--- a/test/cli/unclosed-quote/unclosed_quote_5.rb
+++ b/test/cli/unclosed-quote/unclosed_quote_5.rb
@@ -1,0 +1,16 @@
+# typed: false
+
+def before; end
+
+def main
+  %w(we are the people
+
+  'foo
+
+  %r(foo
+
+end
+
+def after
+end
+

--- a/test/cli/unclosed-quote/unclosed_quote_6.rb
+++ b/test/cli/unclosed-quote/unclosed_quote_6.rb
@@ -1,0 +1,16 @@
+# typed: true
+
+def before; end
+
+class A
+  def foo
+    xyz = "#{}
+    1.times do
+      xyz = nil
+    end
+  end
+end
+
+def after
+end
+

--- a/test/cli/unclosed-quote/unclosed_quote_7.rb
+++ b/test/cli/unclosed-quote/unclosed_quote_7.rb
@@ -1,0 +1,12 @@
+# typed: false
+
+def before; end
+
+def foo
+  x = "first line
+  second line"
+
+  x = "unclosed string
+end
+
+def after; end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


Co-authored-by @elliottt

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #5439

If Sorbet catastrophically fails to parse a file (e.g., produces a `nullptr` for
the parse result), we want to try again, using ad hoc heuristics to try to
produce a better parse. This PR adds a new strategy where we ban **all** string
literals from spanning multiple lines if the list of diagnostics produced by the
first parse is symptomatic of an unclosed string literal.

(This adds to our existing ad hoc strategy where we attempt to use indentation
to produce a better parse, so that we can find mismatched `end` keywords.)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.