### PR TITLE
Replace typecase with if-else chains for node type checking

### DIFF
--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -719,29 +719,26 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 auto newEndIt = remove_if(send->args.begin(), send->args.end(), [&](auto &arg) {
                     bool eraseFromArgs = false;
 
-                    typecase(
-                        arg.get(),
-                        [&](parser::ForwardedArgs *fwdArgs) {
-                            // Pull out the ForwardedArgs (the `...` argument in a method call, like `foo(...)`)
+                    if (parser::NodeWithExpr::isa_node<parser::ForwardedArgs>(arg.get())) {
+                        // Pull out the ForwardedArgs (the `...` argument in a method call, like `foo(...)`)
 
-                            ENFORCE(blockPassArg == nullptr, "The parser should have rejected `foo(&, ...)`");
-                            // Desugar a call like `foo(...)` so it has a block argument like `foo(..., &<fwd-block>)`.
-                            blockPassArg = MK::Local(loc, core::Names::fwdBlock());
+                        ENFORCE(blockPassArg == nullptr, "The parser should have rejected `foo(&, ...)`");
+                        // Desugar a call like `foo(...)` so it has a block argument like `foo(..., &<fwd-block>)`.
+                        blockPassArg = MK::Local(loc, core::Names::fwdBlock());
 
-                            hasFwdArgs = true;
-                            eraseFromArgs = true;
-                        },
-                        [&](parser::ForwardedRestArg *fwdRestArg) {
-                            // Pull out the ForwardedRestArg (an anonymous splat like `f(*)`)
-                            hasFwdRestArg = true;
-                            eraseFromArgs = true;
-                        },
-                        [&](parser::Splat *splat) {
-                            // Detect if there's a splat in the argument list
-                            hasSplat = true;
-                            eraseFromArgs = false;
-                        },
-                        [&](parser::Node *node) { eraseFromArgs = false; });
+                        hasFwdArgs = true;
+                        eraseFromArgs = true;
+                    } else if (parser::NodeWithExpr::isa_node<parser::ForwardedRestArg>(arg.get())) {
+                        // Pull out the ForwardedRestArg (an anonymous splat like `f(*)`)
+                        hasFwdRestArg = true;
+                        eraseFromArgs = true;
+                    } else if (parser::NodeWithExpr::isa_node<parser::Splat>(arg.get())) {
+                        // Detect if there's a splat in the argument list
+                        hasSplat = true;
+                        eraseFromArgs = false;
+                    } else {
+                        eraseFromArgs = false;
+                    }
 
                     return eraseFromArgs;
                 });


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Support checking the type of nodes wrapped in `NodeWithExpr`, which the previous `typecase` approach couldn't support because it relies on `fast_cast`.  The new implementation uses `isa_node`, which handles unwrapping a `NodeWithExpr` when casting. 

`PrismDesugar.cc` and `Desugar.cc` were both updated, to keep the two files in sync.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests.
