### PR TITLE
Desugar `PM_FORWARDING_SUPER_NODE`

### DIFF
--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -1610,7 +1610,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 auto res = node2TreeImpl(dctx, send);
                 result = move(res);
             },
-            [&](parser::ZSuper *zuper) { result = MK::ZSuper(loc, maybeTypedSuper(dctx)); },
+            [&](parser::ZSuper *zuper) { desugaredByPrismTranslator(zuper); },
             [&](parser::For *for_) {
                 MethodDef::ARGS_store args;
                 bool canProvideNiceDesugar = true;

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -981,7 +981,9 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
         }
         case PM_FORWARDING_SUPER_NODE: { // `super` with no `(...)`
             auto forwardingSuperNode = down_cast<pm_forwarding_super_node>(node);
-            auto translatedNode = make_unique<parser::ZSuper>(location);
+
+            auto expr = MK::ZSuper(location, maybeTypedSuper());
+            auto translatedNode = make_node_with_expr<parser::ZSuper>(move(expr), location);
 
             auto blockArgumentNode = forwardingSuperNode->block;
 
@@ -989,7 +991,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
                 return translateCallWithBlock(up_cast(blockArgumentNode), move(translatedNode));
             }
 
-            return move(translatedNode);
+            return translatedNode;
         }
         case PM_GLOBAL_VARIABLE_AND_WRITE_NODE: { // And-assignment to a global variable, e.g. `$g &&= false`
             return translateOpAssignment<pm_global_variable_and_write_node, parser::AndAsgn, parser::GVarLhs>(node);
@@ -2866,6 +2868,13 @@ optional<ast::ClassDef::RHS_store> Translator::desugarScopeBodyToRHSStore(unique
         result.emplace_back(scopeBody->takeDesugaredExpr());
         return result;
     }
+}
+
+core::NameRef Translator::maybeTypedSuper() const {
+    bool typedSuper = ctx.state.cacheSensitiveOptions.typedSuper;
+    bool shouldUseTypedSuper = typedSuper && !isInAnyBlock && !isInModule;
+
+    return shouldUseTypedSuper ? core::Names::super() : core::Names::untypedSuper();
 }
 
 // Context management methods

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -149,6 +149,9 @@ private:
 
     void reportError(core::LocOffsets loc, const std::string &message) const;
 
+    // Helper to determine whether to use super or untypedSuper based on context
+    core::NameRef maybeTypedSuper() const;
+
     // Context management helpers. These return a copy of `this` with some change to the context.
     bool isInMethodDef() const;
     Translator enterMethodDef(bool isSingletonMethod, core::LocOffsets methodLoc, core::NameRef methodName,


### PR DESCRIPTION
Part of #9065 
Desugars `PM_FORWARDING_SUPER_NODE` in `Translator.cc` as part of integrating Prism in Sorbet

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests