### PR TITLE
Rename `exactlyEqual()` → `prismDesugarEqual()`

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -229,7 +229,7 @@ public:
     // Compare the entire tree for equality, ignoring locations.
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
     // Compare the entire tree for equality, including locations.
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string_view nodeName() const;
 
@@ -421,7 +421,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -453,7 +453,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -476,7 +476,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -498,7 +498,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -519,7 +519,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -538,7 +538,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -559,7 +559,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -580,7 +580,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -609,7 +609,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -637,7 +637,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -658,7 +658,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -686,7 +686,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -707,7 +707,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -728,7 +728,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -750,7 +750,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -771,7 +771,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -792,7 +792,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -814,7 +814,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -893,7 +893,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     // Returns nullptr if no block present.
     const ast::Block *block() const;
@@ -1085,7 +1085,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1110,7 +1110,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1134,7 +1134,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1155,7 +1155,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1186,7 +1186,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1406,7 +1406,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1460,7 +1460,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1482,7 +1482,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1508,7 +1508,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1531,7 +1531,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1550,7 +1550,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1569,7 +1569,7 @@ public:
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
-    bool exactlyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
+    bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -293,7 +293,7 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> f
                 // This AST would have been desugared deirectly by Prism::Translator
                 auto directlyDesugaredAST = ast::prismDesugar::node2Tree(ctx, move(directlyDesugaredTree));
 
-                if (!ast.exactlyEqual(gs, directlyDesugaredAST, file)) {
+                if (!ast.prismDesugarEqual(gs, directlyDesugaredAST, file)) {
                     auto expected = ast.showRawWithLocs(gs, file);
                     auto actual = directlyDesugaredAST.showRawWithLocs(gs, file);
 


### PR DESCRIPTION
### Motivation

For our migration, we need to temporarily ignore differences in generated names (see #9284). Part of #9065.

It would be quite unusual to do this within a function literally called _exactly_ equal. Let's not sign cheques we can't cash, so let's call it `prismDesugarEqual` instead.

### Test plan

This is a pure refactor. Existing tests still work.
