### PR TITLE
delete `Send::{setKwSplat,addKwArg}`

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1137,15 +1137,6 @@ void Send::setBlock(ExpressionPtr block) {
     }
 }
 
-void Send::setKwSplat(ExpressionPtr splat) {
-    this->args.emplace(this->args.begin() + numPosArgs_, move(splat));
-}
-
-void Send::addKwArg(ExpressionPtr key, ExpressionPtr value) {
-    auto it = this->args.emplace(this->args.end() - (hasBlock() ? 1 : 0) - (hasKwSplat() ? 1 : 0), move(key));
-    this->args.emplace(it + 1, move(value));
-}
-
 ExpressionPtr Send::withNewBody(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun) {
     auto rv = make_expression<Send>(loc, move(recv), fun, funLoc, numPosArgs_, std::move(args), flags);
 

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -908,10 +908,6 @@ public:
     ExpressionPtr *kwSplat();
 
     void setBlock(ExpressionPtr block);
-    void setKwSplat(ExpressionPtr splat);
-
-    // Add the given keyword argument to the end of the list of keyword arguments.
-    void addKwArg(ExpressionPtr key, ExpressionPtr value);
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -105,8 +105,11 @@ ast::ExpressionPtr toWriterSigForName(ast::Send *sharedSig, const core::NameRef 
         auto recv = ast::cast_tree<ast::ConstantLit>(cur->recv);
         if ((cur->recv.isSelfReference()) || (recv && recv->symbol() == core::Symbols::Sorbet())) {
             auto loc = resultType.loc();
-            auto params = ast::MK::Send0(loc, move(cur->recv), core::Names::params(), loc.copyWithZeroLength());
-            ast::cast_tree_nonnull<ast::Send>(params).addKwArg(ast::MK::Symbol(nameLoc, name), move(resultType));
+            // These will be kwargs for the `param` call, given `numPosArgs` below.
+            auto paramArgs = ast::MK::SendArgs(ast::MK::Symbol(nameLoc, name), move(resultType));
+            const auto numPosArgs = 0;
+            auto params = ast::MK::Send(loc, move(cur->recv), core::Names::params(), loc.copyWithZeroLength(),
+                                        numPosArgs, move(paramArgs));
             cur->recv = move(params);
             break;
         }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I would like to get to a world where we never modify the arguments of a `Send` node after constructing it.  These two functions get in the way of that goal; let's delete them.

The former is unused.  The latter is used, but we can make it unused by tweaking how we construct a `Send` node.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests; there should be no changes to `.exp` tests as a result of this PR.