### PR TITLE
Directly desugar Hash literals

### DIFF
--- a/parser/prism/BUILD
+++ b/parser/prism/BUILD
@@ -15,6 +15,7 @@ cc_library(
     }),
     visibility = ["//visibility:public"],
     deps = [
+        "//ast/desugar",  # Needed for `DuplicateHashKeyCheck.h`
         "//core",
         "//parser",  # Legacy parser, needed for translating to its nodes defined in `parser/Node_gen.h`
         "@prism",

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -97,6 +97,9 @@ private:
 
     NodeVec translateArguments(pm_arguments_node *node, pm_node *blockArgumentNode = nullptr);
     parser::NodeVec translateKeyValuePairs(pm_node_list_t elements);
+
+    ast::ExpressionPtr desugarHash(core::LocOffsets loc, NodeVec &kvPairs);
+
     static bool isKeywordHashElement(sorbet::parser::Node *node);
     std::unique_ptr<parser::Node> translateCallWithBlock(pm_node_t *prismBlockOrLambdaNode,
                                                          std::unique_ptr<parser::Node> sendNode);


### PR DESCRIPTION
### Motivation

Depends on #9284 and #9293, part of #9065

### Test plan

This is tested by existing desugar tests, with the one caveat that the synthetic "unique" names are ignored. See #9284 for details.