### PR TITLE
Two no-op changes to `GlobalState::initEmpty`

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -619,23 +619,6 @@ void GlobalState::initEmpty() {
     klass.data(*this)->setIsModule(false);
     ENFORCE_NO_TIMER(klass == Symbols::PackageSpec());
 
-    klass = klass.data(*this)->singletonClass(*this);
-    ENFORCE_NO_TIMER(klass == Symbols::PackageSpecSingleton());
-
-    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::import())
-                 .typedArg(Names::arg0(), make_type<ClassType>(Symbols::PackageSpecSingleton()))
-                 .build();
-    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_import());
-
-    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::testImport())
-                 .typedArg(Names::arg0(), make_type<ClassType>(Symbols::PackageSpecSingleton()))
-                 .defaultKeywordArg(Names::only())
-                 .build();
-    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_test_import());
-
-    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::export_()).arg(Names::arg0()).build();
-    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_export());
-
     klass = synthesizeClass(core::Names::Constants::Encoding());
     ENFORCE_NO_TIMER(klass == Symbols::Encoding());
 
@@ -652,28 +635,6 @@ void GlobalState::initEmpty() {
 
     method = this->staticInitForClass(core::Symbols::root(), Loc::none());
     ENFORCE_NO_TIMER(method == Symbols::rootStaticInit());
-
-    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::visibleTo()).arg(Names::arg0()).build();
-    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_visible_to());
-
-    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::exportAll()).build();
-    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_export_all());
-
-    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::strictDependencies())
-                 .typedArg(Names::arg0(), Types::String())
-                 .build();
-    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_strict_dependencies());
-
-    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::layer())
-                 .typedArg(Names::arg0(), Types::String())
-                 .build();
-    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_layer());
-
-    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::sorbet())
-                 .keywordArg(Names::min_typed_level(), Types::String())
-                 .keywordArg(Names::tests_min_typed_level(), Types::String())
-                 .build();
-    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_sorbet());
 
     // Magic classes for special proc bindings
     klass = enterClassSymbol(Loc::none(), Symbols::Magic(), core::Names::Constants::BindToAttachedClass());
@@ -722,9 +683,6 @@ void GlobalState::initEmpty() {
             .repeatedTopArg(Names::args())
             .build();
     ENFORCE_NO_TIMER(method == Symbols::Sorbet_Private_Static_typeMember());
-
-    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::preludePackage()).build();
-    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_preludePackage());
 
     typeArgument = enterTypeArgument(Loc::none(), Symbols::Kernel_proc(), Names::returnType(), Variance::CoVariant);
     ENFORCE_NO_TIMER(typeArgument == Symbols::Kernel_proc_returnType());

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -712,6 +712,20 @@ void GlobalState::initEmpty() {
     method = enterMethod(*this, Symbols::Kernel(), Names::proc()).build();
     ENFORCE_NO_TIMER(method == Symbols::Kernel_proc());
 
+    method = enterMethod(*this, Symbols::Module(), Names::syntheticSquareBrackets())
+                 .repeatedUntypedArg(Names::arg())
+                 .build();
+    ENFORCE_NO_TIMER(method == Symbols::Module_syntheticSquareBrackets());
+
+    method =
+        enterMethod(*this, Symbols::Sorbet_Private_Static().data(*this)->singletonClass(*this), Names::typeMember())
+            .repeatedTopArg(Names::args())
+            .build();
+    ENFORCE_NO_TIMER(method == Symbols::Sorbet_Private_Static_typeMember());
+
+    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::preludePackage()).build();
+    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_preludePackage());
+
     typeArgument = enterTypeArgument(Loc::none(), Symbols::Kernel_proc(), Names::returnType(), Variance::CoVariant);
     ENFORCE_NO_TIMER(typeArgument == Symbols::Kernel_proc_returnType());
     typeArgument.data(*this)->resultType = make_type<core::TypeVar>(typeArgument);
@@ -947,20 +961,6 @@ void GlobalState::initEmpty() {
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::Constants::LoadYieldParams());
     ENFORCE_NO_TIMER(field == Symbols::Magic_UntypedSource_LoadYieldParams());
-
-    method = enterMethod(*this, Symbols::Module(), Names::syntheticSquareBrackets())
-                 .repeatedUntypedArg(Names::arg())
-                 .build();
-    ENFORCE_NO_TIMER(method == Symbols::Module_syntheticSquareBrackets());
-
-    method =
-        enterMethod(*this, Symbols::Sorbet_Private_Static().data(*this)->singletonClass(*this), Names::typeMember())
-            .repeatedTopArg(Names::args())
-            .build();
-    ENFORCE_NO_TIMER(method == Symbols::Sorbet_Private_Static_typeMember());
-
-    method = enterMethod(*this, Symbols::PackageSpecSingleton(), Names::preludePackage()).build();
-    ENFORCE_NO_TIMER(method == Symbols::PackageSpec_preludePackage());
 
     int reservedCount = 0;
 

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1124,24 +1124,24 @@ public:
         return MethodRef::fromRaw(24);
     }
 
+    static MethodRef Module_syntheticSquareBrackets() {
+        return MethodRef::fromRaw(25);
+    }
+
+    static MethodRef Sorbet_Private_Static_typeMember() {
+        return MethodRef::fromRaw(26);
+    }
+
+    static MethodRef PackageSpec_preludePackage() {
+        return MethodRef::fromRaw(27);
+    }
+
     static TypeArgumentRef Kernel_proc_returnType() {
         return TypeArgumentRef::fromRaw(5);
     }
 
     static ClassOrModuleRef Magic_UntypedSource() {
         return ClassOrModuleRef::fromRaw(96);
-    }
-
-    static MethodRef Module_syntheticSquareBrackets() {
-        return MethodRef::fromRaw(57);
-    }
-
-    static MethodRef Sorbet_Private_Static_typeMember() {
-        return MethodRef::fromRaw(58);
-    }
-
-    static MethodRef PackageSpec_preludePackage() {
-        return MethodRef::fromRaw(59);
     }
 
     static FieldRef Magic_UntypedSource_super() {

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1024,22 +1024,6 @@ public:
         return ClassOrModuleRef::fromRaw(86);
     }
 
-    static ClassOrModuleRef PackageSpecSingleton() {
-        return ClassOrModuleRef::fromRaw(87);
-    }
-
-    static MethodRef PackageSpec_import() {
-        return MethodRef::fromRaw(10);
-    }
-
-    static MethodRef PackageSpec_test_import() {
-        return MethodRef::fromRaw(11);
-    }
-
-    static MethodRef PackageSpec_export() {
-        return MethodRef::fromRaw(12);
-    }
-
     static ClassOrModuleRef Encoding() {
         return ClassOrModuleRef::fromRaw(88);
     }
@@ -1049,35 +1033,15 @@ public:
     }
 
     static MethodRef Class_new() {
-        return MethodRef::fromRaw(13);
+        return MethodRef::fromRaw(10);
     }
 
     static MethodRef todoMethod() {
-        return MethodRef::fromRaw(14);
+        return MethodRef::fromRaw(11);
     }
 
     static MethodRef rootStaticInit() {
-        return MethodRef::fromRaw(15);
-    }
-
-    static MethodRef PackageSpec_visible_to() {
-        return MethodRef::fromRaw(16);
-    }
-
-    static MethodRef PackageSpec_export_all() {
-        return MethodRef::fromRaw(17);
-    }
-
-    static MethodRef PackageSpec_strict_dependencies() {
-        return MethodRef::fromRaw(18);
-    }
-
-    static MethodRef PackageSpec_layer() {
-        return MethodRef::fromRaw(19);
-    }
-
-    static MethodRef PackageSpec_sorbet() {
-        return MethodRef::fromRaw(20);
+        return MethodRef::fromRaw(12);
     }
 
     static ClassOrModuleRef MagicBindToAttachedClass() {
@@ -1105,11 +1069,11 @@ public:
     }
 
     static MethodRef T_Generic_squareBrackets() {
-        return MethodRef::fromRaw(21);
+        return MethodRef::fromRaw(13);
     }
 
     static MethodRef Kernel_lambda() {
-        return MethodRef::fromRaw(22);
+        return MethodRef::fromRaw(14);
     }
 
     static TypeArgumentRef Kernel_lambda_returnType() {
@@ -1117,23 +1081,19 @@ public:
     }
 
     static MethodRef Kernel_lambdaTLet() {
-        return MethodRef::fromRaw(23);
+        return MethodRef::fromRaw(15);
     }
 
     static MethodRef Kernel_proc() {
-        return MethodRef::fromRaw(24);
+        return MethodRef::fromRaw(16);
     }
 
     static MethodRef Module_syntheticSquareBrackets() {
-        return MethodRef::fromRaw(25);
+        return MethodRef::fromRaw(17);
     }
 
     static MethodRef Sorbet_Private_Static_typeMember() {
-        return MethodRef::fromRaw(26);
-    }
-
-    static MethodRef PackageSpec_preludePackage() {
-        return MethodRef::fromRaw(27);
+        return MethodRef::fromRaw(18);
     }
 
     static TypeArgumentRef Kernel_proc_returnType() {

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -1025,11 +1025,11 @@ public:
     }
 
     static ClassOrModuleRef Encoding() {
-        return ClassOrModuleRef::fromRaw(88);
+        return ClassOrModuleRef::fromRaw(87);
     }
 
     static ClassOrModuleRef Thread() {
-        return ClassOrModuleRef::fromRaw(89);
+        return ClassOrModuleRef::fromRaw(88);
     }
 
     static MethodRef Class_new() {
@@ -1045,27 +1045,27 @@ public:
     }
 
     static ClassOrModuleRef MagicBindToAttachedClass() {
-        return ClassOrModuleRef::fromRaw(90);
+        return ClassOrModuleRef::fromRaw(89);
     }
 
     static ClassOrModuleRef MagicBindToSelfType() {
-        return ClassOrModuleRef::fromRaw(91);
+        return ClassOrModuleRef::fromRaw(90);
     }
 
     static ClassOrModuleRef T_Types() {
-        return ClassOrModuleRef::fromRaw(92);
+        return ClassOrModuleRef::fromRaw(91);
     }
 
     static ClassOrModuleRef T_Types_Base() {
-        return ClassOrModuleRef::fromRaw(93);
+        return ClassOrModuleRef::fromRaw(92);
     }
 
     static ClassOrModuleRef Data() {
-        return ClassOrModuleRef::fromRaw(94);
+        return ClassOrModuleRef::fromRaw(93);
     }
 
     static ClassOrModuleRef T_Class() {
-        return ClassOrModuleRef::fromRaw(95);
+        return ClassOrModuleRef::fromRaw(94);
     }
 
     static MethodRef T_Generic_squareBrackets() {
@@ -1101,7 +1101,7 @@ public:
     }
 
     static ClassOrModuleRef Magic_UntypedSource() {
-        return ClassOrModuleRef::fromRaw(96);
+        return ClassOrModuleRef::fromRaw(95);
     }
 
     static FieldRef Magic_UntypedSource_super() {

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -23,10 +23,10 @@ namespace sorbet::core {
 using namespace std;
 
 const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 215;
-const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 60;
+const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 51;
 const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 20;
 const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 6;
-const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 71;
+const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 70;
 
 namespace {
 constexpr string_view COLON_SEPARATOR = "::"sv;

--- a/rbi/sorbet/packages.rbi
+++ b/rbi/sorbet/packages.rbi
@@ -1,2 +1,37 @@
 # typed: __STDLIB_INTERNAL
-class Sorbet::Private::Static::PackageSpec; end
+module Sorbet::Private::Static
+  class PackageSpec
+    sig { params(arg0: T.class_of(PackageSpec)).void }
+    def self.import(arg0); end
+
+    sig { params(arg0: T.class_of(PackageSpec), only: T.untyped).void }
+    def self.test_import(arg0, only: nil); end
+
+    sig { params(arg0: T.untyped).void }
+    def self.export(arg0); end
+
+    sig { params(arg0: T.untyped).void }
+    def self.export(arg0); end
+
+    sig { params(arg0: T.untyped).void }
+    def self.visible_to(arg0); end
+
+    sig { void }
+    def self.export_all!; end
+
+    sig { params(arg0: String).void }
+    def self.strict_dependencies(arg0); end
+
+    sig { params(arg0: String).void }
+    def self.layer(arg0); end
+
+    sig { params(min_typed_level: String, tests_min_typed_level: String).void }
+    def self.sorbet(min_typed_level:, tests_min_typed_level:); end
+
+    sig { params(min_typed_level: String, tests_min_typed_level: String).void }
+    def self.sorbet(min_typed_level:, tests_min_typed_level:); end
+
+    sig { void }
+    def self.prelude_package; end
+  end
+end

--- a/rbi/sorbet/packages.rbi
+++ b/rbi/sorbet/packages.rbi
@@ -11,9 +11,6 @@ module Sorbet::Private::Static
     def self.export(arg0); end
 
     sig { params(arg0: T.untyped).void }
-    def self.export(arg0); end
-
-    sig { params(arg0: T.untyped).void }
     def self.visible_to(arg0); end
 
     sig { void }
@@ -24,9 +21,6 @@ module Sorbet::Private::Static
 
     sig { params(arg0: String).void }
     def self.layer(arg0); end
-
-    sig { params(min_typed_level: String, tests_min_typed_level: String).void }
-    def self.sorbet(min_typed_level:, tests_min_typed_level:); end
 
     sig { params(min_typed_level: String, tests_min_typed_level: String).void }
     def self.sorbet(min_typed_level:, tests_min_typed_level:); end

--- a/rbi/sorbet/packages.rbi
+++ b/rbi/sorbet/packages.rbi
@@ -4,7 +4,7 @@ module Sorbet::Private::Static
     sig { params(arg0: T.class_of(PackageSpec)).void }
     def self.import(arg0); end
 
-    sig { params(arg0: T.class_of(PackageSpec), only: T.untyped).void }
+    sig { params(arg0: T.class_of(PackageSpec), only: T.nilable(String)).void }
     def self.test_import(arg0, only: nil); end
 
     sig { params(arg0: T.untyped).void }

--- a/rbi/sorbet/packages.rbi
+++ b/rbi/sorbet/packages.rbi
@@ -1,31 +1,29 @@
 # typed: __STDLIB_INTERNAL
-module Sorbet::Private::Static
-  class PackageSpec
-    sig { params(arg0: T.class_of(PackageSpec)).void }
-    def self.import(arg0); end
+class Sorbet::Private::Static::PackageSpec
+  sig { params(arg0: T.class_of(Sorbet::Private::Static::PackageSpec)).void }
+  def self.import(arg0); end
 
-    sig { params(arg0: T.class_of(PackageSpec), only: T.nilable(String)).void }
-    def self.test_import(arg0, only: nil); end
+  sig { params(arg0: T.class_of(Sorbet::Private::Static::PackageSpec), only: T.nilable(String)).void }
+  def self.test_import(arg0, only: nil); end
 
-    sig { params(arg0: T.untyped).void }
-    def self.export(arg0); end
+  sig { params(arg0: T.untyped).void }
+  def self.export(arg0); end
 
-    sig { params(arg0: T.untyped).void }
-    def self.visible_to(arg0); end
+  sig { params(arg0: T.untyped).void }
+  def self.visible_to(arg0); end
 
-    sig { void }
-    def self.export_all!; end
+  sig { void }
+  def self.export_all!; end
 
-    sig { params(arg0: String).void }
-    def self.strict_dependencies(arg0); end
+  sig { params(arg0: String).void }
+  def self.strict_dependencies(arg0); end
 
-    sig { params(arg0: String).void }
-    def self.layer(arg0); end
+  sig { params(arg0: String).void }
+  def self.layer(arg0); end
 
-    sig { params(min_typed_level: String, tests_min_typed_level: String).void }
-    def self.sorbet(min_typed_level:, tests_min_typed_level:); end
+  sig { params(min_typed_level: String, tests_min_typed_level: String).void }
+  def self.sorbet(min_typed_level:, tests_min_typed_level:); end
 
-    sig { void }
-    def self.prelude_package; end
-  end
+  sig { void }
+  def self.prelude_package; end
 end

--- a/test/testdata/packager/invalid_imports_and_exports/__package.rb
+++ b/test/testdata/packager/invalid_imports_and_exports/__package.rb
@@ -29,9 +29,13 @@ class A < PackageSpec
 
   test_import B
   test_import C
-  test_import C, only: :A_MYSTERIOUS_PURPOSE # error: Invalid expression in package
+  test_import C, only: :A_MYSTERIOUS_PURPOSE
+  #                    ^^^^^^^^^^^^^^^^^^^^^ error: Invalid expression in package
+  #                    ^^^^^^^^^^^^^^^^^^^^^ error: Expected `T.nilable(String)` but found `Symbol(:A_MYSTERIOUS_PURPOSE)`
   test_import C, only: "something else" # error: Invalid expression in package
-  test_import C, only: -> { "naught" } # error: Invalid expression in package
+  test_import C, only: -> { "naught" }
+  #                    ^^^^^^^^^^^^^^^ error: Invalid expression in package
+  #                    ^^^^^^^^^^^^^^^ error: Expected `T.nilable(String)` but found `T.proc.returns(String)`
   test_import C, only: "test_rb", only: "test_rb" # error: Hash key `only` is duplicated
   test_import C, with: "cheese" # error: Unrecognized keyword argument
 end

--- a/test/testdata/packager/invalid_imports_and_exports/pass.autocorrects.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.autocorrects.exp
@@ -30,9 +30,13 @@ class A < PackageSpec
 
   test_import B
   test_import C
-  test_import C, only: :A_MYSTERIOUS_PURPOSE # error: Invalid expression in package
+  test_import C, only: :A_MYSTERIOUS_PURPOSE
+  #                    ^^^^^^^^^^^^^^^^^^^^^ error: Invalid expression in package
+  #                    ^^^^^^^^^^^^^^^^^^^^^ error: Expected `T.nilable(String)` but found `Symbol(:A_MYSTERIOUS_PURPOSE)`
   test_import C, only: "something else" # error: Invalid expression in package
-  test_import C, only: -> { "naught" } # error: Invalid expression in package
+  test_import C, only: -> { "naught" }
+  #                    ^^^^^^^^^^^^^^^ error: Invalid expression in package
+  #                    ^^^^^^^^^^^^^^^ error: Expected `T.nilable(String)` but found `T.proc.returns(String)`
   test_import C, only: "test_rb", only: "test_rb" # error: Hash key `only` is duplicated
   test_import C, with: "cheese" # error: Unrecognized keyword argument
 end

--- a/test/testdata/packager/sorbet_min_typed_level/block/__package.rb
+++ b/test/testdata/packager/sorbet_min_typed_level/block/__package.rb
@@ -4,7 +4,9 @@
 # packager-layers: a
 
 class Block < PackageSpec
-  sorbet min_typed_level: 'true', tests_min_typed_level: 'true' do end # error: Invalid expression in package: `Block` not allowed
+  sorbet min_typed_level: 'true', tests_min_typed_level: 'true' do end
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Invalid expression in package: `Block` not allowed
+  #                                                            ^^^^^^^ error: does not take a block
   strict_dependencies 'false'
   layer 'a'
 end

--- a/test/testdata/packager/strict_dependencies/block/__package.rb
+++ b/test/testdata/packager/strict_dependencies/block/__package.rb
@@ -4,6 +4,8 @@
 # packager-layers: a
 
 class Block < PackageSpec
-  strict_dependencies 'false' do end # error: Invalid expression in package: `Block` not allowed
+  strict_dependencies 'false' do end
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Invalid expression in package: `Block` not allowed
+  #                          ^^^^^^^ error: does not take a block
   layer 'a'
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Commit summary


- **no-op: Hoist named, synthetic methods earlier in initEmpty** (091ffcb951)

  I've hoisted these three synthetic MethodRef definitions up to 
  immediately after the last numbered `MethodRef` (`Kernel_proc`), so that 
  adding new method refs which are never actually referred to by symbol ID 
  doesn't require renumbering any method references, while also being able 
  to be organized into the sensible place in `GlobalState::initEmpty`.

- **no-op: Use `rbi/` to define types for PackageSpec methods** (a44f0a3be3)

  There's no need to have to deal with `initEmpty` for this.

  Having it defined in an RBI file makes it slightly nicer, because people 
  can jump-to-def on this. We could also put some documentation here to 
  explain these things in more depth.

- **Re-number these** (cdabc84d60)




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.