### PR TITLE
no-op: Remove unused `ancestors` argument from MK::Module

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -304,9 +304,8 @@ public:
     }
 
     static ExpressionPtr Module(core::LocOffsets loc, core::LocOffsets declLoc, ExpressionPtr name,
-                                ClassDef::ANCESTORS_store ancestors, ClassDef::RHS_store rhs) {
-        return MK::ClassOrModule(loc, declLoc, std::move(name), std::move(ancestors), std::move(rhs),
-                                 ClassDef::Kind::Module);
+                                ClassDef::RHS_store rhs) {
+        return MK::ClassOrModule(loc, declLoc, std::move(name), {}, std::move(rhs), ClassDef::Kind::Module);
     }
 
     static ExpressionPtr Array(core::LocOffsets loc, Array::ENTRY_store entries) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1494,9 +1494,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,
                                      dctx.enclosingMethodName, dctx.inAnyBlock, true, dctx.preserveConcreteSyntax);
                 ClassDef::RHS_store body = scopeNodeToBody(dctx1, move(module->body));
-                ClassDef::ANCESTORS_store ancestors;
-                ExpressionPtr res = MK::Module(module->loc, module->declLoc, node2TreeImpl(dctx, module->name),
-                                               move(ancestors), move(body));
+                ExpressionPtr res =
+                    MK::Module(module->loc, module->declLoc, node2TreeImpl(dctx, module->name), move(body));
                 result = move(res);
             },
             [&](parser::Class *klass) {

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -1442,9 +1442,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,
                                      dctx.enclosingMethodName, dctx.inAnyBlock, true, dctx.preserveConcreteSyntax);
                 ClassDef::RHS_store body = scopeNodeToBody(dctx1, move(module->body));
-                ClassDef::ANCESTORS_store ancestors;
-                ExpressionPtr res = MK::Module(module->loc, module->declLoc, node2TreeImpl(dctx, module->name),
-                                               move(ancestors), move(body));
+                ExpressionPtr res =
+                    MK::Module(module->loc, module->declLoc, node2TreeImpl(dctx, module->name), move(body));
                 result = move(res);
             },
             [&](parser::Class *klass) {

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1382,8 +1382,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
             auto bodyExprs = move(*bodyExprsOpt);
 
             auto nameExpr = name->takeDesugaredExpr();
-            ast::ClassDef::ANCESTORS_store ancestors;
-            auto moduleDef = MK::Module(location, declLoc, move(nameExpr), move(ancestors), move(bodyExprs));
+            auto moduleDef = MK::Module(location, declLoc, move(nameExpr), move(bodyExprs));
 
             return make_node_with_expr<parser::Module>(move(moduleDef), location, declLoc, move(name), move(body));
         }

--- a/rewriter/Concern.cc
+++ b/rewriter/Concern.cc
@@ -106,7 +106,7 @@ void Concern::run(core::MutableContext ctx, ast::ClassDef *klass) {
                     }
                     auto name =
                         ast::MK::UnresolvedConstant(loc, ast::MK::EmptyTree(), core::Names::Constants::ClassMethods());
-                    classMethodsNode = ast::MK::Module(loc, loc, std::move(name), {}, std::move(rhs));
+                    classMethodsNode = ast::MK::Module(loc, loc, std::move(name), std::move(rhs));
                 }
                 continue;
             }
@@ -122,7 +122,7 @@ void Concern::run(core::MutableContext ctx, ast::ClassDef *klass) {
                 } else {
                     // We don't have a ClassMethods module yet. Let's use the defined module (mod)
                     auto loc = mod->loc;
-                    classMethodsNode = ast::MK::Module(loc, loc, std::move(mod->name), {}, std::move(mod->rhs));
+                    classMethodsNode = ast::MK::Module(loc, loc, std::move(mod->name), std::move(mod->rhs));
                 }
                 continue;
             }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

All call sites are just passing an empty ancestors vector.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests