### PR TITLE
Clarify "block pass" in "call-with-block" magic names

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -873,8 +873,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                             // E.g. `foo(*splat, &block)`
 
                             sendargs.emplace_back(move(blockPassArg));
-                            res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplatAndBlock(), send->methodLoc,
-                                           5, move(sendargs), flags);
+                            res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplatAndBlockPass(),
+                                           send->methodLoc, 5, move(sendargs), flags);
                         }
                     }
                     result = move(res);

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -929,7 +929,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                                 sendargs.emplace_back(move(arg));
                             }
 
-                            res = MK::Send(loc, MK::Magic(loc), core::Names::callWithBlock(), send->methodLoc,
+                            res = MK::Send(loc, MK::Magic(loc), core::Names::callWithBlockPass(), send->methodLoc,
                                            numPosArgs, move(sendargs), flags);
                         }
                     }

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -885,7 +885,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                                 sendargs.emplace_back(move(arg));
                             }
 
-                            res = MK::Send(loc, MK::Magic(loc), core::Names::callWithBlock(), send->methodLoc,
+                            res = MK::Send(loc, MK::Magic(loc), core::Names::callWithBlockPass(), send->methodLoc,
                                            numPosArgs, move(sendargs), flags);
                         }
                     }

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -829,8 +829,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                             // E.g. `foo(*splat, &block)`
 
                             sendargs.emplace_back(move(blockPassArg));
-                            res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplatAndBlock(), send->methodLoc,
-                                           5, move(sendargs), flags);
+                            res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplatAndBlockPass(),
+                                           send->methodLoc, 5, move(sendargs), flags);
                         }
                     }
                     result = move(res);

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -114,7 +114,7 @@ public:
                     [[maybe_unused]] auto _substituted = subst.substituteSymbolName(name);
                 }
             }
-        } else if (send.fun == core::Names::callWithSplat() || send.fun == core::Names::callWithBlock() ||
+        } else if (send.fun == core::Names::callWithSplat() || send.fun == core::Names::callWithBlockPass() ||
                    send.fun == core::Names::callWithSplatAndBlock() || send.fun == core::Names::checkAndAnd()) {
             ENFORCE(send.numPosArgs() > 2, "These are special desugar methods, should have at least two args");
 

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -115,7 +115,7 @@ public:
                 }
             }
         } else if (send.fun == core::Names::callWithSplat() || send.fun == core::Names::callWithBlockPass() ||
-                   send.fun == core::Names::callWithSplatAndBlock() || send.fun == core::Names::checkAndAnd()) {
+                   send.fun == core::Names::callWithSplatAndBlockPass() || send.fun == core::Names::checkAndAnd()) {
             ENFORCE(send.numPosArgs() > 2, "These are special desugar methods, should have at least two args");
 
             // We're lucky because all of these methods have the symbol they dispatch to as the

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -747,7 +747,7 @@ void GlobalState::initEmpty() {
                  .repeatedUntypedArg(Names::arg0())
                  .buildWithResultUntyped();
     // Synthesize <Magic>.<call-with-splat-and-block>(args: *T.untyped) => T.untyped
-    method = enterMethod(*this, Symbols::MagicSingleton(), Names::callWithSplatAndBlock())
+    method = enterMethod(*this, Symbols::MagicSingleton(), Names::callWithSplatAndBlockPass())
                  .repeatedUntypedArg(Names::arg0())
                  .buildWithResultUntyped();
     // Synthesize <Magic>.<suggest-constant-type>(arg: *T.untyped) => T.untyped

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -743,7 +743,7 @@ void GlobalState::initEmpty() {
                  .repeatedUntypedArg(Names::arg0())
                  .buildWithResultUntyped();
     // Synthesize <Magic>.<call-with-block>(args: *T.untyped) => T.untyped
-    method = enterMethod(*this, Symbols::MagicSingleton(), Names::callWithBlock())
+    method = enterMethod(*this, Symbols::MagicSingleton(), Names::callWithBlockPass())
                  .repeatedUntypedArg(Names::arg0())
                  .buildWithResultUntyped();
     // Synthesize <Magic>.<call-with-splat-and-block>(args: *T.untyped) => T.untyped

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -742,7 +742,7 @@ void GlobalState::initEmpty() {
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::callWithSplat())
                  .repeatedUntypedArg(Names::arg0())
                  .buildWithResultUntyped();
-    // Synthesize <Magic>.<call-with-block>(args: *T.untyped) => T.untyped
+    // Synthesize <Magic>.<call-with-block-pass>(args: *T.untyped) => T.untyped
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::callWithBlockPass())
                  .repeatedUntypedArg(Names::arg0())
                  .buildWithResultUntyped();

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -746,7 +746,7 @@ void GlobalState::initEmpty() {
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::callWithBlockPass())
                  .repeatedUntypedArg(Names::arg0())
                  .buildWithResultUntyped();
-    // Synthesize <Magic>.<call-with-splat-and-block>(args: *T.untyped) => T.untyped
+    // Synthesize <Magic>.<call-with-splat-and-block-pass>(args: *T.untyped) => T.untyped
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::callWithSplatAndBlockPass())
                  .repeatedUntypedArg(Names::arg0())
                  .buildWithResultUntyped();

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -451,7 +451,7 @@ NameDef names[] = {
 
     {"require"},
     {"callWithSplat", "<call-with-splat>"},
-    {"callWithBlockPass", "<call-with-block>"},
+    {"callWithBlockPass", "<call-with-block-pass>"},
     {"callWithSplatAndBlockPass", "<call-with-splat-and-block>"},
     {"enumerableToH", "enumerable_to_h"},
     {"blockBreak", "<block-break>"},

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -451,7 +451,7 @@ NameDef names[] = {
 
     {"require"},
     {"callWithSplat", "<call-with-splat>"},
-    {"callWithBlock", "<call-with-block>"},
+    {"callWithBlockPass", "<call-with-block>"},
     {"callWithSplatAndBlock", "<call-with-splat-and-block>"},
     {"enumerableToH", "enumerable_to_h"},
     {"blockBreak", "<block-break>"},

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -452,7 +452,7 @@ NameDef names[] = {
     {"require"},
     {"callWithSplat", "<call-with-splat>"},
     {"callWithBlockPass", "<call-with-block-pass>"},
-    {"callWithSplatAndBlockPass", "<call-with-splat-and-block>"},
+    {"callWithSplatAndBlockPass", "<call-with-splat-and-block-pass>"},
     {"enumerableToH", "enumerable_to_h"},
     {"blockBreak", "<block-break>"},
     {"stringInterpolate", "<string-interpolate>"},

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -452,7 +452,7 @@ NameDef names[] = {
     {"require"},
     {"callWithSplat", "<call-with-splat>"},
     {"callWithBlockPass", "<call-with-block>"},
-    {"callWithSplatAndBlock", "<call-with-splat-and-block>"},
+    {"callWithSplatAndBlockPass", "<call-with-splat-and-block>"},
     {"enumerableToH", "enumerable_to_h"},
     {"blockBreak", "<block-break>"},
     {"stringInterpolate", "<string-interpolate>"},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2550,7 +2550,7 @@ public:
     }
 } Magic_callWithSplat;
 
-class Magic_callWithBlock : public IntrinsicMethod {
+class Magic_callWithBlockPass : public IntrinsicMethod {
     friend class Magic_callWithSplatAndBlock;
 
 private:
@@ -2660,14 +2660,14 @@ private:
                 if (auto e = gs.beginError(blockLoc, errors::Infer::ProcArityUnknown)) {
                     e.setHeader("Cannot use a `{}` with unknown arity as a `{}`", "Proc", blockPreType.show(gs));
                     if (!dispatched.secondary) {
-                        Magic_callWithBlock::showLocationOfArgDefn(gs, e, blockPreType, dispatched.main);
+                        Magic_callWithBlockPass::showLocationOfArgDefn(gs, e, blockPreType, dispatched.main);
                     }
                 }
 
                 // Create a new proc of correct arity, with everything as untyped,
                 // and then use this type instead of passedInBlockType in later subtype checks.
                 // This allows the generic parameters to be instantiated with untyped rather than bottom.
-                if (optional<int> procArity = Magic_callWithBlock::getArityForBlock(nonNilableBlockType)) {
+                if (optional<int> procArity = Magic_callWithBlockPass::getArityForBlock(nonNilableBlockType)) {
                     vector<core::TypePtr> targs(*procArity + 1, core::Types::untypedUntracked());
                     auto procWithCorrectArity = core::Symbols::Proc(*procArity);
                     passedInBlockType = make_type<core::AppliedType>(procWithCorrectArity, move(targs));
@@ -2676,7 +2676,7 @@ private:
                 e.setHeader("Expected `{}` but found `{}` for block argument", blockPreType.show(gs),
                             passedInBlockType.show(gs));
                 if (!dispatched.secondary) {
-                    Magic_callWithBlock::showLocationOfArgDefn(gs, e, blockPreType, dispatched.main);
+                    Magic_callWithBlockPass::showLocationOfArgDefn(gs, e, blockPreType, dispatched.main);
                 }
                 e.addErrorSections(move(errorDetailsCollector));
             }
@@ -2782,10 +2782,10 @@ public:
         CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], args.locs.fun, sendArgLocs};
 
         TypePtr finalBlockType =
-            Magic_callWithBlock::typeToProc(gs, *args.args[2], args.locs.file, args.locs.call, args.locs.args[2],
-                                            args.locs.fun, args.originForUninitialized, args.suppressErrors);
-        optional<int> blockArity = Magic_callWithBlock::getArityForBlock(finalBlockType);
-        core::SendAndBlockLink link{fn, Magic_callWithBlock::argInfoByArity(blockArity)};
+            Magic_callWithBlockPass::typeToProc(gs, *args.args[2], args.locs.file, args.locs.call, args.locs.args[2],
+                                                args.locs.fun, args.originForUninitialized, args.suppressErrors);
+        optional<int> blockArity = Magic_callWithBlockPass::getArityForBlock(finalBlockType);
+        core::SendAndBlockLink link{fn, Magic_callWithBlockPass::argInfoByArity(blockArity)};
         res.main.constr = make_unique<TypeConstraint>();
 
         DispatchArgs innerArgs{fn,
@@ -2801,9 +2801,10 @@ public:
                                args.suppressErrors,
                                args.enclosingMethodForSuper};
 
-        Magic_callWithBlock::simulateCall(gs, receiver, innerArgs, finalBlockType, args.argLoc(2), args.callLoc(), res);
+        Magic_callWithBlockPass::simulateCall(gs, receiver, innerArgs, finalBlockType, args.argLoc(2), args.callLoc(),
+                                              res);
     }
-} Magic_callWithBlock;
+} Magic_callWithBlockPass;
 
 class Magic_callWithSplatAndBlock : public IntrinsicMethod {
 public:
@@ -2896,10 +2897,10 @@ public:
         CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], args.locs.fun, sendArgLocs};
 
         TypePtr finalBlockType =
-            Magic_callWithBlock::typeToProc(gs, *args.args[4], args.locs.file, args.locs.call, args.locs.args[4],
-                                            args.locs.fun, args.originForUninitialized, args.suppressErrors);
-        optional<int> blockArity = Magic_callWithBlock::getArityForBlock(finalBlockType);
-        core::SendAndBlockLink link{fn, Magic_callWithBlock::argInfoByArity(blockArity)};
+            Magic_callWithBlockPass::typeToProc(gs, *args.args[4], args.locs.file, args.locs.call, args.locs.args[4],
+                                                args.locs.fun, args.originForUninitialized, args.suppressErrors);
+        optional<int> blockArity = Magic_callWithBlockPass::getArityForBlock(finalBlockType);
+        core::SendAndBlockLink link{fn, Magic_callWithBlockPass::argInfoByArity(blockArity)};
         res.main.constr = make_unique<TypeConstraint>();
 
         DispatchArgs innerArgs{fn,
@@ -2915,7 +2916,8 @@ public:
                                args.suppressErrors,
                                args.enclosingMethodForSuper};
 
-        Magic_callWithBlock::simulateCall(gs, receiver, innerArgs, finalBlockType, args.argLoc(4), args.callLoc(), res);
+        Magic_callWithBlockPass::simulateCall(gs, receiver, innerArgs, finalBlockType, args.argLoc(4), args.callLoc(),
+                                              res);
     }
 } Magic_callWithSplatAndBlock;
 
@@ -4588,7 +4590,7 @@ const vector<Intrinsic> intrinsics{
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::buildRange(), &Magic_buildRange},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::expandSplat(), &Magic_expandSplat},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::callWithSplat(), &Magic_callWithSplat},
-    {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::callWithBlock(), &Magic_callWithBlock},
+    {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::callWithBlockPass(), &Magic_callWithBlockPass},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::callWithSplatAndBlock(), &Magic_callWithSplatAndBlock},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::suggestConstantType(), &Magic_suggestUntypedConstantType},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::suggestFieldType(), &Magic_suggestUntypedFieldType},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2429,7 +2429,7 @@ public:
 } Magic_expandSplat;
 
 class Magic_callWithSplat : public IntrinsicMethod {
-    friend class Magic_callWithSplatAndBlock;
+    friend class Magic_callWithSplatAndBlockPass;
 
 private:
     static InlinedVector<const TypeAndOrigins *, 2> generateSendArgs(const TupleType *posTuple,
@@ -2551,7 +2551,7 @@ public:
 } Magic_callWithSplat;
 
 class Magic_callWithBlockPass : public IntrinsicMethod {
-    friend class Magic_callWithSplatAndBlock;
+    friend class Magic_callWithSplatAndBlockPass;
 
 private:
     static TypePtr typeToProc(const GlobalState &gs, const TypeAndOrigins &blockType, core::FileRef file,
@@ -2806,7 +2806,7 @@ public:
     }
 } Magic_callWithBlockPass;
 
-class Magic_callWithSplatAndBlock : public IntrinsicMethod {
+class Magic_callWithSplatAndBlockPass : public IntrinsicMethod {
 public:
     vector<NameRef> dispatchesTo() const override {
         // This is in addition to the custom handling that we do in Substitute.cc for the dispatch
@@ -2919,7 +2919,7 @@ public:
         Magic_callWithBlockPass::simulateCall(gs, receiver, innerArgs, finalBlockType, args.argLoc(4), args.callLoc(),
                                               res);
     }
-} Magic_callWithSplatAndBlock;
+} Magic_callWithSplatAndBlockPass;
 
 class Magic_suggestUntypedConstantType : public IntrinsicMethod {
 public:
@@ -4591,7 +4591,8 @@ const vector<Intrinsic> intrinsics{
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::expandSplat(), &Magic_expandSplat},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::callWithSplat(), &Magic_callWithSplat},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::callWithBlockPass(), &Magic_callWithBlockPass},
-    {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::callWithSplatAndBlock(), &Magic_callWithSplatAndBlock},
+    {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::callWithSplatAndBlockPass(),
+     &Magic_callWithSplatAndBlockPass},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::suggestConstantType(), &Magic_suggestUntypedConstantType},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::suggestFieldType(), &Magic_suggestUntypedFieldType},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::attachedClass(), &Magic_attachedClass},

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1183,7 +1183,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 if (lspQueryMatch && !ignoreSendForLSPQuery) {
                     auto fun = send.fun;
                     if (fun == core::Names::checkAndAnd() || fun == core::Names::callWithSplat() ||
-                        fun == core::Names::callWithBlock() || fun == core::Names::callWithSplatAndBlock()) {
+                        fun == core::Names::callWithBlockPass() || fun == core::Names::callWithSplatAndBlock()) {
                         ENFORCE(send.numPosArgs > 2, "Desugar invariant");
                         auto lit = core::cast_type_nonnull<core::NamedLiteralType>(args[1]->type);
                         ENFORCE(lit.literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1183,7 +1183,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 if (lspQueryMatch && !ignoreSendForLSPQuery) {
                     auto fun = send.fun;
                     if (fun == core::Names::checkAndAnd() || fun == core::Names::callWithSplat() ||
-                        fun == core::Names::callWithBlockPass() || fun == core::Names::callWithSplatAndBlock()) {
+                        fun == core::Names::callWithBlockPass() || fun == core::Names::callWithSplatAndBlockPass()) {
                         ENFORCE(send.numPosArgs > 2, "Desugar invariant");
                         auto lit = core::cast_type_nonnull<core::NamedLiteralType>(args[1]->type);
                         ENFORCE(lit.literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol);

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -288,7 +288,7 @@ class LocalNameInserter {
         //    Yes           | Yes            | ::<Magic>::<call-with-splat>(..., :super, ...) do <foo> end
         //    Yes           | No             | ::<Magic>::<call-with-splat-and-block>(..., :super, ..., &<blkvar>)
         //    No            | Yes            | super(...) do <foo> end
-        //    No            | No             | ::<Magic>::<call-with-block>(..., :super, ..., &<blkvar>)
+        //    No            | No             | ::<Magic>::<call-with-block-pass>(..., :super, ..., &<blkvar>)
         //
         // (In particular, note that the <blkvar> is thrown on the floor when a "do" is present.)
 

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -431,7 +431,7 @@ class LocalNameInserter {
                 newArgs.push_back(std::move(originalBlock));
             } else if (shouldForwardBlockArg) {
                 // <call-with-splat-and-block>(..., &blk)
-                newFun = core::Names::callWithSplatAndBlock();
+                newFun = core::Names::callWithSplatAndBlockPass();
                 newArgs.push_back(std::move(blockArg));
                 newNumPosArgs++;
             } else {

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -463,7 +463,7 @@ class LocalNameInserter {
             kwArgKeyEntries.clear();
             kwArgValueEntries.clear();
 
-            newFun = core::Names::callWithBlock();
+            newFun = core::Names::callWithBlockPass();
         } else {
             // No positional splat and we have a "do", so we can synthesize an ordinary send.
             newArgs.reserve(posArgsEntries.size() + kwArgKeyEntries.size() * 2 + /* hasKwSplat */

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -286,7 +286,7 @@ class LocalNameInserter {
         //    Posarg splat? | "do" attached? | Lower to...
         //    --------------+----------------+------------
         //    Yes           | Yes            | ::<Magic>::<call-with-splat>(..., :super, ...) do <foo> end
-        //    Yes           | No             | ::<Magic>::<call-with-splat-and-block>(..., :super, ..., &<blkvar>)
+        //    Yes           | No             | ::<Magic>::<call-with-splat-and-block-pass>(..., :super, ..., &<blkvar>)
         //    No            | Yes            | super(...) do <foo> end
         //    No            | No             | ::<Magic>::<call-with-block-pass>(..., :super, ..., &<blkvar>)
         //
@@ -386,20 +386,20 @@ class LocalNameInserter {
 
         if (posArgsArray != nullptr) {
             // We wrap self with T.unsafe in order to get around the requirement for <call-with-splat> and
-            // <call-with-splat-and-block> that the shapes of the splatted hashes be known statically. This is a bit of
-            // a hack, but 'super' is currently treated as untyped anyway.
+            // <call-with-splat-and-block-pass> that the shapes of the splatted hashes be known statically. This is a
+            // bit of a hack, but 'super' is currently treated as untyped anyway.
             // TODO(neil): this probably blames to unsafe, we should find a way to blame to super maybe?
             newArgs.push_back(ast::MK::Unsafe(original.loc, std::move(newRecv)));
             newRecv = ast::MK::Magic(original.loc);
             newArgs.push_back(std::move(method));
 
-            // For <call-with-splat> and <call-with-splat-and-block> posargs are always passed in an array.
+            // For <call-with-splat> and <call-with-splat-and-block-pass> posargs are always passed in an array.
             if (posArgsArray == nullptr) {
                 posArgsArray = ast::MK::Array(original.loc, std::move(posArgsEntries));
             }
             newArgs.push_back(std::move(posArgsArray));
 
-            // For <call-with-splat> and <call-with-splat-and-block>, the kwargs array can either be a
+            // For <call-with-splat> and <call-with-splat-and-block-pass>, the kwargs array can either be a
             // [:key, val, :key, val, ...] array or a one-element [kwargshash] array, depending on whether splatting
             // has taken place, or nil (if no kwargs at all).
             ast::ExpressionPtr boxedKwArgs;
@@ -430,7 +430,7 @@ class LocalNameInserter {
                 newFlags.hasBlock = true;
                 newArgs.push_back(std::move(originalBlock));
             } else if (shouldForwardBlockArg) {
-                // <call-with-splat-and-block>(..., &blk)
+                // <call-with-splat-and-block-pass>(..., &blk)
                 newFun = core::Names::callWithSplatAndBlockPass();
                 newArgs.push_back(std::move(blockArg));
                 newNumPosArgs++;

--- a/main/lsp/ConvertToSingletonClassMethod.cc
+++ b/main/lsp/ConvertToSingletonClassMethod.cc
@@ -106,7 +106,7 @@ public:
         }
 
         if (sendResp->originalName == core::Names::callWithSplat() ||
-            sendResp->originalName == core::Names::callWithBlock() ||
+            sendResp->originalName == core::Names::callWithBlockPass() ||
             sendResp->originalName == core::Names::callWithSplatAndBlock()) {
             // These are too hard... skipping for the time being.
             return;

--- a/main/lsp/ConvertToSingletonClassMethod.cc
+++ b/main/lsp/ConvertToSingletonClassMethod.cc
@@ -107,7 +107,7 @@ public:
 
         if (sendResp->originalName == core::Names::callWithSplat() ||
             sendResp->originalName == core::Names::callWithBlockPass() ||
-            sendResp->originalName == core::Names::callWithSplatAndBlock()) {
+            sendResp->originalName == core::Names::callWithSplatAndBlockPass()) {
             // These are too hard... skipping for the time being.
             return;
         }

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -98,8 +98,8 @@ private:
     NodeVec translateArguments(pm_arguments_node *node, pm_node *blockArgumentNode = nullptr);
     parser::NodeVec translateKeyValuePairs(pm_node_list_t elements);
     static bool isKeywordHashElement(sorbet::parser::Node *node);
-    std::unique_ptr<parser::Node> translateCallWithBlock(pm_node_t *prismBlockOrLambdaNode,
-                                                         std::unique_ptr<parser::Node> sendNode);
+    std::unique_ptr<parser::Node> translatecallWithBlockPass(pm_node_t *prismBlockOrLambdaNode,
+                                                             std::unique_ptr<parser::Node> sendNode);
     std::unique_ptr<parser::Node> translateRescue(pm_rescue_node *prismRescueNode,
                                                   std::unique_ptr<parser::Node> beginNode,
                                                   std::unique_ptr<parser::Node> elseNode);

--- a/test/cli/typed-super-cache/test.out
+++ b/test/cli/typed-super-cache/test.out
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C Child><<C <todo sym>>> < (<emptyTree>::<C Parent>)
     def foo<<todo method>>(&<blk>)
-      ::<Magic>.<call-with-block>(<self>, :<super>, <blk>)
+      ::<Magic>.<call-with-block-pass>(<self>, :<super>, <blk>)
     end
 
     <runtime method definition of foo>
@@ -32,7 +32,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C Child><<C <todo sym>>> < (<emptyTree>::<C Parent>)
     def foo<<todo method>>(&<blk>)
-      ::<Magic>.<call-with-block>(<self>, :<untypedSuper>, <blk>)
+      ::<Magic>.<call-with-block-pass>(<self>, :<untypedSuper>, <blk>)
     end
 
     <runtime method definition of foo>

--- a/test/prism_regression/assign_to_index.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/assign_to_index.rb.desugar-tree-raw.exp
@@ -1101,7 +1101,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $32>
+            name = <D <U <call-with-block-pass>> $32>
           }
           rhs = ConstantLit{
             symbol = (class ::<Magic>)
@@ -1111,7 +1111,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $33>
+            name = <D <U <call-with-block-pass>> $33>
           }
           rhs = Send{
             flags = {privateOk}
@@ -1126,14 +1126,14 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $34>
+            name = <D <U <call-with-block-pass>> $34>
           }
           rhs = Literal{ value = :[] }
         }
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $35>
+            name = <D <U <call-with-block-pass>> $35>
           }
           rhs = Send{
             flags = {privateOk}
@@ -1150,23 +1150,23 @@ ClassDef{
         flags = {}
         recv = UnresolvedIdent{
           kind = Local
-          name = <D <U <call-with-block>> $32>
+          name = <D <U <call-with-block-pass>> $32>
         }
-        fun = <U <call-with-block>=>
+        fun = <U <call-with-block-pass>=>
         block = nullptr
         pos_args = 4
         args = [
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $33>
+            name = <D <U <call-with-block-pass>> $33>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $34>
+            name = <D <U <call-with-block-pass>> $34>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $35>
+            name = <D <U <call-with-block-pass>> $35>
           }
           Send{
             flags = {}
@@ -1174,23 +1174,23 @@ ClassDef{
               flags = {}
               recv = UnresolvedIdent{
                 kind = Local
-                name = <D <U <call-with-block>> $32>
+                name = <D <U <call-with-block-pass>> $32>
               }
-              fun = <U <call-with-block>>
+              fun = <U <call-with-block-pass>>
               block = nullptr
               pos_args = 3
               args = [
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $33>
+                  name = <D <U <call-with-block-pass>> $33>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $34>
+                  name = <D <U <call-with-block-pass>> $34>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $35>
+                  name = <D <U <call-with-block-pass>> $35>
                 }
               ]
             }
@@ -1210,7 +1210,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $36>
+            name = <D <U <call-with-block-pass>> $36>
           }
           rhs = ConstantLit{
             symbol = (class ::<Magic>)
@@ -1220,7 +1220,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $37>
+            name = <D <U <call-with-block-pass>> $37>
           }
           rhs = Send{
             flags = {privateOk}
@@ -1235,14 +1235,14 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $38>
+            name = <D <U <call-with-block-pass>> $38>
           }
           rhs = Literal{ value = :[] }
         }
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $39>
+            name = <D <U <call-with-block-pass>> $39>
           }
           rhs = Send{
             flags = {privateOk}
@@ -1259,23 +1259,23 @@ ClassDef{
         flags = {}
         recv = UnresolvedIdent{
           kind = Local
-          name = <D <U <call-with-block>> $36>
+          name = <D <U <call-with-block-pass>> $36>
         }
-        fun = <U <call-with-block>=>
+        fun = <U <call-with-block-pass>=>
         block = nullptr
         pos_args = 4
         args = [
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $37>
+            name = <D <U <call-with-block-pass>> $37>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $38>
+            name = <D <U <call-with-block-pass>> $38>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $39>
+            name = <D <U <call-with-block-pass>> $39>
           }
           Send{
             flags = {}
@@ -1283,23 +1283,23 @@ ClassDef{
               flags = {}
               recv = UnresolvedIdent{
                 kind = Local
-                name = <D <U <call-with-block>> $36>
+                name = <D <U <call-with-block-pass>> $36>
               }
-              fun = <U <call-with-block>>
+              fun = <U <call-with-block-pass>>
               block = nullptr
               pos_args = 3
               args = [
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $37>
+                  name = <D <U <call-with-block-pass>> $37>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $38>
+                  name = <D <U <call-with-block-pass>> $38>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $39>
+                  name = <D <U <call-with-block-pass>> $39>
                 }
               ]
             }
@@ -1319,7 +1319,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $40>
+            name = <D <U <call-with-block-pass>> $40>
           }
           rhs = ConstantLit{
             symbol = (class ::<Magic>)
@@ -1329,7 +1329,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $41>
+            name = <D <U <call-with-block-pass>> $41>
           }
           rhs = Send{
             flags = {privateOk}
@@ -1344,14 +1344,14 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $42>
+            name = <D <U <call-with-block-pass>> $42>
           }
           rhs = Literal{ value = :[] }
         }
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $43>
+            name = <D <U <call-with-block-pass>> $43>
           }
           rhs = Send{
             flags = {privateOk}
@@ -1368,23 +1368,23 @@ ClassDef{
         flags = {}
         recv = UnresolvedIdent{
           kind = Local
-          name = <D <U <call-with-block>> $40>
+          name = <D <U <call-with-block-pass>> $40>
         }
-        fun = <U <call-with-block>=>
+        fun = <U <call-with-block-pass>=>
         block = nullptr
         pos_args = 4
         args = [
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $41>
+            name = <D <U <call-with-block-pass>> $41>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $42>
+            name = <D <U <call-with-block-pass>> $42>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $43>
+            name = <D <U <call-with-block-pass>> $43>
           }
           Send{
             flags = {}
@@ -1392,23 +1392,23 @@ ClassDef{
               flags = {}
               recv = UnresolvedIdent{
                 kind = Local
-                name = <D <U <call-with-block>> $40>
+                name = <D <U <call-with-block-pass>> $40>
               }
-              fun = <U <call-with-block>>
+              fun = <U <call-with-block-pass>>
               block = nullptr
               pos_args = 3
               args = [
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $41>
+                  name = <D <U <call-with-block-pass>> $41>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $42>
+                  name = <D <U <call-with-block-pass>> $42>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $43>
+                  name = <D <U <call-with-block-pass>> $43>
                 }
               ]
             }
@@ -1428,7 +1428,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $44>
+            name = <D <U <call-with-block-pass>> $44>
           }
           rhs = ConstantLit{
             symbol = (class ::<Magic>)
@@ -1438,7 +1438,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $45>
+            name = <D <U <call-with-block-pass>> $45>
           }
           rhs = Send{
             flags = {privateOk}
@@ -1453,14 +1453,14 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $46>
+            name = <D <U <call-with-block-pass>> $46>
           }
           rhs = Literal{ value = :[] }
         }
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $47>
+            name = <D <U <call-with-block-pass>> $47>
           }
           rhs = Send{
             flags = {privateOk}
@@ -1477,23 +1477,23 @@ ClassDef{
         flags = {}
         recv = UnresolvedIdent{
           kind = Local
-          name = <D <U <call-with-block>> $44>
+          name = <D <U <call-with-block-pass>> $44>
         }
-        fun = <U <call-with-block>=>
+        fun = <U <call-with-block-pass>=>
         block = nullptr
         pos_args = 4
         args = [
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $45>
+            name = <D <U <call-with-block-pass>> $45>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $46>
+            name = <D <U <call-with-block-pass>> $46>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $47>
+            name = <D <U <call-with-block-pass>> $47>
           }
           Send{
             flags = {}
@@ -1501,23 +1501,23 @@ ClassDef{
               flags = {}
               recv = UnresolvedIdent{
                 kind = Local
-                name = <D <U <call-with-block>> $44>
+                name = <D <U <call-with-block-pass>> $44>
               }
-              fun = <U <call-with-block>>
+              fun = <U <call-with-block-pass>>
               block = nullptr
               pos_args = 3
               args = [
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $45>
+                  name = <D <U <call-with-block-pass>> $45>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $46>
+                  name = <D <U <call-with-block-pass>> $46>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $47>
+                  name = <D <U <call-with-block-pass>> $47>
                 }
               ]
             }
@@ -1537,7 +1537,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $48>
+            name = <D <U <call-with-block-pass>> $48>
           }
           rhs = ConstantLit{
             symbol = (class ::<Magic>)
@@ -1547,7 +1547,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $49>
+            name = <D <U <call-with-block-pass>> $49>
           }
           rhs = Send{
             flags = {privateOk}
@@ -1562,14 +1562,14 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $50>
+            name = <D <U <call-with-block-pass>> $50>
           }
           rhs = Literal{ value = :[] }
         }
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $51>
+            name = <D <U <call-with-block-pass>> $51>
           }
           rhs = Send{
             flags = {privateOk}
@@ -1586,23 +1586,23 @@ ClassDef{
         flags = {}
         recv = UnresolvedIdent{
           kind = Local
-          name = <D <U <call-with-block>> $48>
+          name = <D <U <call-with-block-pass>> $48>
         }
-        fun = <U <call-with-block>=>
+        fun = <U <call-with-block-pass>=>
         block = nullptr
         pos_args = 4
         args = [
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $49>
+            name = <D <U <call-with-block-pass>> $49>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $50>
+            name = <D <U <call-with-block-pass>> $50>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $51>
+            name = <D <U <call-with-block-pass>> $51>
           }
           Send{
             flags = {}
@@ -1610,23 +1610,23 @@ ClassDef{
               flags = {}
               recv = UnresolvedIdent{
                 kind = Local
-                name = <D <U <call-with-block>> $48>
+                name = <D <U <call-with-block-pass>> $48>
               }
-              fun = <U <call-with-block>>
+              fun = <U <call-with-block-pass>>
               block = nullptr
               pos_args = 3
               args = [
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $49>
+                  name = <D <U <call-with-block-pass>> $49>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $50>
+                  name = <D <U <call-with-block-pass>> $50>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $51>
+                  name = <D <U <call-with-block-pass>> $51>
                 }
               ]
             }
@@ -1646,7 +1646,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $52>
+            name = <D <U <call-with-block-pass>> $52>
           }
           rhs = ConstantLit{
             symbol = (class ::<Magic>)
@@ -1656,7 +1656,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $53>
+            name = <D <U <call-with-block-pass>> $53>
           }
           rhs = Send{
             flags = {privateOk}
@@ -1671,14 +1671,14 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $54>
+            name = <D <U <call-with-block-pass>> $54>
           }
           rhs = Literal{ value = :[] }
         }
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $55>
+            name = <D <U <call-with-block-pass>> $55>
           }
           rhs = Send{
             flags = {privateOk}
@@ -1695,23 +1695,23 @@ ClassDef{
         flags = {}
         recv = UnresolvedIdent{
           kind = Local
-          name = <D <U <call-with-block>> $52>
+          name = <D <U <call-with-block-pass>> $52>
         }
-        fun = <U <call-with-block>=>
+        fun = <U <call-with-block-pass>=>
         block = nullptr
         pos_args = 4
         args = [
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $53>
+            name = <D <U <call-with-block-pass>> $53>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $54>
+            name = <D <U <call-with-block-pass>> $54>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $55>
+            name = <D <U <call-with-block-pass>> $55>
           }
           Send{
             flags = {}
@@ -1719,23 +1719,23 @@ ClassDef{
               flags = {}
               recv = UnresolvedIdent{
                 kind = Local
-                name = <D <U <call-with-block>> $52>
+                name = <D <U <call-with-block-pass>> $52>
               }
-              fun = <U <call-with-block>>
+              fun = <U <call-with-block-pass>>
               block = nullptr
               pos_args = 3
               args = [
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $53>
+                  name = <D <U <call-with-block-pass>> $53>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $54>
+                  name = <D <U <call-with-block-pass>> $54>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $55>
+                  name = <D <U <call-with-block-pass>> $55>
                 }
               ]
             }
@@ -1755,7 +1755,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $56>
+            name = <D <U <call-with-block-pass>> $56>
           }
           rhs = ConstantLit{
             symbol = (class ::<Magic>)
@@ -1765,7 +1765,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $57>
+            name = <D <U <call-with-block-pass>> $57>
           }
           rhs = Send{
             flags = {privateOk}
@@ -1780,14 +1780,14 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $58>
+            name = <D <U <call-with-block-pass>> $58>
           }
           rhs = Literal{ value = :[] }
         }
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $59>
+            name = <D <U <call-with-block-pass>> $59>
           }
           rhs = Send{
             flags = {privateOk}
@@ -1804,23 +1804,23 @@ ClassDef{
         flags = {}
         recv = UnresolvedIdent{
           kind = Local
-          name = <D <U <call-with-block>> $56>
+          name = <D <U <call-with-block-pass>> $56>
         }
-        fun = <U <call-with-block>=>
+        fun = <U <call-with-block-pass>=>
         block = nullptr
         pos_args = 4
         args = [
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $57>
+            name = <D <U <call-with-block-pass>> $57>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $58>
+            name = <D <U <call-with-block-pass>> $58>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $59>
+            name = <D <U <call-with-block-pass>> $59>
           }
           Send{
             flags = {}
@@ -1828,23 +1828,23 @@ ClassDef{
               flags = {}
               recv = UnresolvedIdent{
                 kind = Local
-                name = <D <U <call-with-block>> $56>
+                name = <D <U <call-with-block-pass>> $56>
               }
-              fun = <U <call-with-block>>
+              fun = <U <call-with-block-pass>>
               block = nullptr
               pos_args = 3
               args = [
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $57>
+                  name = <D <U <call-with-block-pass>> $57>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $58>
+                  name = <D <U <call-with-block-pass>> $58>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $59>
+                  name = <D <U <call-with-block-pass>> $59>
                 }
               ]
             }
@@ -1864,7 +1864,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $60>
+            name = <D <U <call-with-block-pass>> $60>
           }
           rhs = ConstantLit{
             symbol = (class ::<Magic>)
@@ -1874,7 +1874,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $61>
+            name = <D <U <call-with-block-pass>> $61>
           }
           rhs = Send{
             flags = {privateOk}
@@ -1889,14 +1889,14 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $62>
+            name = <D <U <call-with-block-pass>> $62>
           }
           rhs = Literal{ value = :[] }
         }
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $63>
+            name = <D <U <call-with-block-pass>> $63>
           }
           rhs = Send{
             flags = {privateOk}
@@ -1913,23 +1913,23 @@ ClassDef{
         flags = {}
         recv = UnresolvedIdent{
           kind = Local
-          name = <D <U <call-with-block>> $60>
+          name = <D <U <call-with-block-pass>> $60>
         }
-        fun = <U <call-with-block>=>
+        fun = <U <call-with-block-pass>=>
         block = nullptr
         pos_args = 4
         args = [
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $61>
+            name = <D <U <call-with-block-pass>> $61>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $62>
+            name = <D <U <call-with-block-pass>> $62>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $63>
+            name = <D <U <call-with-block-pass>> $63>
           }
           Send{
             flags = {}
@@ -1937,23 +1937,23 @@ ClassDef{
               flags = {}
               recv = UnresolvedIdent{
                 kind = Local
-                name = <D <U <call-with-block>> $60>
+                name = <D <U <call-with-block-pass>> $60>
               }
-              fun = <U <call-with-block>>
+              fun = <U <call-with-block-pass>>
               block = nullptr
               pos_args = 3
               args = [
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $61>
+                  name = <D <U <call-with-block-pass>> $61>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $62>
+                  name = <D <U <call-with-block-pass>> $62>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $63>
+                  name = <D <U <call-with-block-pass>> $63>
                 }
               ]
             }
@@ -1973,7 +1973,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $64>
+            name = <D <U <call-with-block-pass>> $64>
           }
           rhs = ConstantLit{
             symbol = (class ::<Magic>)
@@ -1983,7 +1983,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $65>
+            name = <D <U <call-with-block-pass>> $65>
           }
           rhs = Send{
             flags = {privateOk}
@@ -1998,14 +1998,14 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $66>
+            name = <D <U <call-with-block-pass>> $66>
           }
           rhs = Literal{ value = :[] }
         }
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $67>
+            name = <D <U <call-with-block-pass>> $67>
           }
           rhs = Send{
             flags = {privateOk}
@@ -2022,23 +2022,23 @@ ClassDef{
         flags = {}
         recv = UnresolvedIdent{
           kind = Local
-          name = <D <U <call-with-block>> $64>
+          name = <D <U <call-with-block-pass>> $64>
         }
-        fun = <U <call-with-block>=>
+        fun = <U <call-with-block-pass>=>
         block = nullptr
         pos_args = 4
         args = [
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $65>
+            name = <D <U <call-with-block-pass>> $65>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $66>
+            name = <D <U <call-with-block-pass>> $66>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $67>
+            name = <D <U <call-with-block-pass>> $67>
           }
           Send{
             flags = {}
@@ -2046,23 +2046,23 @@ ClassDef{
               flags = {}
               recv = UnresolvedIdent{
                 kind = Local
-                name = <D <U <call-with-block>> $64>
+                name = <D <U <call-with-block-pass>> $64>
               }
-              fun = <U <call-with-block>>
+              fun = <U <call-with-block-pass>>
               block = nullptr
               pos_args = 3
               args = [
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $65>
+                  name = <D <U <call-with-block-pass>> $65>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $66>
+                  name = <D <U <call-with-block-pass>> $66>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $67>
+                  name = <D <U <call-with-block-pass>> $67>
                 }
               ]
             }
@@ -2082,7 +2082,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $68>
+            name = <D <U <call-with-block-pass>> $68>
           }
           rhs = ConstantLit{
             symbol = (class ::<Magic>)
@@ -2092,7 +2092,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $69>
+            name = <D <U <call-with-block-pass>> $69>
           }
           rhs = Send{
             flags = {privateOk}
@@ -2107,14 +2107,14 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $70>
+            name = <D <U <call-with-block-pass>> $70>
           }
           rhs = Literal{ value = :[] }
         }
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $71>
+            name = <D <U <call-with-block-pass>> $71>
           }
           rhs = Send{
             flags = {privateOk}
@@ -2131,23 +2131,23 @@ ClassDef{
         flags = {}
         recv = UnresolvedIdent{
           kind = Local
-          name = <D <U <call-with-block>> $68>
+          name = <D <U <call-with-block-pass>> $68>
         }
-        fun = <U <call-with-block>=>
+        fun = <U <call-with-block-pass>=>
         block = nullptr
         pos_args = 4
         args = [
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $69>
+            name = <D <U <call-with-block-pass>> $69>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $70>
+            name = <D <U <call-with-block-pass>> $70>
           }
           UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $71>
+            name = <D <U <call-with-block-pass>> $71>
           }
           Send{
             flags = {}
@@ -2155,23 +2155,23 @@ ClassDef{
               flags = {}
               recv = UnresolvedIdent{
                 kind = Local
-                name = <D <U <call-with-block>> $68>
+                name = <D <U <call-with-block-pass>> $68>
               }
-              fun = <U <call-with-block>>
+              fun = <U <call-with-block-pass>>
               block = nullptr
               pos_args = 3
               args = [
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $69>
+                  name = <D <U <call-with-block-pass>> $69>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $70>
+                  name = <D <U <call-with-block-pass>> $70>
                 }
                 UnresolvedIdent{
                   kind = Local
-                  name = <D <U <call-with-block>> $71>
+                  name = <D <U <call-with-block-pass>> $71>
                 }
               ]
             }
@@ -2191,7 +2191,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $72>
+            name = <D <U <call-with-block-pass>> $72>
           }
           rhs = ConstantLit{
             symbol = (class ::<Magic>)
@@ -2201,7 +2201,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $73>
+            name = <D <U <call-with-block-pass>> $73>
           }
           rhs = Send{
             flags = {privateOk}
@@ -2216,14 +2216,14 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $74>
+            name = <D <U <call-with-block-pass>> $74>
           }
           rhs = Literal{ value = :[] }
         }
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $75>
+            name = <D <U <call-with-block-pass>> $75>
           }
           rhs = Send{
             flags = {privateOk}
@@ -2238,29 +2238,29 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $76>
+            name = <D <U <call-with-block-pass>> $76>
           }
           rhs = Send{
             flags = {}
             recv = UnresolvedIdent{
               kind = Local
-              name = <D <U <call-with-block>> $72>
+              name = <D <U <call-with-block-pass>> $72>
             }
-            fun = <U <call-with-block>>
+            fun = <U <call-with-block-pass>>
             block = nullptr
             pos_args = 3
             args = [
               UnresolvedIdent{
                 kind = Local
-                name = <D <U <call-with-block>> $73>
+                name = <D <U <call-with-block-pass>> $73>
               }
               UnresolvedIdent{
                 kind = Local
-                name = <D <U <call-with-block>> $74>
+                name = <D <U <call-with-block-pass>> $74>
               }
               UnresolvedIdent{
                 kind = Local
-                name = <D <U <call-with-block>> $75>
+                name = <D <U <call-with-block-pass>> $75>
               }
             ]
           }
@@ -2269,36 +2269,36 @@ ClassDef{
       expr = If{
         cond = UnresolvedIdent{
           kind = Local
-          name = <D <U <call-with-block>> $76>
+          name = <D <U <call-with-block-pass>> $76>
         }
         thenp = Send{
           flags = {}
           recv = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $72>
+            name = <D <U <call-with-block-pass>> $72>
           }
-          fun = <U <call-with-block>=>
+          fun = <U <call-with-block-pass>=>
           block = nullptr
           pos_args = 4
           args = [
             UnresolvedIdent{
               kind = Local
-              name = <D <U <call-with-block>> $73>
+              name = <D <U <call-with-block-pass>> $73>
             }
             UnresolvedIdent{
               kind = Local
-              name = <D <U <call-with-block>> $74>
+              name = <D <U <call-with-block-pass>> $74>
             }
             UnresolvedIdent{
               kind = Local
-              name = <D <U <call-with-block>> $75>
+              name = <D <U <call-with-block-pass>> $75>
             }
             Literal{ value = 13 }
           ]
         }
         elsep = UnresolvedIdent{
           kind = Local
-          name = <D <U <call-with-block>> $76>
+          name = <D <U <call-with-block-pass>> $76>
         }
       }
     }
@@ -2308,7 +2308,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $77>
+            name = <D <U <call-with-block-pass>> $77>
           }
           rhs = ConstantLit{
             symbol = (class ::<Magic>)
@@ -2318,7 +2318,7 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $78>
+            name = <D <U <call-with-block-pass>> $78>
           }
           rhs = Send{
             flags = {privateOk}
@@ -2333,14 +2333,14 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $79>
+            name = <D <U <call-with-block-pass>> $79>
           }
           rhs = Literal{ value = :[] }
         }
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $80>
+            name = <D <U <call-with-block-pass>> $80>
           }
           rhs = Send{
             flags = {privateOk}
@@ -2355,29 +2355,29 @@ ClassDef{
         Assign{
           lhs = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $81>
+            name = <D <U <call-with-block-pass>> $81>
           }
           rhs = Send{
             flags = {}
             recv = UnresolvedIdent{
               kind = Local
-              name = <D <U <call-with-block>> $77>
+              name = <D <U <call-with-block-pass>> $77>
             }
-            fun = <U <call-with-block>>
+            fun = <U <call-with-block-pass>>
             block = nullptr
             pos_args = 3
             args = [
               UnresolvedIdent{
                 kind = Local
-                name = <D <U <call-with-block>> $78>
+                name = <D <U <call-with-block-pass>> $78>
               }
               UnresolvedIdent{
                 kind = Local
-                name = <D <U <call-with-block>> $79>
+                name = <D <U <call-with-block-pass>> $79>
               }
               UnresolvedIdent{
                 kind = Local
-                name = <D <U <call-with-block>> $80>
+                name = <D <U <call-with-block-pass>> $80>
               }
             ]
           }
@@ -2386,33 +2386,33 @@ ClassDef{
       expr = If{
         cond = UnresolvedIdent{
           kind = Local
-          name = <D <U <call-with-block>> $81>
+          name = <D <U <call-with-block-pass>> $81>
         }
         thenp = UnresolvedIdent{
           kind = Local
-          name = <D <U <call-with-block>> $81>
+          name = <D <U <call-with-block-pass>> $81>
         }
         elsep = Send{
           flags = {}
           recv = UnresolvedIdent{
             kind = Local
-            name = <D <U <call-with-block>> $77>
+            name = <D <U <call-with-block-pass>> $77>
           }
-          fun = <U <call-with-block>=>
+          fun = <U <call-with-block-pass>=>
           block = nullptr
           pos_args = 4
           args = [
             UnresolvedIdent{
               kind = Local
-              name = <D <U <call-with-block>> $78>
+              name = <D <U <call-with-block-pass>> $78>
             }
             UnresolvedIdent{
               kind = Local
-              name = <D <U <call-with-block>> $79>
+              name = <D <U <call-with-block-pass>> $79>
             }
             UnresolvedIdent{
               kind = Local
-              name = <D <U <call-with-block>> $80>
+              name = <D <U <call-with-block-pass>> $80>
             }
             Literal{ value = 14 }
           ]
@@ -2459,7 +2459,7 @@ ClassDef{
             symbol = (class ::<Magic>)
             orig = nullptr
           }
-          fun = <U <call-with-block>>
+          fun = <U <call-with-block-pass>>
           block = nullptr
           pos_args = 4
           args = [

--- a/test/prism_regression/call_all_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_all_params.rb.desugar-tree-raw.exp
@@ -13,7 +13,7 @@ ClassDef{
         symbol = (class ::<Magic>)
         orig = nullptr
       }
-      fun = <U <call-with-splat-and-block>>
+      fun = <U <call-with-splat-and-block-pass>>
       block = nullptr
       pos_args = 5
       args = [

--- a/test/prism_regression/call_block_param.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_block_param.rb.desugar-tree-raw.exp
@@ -393,7 +393,7 @@ ClassDef{
         symbol = (class ::<Magic>)
         orig = nullptr
       }
-      fun = <U <call-with-block>>
+      fun = <U <call-with-block-pass>>
       block = nullptr
       pos_args = 3
       args = [

--- a/test/prism_regression/call_forwarding_param.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_forwarding_param.rb.desugar-tree-raw.exp
@@ -26,7 +26,7 @@ ClassDef{
           symbol = (class ::<Magic>)
           orig = nullptr
         }
-        fun = <U <call-with-splat-and-block>>
+        fun = <U <call-with-splat-and-block-pass>>
         block = nullptr
         pos_args = 5
         args = [

--- a/test/prism_regression/def_singleton.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_singleton.rb.desugar-tree-raw.exp
@@ -40,7 +40,7 @@ ClassDef{
           symbol = (class ::<Magic>)
           orig = nullptr
         }
-        fun = <U <call-with-block>>
+        fun = <U <call-with-block-pass>>
         block = nullptr
         pos_args = 3
         args = [

--- a/test/testdata/compiler/send_with_splat_and_block.rb
+++ b/test/testdata/compiler/send_with_splat_and_block.rb
@@ -12,7 +12,7 @@ end
 def forward(&blk)
   args = [1,2,3]
 
-  # this produces a call to `<Magic>.<call-with-splat-and-block>`
+  # this produces a call to `<Magic>.<call-with-splat-and-block-pass>`
   foo(*args, &blk)
 end
 

--- a/test/testdata/desugar/anonymous_blockarg.rb.desugar-tree.exp
+++ b/test/testdata/desugar/anonymous_blockarg.rb.desugar-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   def bar<<todo method>>(args, &&$3)
-    ::<Magic>.<call-with-block>(<self>, :baz, &)
+    ::<Magic>.<call-with-block-pass>(<self>, :baz, &)
   end
 
   <self>.foo(1) do ||

--- a/test/testdata/desugar/anonymous_blockarg.rb.desugar-tree.exp
+++ b/test/testdata/desugar/anonymous_blockarg.rb.desugar-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   def foo<<todo method>>(args, &&$2)
-    ::<Magic>.<call-with-splat-and-block>(<self>, :bar, ::<Magic>.<splat>(args), nil, &)
+    ::<Magic>.<call-with-splat-and-block-pass>(<self>, :bar, ::<Magic>.<splat>(args), nil, &)
   end
 
   def bar<<todo method>>(args, &&$3)

--- a/test/testdata/desugar/blockpass.rb.desugar-tree.exp
+++ b/test/testdata/desugar/blockpass.rb.desugar-tree.exp
@@ -22,7 +22,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   def calls_with_object<<todo method>>(&blk)
-    ::<Magic>.<call-with-block>(<self>, :calls_arg_with_object, blk, <emptyTree>::<C HasMeth>.new())
+    ::<Magic>.<call-with-block-pass>(<self>, :calls_arg_with_object, blk, <emptyTree>::<C HasMeth>.new())
   end
 
   class <emptyTree>::<C CallsWithObject><<C <todo sym>>> < (::<todo sym>)
@@ -33,7 +33,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C CallsWithObjectChild><<C <todo sym>>> < (<emptyTree>::<C CallsWithObject>)
     def self.calls_with_object<<todo method>>(&blk)
-      ::<Magic>.<call-with-block>(<self>, :<super>, blk)
+      ::<Magic>.<call-with-block-pass>(<self>, :<super>, blk)
     end
   end
 
@@ -51,9 +51,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.calls_with_object() do |x|
         x.meth()
       end
-      ::<Magic>.<call-with-block>(<self>, :calls_with_object, blk)
-      ::<Magic>.<call-with-block>(<self>, :calls_with_object, <self>.returns_lambda())
-      ::<Magic>.<call-with-block>(<self>, :calls_with_object, <emptyTree>::<C HasToProc>.new())
+      ::<Magic>.<call-with-block-pass>(<self>, :calls_with_object, blk)
+      ::<Magic>.<call-with-block-pass>(<self>, :calls_with_object, <self>.returns_lambda())
+      ::<Magic>.<call-with-block-pass>(<self>, :calls_with_object, <emptyTree>::<C HasToProc>.new())
       <self>.calls_with_object() do |*args|
         ::<Magic>.<call-with-splat>(<emptyTree>::<C HasToProc>.new().to_proc(), :call, ::<Magic>.<splat>(args), nil)
       end

--- a/test/testdata/desugar/forward_args.rb.desugar-tree.exp
+++ b/test/testdata/desugar/forward_args.rb.desugar-tree.exp
@@ -5,22 +5,22 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo<<todo method>>(*<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
-      ::<Magic>.<call-with-splat-and-block>(<emptyTree>::<C T>.unsafe(<self>), :bar, [].concat(<fwd-args>.to_a()).concat([::<Magic>.<to-hash-dup>(<fwd-kwargs>)]), nil, <fwd-block>)
+      ::<Magic>.<call-with-splat-and-block-pass>(<emptyTree>::<C T>.unsafe(<self>), :bar, [].concat(<fwd-args>.to_a()).concat([::<Magic>.<to-hash-dup>(<fwd-kwargs>)]), nil, <fwd-block>)
     end
 
     def foo2<<todo method>>(*args, *kwargs:, &block)
-      ::<Magic>.<call-with-splat-and-block>(<emptyTree>::<C T>.unsafe(<self>), :bar, ::<Magic>.<splat>(args), [begin
+      ::<Magic>.<call-with-splat-and-block-pass>(<emptyTree>::<C T>.unsafe(<self>), :bar, ::<Magic>.<splat>(args), [begin
             <hashTemp>$2 = ::<Magic>.<to-hash-dup>(kwargs)
             <hashTemp>$2
           end], block)
     end
 
     def foo3<<todo method>>(*<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
-      ::<Magic>.<call-with-splat-and-block>(<emptyTree>::<C T>.unsafe(<self>), :bar, ::<Magic>.<splat>([1, 2, 3]).concat(<fwd-args>.to_a()).concat([::<Magic>.<to-hash-dup>(<fwd-kwargs>)]), nil, <fwd-block>)
+      ::<Magic>.<call-with-splat-and-block-pass>(<emptyTree>::<C T>.unsafe(<self>), :bar, ::<Magic>.<splat>([1, 2, 3]).concat(<fwd-args>.to_a()).concat([::<Magic>.<to-hash-dup>(<fwd-kwargs>)]), nil, <fwd-block>)
     end
 
     def foo4<<todo method>>(*args, *kwargs:, &block)
-      ::<Magic>.<call-with-splat-and-block>(<emptyTree>::<C T>.unsafe(<self>), :bar, ::<Magic>.<splat>([1, 2, 3]).concat(::<Magic>.<splat>(args)), [begin
+      ::<Magic>.<call-with-splat-and-block-pass>(<emptyTree>::<C T>.unsafe(<self>), :bar, ::<Magic>.<splat>([1, 2, 3]).concat(::<Magic>.<splat>(args)), [begin
             <hashTemp>$2 = ::<Magic>.<to-hash-dup>(kwargs)
             <hashTemp>$2
           end], block)

--- a/test/testdata/local_vars/z_super_args.rb.index-tree-raw.exp
+++ b/test/testdata/local_vars/z_super_args.rb.index-tree-raw.exp
@@ -394,7 +394,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [

--- a/test/testdata/local_vars/z_super_args.rb.index-tree-raw.exp
+++ b/test/testdata/local_vars/z_super_args.rb.index-tree-raw.exp
@@ -260,7 +260,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-block>>
+            fun = <U <call-with-block-pass>>
             block = nullptr
             pos_args = 4
             args = [
@@ -290,7 +290,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-block>>
+            fun = <U <call-with-block-pass>>
             block = nullptr
             pos_args = 3
             args = [
@@ -323,7 +323,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-block>>
+            fun = <U <call-with-block-pass>>
             block = nullptr
             pos_args = 3
             args = [
@@ -360,7 +360,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-block>>
+            fun = <U <call-with-block-pass>>
             block = nullptr
             pos_args = 4
             args = [
@@ -449,7 +449,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-block>>
+            fun = <U <call-with-block-pass>>
             block = nullptr
             pos_args = 3
             args = [
@@ -489,7 +489,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-block>>
+            fun = <U <call-with-block-pass>>
             block = nullptr
             pos_args = 3
             args = [
@@ -524,7 +524,7 @@ ClassDef{
                   symbol = (class ::<Magic>)
                   orig = nullptr
                 }
-                fun = <U <call-with-block>>
+                fun = <U <call-with-block-pass>>
                 block = nullptr
                 pos_args = 3
                 args = [
@@ -581,7 +581,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-block>>
+            fun = <U <call-with-block-pass>>
             block = nullptr
             pos_args = 3
             args = [

--- a/test/testdata/local_vars/z_super_args_splats_blocks.rb.index-tree-raw.exp
+++ b/test/testdata/local_vars/z_super_args_splats_blocks.rb.index-tree-raw.exp
@@ -98,7 +98,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -216,7 +216,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -372,7 +372,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -538,7 +538,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -805,7 +805,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -923,7 +923,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -1079,7 +1079,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -1245,7 +1245,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -1536,7 +1536,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -1680,7 +1680,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -1862,7 +1862,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -2054,7 +2054,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -2377,7 +2377,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -2533,7 +2533,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -2727,7 +2727,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -2931,7 +2931,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -3324,7 +3324,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -3532,7 +3532,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -3778,7 +3778,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -4034,7 +4034,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -4409,7 +4409,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -4553,7 +4553,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -4735,7 +4735,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -4927,7 +4927,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -5250,7 +5250,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -5406,7 +5406,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -5600,7 +5600,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -5804,7 +5804,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -6197,7 +6197,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -6405,7 +6405,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -6651,7 +6651,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [
@@ -6907,7 +6907,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-splat-and-block>>
+            fun = <U <call-with-splat-and-block-pass>>
             block = nullptr
             pos_args = 5
             args = [

--- a/test/testdata/local_vars/z_super_args_splats_blocks.rb.index-tree-raw.exp
+++ b/test/testdata/local_vars/z_super_args_splats_blocks.rb.index-tree-raw.exp
@@ -27,7 +27,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-block>>
+            fun = <U <call-with-block-pass>>
             block = nullptr
             pos_args = 6
             args = [
@@ -734,7 +734,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-block>>
+            fun = <U <call-with-block-pass>>
             block = nullptr
             pos_args = 6
             args = [
@@ -1445,7 +1445,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-block>>
+            fun = <U <call-with-block-pass>>
             block = nullptr
             pos_args = 6
             args = [
@@ -2274,7 +2274,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-block>>
+            fun = <U <call-with-block-pass>>
             block = nullptr
             pos_args = 6
             args = [
@@ -3169,7 +3169,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-block>>
+            fun = <U <call-with-block-pass>>
             block = nullptr
             pos_args = 6
             args = [
@@ -4318,7 +4318,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-block>>
+            fun = <U <call-with-block-pass>>
             block = nullptr
             pos_args = 6
             args = [
@@ -5147,7 +5147,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-block>>
+            fun = <U <call-with-block-pass>>
             block = nullptr
             pos_args = 6
             args = [
@@ -6042,7 +6042,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-block>>
+            fun = <U <call-with-block-pass>>
             block = nullptr
             pos_args = 6
             args = [

--- a/test/testdata/local_vars/z_super_args_strict.rb.index-tree-raw.exp
+++ b/test/testdata/local_vars/z_super_args_strict.rb.index-tree-raw.exp
@@ -1119,7 +1119,7 @@ ClassDef{
               symbol = (class ::<Magic>)
               orig = nullptr
             }
-            fun = <U <call-with-block>>
+            fun = <U <call-with-block-pass>>
             block = nullptr
             pos_args = 3
             args = [

--- a/test/testdata/namer/yield.rb.cfg-text.exp
+++ b/test/testdata/namer/yield.rb.cfg-text.exp
@@ -137,16 +137,16 @@ bb3[firstDead=15](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfR
     <self>: Main = <selfRestore>$6
     <cfgAlias>$15: T.class_of(<Magic>) = alias <C <Magic>>
     <statTemp>$17: Symbol(:yielder) = :yielder
-    <statTemp>$13: T.untyped = <cfgAlias>$15: T.class_of(<Magic>).<call-with-block>(<self>: Main, <statTemp>$17: Symbol(:yielder), l: T.proc.params(arg0: T.untyped).returns(Integer))
+    <statTemp>$13: T.untyped = <cfgAlias>$15: T.class_of(<Magic>).<call-with-block-pass>(<self>: Main, <statTemp>$17: Symbol(:yielder), l: T.proc.params(arg0: T.untyped).returns(Integer))
     <cfgAlias>$21: T.class_of(<Magic>) = alias <C <Magic>>
     <statTemp>$23: Symbol(:blockpass) = :blockpass
-    <statTemp>$19: T.untyped = <cfgAlias>$21: T.class_of(<Magic>).<call-with-block>(<self>: Main, <statTemp>$23: Symbol(:blockpass), l: T.proc.params(arg0: T.untyped).returns(Integer))
+    <statTemp>$19: T.untyped = <cfgAlias>$21: T.class_of(<Magic>).<call-with-block-pass>(<self>: Main, <statTemp>$23: Symbol(:blockpass), l: T.proc.params(arg0: T.untyped).returns(Integer))
     <cfgAlias>$27: T.class_of(<Magic>) = alias <C <Magic>>
     <statTemp>$29: Symbol(:mixed) = :mixed
-    <statTemp>$25: T.untyped = <cfgAlias>$27: T.class_of(<Magic>).<call-with-block>(<self>: Main, <statTemp>$29: Symbol(:mixed), l: T.proc.params(arg0: T.untyped).returns(Integer))
+    <statTemp>$25: T.untyped = <cfgAlias>$27: T.class_of(<Magic>).<call-with-block-pass>(<self>: Main, <statTemp>$29: Symbol(:mixed), l: T.proc.params(arg0: T.untyped).returns(Integer))
     <cfgAlias>$32: T.class_of(<Magic>) = alias <C <Magic>>
     <statTemp>$34: Symbol(:blockyield) = :blockyield
-    <returnMethodTemp>$2: T.untyped = <cfgAlias>$32: T.class_of(<Magic>).<call-with-block>(<self>: Main, <statTemp>$34: Symbol(:blockyield), l: T.proc.params(arg0: T.untyped).returns(Integer))
+    <returnMethodTemp>$2: T.untyped = <cfgAlias>$32: T.class_of(<Magic>).<call-with-block-pass>(<self>: Main, <statTemp>$34: Symbol(:blockyield), l: T.proc.params(arg0: T.untyped).returns(Integer))
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 

--- a/test/testdata/namer/yield.rb.flatten-tree.exp
+++ b/test/testdata/namer/yield.rb.flatten-tree.exp
@@ -42,10 +42,10 @@ begin
             3
           end
         end
-        ::<Magic>.<call-with-block>(<self>, :yielder, l)
-        ::<Magic>.<call-with-block>(<self>, :blockpass, l)
-        ::<Magic>.<call-with-block>(<self>, :mixed, l)
-        ::<Magic>.<call-with-block>(<self>, :blockyield, l)
+        ::<Magic>.<call-with-block-pass>(<self>, :yielder, l)
+        ::<Magic>.<call-with-block-pass>(<self>, :blockpass, l)
+        ::<Magic>.<call-with-block-pass>(<self>, :mixed, l)
+        ::<Magic>.<call-with-block-pass>(<self>, :blockyield, l)
       end
     end
 

--- a/test/testdata/parser/error_recovery/block_arg_and_block.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/block_arg_and_block.rb.desugar-tree.exp
@@ -1,6 +1,6 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   [1, 2, 3].each() do |x|
-    ::<Magic>.<call-with-block>(<self>, :foo, <self>.bar()) do ||
+    ::<Magic>.<call-with-block-pass>(<self>, :foo, <self>.bar()) do ||
       <self>.puts(x)
     end
   end

--- a/test/testdata/parser/error_recovery/forward_args_with_block.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/forward_args_with_block.rb.desugar-tree.exp
@@ -1,7 +1,7 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   def test<<todo method>>(*<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
     [1, 2, 3].each() do ||
-      ::<Magic>.<call-with-splat-and-block>(<self>, :foo, [].concat(<fwd-args>.to_a()).concat([::<Magic>.<to-hash-dup>(<fwd-kwargs>)]), nil, <fwd-block>) do ||
+      ::<Magic>.<call-with-splat-and-block-pass>(<self>, :foo, [].concat(<fwd-args>.to_a()).concat([::<Magic>.<to-hash-dup>(<fwd-kwargs>)]), nil, <fwd-block>) do ||
         <emptyTree>
       end
     end

--- a/test/testdata/rewriter/test_each_describe.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/test_each_describe.rb.rewrite-tree.exp
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   class <emptyTree>::<C Minitest>::<C Spec><<C <todo sym>>> < (::<todo sym>)
     def self.test_each<<todo method>>(arg, &blk)
-      ::<Magic>.<call-with-block>(arg, :each, blk)
+      ::<Magic>.<call-with-block-pass>(arg, :each, blk)
     end
 
     <runtime method definition of self.test_each>


### PR DESCRIPTION
### Motivation

These intrinsics are only needed for block pass args (`foo(&block)`), and not block literals (`foo do ... end`). Rename this to clarify. Related #9226.

Spoke about this on our monthly sync. Went ahead and just did it :)

Each kind of change is split into a separate commit, to make it easy to review.

### Test plan

This is covered by existing tests, which have been updated to expect the new string.