### PR TITLE
Add support for RSpec's SharedExampleGroup

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -280,8 +280,16 @@ NameDef names[] = {
     {"itAngles", "<it>"},
     {"testEach", "test_each"},
     {"testEachHash", "test_each_hash"},
+    {"sharedExamples", "shared_examples"},
+    {"sharedContext", "shared_context"},
+    {"sharedExamplesFor", "shared_examples_for"},
+    {"includeExamples", "include_examples"},
+    {"includeContext", "include_context"},
+    {"RSpec", "RSpec", true},
+    {"Core", "Core", true},
+    {"ExampleGroup", "ExampleGroup", true},
+
     {"constSet", "const_set"},
-    {"collect"},
 
     {"dslOptional", "dsl_optional"},
     {"dslRequired", "dsl_required"},

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -509,10 +509,6 @@ ast::ExpressionPtr prepareBody(core::MutableContext ctx, bool isClass, ast::Expr
 }
 
 ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *send, bool insideDescribe) {
-    if (!send->hasBlock()) {
-        return nullptr;
-    }
-
     auto *block = send->block();
 
     if (!send->recv.isSelfReference()) {
@@ -522,6 +518,10 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
     switch (send->fun.rawId()) {
         case core::Names::testEach().rawId():
         case core::Names::testEachHash().rawId(): {
+            if (!send->hasBlock()) {
+                return nullptr;
+            }
+
             if (send->numPosArgs() != 1) {
                 if (send->fun == core::Names::testEachHash() && send->numKwArgs() > 0) {
                     auto errLoc = send->getKwKey(0).loc().join(send->getKwValue(send->numKwArgs() - 1).loc());
@@ -561,7 +561,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
         }
 
         case core::Names::describe().rawId(): {
-            if (send->numPosArgs() != 1) {
+            if (!send->hasBlock() || send->numPosArgs() != 1) {
                 return nullptr;
             }
             auto &arg = send->getPosArg(0);
@@ -606,7 +606,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
         case core::Names::focus().rawId():
         case core::Names::pending().rawId():
         case core::Names::skip().rawId(): {
-            if (!insideDescribe && requiresSecondFactor(send->fun)) {
+            if (!send->hasBlock() || (!insideDescribe && requiresSecondFactor(send->fun))) {
                 return nullptr;
             }
 
@@ -635,7 +635,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
         case core::Names::let().rawId():
         case core::Names::let_bang().rawId():
         case core::Names::subject().rawId(): {
-            if (!insideDescribe) {
+            if (!send->hasBlock() || !insideDescribe) {
                 return nullptr;
             }
 
@@ -655,7 +655,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
         case core::Names::sharedExamples().rawId():
         case core::Names::sharedContext().rawId():
         case core::Names::sharedExamplesFor().rawId(): {
-            if (!insideDescribe || send->numPosArgs() != 1) {
+            if (!send->hasBlock() || !insideDescribe || send->numPosArgs() != 1) {
                 return nullptr;
             }
 
@@ -695,7 +695,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
 
         case core::Names::includeExamples().rawId():
         case core::Names::includeContext().rawId(): {
-            if (!insideDescribe || send->numPosArgs() != 1) {
+            if (send->hasBlock() || !insideDescribe || send->numPosArgs() != 1) {
                 return nullptr;
             }
 

--- a/test/testdata/rewriter/rspec_example.rb
+++ b/test/testdata/rewriter/rspec_example.rb
@@ -30,11 +30,11 @@ class A
       my_helper
     end
 
-    shared_examples "some examples" do # error: does not exist
-      let(:defined_in_shared_examples) { "foo" } # error: does not exist
+    shared_examples "some examples" do
+      let(:defined_in_shared_examples) { "foo" }
 
-      it("a shared example") do # error: does not exist
-        described_class # error: does not exist
+      it("a shared example") do
+        described_class
       end
     end
 
@@ -49,8 +49,6 @@ class A
     test_each([]) do |x|
       describe("shared examples in test_each") do
         include_examples("some examples")
-      # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Only valid `it`
-      # ^^^^^^^^^^^^^^^^ error: does not exist
 
         it "has access to defined_in_shared_examples" do
           defined_in_shared_examples # error: does not exist

--- a/test/testdata/rewriter/rspec_example.rb
+++ b/test/testdata/rewriter/rspec_example.rb
@@ -38,11 +38,11 @@ class A
       end
     end
 
-    describe "will include shared examples" do
-      include_examples("some examples") # error: does not exist
+    describe "will include shared examples" do # error: `A::<describe 'inside describe'>::<describe 'will include shared examples'>` must inherit `RSpec::Core::ExampleGroup` (required by `A::<describe 'inside describe'>::<shared_examples 'some examples'>`)
+      include_examples("some examples")
 
       it "has access to defined_in_shared_examples" do
-        defined_in_shared_examples # error: does not exist
+        defined_in_shared_examples
       end
     end
 

--- a/test/testdata/rewriter/rspec_example.rb
+++ b/test/testdata/rewriter/rspec_example.rb
@@ -1,6 +1,18 @@
 # typed: true
+# enable-experimental-requires-ancestor: true
+
+module RSpec
+  module Core
+    class ExampleGroup
+      def described_class
+      end
+    end
+  end
+end
 
 class A
+  def self.test_each(arg, &blk) = arg.each(&blk)
+
   def outer_helper; end
 
   describe "inside describe" do
@@ -16,6 +28,34 @@ class A
 
     example do
       my_helper
+    end
+
+    shared_examples "some examples" do # error: does not exist
+      let(:defined_in_shared_examples) { "foo" } # error: does not exist
+
+      it("a shared example") do # error: does not exist
+        described_class # error: does not exist
+      end
+    end
+
+    describe "will include shared examples" do
+      include_examples("some examples") # error: does not exist
+
+      it "has access to defined_in_shared_examples" do
+        defined_in_shared_examples # error: does not exist
+      end
+    end
+
+    test_each([]) do |x|
+      describe("shared examples in test_each") do
+        include_examples("some examples")
+      # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Only valid `it`
+      # ^^^^^^^^^^^^^^^^ error: does not exist
+
+        it "has access to defined_in_shared_examples" do
+          defined_in_shared_examples # error: does not exist
+        end
+      end
     end
   end
 

--- a/test/testdata/rewriter/rspec_example.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_example.rb.rewrite-tree.exp
@@ -70,7 +70,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           <self>.defined_in_shared_examples()
         end
 
-        <self>.include_examples("some examples")
+        <self>.include(<emptyTree>::<C <shared_examples 'some examples'>>)
       end
 
       <self>.test_each([]) do |x|

--- a/test/testdata/rewriter/rspec_example.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_example.rb.rewrite-tree.exp
@@ -1,8 +1,26 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C RSpec><<C <todo sym>>> < ()
+    module <emptyTree>::<C Core><<C <todo sym>>> < ()
+      class <emptyTree>::<C ExampleGroup><<C <todo sym>>> < (::<todo sym>)
+        def described_class<<todo method>>(&<blk>)
+          <emptyTree>
+        end
+
+        <runtime method definition of described_class>
+      end
+    end
+  end
+
   class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
+    def self.test_each<<todo method>>(arg, &blk)
+      ::<Magic>.<call-with-block-pass>(arg, :each, blk)
+    end
+
     def outer_helper<<todo method>>(&<blk>)
       <emptyTree>
     end
+
+    <runtime method definition of self.test_each>
 
     <runtime method definition of outer_helper>
 
@@ -23,7 +41,39 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.my_helper()
       end
 
+      def <it 'has access to defined_in_shared_examples'><<todo method>>(&<blk>)
+        [].each() do |x|
+          <self>.defined_in_shared_examples()
+        end
+      end
+
       <runtime method definition of my_helper>
+
+      <self>.shared_examples("some examples") do ||
+        begin
+          <self>.let(:defined_in_shared_examples) do ||
+            "foo"
+          end
+          <self>.it("a shared example") do ||
+            <self>.described_class()
+          end
+        end
+      end
+
+      class <emptyTree>::<C <describe 'will include shared examples'>><<C <todo sym>>> < (<self>)
+        def <it 'has access to defined_in_shared_examples'><<todo method>>(&<blk>)
+          <self>.defined_in_shared_examples()
+        end
+
+        <self>.include_examples("some examples")
+      end
+
+      <self>.test_each([]) do |x|
+        begin
+          <self>.include_examples("some examples")
+          <runtime method definition of <it 'has access to defined_in_shared_examples'>>
+        end
+      end
     end
 
     <self>.example() do ||

--- a/test/testdata/rewriter/rspec_example.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_example.rb.rewrite-tree.exp
@@ -49,14 +49,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
       <runtime method definition of my_helper>
 
-      <self>.shared_examples("some examples") do ||
-        begin
-          <self>.let(:defined_in_shared_examples) do ||
-            "foo"
-          end
-          <self>.it("a shared example") do ||
-            <self>.described_class()
-          end
+      module <emptyTree>::<C <shared_examples 'some examples'>><<C <todo sym>>> < ()
+        def defined_in_shared_examples<<todo method>>(&<blk>)
+          "foo"
+        end
+
+        def <it 'a shared example'><<todo method>>(&<blk>)
+          <self>.described_class()
+        end
+
+        <runtime method definition of defined_in_shared_examples>
+
+        ::<Magic>.requires_ancestor() do ||
+          <emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>
         end
       end
 
@@ -70,7 +75,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
       <self>.test_each([]) do |x|
         begin
-          <self>.include_examples("some examples")
+          <self>.include(<emptyTree>::<C <shared_examples 'some examples'>>)
           <runtime method definition of <it 'has access to defined_in_shared_examples'>>
         end
       end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Attempting to recreate #9119, but with smaller pieces.

The thesis behind this change is that anyone whose tests relied on `shared_examples` or `include_examples` to work in their codebase today either:

1.  Has `# typed: false`'d all their tests
2.  Has gone to great lengths to `T.unsafe` or `T.bind` all the relevant call sites

Technically, this change will immediately apply to all `'minitest'` test users too, not just RSpec users. That could be a problem, because this rewriter hard-codes a `requires_ancestor` line inside the newly-created `shared_examples` modules. We just reverted a similar PR that used that strategy: #9379, and it's not clear how disruptive it will be to also revert this change. The alternative would be that we require people to write `requires_ancestor { RSpec::Core::ExampleGroup }` in these modules themselves.

e.g. maybe someone using minitest, not rspec, has defined a `shared_examples` and `include_examples` helper that is meant to work like RSpec's but powered by different underlying machinery. This would break those users, but it's not clear whether there are any such users—minitest does not ship with these methods out of the box.

### Commit summary

- **Add test showing behavior before** (795faceddb)


- **Add support for RSpec's SharedExampleGroup** (6a6db594dd)

  <https://github.com/rspec/rspec/blob/main/rspec-core/lib/rspec/core/shared_example_group.rb#L90-L101>



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- included tests
- tested on Stripe's codebase, which is understandably a no-op (does not use RSpec)
- tested on Bridge's codebase, which does use RSpec