### PR TITLE
minitest: Fix nested constant definitions

### DIFF
--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -17,7 +17,6 @@ class ConstantMover {
     uint32_t classDepth = 0;
     vector<ast::ExpressionPtr> movedConstants = {};
 
-public:
     ast::ExpressionPtr createConstAssign(ast::Assign &asgn) {
         auto loc = asgn.loc;
         auto raiseUnimplemented = ast::MK::RaiseUnimplemented(loc);
@@ -31,6 +30,7 @@ public:
         return ast::MK::Assign(asgn.loc, move(asgn.lhs), move(raiseUnimplemented));
     }
 
+public:
     void postTransformAssign(core::MutableContext ctx, ast::ExpressionPtr &tree) {
         auto asgn = ast::cast_tree<ast::Assign>(tree);
         if (auto cnst = ast::cast_tree<ast::UnresolvedConstantLit>(asgn->lhs)) {

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -32,6 +32,11 @@ class ConstantMover {
 
 public:
     void postTransformAssign(core::MutableContext ctx, ast::ExpressionPtr &tree) {
+        if (classDepth != 0) {
+            // These will be moved when we move the whole enclosing class def
+            return;
+        }
+
         auto asgn = ast::cast_tree<ast::Assign>(tree);
         if (auto cnst = ast::cast_tree<ast::UnresolvedConstantLit>(asgn->lhs)) {
             if (ast::isa_tree<ast::UnresolvedConstantLit>(asgn->rhs)) {

--- a/test/testdata/rewriter/minitest_nested_class.rb
+++ b/test/testdata/rewriter/minitest_nested_class.rb
@@ -1,0 +1,10 @@
+# typed: true
+
+describe 'bar' do
+  it 'foo' do
+    class A
+      X = 1
+    end
+    p(X)
+  end
+end

--- a/test/testdata/rewriter/minitest_nested_class.rb
+++ b/test/testdata/rewriter/minitest_nested_class.rb
@@ -5,6 +5,6 @@ describe 'bar' do
     class A
       X = 1
     end
-    p(X)
+    p(X) # error: Unable to resolve constant `X`
   end
 end

--- a/test/testdata/rewriter/minitest_nested_class.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_nested_class.rb.rewrite-tree.exp
@@ -1,0 +1,13 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C <describe 'bar'>><<C <todo sym>>> < (<self>)
+    def <it 'foo'><<todo method>>(&<blk>)
+      <self>.p(<emptyTree>::<C X>)
+    end
+
+    <emptyTree>::<C X> = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+
+    class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
+      ::Module.const_set(:X, 1)
+    end
+  end
+end

--- a/test/testdata/rewriter/minitest_nested_class.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_nested_class.rb.rewrite-tree.exp
@@ -4,10 +4,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.p(<emptyTree>::<C X>)
     end
 
-    <emptyTree>::<C X> = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-
     class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
-      ::Module.const_set(:X, 1)
+      <emptyTree>::<C X> = 1
     end
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This more closely matches the runtime. If we're going to move the whole
class definition, we don't need to move the individual constants defined
inside that class definition, because doing so will effectively hoist
the constant definition outside of the class definition.

See for example:

```
❯ ruby -r 'minitest/autorun' test/testdata/rewriter/minitest_nested_class.rb
Run options: --seed 54972

# Running:

E

Finished in 0.000495s, 2020.2028 runs/s, 0.0000 assertions/s.

  1) Error:
bar#test_0001_foo:
NameError: uninitialized constant X

    p(X) # error: Unable to resolve constant `X`
      ^
    test/testdata/rewriter/minitest_nested_class.rb:8:in `block (2 levels) in <main>'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Commits show before+after, including exp file changes