### PR TITLE
Fix ENFORCE failure in test_each+let support

### DIFF
--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -289,7 +289,13 @@ ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName
             if (argLiteral.isName()) {
                 auto declLoc = send->loc.copyWithZeroLength().join(argLiteral.loc);
                 auto methodName = argLiteral.asName();
-                return ast::MK::SyntheticMethod0(send->loc, declLoc, methodName, std::move(send->block()->body));
+
+                ConstantMover constantMover;
+                auto body = move(send->block()->body);
+                ast::TreeWalk::apply(ctx, constantMover, body);
+
+                auto method = ast::MK::SyntheticMethod0(send->loc, declLoc, methodName, move(body));
+                return constantMover.addConstantsToExpression(send->loc, move(method));
             }
         }
     }

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -525,9 +525,13 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
                 return nullptr;
             }
 
+            ConstantMover constantMover;
+            ast::TreeWalk::apply(ctx, constantMover, block->body);
+
             auto declLoc = send->loc.copyWithZeroLength().join(argLiteral.loc);
             auto methodName = argLiteral.asName();
-            return ast::MK::SyntheticMethod0(send->loc, declLoc, methodName, std::move(block->body));
+            auto method = ast::MK::SyntheticMethod0(send->loc, declLoc, methodName, std::move(block->body));
+            return constantMover.addConstantsToExpression(send->loc, move(method));
         }
     }
 

--- a/test/testdata/rewriter/minitest_let.rb
+++ b/test/testdata/rewriter/minitest_let.rb
@@ -47,6 +47,12 @@ class MyTestHelper < Minitest::Spec
       'not an int' # error: Expected `Integer` but found
     }
 
+    sig { returns(Integer) }
+    let(:has_constant_definitions) {
+      X = T.let(1, Integer)
+      X
+    }
+
     it 'example' do
       res = untyped_helper()
       T.reveal_type(res) # error: `T.untyped`

--- a/test/testdata/rewriter/minitest_tables.rb
+++ b/test/testdata/rewriter/minitest_tables.rb
@@ -224,4 +224,26 @@ class MyTest
     end
   end
 
+
+  module Mod; class C; end; end
+  describe 'foo' do
+    test_each([]) do |val|
+      it "hoists constants inside of it" do
+        CONST = 10
+      end
+
+      it "hoists let-ed constants inside of it" do
+        C2 = T.let(10, Integer)
+      end
+
+      it "hoists path constants inside of it" do
+        C3 = Mod::C
+        C3.new
+      end
+
+      let(:hoists_in_let_too) do
+        C4 = 10
+      end
+    end
+  end
 end

--- a/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
@@ -460,5 +460,52 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <emptyTree>
       end
     end
+
+    module <emptyTree>::<C Mod><<C <todo sym>>> < ()
+      class <emptyTree>::<C C><<C <todo sym>>> < (::<todo sym>)
+      end
+    end
+
+    class <emptyTree>::<C <describe 'foo'>><<C <todo sym>>> < (<self>)
+      def <it 'hoists constants inside of it'><<todo method>>(&<blk>)
+        [].each() do |val|
+          ::Module.const_set(:CONST, 10)
+        end
+      end
+
+      def <it 'hoists let-ed constants inside of it'><<todo method>>(&<blk>)
+        [].each() do |val|
+          ::Module.const_set(:C2, <cast:let>(10, <todo sym>, <emptyTree>::<C Integer>))
+        end
+      end
+
+      def <it 'hoists path constants inside of it'><<todo method>>(&<blk>)
+        [].each() do |val|
+          <emptyTree>::<C C3>.new()
+        end
+      end
+
+      def hoists_in_let_too<<todo method>>(&<blk>)
+        <emptyTree>::<C C4> = 10
+      end
+
+      <self>.test_each([]) do |val|
+        begin
+          begin
+            <emptyTree>::<C CONST> = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+            <runtime method definition of <it 'hoists constants inside of it'>>
+          end
+          begin
+            <emptyTree>::<C C2> = <cast:let>(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented"), <todo sym>, <emptyTree>::<C Integer>)
+            <runtime method definition of <it 'hoists let-ed constants inside of it'>>
+          end
+          begin
+            <emptyTree>::<C C3> = <emptyTree>::<C Mod>::<C C>
+            <runtime method definition of <it 'hoists path constants inside of it'>>
+          end
+          <runtime method definition of hoists_in_let_too>
+        end
+      end
+    end
   end
 end

--- a/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
@@ -486,7 +486,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def hoists_in_let_too<<todo method>>(&<blk>)
-        <emptyTree>::<C C4> = 10
+        ::Module.const_set(:C4, 10)
       end
 
       <self>.test_each([]) do |val|
@@ -503,7 +503,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
             <emptyTree>::<C C3> = <emptyTree>::<C Mod>::<C C>
             <runtime method definition of <it 'hoists path constants inside of it'>>
           end
-          <runtime method definition of hoists_in_let_too>
+          begin
+            <emptyTree>::<C C4> = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+            <runtime method definition of hoists_in_let_too>
+          end
         end
       end
     end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

See also: #2128 for original context of this.

We don't actually depend on this except via code in `Verifier::run`.

It appears that Sorbet is actually able to define and resolve constants defined inside method bodies without issue (but the original motivations of introducing the ENFORCE) remain.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This came up during the review of #9119, but it's independent of that change so
I'd like to land it separately.

fyi @alexevanczuk


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See the tests for a before+after