### PR TITLE
Always use legacy desugar tree

### DIFF
--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -305,10 +305,6 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> f
                     CHECK_EQ_DIFF(expected, actual,
                                   fmt::format("Prism desugared tree does not match legacy desugared tree"));
                 }
-
-                // If we get to here, we know the two trees are equivalent, so it doesn't really matter which we use.
-                // Let's just use the directly desugared one.
-                ast = move(directlyDesugaredAST);
             }
 
             desugared = testSerialize(gs, ast::ParsedFile{move(ast), file});


### PR DESCRIPTION
### Motivation

When this code was written, the `ast` and `directlyDesugaredAST` were exactly equal, so the choice of which to use for the rest of the pipeline was arbitrary. I happened to choose `directlyDesugaredAST`.

Since #9284, they're no longer _exactly_ the same, they can differ by the numbering of the unique names generated during desugaring (see that PR for further explanation). The names generated during the direct desugaring won't match the names expected by the `test/prism_regression/*.rb.desugar-tree-raw.exp` tests added by #9280.

To fix this, let's always use the `ast`, which was desugared by the legacy `Desugar.cc`.
