### PR TITLE
add a test for unsupported node desugaring edge case

### DIFF
--- a/test/prism_regression/flip_flop.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/flip_flop.rb.desugar-tree-raw.exp
@@ -1,0 +1,56 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    If{
+      cond = EmptyTree
+      thenp = Literal{ value = "body 1" }
+      elsep = EmptyTree
+    }
+
+    If{
+      cond = EmptyTree
+      thenp = Literal{ value = "body 2" }
+      elsep = EmptyTree
+    }
+
+    If{
+      cond = EmptyTree
+      thenp = Literal{ value = "body 3" }
+      elsep = EmptyTree
+    }
+
+    If{
+      cond = EmptyTree
+      thenp = EmptyTree
+      elsep = Literal{ value = "body 4" }
+    }
+
+    If{
+      cond = EmptyTree
+      thenp = EmptyTree
+      elsep = Literal{ value = "body 5" }
+    }
+
+    Assign{
+      lhs = UnresolvedIdent{
+        kind = Local
+        name = <U b>
+      }
+      rhs = Send{
+        flags = {privateOk}
+        recv = Self
+        fun = <U !>
+        block = nullptr
+        pos_args = 0
+        args = [
+        ]
+      }
+    }
+  ]
+}

--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -60,7 +60,7 @@ EOF
 
 BUILD=1
 if [ $# -eq 0 ]; then
-  paths=(test/testdata)
+  paths=(test/testdata test/prism_regression)
 else
   while true; do
     case $1 in
@@ -122,6 +122,14 @@ for this_src in "${rb_src[@]}" DUMMY; do
   fi
 
   if [ -n "$basename" ]; then
+    case "${srcs[0]}" in
+      test/prism_regression/*)
+        uses_prism=true
+        ;;
+      *)
+        uses_prism=false
+    esac
+
     needs_stripe_packages=false
     if grep -q '^# enable-packager: true' "${srcs[@]}"; then
       needs_stripe_packages=true
@@ -251,6 +259,10 @@ for this_src in "${rb_src[@]}" DUMMY; do
         fi
       fi
 
+      if $uses_prism; then
+        args+=("--parser=prism")
+      fi
+
       case "$pass" in
         document-symbols)
           # See above for why this case is weird.
@@ -297,5 +309,6 @@ fi
 if [ "${EMIT_SYNCBACK:-}" != "" ]; then
   echo '### BEGIN SYNCBACK ###'
   echo 'test/testdata/'
+  echo 'test/prism_regression/'
   echo '### END SYNCBACK ###'
 fi


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Capturing the discussion from https://github.com/sorbet/sorbet/pull/9274#pullrequestreview-3189394253 in the form of a test case.

The modifications to the `update_testdata_exp.sh` script are necessary for automatic updates of the `test/prism_regression` exp files.

It is mildly annoying that said script doesn't work in one shot anymore due to:

https://github.com/sorbet/sorbet/blob/0b25596d9bb3e11e724b2231cc753fabffb15002/test/BUILD#L282-L295

which means that you have to manually revert changes.

Maybe all tests in `test/prism_regression` should have a `desugar-tree-raw.exp` testcase?  (cc @amomchilov )

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
