### PR TITLE
reduce the overhead of generating serialization methods for `T::Props`

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -261,6 +261,8 @@ class T::Props::Decorator
   end
 
   SAFE_NAME = T.let(/\A[A-Za-z_][A-Za-z0-9_-]*\z/.freeze, Regexp, checked: false)
+  # Should be exactly the same as `SAFE_NAME`, but with a leading `@`.
+  SAFE_ACCESSOR_KEY_NAME = T.let(/\A@[A-Za-z_][A-Za-z0-9_-]*\z/.freeze, Regexp, checked: false)
 
   # Used to validate both prop names and serialized forms
   sig { params(name: T.any(Symbol, String)).void.checked(:never) }

--- a/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
@@ -41,7 +41,7 @@ module T::Props
           raise unless T::Props::Decorator::SAFE_NAME.match?(hash_key)
 
           ivar_name = rules.fetch(:accessor_key).to_s
-          raise unless ivar_name.start_with?('@') && T::Props::Decorator::SAFE_NAME.match?(ivar_name[1..-1])
+          raise unless ivar_name.start_with?('@') && T::Props::Decorator::SAFE_ACCESSOR_KEY_NAME.match?(ivar_name)
 
           transformation = SerdeTransform.generate(
             T::Utils::Nilable.get_underlying_type_object(rules.fetch(:type_object)),

--- a/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
@@ -16,7 +16,7 @@ module T::Props
     module DeserializerGenerator
       extend T::Sig
 
-      CAN_USE_SYMBOL_NAME = RUBY_VERSION >= "3.3.0"
+      CAN_USE_SYMBOL_NAME = T.let(RUBY_VERSION >= "3.3.0", T::Boolean)
 
       # Generate a method that takes a T::Hash[String, T.untyped] representing
       # serialized props, sets instance variables for each prop found in the

--- a/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
@@ -96,7 +96,7 @@ module T::Props
 
         <<~RUBY
           def __t_props_generated_deserialize(hash)
-            found = #{stored_props.size}
+            found = #{parts.size}
             #{parts.join("\n\n")}
             found
           end

--- a/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
@@ -43,10 +43,8 @@ module T::Props
           hash_key = rules.fetch(:serialized_form)
           raise unless T::Props::Decorator::SAFE_NAME.match?(hash_key)
 
-          ivar_name = begin
-                        key = rules.fetch(:accessor_key)
-                        CAN_USE_SYMBOL_NAME ? key.name : key.to_s
-                      end
+          key = rules.fetch(:accessor_key)
+          ivar_name = CAN_USE_SYMBOL_NAME ? key.name : key.to_s
           raise unless ivar_name.start_with?('@') && T::Props::Decorator::SAFE_ACCESSOR_KEY_NAME.match?(ivar_name)
 
           transformation = SerdeTransform.generate(

--- a/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
@@ -31,8 +31,9 @@ module T::Props
         .checked(:never)
       end
       def self.generate(props, defaults)
-        stored_props = props.reject { |_, rules| rules[:dont_store] }
-        parts = stored_props.map do |prop, rules|
+        parts = props.filter_map do |prop, rules|
+          next if rules[:dont_store]
+
           # All of these strings should already be validated (directly or
           # indirectly) in `validate_prop_name`, so we don't bother with a nice
           # error message, but we double check here to prevent a refactoring

--- a/gems/sorbet-runtime/lib/types/props/private/serializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/serializer_generator.rb
@@ -26,8 +26,9 @@ module T::Props
         .checked(:never)
       end
       def self.generate(props)
-        stored_props = props.reject { |_, rules| rules[:dont_store] }
-        parts = stored_props.map do |prop, rules|
+        parts = props.filter_map do |prop, rules|
+          next if rules[:dont_store]
+
           # All of these strings should already be validated (directly or
           # indirectly) in `validate_prop_name`, so we don't bother with a nice
           # error message, but we double check here to prevent a refactoring

--- a/gems/sorbet-runtime/lib/types/props/private/serializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/serializer_generator.rb
@@ -36,7 +36,7 @@ module T::Props
           raise unless T::Props::Decorator::SAFE_NAME.match?(hash_key)
 
           ivar_name = rules.fetch(:accessor_key).to_s
-          raise unless ivar_name.start_with?('@') && T::Props::Decorator::SAFE_NAME.match?(ivar_name[1..-1])
+          raise unless ivar_name.start_with?('@') && T::Props::Decorator::SAFE_ACCESSOR_KEY_NAME.match?(ivar_name)
 
           transformed_val = SerdeTransform.generate(
             T::Utils::Nilable.get_underlying_type_object(rules.fetch(:type_object)),

--- a/gems/sorbet-runtime/lib/types/props/private/serializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/serializer_generator.rb
@@ -16,7 +16,7 @@ module T::Props
     module SerializerGenerator
       extend T::Sig
 
-      CAN_USE_SYMBOL_NAME = RUBY_VERSION >= "3.3.0"
+      CAN_USE_SYMBOL_NAME = T.let(RUBY_VERSION >= "3.3.0", T::Boolean)
 
       sig do
         params(

--- a/gems/sorbet-runtime/lib/types/props/private/serializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/serializer_generator.rb
@@ -16,6 +16,8 @@ module T::Props
     module SerializerGenerator
       extend T::Sig
 
+      CAN_USE_SYMBOL_NAME = RUBY_VERSION >= "3.3.0"
+
       sig do
         params(
           props: T::Hash[Symbol, T::Hash[Symbol, T.untyped]],
@@ -30,12 +32,15 @@ module T::Props
           # indirectly) in `validate_prop_name`, so we don't bother with a nice
           # error message, but we double check here to prevent a refactoring
           # from introducing a security vulnerability.
-          raise unless T::Props::Decorator::SAFE_NAME.match?(prop.to_s)
+          raise unless T::Props::Decorator::SAFE_NAME.match?(CAN_USE_SYMBOL_NAME ? prop.name : prop.to_s)
 
           hash_key = rules.fetch(:serialized_form)
           raise unless T::Props::Decorator::SAFE_NAME.match?(hash_key)
 
-          ivar_name = rules.fetch(:accessor_key).to_s
+          ivar_name = begin
+                        key = rules.fetch(:accessor_key)
+                        CAN_USE_SYMBOL_NAME ? key.name : key.to_s
+                      end
           raise unless ivar_name.start_with?('@') && T::Props::Decorator::SAFE_ACCESSOR_KEY_NAME.match?(ivar_name)
 
           transformed_val = SerdeTransform.generate(

--- a/gems/sorbet-runtime/lib/types/props/private/serializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/serializer_generator.rb
@@ -38,10 +38,8 @@ module T::Props
           hash_key = rules.fetch(:serialized_form)
           raise unless T::Props::Decorator::SAFE_NAME.match?(hash_key)
 
-          ivar_name = begin
-                        key = rules.fetch(:accessor_key)
-                        CAN_USE_SYMBOL_NAME ? key.name : key.to_s
-                      end
+          key = rules.fetch(:accessor_key)
+          ivar_name = CAN_USE_SYMBOL_NAME ? key.name : key.to_s
           raise unless ivar_name.start_with?('@') && T::Props::Decorator::SAFE_ACCESSOR_KEY_NAME.match?(ivar_name)
 
           transformed_val = SerdeTransform.generate(


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The string allocations for checking valid `:accessor_key` values and `Symbol#to_s` calls show up as relatively hot in a service preloading profile, and we don't have to allocate for either one:

1. For `:accessor_key` checking, we can just use a better regex.  We cannot use `.match?(string, offset)` because we're using `\A` in the regex.  (I can see arguments both ways for that choice...)
2. For `Symbol#to_s`, we can make a runtime determination whether we can use `Symbol#name`, which doesn't allocate.

...and while we're here, we might as use `filter_map` rather than allocating a hash of storable props.  (This didn't show up as particularly hot, but hey, it's a nice improvement.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.