### PR TITLE
Desugar `PM_LOCAL_VARIABLE_TARGET_NODE`

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1290,8 +1290,9 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
             // ... like `target1, target2 = 1, 2`, `rescue => target`, etc.
             auto localVarTargetNode = down_cast<pm_local_variable_target_node>(node);
             auto name = translateConstantName(localVarTargetNode->name);
+            auto expr = MK::Local(location, name);
 
-            return make_unique<parser::LVarLhs>(location, name);
+            return make_node_with_expr<parser::LVarLhs>(move(expr), location, name);
         }
         case PM_LOCAL_VARIABLE_WRITE_NODE: { // Regular assignment to a local variable, e.g. `local = 1`
             return translateAssignment<pm_local_variable_write_node, parser::LVarLhs>(node);


### PR DESCRIPTION
Part of #9065 
Desugars `PM_LOCAL_VARIABLE_TARGET_NODE` in `Translator.cc` as part of integrating Prism in Sorbet

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests