### PR TITLE
Accidentally deleted rubocop from CI

### DIFF
--- a/.buildkite/build-sorbet-runtime.sh
+++ b/.buildkite/build-sorbet-runtime.sh
@@ -23,6 +23,12 @@ for runtime_version in "${runtime_versions[@]}"; do
 
   failed=
 
+  # Our Rubocop version doesn't understand Ruby 3.1 as a valid Ruby version
+  echo "+++ rubocop ($runtime_version)"
+  if ! rbenv exec bundle exec rake rubocop; then
+    failed=1
+  fi
+
   echo "+++ tests ($runtime_version)"
   if ! rbenv exec bundle exec rake test; then
     failed=1

--- a/gems/sorbet-runtime/.rubocop.yml
+++ b/gems/sorbet-runtime/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
   TargetRubyVersion: 2.7
   Exclude:
     - 'vendor/**/*'
+    - 'test/wholesome/vendor/**/*'
 
 
 # Stripe in-house styles that are prevalent in the codebase already.

--- a/gems/sorbet-runtime/.rubocop.yml
+++ b/gems/sorbet-runtime/.rubocop.yml
@@ -5,6 +5,8 @@ AllCops:
   NewCops: disable
   SuggestExtensions: false
   TargetRubyVersion: 2.7
+  Exclude:
+    - 'vendor/**/*'
 
 
 # Stripe in-house styles that are prevalent in the codebase already.

--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
@@ -277,7 +277,7 @@ module T::Private::Methods::SignatureValidation
     end
   end
 
-  ALLOW_INCOMPATIBLE_VISIBILITY = [:visibility, true]
+  ALLOW_INCOMPATIBLE_VISIBILITY = [:visibility, true].freeze
   private_constant :ALLOW_INCOMPATIBLE_VISIBILITY
 
   def self.validate_override_visibility(signature, super_signature)
@@ -308,7 +308,7 @@ module T::Private::Methods::SignatureValidation
   end
 
   # Higher = more restrictive.
-  METHOD_VISIBILITIES = %i[public protected private]
+  METHOD_VISIBILITIES = %i[public protected private].freeze
   private_constant :METHOD_VISIBILITIES
 
   private_class_method def self.visibility_strength(vis)

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -323,9 +323,9 @@ class T::Props::Decorator
   sig(:final) { params(name: Symbol).returns(T::Boolean).checked(:never) }
   private def method_defined_on_ancestor?(name)
     (@class.method_defined?(name) || @class.private_method_defined?(name)) &&
-      # Unfortunately, older versions of ruby don't allow the second parameter on
-      # `private_method_defined?`.
-      (!@class.method_defined?(name, false) && !@class.private_method_defined?(name, false))
+    # Unfortunately, older versions of ruby don't allow the second parameter on
+    # `private_method_defined?`.
+    (!@class.method_defined?(name, false) && !@class.private_method_defined?(name, false))
   end
 
   sig(:final) { params(name: Symbol, rules: Rules).void.checked(:never) }

--- a/gems/sorbet-runtime/test/types/props/_props.rb
+++ b/gems/sorbet-runtime/test/types/props/_props.rb
@@ -477,8 +477,7 @@ class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest
         abstract!
 
         sig { abstract.returns(Integer) }
-        private def foo
-        end
+        private def foo; end
       end
 
       class B < T::Struct

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1237,7 +1237,6 @@ module Opus::Types::Test
     end
 
     describe "TEnum" do
-
       it 'allows T::Enum values when coercing' do
         a = T::Utils.coerce(::MyEnum::A)
         assert_instance_of(T::Types::TEnum, a)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In db6c1688c14b2da6346c5e0d192bb65d76ecdbc0, in my haste, I deleted
rubocop from running in CI.

There was a condition that evaluated to false once we dropped the
`2.7.7` run from CI, so I constant folded the whole condition away, not
thinking about what was inside the condition. Turns out, it was
important: it's the only place we ran rubocop.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.