### PR TITLE
Generate names from the correct counter

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -2740,7 +2740,7 @@ core::NameRef Translator::nextUniqueParserName(core::NameRef original) {
 
 core::NameRef Translator::nextUniqueDesugarName(core::NameRef original) {
     ENFORCE(directlyDesugar, "This shouldn't be called if we're not directly desugaring.");
-    return ctx.state.freshNameUnique(core::UniqueNameKind::Desugar, original, ++parserUniqueCounter);
+    return ctx.state.freshNameUnique(core::UniqueNameKind::Desugar, original, ++desugarUniqueCounter);
 }
 
 // Translate the options from a Regexp literal, if any. E.g. the `i` in `/foo/i`


### PR DESCRIPTION
### Motivation

Obvious mistake, which fails tests on some up-stack work that starts using `nextUniqueDesugarName()`.

Part of #9065

### Test plan

Tested in up-coming PRs.
