### PR TITLE
minitest: Also support `let!` and `subject`

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -156,6 +156,8 @@ NameDef names[] = {
     {"assertType", "assert_type!"},
     {"cast"},
     {"let"},
+    {"let_bang", "let!"},
+    {"subject"},
     {"uncheckedLet", "<unchecked_let>"},
     {"syntheticBind", "<synthetic bind>"},
     {"assumeType", "<assume type>"},

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -243,7 +243,11 @@ ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName
                                 const ast::MethodDef::ARGS_store &args, ast::ExpressionPtr &iteratee,
                                 bool insideDescribe) {
     // this statement must be a send
-    if (auto send = ast::cast_tree<ast::Send>(stmt)) {
+    auto send = ast::cast_tree<ast::Send>(stmt);
+    if (send == nullptr) {
+        return invalidUnderTestEach(ctx, eachName, move(stmt));
+    }
+
         auto correctBlockArity = send->hasBlock() && send->block()->args.size() == 0;
         // the send must be a call to `it` with a single argument (the test name) and a block with no arguments
         if ((send->fun == core::Names::it() && send->numPosArgs() == 1 && correctBlockArity) ||
@@ -311,7 +315,6 @@ ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName
                 return constantMover.addConstantsToExpression(send->loc, move(method));
             }
         }
-    }
 
     return invalidUnderTestEach(ctx, eachName, move(stmt));
 }

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -332,8 +332,7 @@ ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName
                (send->fun == core::Names::let() || send->fun == core::Names::let_bang() ||
                 send->fun == core::Names::subject()) &&
                (send->numPosArgs() == 0 || ast::isa_tree<ast::Literal>(send->getPosArg(0)))) {
-        auto maybeDecl = getLetNameAndDeclLoc(*send);
-        if (maybeDecl.has_value()) {
+        if (auto maybeDecl = getLetNameAndDeclLoc(*send)) {
             auto [methodName, declLoc] = maybeDecl.value();
 
             ConstantMover constantMover;

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -329,9 +329,8 @@ ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName
         return prepareTestEachBody(ctx, eachName, std::move(send->block()->body), args, destructuringStmts, iteratee,
                                    /* insideDescribe */ true);
     } else if (insideDescribe &&
-               ((send->fun == core::Names::let() && send->numPosArgs() == 1) ||
-                (send->fun == core::Names::let_bang() && send->numPosArgs() == 1) ||
-                (send->fun == core::Names::subject() && send->numPosArgs() <= 1)) &&
+               (send->fun == core::Names::let() || send->fun == core::Names::let_bang() ||
+                send->fun == core::Names::subject()) &&
                (send->numPosArgs() == 0 || ast::isa_tree<ast::Literal>(send->getPosArg(0)))) {
         auto maybeDecl = getLetNameAndDeclLoc(*send);
         if (maybeDecl.has_value()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Minitest natively includes support for `subject`:

<https://github.com/minitest/minitest/blob/7c907429e8e7ec7c3b6ee0c7045e67249f4ad505/lib/minitest/spec.rb#L271>

It doesn't support `let!`, but there are third-party gems to add it:

<https://github.com/kstevens715/minitest-bang>

Also, in #9119, this code path will also be used to power RSpec, which
definitely supports `let!`.

Since these changes can affect non-RSpec codebases, let's pull them out, so
that they can be independently tested and reviewed.

### Commit summary

Most of this change is a sequence of no-op refactoring commits, followed by a single change that basically just adds some more `NameRef` to the appropriate conditions.

- **no-op: Factor a helper function** (6b7207858b)


- **no-op: Hoist error condition to the top** (a7a4e20f02)


- **no-op: clang-format** (5c422ab5f0)


- **no-op: Only do the `correctBlockArity` check once** (671e41f03c)


- **no-op: Factor a helper to get let methodName and declLoc** (faf96fde6b)


- **Also support `let!` and `subject`** (21aa7f837f)

  Minitest natively includes support for `subject`:

  <https://github.com/minitest/minitest/blob/7c907429e8e7ec7c3b6ee0c7045e67249f4ad505/lib/minitest/spec.rb#L271>

  It doesn't support `let!`, but there are third-party gems to add it:

  <https://github.com/kstevens715/minitest-bang>

  Also, in #9119, this code path will also be used to power RSpec, which 
  definitely supports `let!`.

  Since these changes can affect non-RSpec codebases, let's pull them out, 
  so that they can be independently tested and reviewed.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.