### PR TITLE
Add all RSpec ExampleGroup methods

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -261,6 +261,12 @@ NameDef names[] = {
     {"classAttribute", "class_attribute"},
 
     {"describe"},
+    {"exampleGroup", "example_group"},
+    {"context"},
+    {"xdescribe"},
+    {"xcontext"},
+    {"fdescribe"},
+    {"fcontext"},
     {"it"},
     {"fit"},
     {"xit"},

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -510,14 +510,10 @@ ast::ExpressionPtr prepareBody(core::MutableContext ctx, bool isClass, ast::Expr
 ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *send, bool insideDescribe) {
     auto *block = send->block();
 
-    if (!send->recv.isSelfReference()) {
-        return nullptr;
-    }
-
     switch (send->fun.rawId()) {
         case core::Names::testEach().rawId():
         case core::Names::testEachHash().rawId(): {
-            if (block == nullptr) {
+            if (block == nullptr || !send->recv.isSelfReference()) {
                 return nullptr;
             }
 
@@ -560,7 +556,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
         }
 
         case core::Names::describe().rawId(): {
-            if (block == nullptr || send->numPosArgs() != 1) {
+            if (block == nullptr || send->numPosArgs() != 1 || !send->recv.isSelfReference()) {
                 return nullptr;
             }
             auto &arg = send->getPosArg(0);
@@ -605,7 +601,8 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
         case core::Names::focus().rawId():
         case core::Names::pending().rawId():
         case core::Names::skip().rawId(): {
-            if (block == nullptr || (!insideDescribe && requiresSecondFactor(send->fun))) {
+            if (block == nullptr || !send->recv.isSelfReference() ||
+                (!insideDescribe && requiresSecondFactor(send->fun))) {
                 return nullptr;
             }
 
@@ -634,7 +631,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
         case core::Names::let().rawId():
         case core::Names::let_bang().rawId():
         case core::Names::subject().rawId(): {
-            if (block == nullptr || !insideDescribe) {
+            if (block == nullptr || !send->recv.isSelfReference() || !insideDescribe) {
                 return nullptr;
             }
 
@@ -654,7 +651,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
         case core::Names::sharedExamples().rawId():
         case core::Names::sharedContext().rawId():
         case core::Names::sharedExamplesFor().rawId(): {
-            if (block == nullptr || !insideDescribe || send->numPosArgs() != 1) {
+            if (block == nullptr || !send->recv.isSelfReference() || !insideDescribe || send->numPosArgs() != 1) {
                 return nullptr;
             }
 
@@ -694,7 +691,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
 
         case core::Names::includeExamples().rawId():
         case core::Names::includeContext().rawId(): {
-            if (block != nullptr || !insideDescribe || send->numPosArgs() != 1) {
+            if (block != nullptr || !send->recv.isSelfReference() || !insideDescribe || send->numPosArgs() != 1) {
                 return nullptr;
             }
 

--- a/test/testdata/rewriter/rspec_example.rb
+++ b/test/testdata/rewriter/rspec_example.rb
@@ -76,22 +76,22 @@ class A
   end
 
   describe "contains generic name group" do
-    example_group "example_group group" do # error: Method `example_group` does not exist
-      it do # error: does not exist
-        outer_helper # error: Method `outer_helper` does not exist
+    example_group "example_group group" do
+      it do
+        outer_helper
       end
     end
 
-    context "context group" do # error: Method `context` does not exist
-      it do # error: does not exist
-        outer_helper # error: Method `outer_helper` does not exist
+    context "context group" do
+      it do
+        outer_helper
       end
     end
   end
 
-  xdescribe "xdescribe group" do # error: Method `xdescribe` does not exist
-    it do # error: does not exist
-      outer_helper # error: Method `outer_helper` does not exist
+  xdescribe "xdescribe group" do
+    it do
+      outer_helper
     end
   end
 end

--- a/test/testdata/rewriter/rspec_example.rb
+++ b/test/testdata/rewriter/rspec_example.rb
@@ -2,6 +2,7 @@
 # enable-experimental-requires-ancestor: true
 
 module RSpec
+  def self.context(arg0, &blk); end
   module Core
     class ExampleGroup
       def described_class
@@ -20,6 +21,7 @@ class A
 
     xit do
       my_helper
+      described_class # error: does not exist
     end
 
     it "example", focus: true do
@@ -59,5 +61,56 @@ class A
 
   example do # error: Method `example` does not exist
     outer_helper # error: Method `outer_helper` does not exist
+  end
+
+  example_group "example_group group" do # error: Method `example_group` does not exist
+    it do # error: does not exist
+      outer_helper # error: Method `outer_helper` does not exist
+    end
+  end
+
+  context "context group" do # error: Method `context` does not exist
+    it do # error: does not exist
+      outer_helper # error: Method `outer_helper` does not exist
+    end
+  end
+
+  describe "contains generic name group" do
+    example_group "example_group group" do # error: Method `example_group` does not exist
+      it do # error: does not exist
+        outer_helper # error: Method `outer_helper` does not exist
+      end
+    end
+
+    context "context group" do # error: Method `context` does not exist
+      it do # error: does not exist
+        outer_helper # error: Method `outer_helper` does not exist
+      end
+    end
+  end
+
+  xdescribe "xdescribe group" do # error: Method `xdescribe` does not exist
+    it do # error: does not exist
+      outer_helper # error: Method `outer_helper` does not exist
+    end
+  end
+end
+
+RSpec.context("B") do
+  def another_outer_helper; end
+
+  it "inside B" do
+# ^^ error: does not exist
+    another_outer_helper
+  end
+
+  context("Nested, no RSpec") do
+# ^^^^^^^ error: does not exist
+    it "inside Nested" do
+  # ^^ error: does not exist
+      another_outer_helper
+      described_class
+    # ^^^^^^^^^^^^^^^ error: does not exist
+    end
   end
 end

--- a/test/testdata/rewriter/rspec_example.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_example.rb.rewrite-tree.exp
@@ -111,21 +111,21 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C <describe 'contains generic name group'>><<C <todo sym>>> < (<self>)
-      <self>.example_group("example_group group") do ||
-        <self>.it() do ||
+      class <emptyTree>::<C <example_group 'example_group group'>><<C <todo sym>>> < (<self>)
+        def <it><<todo method>>(&<blk>)
           <self>.outer_helper()
         end
       end
 
-      <self>.context("context group") do ||
-        <self>.it() do ||
+      class <emptyTree>::<C <context 'context group'>><<C <todo sym>>> < (<self>)
+        def <it><<todo method>>(&<blk>)
           <self>.outer_helper()
         end
       end
     end
 
-    <self>.xdescribe("xdescribe group") do ||
-      <self>.it() do ||
+    class <emptyTree>::<C <xdescribe 'xdescribe group'>><<C <todo sym>>> < (<self>)
+      def <it><<todo method>>(&<blk>)
         <self>.outer_helper()
       end
     end

--- a/test/testdata/rewriter/rspec_example.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_example.rb.rewrite-tree.exp
@@ -1,5 +1,15 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
+  def another_outer_helper<<todo method>>(&<blk>)
+    <emptyTree>
+  end
+
   module <emptyTree>::<C RSpec><<C <todo sym>>> < ()
+    def self.context<<todo method>>(arg0, &blk)
+      <emptyTree>
+    end
+
+    <runtime method definition of self.context>
+
     module <emptyTree>::<C Core><<C <todo sym>>> < ()
       class <emptyTree>::<C ExampleGroup><<C <todo sym>>> < (::<todo sym>)
         def described_class<<todo method>>(&<blk>)
@@ -30,7 +40,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
 
       def <it><<todo method>>(&<blk>)
-        <self>.my_helper()
+        begin
+          <self>.my_helper()
+          <self>.described_class()
+        end
       end
 
       def <it 'example'><<todo method>>(&<blk>)
@@ -83,6 +96,55 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.example() do ||
       <self>.outer_helper()
+    end
+
+    <self>.example_group("example_group group") do ||
+      <self>.it() do ||
+        <self>.outer_helper()
+      end
+    end
+
+    <self>.context("context group") do ||
+      <self>.it() do ||
+        <self>.outer_helper()
+      end
+    end
+
+    class <emptyTree>::<C <describe 'contains generic name group'>><<C <todo sym>>> < (<self>)
+      <self>.example_group("example_group group") do ||
+        <self>.it() do ||
+          <self>.outer_helper()
+        end
+      end
+
+      <self>.context("context group") do ||
+        <self>.it() do ||
+          <self>.outer_helper()
+        end
+      end
+    end
+
+    <self>.xdescribe("xdescribe group") do ||
+      <self>.it() do ||
+        <self>.outer_helper()
+      end
+    end
+  end
+
+  <emptyTree>::<C RSpec>.context("B") do ||
+    begin
+      <runtime method definition of another_outer_helper>
+      <self>.it("inside B") do ||
+        <self>.another_outer_helper()
+      end
+      <self>.context("Nested, no RSpec") do ||
+        <self>.it("inside Nested") do ||
+          begin
+            <self>.another_outer_helper()
+            <self>.described_class()
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Adds the aliases that RSpec uses for example group names, in addition to the minitest names (e.g., just "describe"). c.f. example_group.rb:
   
<https://github.com/rspec/rspec/blob/main/rspec-core/lib/rspec/core/example_group.rb#L282-L308>

There is one caveat, which is that `example_group` and `context` felt somewhat too generic to trigger on. In the interest of erring on the conservative side, I decided that those two names should only have special meaning if we're already in some `describe` block. This guarantees that this PR doesn't make it so that the Minitest.cc rewriter fires in **more** files than it is firing in today, so this is unlikely to cause new errors.

Rather, this should make it so that if someone tries to convert a `# typed: false` test file to a `# typed: true` file, they find it easier than it was before, because Sorbet understands more of it.

Importantly, this still does not support RSpec's `RSpec.describe` syntax for defining example groups at the top level.

Until we find a way to enable that, the recommended approach remains to put the bare `describe {...}` calls inside some class that includes at least `RSpec::Core::ExampleGroup`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.