### PR TITLE
Take `NodeVec` instead of `Args` node

### DIFF
--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -93,7 +93,7 @@ private:
     translateParametersNode(pm_parameters_node *paramsNode);
 
     std::tuple<ast::MethodDef::ARGS_store, ast::InsSeq::STATS_store, bool>
-    desugarParametersNode(parser::Args *paramsNode, bool attemptToDesugarParams);
+    desugarParametersNode(NodeVec &params, bool attemptToDesugarParams);
 
     NodeVec translateArguments(pm_arguments_node *node, pm_node *blockArgumentNode = nullptr);
     parser::NodeVec translateKeyValuePairs(pm_node_list_t elements);


### PR DESCRIPTION
### Motivation

In an up-coming PR, I need to reuse this function for both `parser::Args` and `parser::NumParams` nodes. I only needed this node to get at is `NodeVec` of params, so just accept those directly.

Part of #9065

### Test plan

Pure refactor