### PR TITLE
Rename "args" to "params" where appropriate (part 1)

### DIFF
--- a/ast/ArgParsing.cc
+++ b/ast/ArgParsing.cc
@@ -8,41 +8,41 @@ using namespace std;
 namespace sorbet::ast {
 
 namespace {
-core::ParsedParam parseArg(const ast::ExpressionPtr &arg) {
-    core::ParsedParam parsedArg;
-    auto *cursor = &arg;
+core::ParsedParam parseParam(const ast::ExpressionPtr &param) {
+    core::ParsedParam parsedParam;
+    auto *cursor = &param;
 
     while (cursor != nullptr) {
         typecase(
             *cursor,
             [&](const ast::RestArg &rest) {
-                parsedArg.flags.isRepeated = true;
+                parsedParam.flags.isRepeated = true;
                 cursor = &rest.expr;
             },
             [&](const ast::KeywordArg &kw) {
-                parsedArg.flags.isKeyword = true;
+                parsedParam.flags.isKeyword = true;
                 cursor = &kw.expr;
             },
             [&](const ast::OptionalArg &opt) {
-                parsedArg.flags.isDefault = true;
+                parsedParam.flags.isDefault = true;
                 cursor = &opt.expr;
             },
             [&](const ast::BlockArg &blk) {
-                parsedArg.flags.isBlock = true;
+                parsedParam.flags.isBlock = true;
                 cursor = &blk.expr;
             },
             [&](const ast::ShadowArg &shadow) {
-                parsedArg.flags.isShadow = true;
+                parsedParam.flags.isShadow = true;
                 cursor = &shadow.expr;
             },
             [&](const ast::Local &local) {
-                parsedArg.local = local.localVariable;
-                parsedArg.loc = local.loc;
+                parsedParam.local = local.localVariable;
+                parsedParam.loc = local.loc;
                 cursor = nullptr;
             });
     }
 
-    return parsedArg;
+    return parsedParam;
 }
 
 ExpressionPtr getDefaultValue(ExpressionPtr arg) {
@@ -68,16 +68,16 @@ ExpressionPtr getDefaultValue(ExpressionPtr arg) {
 
 } // namespace
 
-vector<core::ParsedParam> ArgParsing::parseArgs(const ast::MethodDef::PARAMS_store &args) {
-    vector<core::ParsedParam> parsedArgs;
-    for (auto &arg : args) {
-        if (!ast::isa_reference(arg)) {
+vector<core::ParsedParam> ArgParsing::parseParams(const ast::MethodDef::PARAMS_store &params) {
+    vector<core::ParsedParam> parsedParams;
+    for (auto &param : params) {
+        if (!ast::isa_reference(param)) {
             Exception::raise("Must be a reference!");
         }
-        parsedArgs.emplace_back(parseArg(arg));
+        parsedParams.emplace_back(parseParam(param));
     }
 
-    return parsedArgs;
+    return parsedParams;
 }
 
 // This has to match the implementation of Method::methodArityHash

--- a/ast/ArgParsing.cc
+++ b/ast/ArgParsing.cc
@@ -68,7 +68,7 @@ ExpressionPtr getDefaultValue(ExpressionPtr arg) {
 
 } // namespace
 
-vector<core::ParsedArg> ArgParsing::parseArgs(const ast::MethodDef::ARGS_store &args) {
+vector<core::ParsedArg> ArgParsing::parseArgs(const ast::MethodDef::PARAMS_store &args) {
     vector<core::ParsedArg> parsedArgs;
     for (auto &arg : args) {
         if (!ast::isa_reference(arg)) {

--- a/ast/ArgParsing.cc
+++ b/ast/ArgParsing.cc
@@ -8,8 +8,8 @@ using namespace std;
 namespace sorbet::ast {
 
 namespace {
-core::ParsedArg parseArg(const ast::ExpressionPtr &arg) {
-    core::ParsedArg parsedArg;
+core::ParsedParam parseArg(const ast::ExpressionPtr &arg) {
+    core::ParsedParam parsedArg;
     auto *cursor = &arg;
 
     while (cursor != nullptr) {
@@ -68,8 +68,8 @@ ExpressionPtr getDefaultValue(ExpressionPtr arg) {
 
 } // namespace
 
-vector<core::ParsedArg> ArgParsing::parseArgs(const ast::MethodDef::PARAMS_store &args) {
-    vector<core::ParsedArg> parsedArgs;
+vector<core::ParsedParam> ArgParsing::parseArgs(const ast::MethodDef::PARAMS_store &args) {
+    vector<core::ParsedParam> parsedArgs;
     for (auto &arg : args) {
         if (!ast::isa_reference(arg)) {
             Exception::raise("Must be a reference!");
@@ -81,7 +81,7 @@ vector<core::ParsedArg> ArgParsing::parseArgs(const ast::MethodDef::PARAMS_store
 }
 
 // This has to match the implementation of Method::methodArityHash
-core::ArityHash ArgParsing::hashArgs(core::Context ctx, const vector<core::ParsedArg> &args) {
+core::ArityHash ArgParsing::hashArgs(core::Context ctx, const vector<core::ParsedParam> &args) {
     uint32_t result = 0;
     result = core::mix(result, args.size());
     for (const auto &e : args) {
@@ -99,7 +99,7 @@ core::ArityHash ArgParsing::hashArgs(core::Context ctx, const vector<core::Parse
     return core::ArityHash(result);
 }
 
-ExpressionPtr ArgParsing::getDefault(const core::ParsedArg &parsedArg, ExpressionPtr arg) {
+ExpressionPtr ArgParsing::getDefault(const core::ParsedParam &parsedArg, ExpressionPtr arg) {
     if (!parsedArg.flags.isDefault) {
         return nullptr;
     }

--- a/ast/ArgParsing.cc
+++ b/ast/ArgParsing.cc
@@ -81,10 +81,10 @@ vector<core::ParsedParam> ArgParsing::parseParams(const ast::MethodDef::PARAMS_s
 }
 
 // This has to match the implementation of Method::methodArityHash
-core::ArityHash ArgParsing::hashArgs(core::Context ctx, const vector<core::ParsedParam> &args) {
+core::ArityHash ArgParsing::hashParams(core::Context ctx, const vector<core::ParsedParam> &params) {
     uint32_t result = 0;
-    result = core::mix(result, args.size());
-    for (const auto &e : args) {
+    result = core::mix(result, params.size());
+    for (const auto &e : params) {
         if (e.flags.isKeyword) {
             if (e.flags.isRepeated && e.local._name != core::Names::fwdKwargs()) {
                 auto name = core::Names::kwargs();

--- a/ast/ArgParsing.h
+++ b/ast/ArgParsing.h
@@ -6,9 +6,9 @@ namespace sorbet::ast {
 class ArgParsing {
 public:
     static std::vector<core::ParsedParam> parseParams(const ast::MethodDef::PARAMS_store &params);
-    static core::ArityHash hashArgs(core::Context ctx, const std::vector<core::ParsedParam> &args);
-    // Returns the default argument value for the given argument, or nullptr if not specified. Mutates arg.
-    static ExpressionPtr getDefault(const core::ParsedParam &parsedArg, ExpressionPtr arg);
+    static core::ArityHash hashParams(core::Context ctx, const std::vector<core::ParsedParam> &params);
+    // Returns the default argument value for the given parameter, or nullptr if not specified. Mutates param.
+    static ExpressionPtr getDefault(const core::ParsedParam &parsedParam, ExpressionPtr param);
 };
 }; // namespace sorbet::ast
 

--- a/ast/ArgParsing.h
+++ b/ast/ArgParsing.h
@@ -5,10 +5,10 @@
 namespace sorbet::ast {
 class ArgParsing {
 public:
-    static std::vector<core::ParsedArg> parseArgs(const ast::MethodDef::PARAMS_store &args);
-    static core::ArityHash hashArgs(core::Context ctx, const std::vector<core::ParsedArg> &args);
+    static std::vector<core::ParsedParam> parseArgs(const ast::MethodDef::PARAMS_store &args);
+    static core::ArityHash hashArgs(core::Context ctx, const std::vector<core::ParsedParam> &args);
     // Returns the default argument value for the given argument, or nullptr if not specified. Mutates arg.
-    static ExpressionPtr getDefault(const core::ParsedArg &parsedArg, ExpressionPtr arg);
+    static ExpressionPtr getDefault(const core::ParsedParam &parsedArg, ExpressionPtr arg);
 };
 }; // namespace sorbet::ast
 

--- a/ast/ArgParsing.h
+++ b/ast/ArgParsing.h
@@ -5,7 +5,7 @@
 namespace sorbet::ast {
 class ArgParsing {
 public:
-    static std::vector<core::ParsedArg> parseArgs(const ast::MethodDef::ARGS_store &args);
+    static std::vector<core::ParsedArg> parseArgs(const ast::MethodDef::PARAMS_store &args);
     static core::ArityHash hashArgs(core::Context ctx, const std::vector<core::ParsedArg> &args);
     // Returns the default argument value for the given argument, or nullptr if not specified. Mutates arg.
     static ExpressionPtr getDefault(const core::ParsedArg &parsedArg, ExpressionPtr arg);

--- a/ast/ArgParsing.h
+++ b/ast/ArgParsing.h
@@ -5,7 +5,7 @@
 namespace sorbet::ast {
 class ArgParsing {
 public:
-    static std::vector<core::ParsedParam> parseArgs(const ast::MethodDef::PARAMS_store &args);
+    static std::vector<core::ParsedParam> parseParams(const ast::MethodDef::PARAMS_store &params);
     static core::ArityHash hashArgs(core::Context ctx, const std::vector<core::ParsedParam> &args);
     // Returns the default argument value for the given argument, or nullptr if not specified. Mutates arg.
     static ExpressionPtr getDefault(const core::ParsedParam &parsedArg, ExpressionPtr arg);

--- a/ast/BUILD
+++ b/ast/BUILD
@@ -13,7 +13,7 @@ cc_library(
         ],
     ),
     hdrs = [
-        "ArgParsing.h",
+        "ParamParsing.h",
         "ast.h",
     ],
     linkstatic = select({

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -13,19 +13,19 @@ public:
         return make_expression<ast::EmptyTree>();
     }
 
-    static ExpressionPtr Block(core::LocOffsets loc, ExpressionPtr body, MethodDef::ARGS_store args) {
-        return make_expression<ast::Block>(loc, std::move(args), std::move(body));
+    static ExpressionPtr Block(core::LocOffsets loc, ExpressionPtr body, MethodDef::PARAMS_store params) {
+        return make_expression<ast::Block>(loc, std::move(params), std::move(body));
     }
 
     static ExpressionPtr Block0(core::LocOffsets loc, ExpressionPtr body) {
-        MethodDef::ARGS_store args;
-        return Block(loc, std::move(body), std::move(args));
+        MethodDef::PARAMS_store params;
+        return Block(loc, std::move(body), std::move(params));
     }
 
-    static ExpressionPtr Block1(core::LocOffsets loc, ExpressionPtr body, ExpressionPtr arg1) {
-        MethodDef::ARGS_store args;
-        args.emplace_back(std::move(arg1));
-        return Block(loc, std::move(body), std::move(args));
+    static ExpressionPtr Block1(core::LocOffsets loc, ExpressionPtr body, ExpressionPtr param1) {
+        MethodDef::PARAMS_store params;
+        params.emplace_back(std::move(param1));
+        return Block(loc, std::move(body), std::move(params));
     }
 
     template <typename... Args> static Send::ARGS_store SendArgs(Args &&...args) {
@@ -245,48 +245,48 @@ public:
     }
 
     static ExpressionPtr Method(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
-                                MethodDef::ARGS_store args, ExpressionPtr rhs,
+                                MethodDef::PARAMS_store params, ExpressionPtr rhs,
                                 MethodDef::Flags flags = MethodDef::Flags()) {
-        if (args.empty() || (!isa_tree<ast::Local>(args.back()) && !isa_tree<ast::BlockArg>(args.back()))) {
+        if (params.empty() || (!isa_tree<ast::Local>(params.back()) && !isa_tree<ast::BlockArg>(params.back()))) {
             auto blkLoc = core::LocOffsets::none();
-            args.emplace_back(make_expression<ast::BlockArg>(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
+            params.emplace_back(make_expression<ast::BlockArg>(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
         }
-        return make_expression<MethodDef>(loc, declLoc, core::Symbols::todoMethod(), name, std::move(args),
+        return make_expression<MethodDef>(loc, declLoc, core::Symbols::todoMethod(), name, std::move(params),
                                           std::move(rhs), flags);
     }
 
     static ExpressionPtr Method0(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name, ExpressionPtr rhs,
                                  MethodDef::Flags flags = MethodDef::Flags()) {
-        MethodDef::ARGS_store args;
-        return Method(loc, declLoc, name, std::move(args), std::move(rhs), flags);
+        MethodDef::PARAMS_store params;
+        return Method(loc, declLoc, name, std::move(params), std::move(rhs), flags);
     }
 
-    static ExpressionPtr Method1(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name, ExpressionPtr arg0,
-                                 ExpressionPtr rhs, MethodDef::Flags flags = MethodDef::Flags()) {
-        MethodDef::ARGS_store args;
-        args.emplace_back(std::move(arg0));
-        return Method(loc, declLoc, name, std::move(args), std::move(rhs), flags);
+    static ExpressionPtr Method1(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
+                                 ExpressionPtr param0, ExpressionPtr rhs, MethodDef::Flags flags = MethodDef::Flags()) {
+        MethodDef::PARAMS_store params;
+        params.emplace_back(std::move(param0));
+        return Method(loc, declLoc, name, std::move(params), std::move(rhs), flags);
     }
 
     static ExpressionPtr SyntheticMethod(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
-                                         MethodDef::ARGS_store args, ExpressionPtr rhs,
+                                         MethodDef::PARAMS_store params, ExpressionPtr rhs,
                                          MethodDef::Flags flags = MethodDef::Flags()) {
         flags.isRewriterSynthesized = true;
-        return Method(loc, declLoc, name, std::move(args), std::move(rhs), flags);
+        return Method(loc, declLoc, name, std::move(params), std::move(rhs), flags);
     }
 
     static ExpressionPtr SyntheticMethod0(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
                                           ExpressionPtr rhs, MethodDef::Flags flags = MethodDef::Flags()) {
-        MethodDef::ARGS_store args;
-        return SyntheticMethod(loc, declLoc, name, std::move(args), std::move(rhs), flags);
+        MethodDef::PARAMS_store params;
+        return SyntheticMethod(loc, declLoc, name, std::move(params), std::move(rhs), flags);
     }
 
     static ExpressionPtr SyntheticMethod1(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
-                                          ExpressionPtr arg0, ExpressionPtr rhs,
+                                          ExpressionPtr param0, ExpressionPtr rhs,
                                           MethodDef::Flags flags = MethodDef::Flags()) {
-        MethodDef::ARGS_store args;
-        args.emplace_back(std::move(arg0));
-        return SyntheticMethod(loc, declLoc, name, std::move(args), std::move(rhs), flags);
+        MethodDef::PARAMS_store params;
+        params.emplace_back(std::move(param0));
+        return SyntheticMethod(loc, declLoc, name, std::move(params), std::move(rhs), flags);
     }
 
     static ExpressionPtr ClassOrModule(core::LocOffsets loc, core::LocOffsets declLoc, ExpressionPtr name,

--- a/ast/ParamParsing.cc
+++ b/ast/ParamParsing.cc
@@ -1,4 +1,4 @@
-#include "ast/ArgParsing.h"
+#include "ast/ParamParsing.h"
 #include "common/typecase.h"
 #include "core/Context.h"
 #include "core/hashing/hashing.h"
@@ -45,8 +45,8 @@ core::ParsedParam parseParam(const ast::ExpressionPtr &param) {
     return parsedParam;
 }
 
-ExpressionPtr getDefaultValue(ExpressionPtr arg) {
-    auto *cursor = &arg;
+ExpressionPtr getDefaultValue(ExpressionPtr param) {
+    auto *cursor = &param;
     bool done = false;
     while (!done) {
         typecase(
@@ -62,13 +62,13 @@ ExpressionPtr getDefaultValue(ExpressionPtr arg) {
                 // No default.
             });
     }
-    ENFORCE(cursor != &arg);
+    ENFORCE(cursor != &param);
     return std::move(*cursor);
 }
 
 } // namespace
 
-vector<core::ParsedParam> ArgParsing::parseParams(const ast::MethodDef::PARAMS_store &params) {
+vector<core::ParsedParam> ParamParsing::parseParams(const ast::MethodDef::PARAMS_store &params) {
     vector<core::ParsedParam> parsedParams;
     for (auto &param : params) {
         if (!ast::isa_reference(param)) {
@@ -81,7 +81,7 @@ vector<core::ParsedParam> ArgParsing::parseParams(const ast::MethodDef::PARAMS_s
 }
 
 // This has to match the implementation of Method::methodArityHash
-core::ArityHash ArgParsing::hashParams(core::Context ctx, const vector<core::ParsedParam> &params) {
+core::ArityHash ParamParsing::hashParams(core::Context ctx, const vector<core::ParsedParam> &params) {
     uint32_t result = 0;
     result = core::mix(result, params.size());
     for (const auto &e : params) {
@@ -99,7 +99,7 @@ core::ArityHash ArgParsing::hashParams(core::Context ctx, const vector<core::Par
     return core::ArityHash(result);
 }
 
-ExpressionPtr ArgParsing::getDefault(const core::ParsedParam &parsedArg, ExpressionPtr arg) {
+ExpressionPtr ParamParsing::getDefault(const core::ParsedParam &parsedArg, ExpressionPtr arg) {
     if (!parsedArg.flags.isDefault) {
         return nullptr;
     }

--- a/ast/ParamParsing.h
+++ b/ast/ParamParsing.h
@@ -1,9 +1,10 @@
-#ifndef SORBET_AST_ARG_PARSING_H
-#define SORBET_AST_ARG_PARSING_H
+#ifndef SORBET_AST_PARAM_PARSING_H
+#define SORBET_AST_PARAM_PARSING_H
 #include "ast/ast.h"
 #include "core/ArityHash.h"
+
 namespace sorbet::ast {
-class ArgParsing {
+class ParamParsing {
 public:
     static std::vector<core::ParsedParam> parseParams(const ast::MethodDef::PARAMS_store &params);
     static core::ArityHash hashParams(core::Context ctx, const std::vector<core::ParsedParam> &params);

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -46,7 +46,7 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
         case Tag::MethodDef: {
             auto *exp = reinterpret_cast<const MethodDef *>(tree);
             return make_expression<MethodDef>(exp->loc, exp->declLoc, exp->symbol, exp->name,
-                                              deepCopyVec(avoid, exp->args), deepCopy(avoid, exp->rhs), exp->flags);
+                                              deepCopyVec(avoid, exp->params), deepCopy(avoid, exp->rhs), exp->flags);
         }
 
         case Tag::If: {

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -177,7 +177,7 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
 
         case Tag::Block: {
             auto *exp = reinterpret_cast<const Block *>(tree);
-            return make_expression<Block>(exp->loc, deepCopyVec(avoid, exp->args), deepCopy(avoid, exp->body));
+            return make_expression<Block>(exp->loc, deepCopyVec(avoid, exp->params), deepCopy(avoid, exp->body));
         }
 
         case Tag::InsSeq: {

--- a/ast/TreeEquality.cc
+++ b/ast/TreeEquality.cc
@@ -95,7 +95,7 @@ bool compareTrees(const core::GlobalState &gs, const void *avoid, const Tag tag,
             if (!Comparator::compareNodes(gs, avoid, a->rhs, b->rhs, file)) {
                 return false;
             }
-            if (!Comparator::compareSpans(gs, avoid, a->args, b->args, file)) {
+            if (!Comparator::compareSpans(gs, avoid, a->params, b->params, file)) {
                 return false;
             }
             return true;

--- a/ast/TreeEquality.cc
+++ b/ast/TreeEquality.cc
@@ -307,7 +307,7 @@ bool compareTrees(const core::GlobalState &gs, const void *avoid, const Tag tag,
         case Tag::Block: {
             auto *a = reinterpret_cast<const Block *>(tree);
             auto *b = reinterpret_cast<const Block *>(other);
-            return Comparator::compareSpans(gs, avoid, a->args, b->args, file) &&
+            return Comparator::compareSpans(gs, avoid, a->params, b->params, file) &&
                    Comparator::compareNodes(gs, avoid, a->body, b->body, file);
         }
 

--- a/ast/TreeSanityChecks.cc
+++ b/ast/TreeSanityChecks.cc
@@ -156,10 +156,10 @@ void Local::_sanityCheck() {
 
 void MethodDef::_sanityCheck() {
     ENFORCE(name.exists());
-    ENFORCE(!args.empty(), "Every method should have at least one arg (the block arg).\n");
-    ENFORCE(isa_tree<BlockArg>(args.back()) || isa_tree<Local>(args.back()),
-            "Last arg must be a block arg (or a local, if block args have already been removed).");
-    for (auto &node : args) {
+    ENFORCE(!params.empty(), "Every method should have at least one param (the block param).\n");
+    ENFORCE(isa_tree<BlockArg>(params.back()) || isa_tree<Local>(params.back()),
+            "Last param must be a block param (or a local, if block param has already been removed).");
+    for (auto &node : params) {
         ENFORCE(node);
     }
     ENFORCE(rhs);

--- a/ast/TreeSanityChecks.cc
+++ b/ast/TreeSanityChecks.cc
@@ -61,7 +61,7 @@ void Assign::_sanityCheck() {
 }
 
 void Block::_sanityCheck() {
-    for (auto &node : args) {
+    for (auto &node : params) {
         ENFORCE(node);
     }
     ENFORCE(body);

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -181,8 +181,9 @@ ClassDef::ClassDef(core::LocOffsets loc, core::LocOffsets declLoc, core::ClassOr
 }
 
 MethodDef::MethodDef(core::LocOffsets loc, core::LocOffsets declLoc, core::MethodRef symbol, core::NameRef name,
-                     ARGS_store args, ExpressionPtr rhs, Flags flags)
-    : loc(loc), declLoc(declLoc), symbol(symbol), rhs(std::move(rhs)), args(std::move(args)), name(name), flags(flags) {
+                     PARAMS_store params, ExpressionPtr rhs, Flags flags)
+    : loc(loc), declLoc(declLoc), symbol(symbol), rhs(std::move(rhs)), args(std::move(params)), name(name),
+      flags(flags) {
     categoryCounterInc("trees", "methoddef");
     histogramInc("trees.methodDef.args", this->args.size());
     _sanityCheck();
@@ -363,8 +364,8 @@ optional<pair<core::SymbolRef, vector<core::NameRef>>> ConstantLit::fullUnresolv
     return make_pair(prefix, move(namesFailedToResolve));
 }
 
-Block::Block(core::LocOffsets loc, MethodDef::ARGS_store args, ExpressionPtr body)
-    : loc(loc), args(std::move(args)), body(std::move(body)) {
+Block::Block(core::LocOffsets loc, MethodDef::PARAMS_store params, ExpressionPtr body)
+    : loc(loc), args(std::move(params)), body(std::move(body)) {
     categoryCounterInc("trees", "block");
     histogramInc("trees.block.args", this->args.size());
     _sanityCheck();

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -365,9 +365,9 @@ optional<pair<core::SymbolRef, vector<core::NameRef>>> ConstantLit::fullUnresolv
 }
 
 Block::Block(core::LocOffsets loc, MethodDef::PARAMS_store params, ExpressionPtr body)
-    : loc(loc), args(std::move(params)), body(std::move(body)) {
+    : loc(loc), params(std::move(params)), body(std::move(body)) {
     categoryCounterInc("trees", "block");
-    histogramInc("trees.block.args", this->args.size());
+    histogramInc("trees.block.params", this->params.size());
     _sanityCheck();
 };
 
@@ -622,7 +622,7 @@ string MethodDef::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::format_to(std::back_inserter(buf), "name = {}<{}>\n", name.showRaw(gs),
                    this->symbol.data(gs)->name.showRaw(gs));
     printTabs(buf, tabs + 1);
-    fmt::format_to(std::back_inserter(buf), "args = [");
+    fmt::format_to(std::back_inserter(buf), "params = [");
     bool first = true;
     if (this->symbol == core::Symbols::todoMethod()) {
         for (auto &a : this->args) {
@@ -1257,7 +1257,7 @@ string Array::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
 string Block::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), " do |");
-    printElems(gs, buf, this->args, tabs + 1);
+    printElems(gs, buf, this->params, tabs + 1);
     fmt::format_to(std::back_inserter(buf), "|\n");
     printTabs(buf, tabs + 1);
     fmt::format_to(std::back_inserter(buf), "{}\n", this->body.toStringWithTabs(gs, tabs + 1));
@@ -1270,10 +1270,10 @@ string Block::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), "{} {{\n", nodeName());
     printTabs(buf, tabs + 1);
-    fmt::format_to(std::back_inserter(buf), "args = [\n");
-    for (auto &a : this->args) {
+    fmt::format_to(std::back_inserter(buf), "params = [\n");
+    for (auto &p : this->params) {
         printTabs(buf, tabs + 2);
-        fmt::format_to(std::back_inserter(buf), "{}\n", a.showRaw(gs, tabs + 2));
+        fmt::format_to(std::back_inserter(buf), "{}\n", p.showRaw(gs, tabs + 2));
     }
     printTabs(buf, tabs + 1);
     fmt::format_to(std::back_inserter(buf), "]\n");
@@ -1787,10 +1787,10 @@ string Block::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, i
     printTabs(buf, tabs + 1);
     fmt::format_to(std::back_inserter(buf), "loc = {}\n", core::Loc(file, this->loc).fileShortPosToString(gs));
     printTabs(buf, tabs + 1);
-    fmt::format_to(std::back_inserter(buf), "args = [\n");
-    for (auto &a : this->args) {
+    fmt::format_to(std::back_inserter(buf), "params = [\n");
+    for (auto &p : this->params) {
         printTabs(buf, tabs + 2);
-        fmt::format_to(std::back_inserter(buf), "{}\n", a.showRawWithLocs(gs, file, tabs + 2));
+        fmt::format_to(std::back_inserter(buf), "{}\n", p.showRawWithLocs(gs, file, tabs + 2));
     }
     printTabs(buf, tabs + 1);
     fmt::format_to(std::back_inserter(buf), "]\n");

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -182,10 +182,10 @@ ClassDef::ClassDef(core::LocOffsets loc, core::LocOffsets declLoc, core::ClassOr
 
 MethodDef::MethodDef(core::LocOffsets loc, core::LocOffsets declLoc, core::MethodRef symbol, core::NameRef name,
                      PARAMS_store params, ExpressionPtr rhs, Flags flags)
-    : loc(loc), declLoc(declLoc), symbol(symbol), rhs(std::move(rhs)), args(std::move(params)), name(name),
+    : loc(loc), declLoc(declLoc), symbol(symbol), rhs(std::move(rhs)), params(std::move(params)), name(name),
       flags(flags) {
     categoryCounterInc("trees", "methoddef");
-    histogramInc("trees.methodDef.args", this->args.size());
+    histogramInc("trees.methodDef.params", this->params.size());
     _sanityCheck();
 }
 
@@ -580,12 +580,12 @@ string MethodDef::toStringWithTabs(const core::GlobalState &gs, int tabs) const 
     fmt::format_to(std::back_inserter(buf), "(");
     bool first = true;
     if (this->symbol == core::Symbols::todoMethod()) {
-        for (auto &a : this->args) {
+        for (auto &p : this->params) {
             if (!first) {
                 fmt::format_to(std::back_inserter(buf), ", ");
             }
             first = false;
-            fmt::format_to(std::back_inserter(buf), "{}", a.toStringWithTabs(gs, tabs + 1));
+            fmt::format_to(std::back_inserter(buf), "{}", p.toStringWithTabs(gs, tabs + 1));
         }
     } else {
         for (auto &a : data->arguments) {
@@ -625,20 +625,20 @@ string MethodDef::showRaw(const core::GlobalState &gs, int tabs) const {
     fmt::format_to(std::back_inserter(buf), "params = [");
     bool first = true;
     if (this->symbol == core::Symbols::todoMethod()) {
-        for (auto &a : this->args) {
+        for (auto &p : this->params) {
             if (!first) {
                 fmt::format_to(std::back_inserter(buf), ", ");
             }
             first = false;
-            fmt::format_to(std::back_inserter(buf), "{}", a.showRaw(gs, tabs + 2));
+            fmt::format_to(std::back_inserter(buf), "{}", p.showRaw(gs, tabs + 2));
         }
     } else {
-        for (auto &a : this->args) {
+        for (auto &p : this->params) {
             if (!first) {
                 fmt::format_to(std::back_inserter(buf), ", ");
             }
             first = false;
-            fmt::format_to(std::back_inserter(buf), "{}", a.showRaw(gs, tabs + 2));
+            fmt::format_to(std::back_inserter(buf), "{}", p.showRaw(gs, tabs + 2));
         }
     }
     fmt::format_to(std::back_inserter(buf), "]\n");
@@ -1586,20 +1586,20 @@ string MethodDef::showRawWithLocs(const core::GlobalState &gs, core::FileRef fil
     fmt::format_to(std::back_inserter(buf), "args = [");
     bool first = true;
     if (this->symbol == core::Symbols::todoMethod()) {
-        for (auto &a : this->args) {
+        for (auto &p : this->params) {
             if (!first) {
                 fmt::format_to(std::back_inserter(buf), ", ");
             }
             first = false;
-            fmt::format_to(std::back_inserter(buf), "{}", a.showRawWithLocs(gs, file, tabs + 2));
+            fmt::format_to(std::back_inserter(buf), "{}", p.showRawWithLocs(gs, file, tabs + 2));
         }
     } else {
-        for (auto &a : this->args) {
+        for (auto &p : this->params) {
             if (!first) {
                 fmt::format_to(std::back_inserter(buf), ", ");
             }
             first = false;
-            fmt::format_to(std::back_inserter(buf), "{}", a.showRawWithLocs(gs, file, tabs + 2));
+            fmt::format_to(std::back_inserter(buf), "{}", p.showRawWithLocs(gs, file, tabs + 2));
         }
     }
     fmt::format_to(std::back_inserter(buf), "]\n");

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -441,7 +441,7 @@ public:
     ExpressionPtr rhs;
 
     using PARAMS_store = InlinedVector<ExpressionPtr, core::SymbolRef::EXPECTED_METHOD_ARGS_COUNT>;
-    PARAMS_store args;
+    PARAMS_store params;
 
     core::NameRef name;
 
@@ -449,7 +449,7 @@ public:
     Flags flags;
 
     MethodDef(core::LocOffsets loc, core::LocOffsets declLoc, core::MethodRef symbol, core::NameRef name,
-              PARAMS_store args, ExpressionPtr rhs, Flags flags);
+              PARAMS_store params, ExpressionPtr rhs, Flags flags);
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -1471,10 +1471,10 @@ EXPRESSION(Block) {
 public:
     const core::LocOffsets loc;
 
-    MethodDef::PARAMS_store args;
+    MethodDef::PARAMS_store params;
     ExpressionPtr body;
 
-    Block(core::LocOffsets loc, MethodDef::PARAMS_store args, ExpressionPtr body);
+    Block(core::LocOffsets loc, MethodDef::PARAMS_store params, ExpressionPtr body);
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -440,8 +440,8 @@ public:
 
     ExpressionPtr rhs;
 
-    using ARGS_store = InlinedVector<ExpressionPtr, core::SymbolRef::EXPECTED_METHOD_ARGS_COUNT>;
-    ARGS_store args;
+    using PARAMS_store = InlinedVector<ExpressionPtr, core::SymbolRef::EXPECTED_METHOD_ARGS_COUNT>;
+    PARAMS_store args;
 
     core::NameRef name;
 
@@ -449,7 +449,7 @@ public:
     Flags flags;
 
     MethodDef(core::LocOffsets loc, core::LocOffsets declLoc, core::MethodRef symbol, core::NameRef name,
-              ARGS_store args, ExpressionPtr rhs, Flags flags);
+              PARAMS_store args, ExpressionPtr rhs, Flags flags);
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
@@ -1471,10 +1471,10 @@ EXPRESSION(Block) {
 public:
     const core::LocOffsets loc;
 
-    MethodDef::ARGS_store args;
+    MethodDef::PARAMS_store args;
     ExpressionPtr body;
 
-    Block(core::LocOffsets loc, MethodDef::ARGS_store args, ExpressionPtr body);
+    Block(core::LocOffsets loc, MethodDef::PARAMS_store args, ExpressionPtr body);
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -90,17 +90,17 @@ ExpressionPtr numparamTree(DesugarContext dctx, int num, parser::NodeVec *decls)
 
 ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> &what);
 
-pair<MethodDef::ARGS_store, InsSeq::STATS_store> desugarArgs(DesugarContext dctx, core::LocOffsets loc,
-                                                             parser::Node *argnode) {
-    MethodDef::ARGS_store args;
+pair<MethodDef::PARAMS_store, InsSeq::STATS_store> desugarArgs(DesugarContext dctx, core::LocOffsets loc,
+                                                               parser::Node *argnode) {
+    MethodDef::PARAMS_store params;
     InsSeq::STATS_store destructures;
 
     if (auto *oargs = parser::cast_node<parser::Args>(argnode)) {
-        args.reserve(oargs->args.size());
+        params.reserve(oargs->args.size());
         for (auto &arg : oargs->args) {
             if (parser::isa_node<parser::Mlhs>(arg.get())) {
                 core::NameRef temporary = dctx.freshNameUnique(core::Names::destructureArg());
-                args.emplace_back(MK::Local(arg->loc, temporary));
+                params.emplace_back(MK::Local(arg->loc, temporary));
                 unique_ptr<parser::Node> lvarNode = make_unique<parser::LVar>(arg->loc, temporary);
                 unique_ptr<parser::Node> destructure = make_unique<parser::Masgn>(arg->loc, move(arg), move(lvarNode));
                 destructures.emplace_back(node2TreeImpl(dctx, destructure));
@@ -111,22 +111,22 @@ pair<MethodDef::ARGS_store, InsSeq::STATS_store> desugarArgs(DesugarContext dctx
                 // add `*<fwd-args>`
                 unique_ptr<parser::Node> rest =
                     make_unique<parser::Restarg>(fargs->loc, core::Names::fwdArgs(), fargs->loc);
-                args.emplace_back(node2TreeImpl(dctx, rest));
+                params.emplace_back(node2TreeImpl(dctx, rest));
                 // add `**<fwd-kwargs>`
                 unique_ptr<parser::Node> kwrest = make_unique<parser::Kwrestarg>(fargs->loc, core::Names::fwdKwargs());
-                args.emplace_back(node2TreeImpl(dctx, kwrest));
+                params.emplace_back(node2TreeImpl(dctx, kwrest));
                 // add `&<fwd-block>`
                 unique_ptr<parser::Node> block = make_unique<parser::Blockarg>(fargs->loc, core::Names::fwdBlock());
-                args.emplace_back(node2TreeImpl(dctx, block));
+                params.emplace_back(node2TreeImpl(dctx, block));
             } else {
-                args.emplace_back(node2TreeImpl(dctx, arg));
+                params.emplace_back(node2TreeImpl(dctx, arg));
             }
         }
     } else if (auto *numparams = parser::cast_node<parser::NumParams>(argnode)) {
         // The block uses numbered parameters like `_1` or `_9` so we add them as parameters
         // from _1 to the highest number used.
         for (int i = 1; i <= numparamMax(dctx, &numparams->decls); i++) {
-            args.emplace_back(numparamTree(dctx, i, &numparams->decls));
+            params.emplace_back(numparamTree(dctx, i, &numparams->decls));
         }
     } else if (argnode == nullptr) {
         // do nothing
@@ -134,7 +134,7 @@ pair<MethodDef::ARGS_store, InsSeq::STATS_store> desugarArgs(DesugarContext dctx
         Exception::raise("not implemented: {}", argnode->nodeName());
     }
 
-    return make_pair(move(args), move(destructures));
+    return make_pair(move(params), move(destructures));
 }
 
 ExpressionPtr desugarBody(DesugarContext dctx, core::LocOffsets loc, unique_ptr<parser::Node> &bodynode,
@@ -153,7 +153,7 @@ ExpressionPtr desugarBody(DesugarContext dctx, core::LocOffsets loc, unique_ptr<
 
 // It's not possible to use an anonymous rest parameter in a block, as it always refers to the forwarded arguments
 // from the method. This function raises an error if the anonymous rest arg is present in a parameter list.
-void checkBlockRestArg(DesugarContext dctx, const MethodDef::ARGS_store &args) {
+void checkBlockRestArg(DesugarContext dctx, const MethodDef::PARAMS_store &args) {
     auto it = absl::c_find_if(args, [](const auto &arg) { return isa_tree<RestArg>(arg); });
     if (it == args.end()) {
         return;
@@ -1682,7 +1682,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
             },
             [&](parser::ZSuper *zuper) { result = MK::ZSuper(loc, maybeTypedSuper(dctx)); },
             [&](parser::For *for_) {
-                MethodDef::ARGS_store args;
+                MethodDef::PARAMS_store params;
                 bool canProvideNiceDesugar = true;
                 auto mlhsNode = move(for_->vars);
                 if (auto *mlhs = parser::cast_node<parser::Mlhs>(mlhsNode.get())) {
@@ -1694,14 +1694,14 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     }
                     if (canProvideNiceDesugar) {
                         for (auto &c : mlhs->exprs) {
-                            args.emplace_back(node2TreeImpl(dctx, c));
+                            params.emplace_back(node2TreeImpl(dctx, c));
                         }
                     }
                 } else {
                     canProvideNiceDesugar = parser::isa_node<parser::LVarLhs>(mlhsNode.get());
                     if (canProvideNiceDesugar) {
                         ExpressionPtr lhs = node2TreeImpl(dctx, mlhsNode);
-                        args.emplace_back(move(lhs));
+                        params.emplace_back(move(lhs));
                     } else {
                         parser::NodeVec vars;
                         vars.emplace_back(move(mlhsNode));
@@ -1713,7 +1713,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
 
                 ExpressionPtr block;
                 if (canProvideNiceDesugar) {
-                    block = MK::Block(loc, move(body), move(args));
+                    block = MK::Block(loc, move(body), move(params));
                 } else {
                     auto temp = dctx.freshNameUnique(core::Names::forTemp());
 
@@ -1721,7 +1721,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         make_unique<parser::Masgn>(loc, move(mlhsNode), make_unique<parser::LVar>(loc, temp));
 
                     body = MK::InsSeq1(loc, node2TreeImpl(dctx, masgn), move(body));
-                    block = MK::Block(loc, move(body), move(args));
+                    block = MK::Block(loc, move(body), move(params));
                 }
 
                 auto res =

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -73,8 +73,8 @@ public:
 
     void preTransformBlock(core::Context ctx, ExpressionPtr &tree) {
         auto &original = cast_tree_nonnull<Block>(tree);
-        for (auto &arg : original.args) {
-            substArg(arg);
+        for (auto &param : original.params) {
+            substArg(param);
         }
     }
 

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -66,8 +66,8 @@ public:
     void preTransformMethodDef(core::Context ctx, ExpressionPtr &tree) {
         auto &original = cast_tree_nonnull<MethodDef>(tree);
         original.name = subst.substituteSymbolName(original.name);
-        for (auto &arg : original.args) {
-            substArg(arg);
+        for (auto &param : original.params) {
+            substArg(param);
         }
     }
 

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -510,9 +510,9 @@ private:
     return_type mapBlock(arg_type v, CTX ctx) {
         CALL_PRE(Block);
 
-        for (auto &arg : cast_tree_nonnull<Block>(v).args) {
+        for (auto &param : cast_tree_nonnull<Block>(v).params) {
             // Only OptionalArgs have subexpressions within them.
-            if (auto optArg = cast_tree<OptionalArg>(arg)) {
+            if (auto optArg = cast_tree<OptionalArg>(param)) {
                 CALL_MAP(optArg->default_, ctx);
             }
         }

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -343,9 +343,9 @@ private:
     return_type mapMethodDef(arg_type v, CTX ctx) {
         CALL_PRE(MethodDef);
 
-        for (auto &arg : cast_tree_nonnull<MethodDef>(v).args) {
+        for (auto &param : cast_tree_nonnull<MethodDef>(v).params) {
             // Only OptionalArgs have subexpressions within them.
-            if (auto optArg = cast_tree<OptionalArg>(arg)) {
+            if (auto optArg = cast_tree<OptionalArg>(param)) {
                 CALL_MAP(optArg->default_, ctx.withOwner(cast_tree_nonnull<MethodDef>(v).symbol));
             }
         }

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -627,8 +627,8 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 }
 
                 if (auto *block = s.block()) {
-                    auto &blockArgs = block->args;
-                    vector<core::ParsedArg> blockArgFlags = ast::ArgParsing::parseArgs(blockArgs);
+                    auto &blockParams = block->params;
+                    vector<core::ParsedArg> blockArgFlags = ast::ArgParsing::parseArgs(blockParams);
                     vector<core::ArgInfo::ArgFlags> argFlags;
                     for (auto &e : blockArgFlags) {
                         argFlags.emplace_back(e.flags);
@@ -672,7 +672,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                                 continue;
                             }
 
-                            if (auto opt = ast::cast_tree<ast::OptionalArg>(blockArgs[i])) {
+                            if (auto opt = ast::cast_tree<ast::OptionalArg>(blockParams[i])) {
                                 auto *presentBlock = cctx.inWhat.freshBlock(bodyLoops);
                                 auto *missingBlock = cctx.inWhat.freshBlock(bodyLoops);
 

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -1,5 +1,5 @@
-#include "ast/ArgParsing.h"
 #include "ast/Helpers.h"
+#include "ast/ParamParsing.h"
 #include "cfg/builder/builder.h"
 #include "common/typecase.h"
 #include "core/Names.h"
@@ -628,7 +628,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
 
                 if (auto *block = s.block()) {
                     auto &blockParams = block->params;
-                    vector<core::ParsedParam> blockArgFlags = ast::ArgParsing::parseParams(blockParams);
+                    vector<core::ParsedParam> blockArgFlags = ast::ParamParsing::parseParams(blockParams);
                     vector<core::ArgInfo::ArgFlags> argFlags;
                     for (auto &e : blockArgFlags) {
                         argFlags.emplace_back(e.flags);

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -628,7 +628,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
 
                 if (auto *block = s.block()) {
                     auto &blockParams = block->params;
-                    vector<core::ParsedArg> blockArgFlags = ast::ArgParsing::parseArgs(blockParams);
+                    vector<core::ParsedParam> blockArgFlags = ast::ArgParsing::parseArgs(blockParams);
                     vector<core::ArgInfo::ArgFlags> argFlags;
                     for (auto &e : blockArgFlags) {
                         argFlags.emplace_back(e.flags);

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -628,7 +628,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
 
                 if (auto *block = s.block()) {
                     auto &blockParams = block->params;
-                    vector<core::ParsedParam> blockArgFlags = ast::ArgParsing::parseArgs(blockParams);
+                    vector<core::ParsedParam> blockArgFlags = ast::ArgParsing::parseParams(blockParams);
                     vector<core::ArgInfo::ArgFlags> argFlags;
                     for (auto &e : blockArgFlags) {
                         argFlags.emplace_back(e.flags);

--- a/class_flatten/class_flatten.cc
+++ b/class_flatten/class_flatten.cc
@@ -96,12 +96,12 @@ public:
         // methods and block arguments before us.
         auto blkLoc = core::LocOffsets::none();
         core::LocalVariable blkLocalVar(core::Names::blkArg(), 0);
-        ast::MethodDef::ARGS_store args;
-        args.emplace_back(ast::make_expression<ast::Local>(blkLoc, blkLocalVar));
+        ast::MethodDef::PARAMS_store params;
+        params.emplace_back(ast::make_expression<ast::Local>(blkLoc, blkLocalVar));
 
         auto init =
             ast::make_expression<ast::MethodDef>(classDef->declLoc, classDef->declLoc, sym, core::Names::staticInit(),
-                                                 std::move(args), std::move(inits), ast::MethodDef::Flags());
+                                                 std::move(params), std::move(inits), ast::MethodDef::Flags());
         ast::cast_tree_nonnull<ast::MethodDef>(init).flags.isRewriterSynthesized = false;
         ast::cast_tree_nonnull<ast::MethodDef>(init).flags.isSelfMethod = true;
 

--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -5,7 +5,7 @@
 #include "core/ArityHash.h"
 #include "core/Loc.h"
 #include "core/NameRef.h"
-#include "core/ParsedArg.h"
+#include "core/ParsedParam.h"
 #include "core/SymbolRef.h"
 #include <vector>
 
@@ -150,7 +150,7 @@ struct FoundMethod final {
     core::NameRef name;
     core::LocOffsets loc;
     core::LocOffsets declLoc;
-    std::vector<core::ParsedArg> parsedArgs;
+    std::vector<core::ParsedParam> parsedArgs;
     core::ArityHash arityHash;
     struct Flags {
         bool isSelfMethod : 1;

--- a/core/ParsedParam.h
+++ b/core/ParsedParam.h
@@ -1,12 +1,12 @@
-#ifndef SORBET_PARSED_ARG_H
-#define SORBET_PARSED_ARG_H
+#ifndef SORBET_PARSED_PARAM_H
+#define SORBET_PARSED_PARAM_H
 
 #include "core/Loc.h"
 #include "core/LocalVariable.h"
 
 namespace sorbet::core {
 
-struct ParsedArg {
+struct ParsedParam {
     struct ArgFlags {
         bool isKeyword : 1;
         bool isRepeated : 1;

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2494,7 +2494,7 @@ uint32_t Field::fieldShapeHash(const GlobalState &gs) const {
     return result;
 }
 
-// This has to match the implementation of ArgParsing::hashParams
+// This has to match the implementation of ParamParsing::hashParams
 ArityHash Method::methodArityHash(const GlobalState &gs) const {
     uint32_t result = 0;
     result = mix(result, arguments.size());

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2494,7 +2494,7 @@ uint32_t Field::fieldShapeHash(const GlobalState &gs) const {
     return result;
 }
 
-// This has to match the implementation of ArgParsing::hashArgs
+// This has to match the implementation of ArgParsing::hashParams
 ArityHash Method::methodArityHash(const GlobalState &gs) const {
     uint32_t result = 0;
     result = mix(result, arguments.size());

--- a/core/Types.h
+++ b/core/Types.h
@@ -6,7 +6,7 @@
 #include "common/counters/Counters.h"
 #include "core/Context.h"
 #include "core/Error.h"
-#include "core/ParsedArg.h"
+#include "core/ParsedParam.h"
 #include "core/ShowOptions.h"
 #include "core/SymbolRef.h"
 #include "core/TypeConstraint.h"
@@ -29,7 +29,7 @@ class TypeAndOrigins;
 
 class ArgInfo {
 public:
-    using ArgFlags = core::ParsedArg::ArgFlags;
+    using ArgFlags = core::ParsedParam::ArgFlags;
     ArgFlags flags;
     NameRef name;
     // Stores the `.bind(...)` symbol if the `&blk` arg's type had one

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1380,10 +1380,10 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
             p.putU1(flags);
             p.putU4(c.name.rawId());
             p.putU4(c.symbol.id());
-            p.putU4(c.args.size());
+            p.putU4(c.params.size());
             pickle(p, c.rhs);
-            for (auto &a : c.args) {
-                pickle(p, a);
+            for (auto &param : c.params) {
+                pickle(p, param);
             }
             break;
         }

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1217,10 +1217,10 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
         case ast::Tag::Block: {
             auto &a = ast::cast_tree_nonnull<ast::Block>(what);
             pickle(p, a.loc);
-            p.putU4(a.args.size());
+            p.putU4(a.params.size());
             pickle(p, a.body);
-            for (auto &arg : a.args) {
-                pickle(p, arg);
+            for (auto &param : a.params) {
+                pickle(p, param);
             }
             break;
         }

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1534,13 +1534,13 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
         }
         case ast::Tag::Block: {
             auto loc = unpickleLocOffsets(p);
-            auto argsSize = p.getU4();
+            auto paramsSize = p.getU4();
             auto body = unpickleExpr(p, gs);
-            ast::MethodDef::ARGS_store args(argsSize);
-            for (auto &arg : args) {
-                arg = unpickleExpr(p, gs);
+            ast::MethodDef::PARAMS_store params(paramsSize);
+            for (auto &param : params) {
+                param = unpickleExpr(p, gs);
             }
-            return ast::MK::Block(loc, std::move(body), std::move(args));
+            return ast::MK::Block(loc, std::move(body), std::move(params));
         }
         case ast::Tag::Literal: {
             auto loc = unpickleLocOffsets(p);
@@ -1681,11 +1681,11 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
             auto symbol = MethodRef::fromRaw(p.getU4());
             auto argsSize = p.getU4();
             auto rhs = unpickleExpr(p, gs);
-            ast::MethodDef::ARGS_store args(argsSize);
-            for (auto &arg : args) {
-                arg = unpickleExpr(p, gs);
+            ast::MethodDef::PARAMS_store params(argsSize);
+            for (auto &param : params) {
+                param = unpickleExpr(p, gs);
             }
-            auto ret = ast::MK::Method(loc, declLoc, name, std::move(args), std::move(rhs));
+            auto ret = ast::MK::Method(loc, declLoc, name, std::move(params), std::move(rhs));
 
             {
                 auto &method = ast::cast_tree_nonnull<ast::MethodDef>(ret);

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -38,7 +38,7 @@ class LocalNameInserter {
     };
     CheckSize(ArgFlags, 1, 1);
 
-    struct NamedArg {
+    struct NamedParam {
         core::NameRef name;
         ArgFlags flags;
         core::LocalVariable local;
@@ -47,7 +47,7 @@ class LocalNameInserter {
     };
 
     // Handle the mangling of keyword argument names, if the name passed has already been seen in the argument list.
-    core::NameRef mangleKeyword(core::MutableContext ctx, const vector<NamedArg> &seen, core::LocOffsets loc,
+    core::NameRef mangleKeyword(core::MutableContext ctx, const vector<NamedParam> &seen, core::LocOffsets loc,
                                 bool isKeyword, core::NameRef name, uint32_t pos) const {
         if (!isKeyword) {
             return name;
@@ -76,8 +76,8 @@ class LocalNameInserter {
 
     // Map through the reference structure, naming the locals, and preserving
     // the outer structure for the namer proper.
-    NamedArg nameArg(core::MutableContext ctx, const vector<NamedArg> &seen, ast::ExpressionPtr arg, uint32_t pos) {
-        NamedArg named;
+    NamedParam nameArg(core::MutableContext ctx, const vector<NamedParam> &seen, ast::ExpressionPtr arg, uint32_t pos) {
+        NamedParam named;
         auto *cursor = &arg;
 
         while (cursor != nullptr) {
@@ -115,8 +115,8 @@ class LocalNameInserter {
         return named;
     }
 
-    vector<NamedArg> nameArgs(core::MutableContext ctx, ast::MethodDef::PARAMS_store &methodArgs) {
-        vector<NamedArg> namedArgs;
+    vector<NamedParam> nameArgs(core::MutableContext ctx, ast::MethodDef::PARAMS_store &methodArgs) {
+        vector<NamedParam> namedArgs;
         int pos = -1;
         for (auto &arg : methodArgs) {
             ++pos;
@@ -209,7 +209,7 @@ class LocalNameInserter {
 
     // Enter names from parameters into the current frame,
     // building a new parameter list back up for the original context.
-    ast::MethodDef::PARAMS_store fillInArgs(vector<NamedArg> namedArgs) {
+    ast::MethodDef::PARAMS_store fillInArgs(vector<NamedParam> namedArgs) {
         ast::MethodDef::PARAMS_store params;
 
         for (auto &param : namedArgs) {

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -115,7 +115,7 @@ class LocalNameInserter {
         return named;
     }
 
-    vector<NamedArg> nameArgs(core::MutableContext ctx, ast::MethodDef::ARGS_store &methodArgs) {
+    vector<NamedArg> nameArgs(core::MutableContext ctx, ast::MethodDef::PARAMS_store &methodArgs) {
         vector<NamedArg> namedArgs;
         int pos = -1;
         for (auto &arg : methodArgs) {
@@ -207,19 +207,19 @@ class LocalNameInserter {
         return core::LocalVariable(name, frame.localId);
     }
 
-    // Enter names from arguments into the current frame, building a new
-    // argument list back up for the original context.
-    ast::MethodDef::ARGS_store fillInArgs(vector<NamedArg> namedArgs) {
-        ast::MethodDef::ARGS_store args;
+    // Enter names from parameters into the current frame,
+    // building a new parameter list back up for the original context.
+    ast::MethodDef::PARAMS_store fillInArgs(vector<NamedArg> namedArgs) {
+        ast::MethodDef::PARAMS_store params;
 
-        for (auto &named : namedArgs) {
-            args.emplace_back(move(named.expr));
+        for (auto &param : namedArgs) {
+            params.emplace_back(move(param.expr));
             auto &frame = scopeStack.back();
-            frame.locals[named.name] = named.local;
-            frame.args.emplace_back(LocalFrame::Arg{named.local, named.flags});
+            frame.locals[param.name] = param.local;
+            frame.args.emplace_back(LocalFrame::Arg{param.local, param.flags});
         }
 
-        return args;
+        return params;
     }
 
     core::ClassOrModuleRef methodOwner(core::MutableContext ctx) {

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -526,7 +526,7 @@ public:
         enterMethod();
 
         auto &method = ast::cast_tree_nonnull<ast::MethodDef>(tree);
-        method.args = fillInArgs(nameArgs(ctx, method.args));
+        method.params = fillInArgs(nameArgs(ctx, method.params));
     }
 
     void postTransformMethodDef(core::MutableContext ctx, ast::ExpressionPtr &tree) {

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -115,20 +115,20 @@ class LocalNameInserter {
         return named;
     }
 
-    vector<NamedParam> nameArgs(core::MutableContext ctx, ast::MethodDef::PARAMS_store &methodArgs) {
-        vector<NamedParam> namedArgs;
+    vector<NamedParam> nameParams(core::MutableContext ctx, ast::MethodDef::PARAMS_store &methodParams) {
+        vector<NamedParam> namedParams;
         int pos = -1;
-        for (auto &arg : methodArgs) {
+        for (auto &param : methodParams) {
             ++pos;
 
-            if (!ast::isa_reference(arg)) {
+            if (!ast::isa_reference(param)) {
                 Exception::raise("Must be a reference!");
             }
-            auto named = nameArg(ctx, namedArgs, move(arg), pos);
-            namedArgs.emplace_back(move(named));
+            auto named = nameArg(ctx, namedParams, move(param), pos);
+            namedParams.emplace_back(move(named));
         }
 
-        return namedArgs;
+        return namedParams;
     }
 
     struct LocalFrame {
@@ -526,7 +526,7 @@ public:
         enterMethod();
 
         auto &method = ast::cast_tree_nonnull<ast::MethodDef>(tree);
-        method.params = fillInArgs(nameArgs(ctx, method.params));
+        method.params = fillInArgs(nameParams(ctx, method.params));
     }
 
     void postTransformMethodDef(core::MutableContext ctx, ast::ExpressionPtr &tree) {
@@ -554,7 +554,7 @@ public:
 
         // If any of our arguments shadow our parent, fillInArgs will overwrite
         // them in `frame.locals`
-        blk.params = fillInArgs(nameArgs(ctx, blk.params));
+        blk.params = fillInArgs(nameParams(ctx, blk.params));
     }
 
     void postTransformBlock(core::MutableContext ctx, ast::ExpressionPtr &tree) {

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -209,10 +209,10 @@ class LocalNameInserter {
 
     // Enter names from parameters into the current frame,
     // building a new parameter list back up for the original context.
-    ast::MethodDef::PARAMS_store fillInArgs(vector<NamedParam> namedArgs) {
+    ast::MethodDef::PARAMS_store fillInParams(vector<NamedParam> namedParams) {
         ast::MethodDef::PARAMS_store params;
 
-        for (auto &param : namedArgs) {
+        for (auto &param : namedParams) {
             params.emplace_back(move(param.expr));
             auto &frame = scopeStack.back();
             frame.locals[param.name] = param.local;
@@ -526,7 +526,7 @@ public:
         enterMethod();
 
         auto &method = ast::cast_tree_nonnull<ast::MethodDef>(tree);
-        method.params = fillInArgs(nameParams(ctx, method.params));
+        method.params = fillInParams(nameParams(ctx, method.params));
     }
 
     void postTransformMethodDef(core::MutableContext ctx, ast::ExpressionPtr &tree) {
@@ -554,7 +554,7 @@ public:
 
         // If any of our arguments shadow our parent, fillInArgs will overwrite
         // them in `frame.locals`
-        blk.params = fillInArgs(nameParams(ctx, blk.params));
+        blk.params = fillInParams(nameParams(ctx, blk.params));
     }
 
     void postTransformBlock(core::MutableContext ctx, ast::ExpressionPtr &tree) {

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -554,7 +554,7 @@ public:
 
         // If any of our arguments shadow our parent, fillInArgs will overwrite
         // them in `frame.locals`
-        blk.args = fillInArgs(nameArgs(ctx, blk.args));
+        blk.params = fillInArgs(nameArgs(ctx, blk.params));
     }
 
     void postTransformBlock(core::MutableContext ctx, ast::ExpressionPtr &tree) {

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -15,17 +15,17 @@ void DefLocSaver::postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &
     if (lspQueryMatch) {
         // Query matches against the method definition as a whole.
         auto symbolData = methodDef.symbol.data(ctx);
-        auto &argTypes = symbolData->arguments;
+        auto &paramTypes = symbolData->arguments;
         core::TypeAndOrigins tp;
 
-        // Check if it matches against a specific argument. If it does, send that instead;
+        // Check if it matches against a specific parameter. If it does, send that instead;
         // it's more specific.
-        const int numArgs = methodDef.args.size();
+        const int numParams = methodDef.params.size();
 
-        ENFORCE(numArgs == argTypes.size());
-        for (int i = 0; i < numArgs; i++) {
-            auto &arg = methodDef.args[i];
-            auto &argType = argTypes[i];
+        ENFORCE(numParams == paramTypes.size());
+        for (int i = 0; i < numParams; i++) {
+            auto &arg = methodDef.params[i];
+            auto &argType = paramTypes[i];
             auto *localExp = ast::MK::arg2Local(arg);
             // localExp should never be null, but guard against the possibility.
             if (localExp && lspQuery.matchesLoc(ctx.locAt(localExp->loc))) {

--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -248,8 +248,8 @@ public:
 
     void preTransformBlock(core::Context ctx, const ast::ExpressionPtr &tree) {
         auto &block = ast::cast_tree_nonnull<ast::Block>(tree);
-        if (!block.args.empty()) {
-            skipLocRange(block.args.front().loc().join(block.args.back().loc()));
+        if (!block.params.empty()) {
+            skipLocRange(block.params.front().loc().join(block.params.back().loc()));
         }
         updateEnclosingScope(tree, block.body.loc());
     }

--- a/main/lsp/ExtractVariable.cc
+++ b/main/lsp/ExtractVariable.cc
@@ -229,8 +229,8 @@ public:
     void preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
         enclosingMethodStack.push_back(&tree);
         auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
-        if (!methodDef.args.empty()) {
-            skipLocRange(methodDef.args.front().loc().join(methodDef.args.back().loc()));
+        if (!methodDef.params.empty()) {
+            skipLocRange(methodDef.params.front().loc().join(methodDef.params.back().loc()));
         }
         if (methodDef.loc.endPos() == methodDef.rhs.loc().endPos()) {
             // methodDef.loc.endPos() represent the location right after the `end`,

--- a/main/lsp/FieldFinder.cc
+++ b/main/lsp/FieldFinder.cc
@@ -1,5 +1,5 @@
 #include "FieldFinder.h"
-#include "ast/ArgParsing.h"
+#include "ast/ParamParsing.h"
 #include "core/GlobalState.h"
 
 using namespace std;

--- a/main/lsp/LocalVarFinder.cc
+++ b/main/lsp/LocalVarFinder.cc
@@ -1,5 +1,5 @@
 #include "LocalVarFinder.h"
-#include "ast/ArgParsing.h"
+#include "ast/ParamParsing.h"
 #include "core/GlobalState.h"
 
 using namespace std;
@@ -18,7 +18,7 @@ void LocalVarFinder::preTransformBlock(core::Context ctx, const ast::Block &bloc
         return;
     }
 
-    auto parsedParams = ast::ArgParsing::parseParams(block.params);
+    auto parsedParams = ast::ParamParsing::parseParams(block.params);
     for (const auto &parsedParam : parsedParams) {
         this->result_.emplace_back(parsedParam.local._name);
     }
@@ -44,7 +44,7 @@ void LocalVarFinder::preTransformMethodDef(core::Context ctx, const ast::MethodD
     auto currentMethod = methodDef.symbol;
 
     if (currentMethod == this->targetMethod) {
-        auto parsedParams = ast::ArgParsing::parseParams(methodDef.params);
+        auto parsedParams = ast::ParamParsing::parseParams(methodDef.params);
         for (const auto &parsedParam : parsedParams) {
             this->result_.emplace_back(parsedParam.local._name);
         }

--- a/main/lsp/LocalVarFinder.cc
+++ b/main/lsp/LocalVarFinder.cc
@@ -18,7 +18,7 @@ void LocalVarFinder::preTransformBlock(core::Context ctx, const ast::Block &bloc
         return;
     }
 
-    auto parsedArgs = ast::ArgParsing::parseArgs(block.args);
+    auto parsedArgs = ast::ArgParsing::parseArgs(block.params);
     for (const auto &parsedArg : parsedArgs) {
         this->result_.emplace_back(parsedArg.local._name);
     }

--- a/main/lsp/LocalVarFinder.cc
+++ b/main/lsp/LocalVarFinder.cc
@@ -18,9 +18,9 @@ void LocalVarFinder::preTransformBlock(core::Context ctx, const ast::Block &bloc
         return;
     }
 
-    auto parsedArgs = ast::ArgParsing::parseArgs(block.params);
-    for (const auto &parsedArg : parsedArgs) {
-        this->result_.emplace_back(parsedArg.local._name);
+    auto parsedParams = ast::ArgParsing::parseParams(block.params);
+    for (const auto &parsedParam : parsedParams) {
+        this->result_.emplace_back(parsedParam.local._name);
     }
 }
 
@@ -44,9 +44,9 @@ void LocalVarFinder::preTransformMethodDef(core::Context ctx, const ast::MethodD
     auto currentMethod = methodDef.symbol;
 
     if (currentMethod == this->targetMethod) {
-        auto parsedArgs = ast::ArgParsing::parseArgs(methodDef.params);
-        for (const auto &parsedArg : parsedArgs) {
-            this->result_.emplace_back(parsedArg.local._name);
+        auto parsedParams = ast::ArgParsing::parseParams(methodDef.params);
+        for (const auto &parsedParam : parsedParams) {
+            this->result_.emplace_back(parsedParam.local._name);
         }
     }
 

--- a/main/lsp/LocalVarFinder.cc
+++ b/main/lsp/LocalVarFinder.cc
@@ -44,7 +44,7 @@ void LocalVarFinder::preTransformMethodDef(core::Context ctx, const ast::MethodD
     auto currentMethod = methodDef.symbol;
 
     if (currentMethod == this->targetMethod) {
-        auto parsedArgs = ast::ArgParsing::parseArgs(methodDef.args);
+        auto parsedArgs = ast::ArgParsing::parseArgs(methodDef.params);
         for (const auto &parsedArg : parsedArgs) {
             this->result_.emplace_back(parsedArg.local._name);
         }

--- a/main/lsp/LocalVarSaver.cc
+++ b/main/lsp/LocalVarSaver.cc
@@ -24,7 +24,7 @@ core::MethodRef enclosingMethod(core::Context ctx) {
 void LocalVarSaver::postTransformBlock(core::Context ctx, const ast::Block &block) {
     auto method = enclosingMethod(ctx);
 
-    for (auto &arg : block.args) {
+    for (auto &arg : block.params) {
         if (auto *localExp = ast::MK::arg2Local(arg)) {
             bool lspQueryMatch = ctx.state.lspQuery.matchesVar(method, localExp->localVariable);
             if (lspQueryMatch) {

--- a/main/lsp/LocalVarSaver.cc
+++ b/main/lsp/LocalVarSaver.cc
@@ -58,10 +58,10 @@ void LocalVarSaver::preTransformMethodDef(core::Context ctx, const ast::MethodDe
 void LocalVarSaver::postTransformMethodDef(core::Context ctx, const ast::MethodDef &methodDef) {
     this->enclosingMethodDefLoc.pop_back();
 
-    // Check args.
-    for (auto &arg : methodDef.args) {
+    // Check params.
+    for (auto &param : methodDef.params) {
         // nullptrs should never happen, but guard against it anyway.
-        if (auto *localExp = ast::MK::arg2Local(arg)) {
+        if (auto *localExp = ast::MK::arg2Local(param)) {
             bool lspQueryMatch = ctx.state.lspQuery.matchesVar(methodDef.symbol, localExp->localVariable);
             if (lspQueryMatch) {
                 auto methodDefLoc = ctx.locAt(methodDef.loc);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -313,7 +313,7 @@ public:
         foundMethod.declLoc = method.declLoc;
         foundMethod.flags = method.flags;
         foundMethod.parsedArgs = ast::ArgParsing::parseParams(method.params);
-        foundMethod.arityHash = ast::ArgParsing::hashArgs(ctx, foundMethod.parsedArgs);
+        foundMethod.arityHash = ast::ArgParsing::hashParams(ctx, foundMethod.parsedArgs);
         auto def = foundDefs->addMethod(move(foundMethod));
 
         // After flatten, method defs have been hoisted and reordered, so instead we look for the
@@ -1805,7 +1805,7 @@ public:
         auto owner = methodOwner(ctx, ctx.owner, method.flags.isSelfMethod);
         auto parsedParams = ast::ArgParsing::parseParams(method.params);
         auto sym =
-            ctx.state.lookupMethodSymbolWithHash(owner, method.name, ast::ArgParsing::hashArgs(ctx, parsedParams));
+            ctx.state.lookupMethodSymbolWithHash(owner, method.name, ast::ArgParsing::hashParams(ctx, parsedParams));
         ENFORCE(sym.exists());
         method.symbol = sym;
         method.params = fillInParams(move(parsedParams), move(method.params));

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -312,7 +312,7 @@ public:
         foundMethod.loc = method.loc;
         foundMethod.declLoc = method.declLoc;
         foundMethod.flags = method.flags;
-        foundMethod.parsedArgs = ast::ArgParsing::parseArgs(method.args);
+        foundMethod.parsedArgs = ast::ArgParsing::parseArgs(method.params);
         foundMethod.arityHash = ast::ArgParsing::hashArgs(ctx, foundMethod.parsedArgs);
         auto def = foundDefs->addMethod(move(foundMethod));
 
@@ -1802,19 +1802,20 @@ public:
         auto &method = ast::cast_tree_nonnull<ast::MethodDef>(tree);
 
         auto owner = methodOwner(ctx, ctx.owner, method.flags.isSelfMethod);
-        auto parsedArgs = ast::ArgParsing::parseArgs(method.args);
-        auto sym = ctx.state.lookupMethodSymbolWithHash(owner, method.name, ast::ArgParsing::hashArgs(ctx, parsedArgs));
+        auto parsedParams = ast::ArgParsing::parseArgs(method.params);
+        auto sym =
+            ctx.state.lookupMethodSymbolWithHash(owner, method.name, ast::ArgParsing::hashArgs(ctx, parsedParams));
         ENFORCE(sym.exists());
         method.symbol = sym;
-        method.args = fillInArgs(move(parsedArgs), std::move(method.args));
+        method.params = fillInArgs(move(parsedParams), std::move(method.params));
     }
 
     void postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &method = ast::cast_tree_nonnull<ast::MethodDef>(tree);
         ENFORCE(method.symbol != core::Symbols::todoMethod());
 
-        ENFORCE(method.args.size() == method.symbol.data(ctx)->arguments.size(), "{}: {} != {}",
-                method.name.showRaw(ctx), method.args.size(), method.symbol.data(ctx)->arguments.size());
+        ENFORCE(method.params.size() == method.symbol.data(ctx)->arguments.size(), "{}: {} != {}",
+                method.name.showRaw(ctx), method.params.size(), method.symbol.data(ctx)->arguments.size());
     }
 
     ast::ExpressionPtr handleAssignment(core::Context ctx, ast::ExpressionPtr tree) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -2,8 +2,8 @@
 #include "absl/algorithm/container.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_replace.h"
-#include "ast/ArgParsing.h"
 #include "ast/Helpers.h"
+#include "ast/ParamParsing.h"
 #include "ast/ast.h"
 #include "ast/treemap/treemap.h"
 #include "common/concurrency/ConcurrentQueue.h"
@@ -312,8 +312,8 @@ public:
         foundMethod.loc = method.loc;
         foundMethod.declLoc = method.declLoc;
         foundMethod.flags = method.flags;
-        foundMethod.parsedArgs = ast::ArgParsing::parseParams(method.params);
-        foundMethod.arityHash = ast::ArgParsing::hashParams(ctx, foundMethod.parsedArgs);
+        foundMethod.parsedArgs = ast::ParamParsing::parseParams(method.params);
+        foundMethod.arityHash = ast::ParamParsing::hashParams(ctx, foundMethod.parsedArgs);
         auto def = foundDefs->addMethod(move(foundMethod));
 
         // After flatten, method defs have been hoisted and reordered, so instead we look for the
@@ -1725,8 +1725,8 @@ class TreeSymbolizer {
     ast::ExpressionPtr arg2Symbol(int pos, const core::ParsedParam &parsedArg, ast::ExpressionPtr arg) {
         ast::ExpressionPtr localExpr = ast::make_expression<ast::Local>(parsedArg.loc, parsedArg.local);
         if (parsedArg.flags.isDefault) {
-            localExpr =
-                ast::MK::OptionalArg(parsedArg.loc, move(localExpr), ast::ArgParsing::getDefault(parsedArg, move(arg)));
+            localExpr = ast::MK::OptionalArg(parsedArg.loc, move(localExpr),
+                                             ast::ParamParsing::getDefault(parsedArg, move(arg)));
         }
         return localExpr;
     }
@@ -1803,9 +1803,9 @@ public:
         auto &method = ast::cast_tree_nonnull<ast::MethodDef>(tree);
 
         auto owner = methodOwner(ctx, ctx.owner, method.flags.isSelfMethod);
-        auto parsedParams = ast::ArgParsing::parseParams(method.params);
+        auto parsedParams = ast::ParamParsing::parseParams(method.params);
         auto sym =
-            ctx.state.lookupMethodSymbolWithHash(owner, method.name, ast::ArgParsing::hashParams(ctx, parsedParams));
+            ctx.state.lookupMethodSymbolWithHash(owner, method.name, ast::ParamParsing::hashParams(ctx, parsedParams));
         ENFORCE(sym.exists());
         method.symbol = sym;
         method.params = fillInParams(move(parsedParams), move(method.params));

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -773,7 +773,8 @@ private:
         emitRedefinedConstantError(ctx, errorLoc, symbol.name(ctx), symbol.kind(), prevSymbol);
     }
 
-    void defineArg(core::MutableContext ctx, core::MethodData &methodData, int pos, const core::ParsedArg &parsedArg) {
+    void defineArg(core::MutableContext ctx, core::MethodData &methodData, int pos,
+                   const core::ParsedParam &parsedArg) {
         if (pos < methodData->arguments.size()) {
             // TODO: check that flags match;
             if (parsedArg.loc.exists()) {
@@ -808,7 +809,7 @@ private:
         argInfo.flags = parsedArg.flags;
     }
 
-    void defineArgs(core::MutableContext ctx, const vector<core::ParsedArg> &parsedArgs) {
+    void defineArgs(core::MutableContext ctx, const vector<core::ParsedParam> &parsedArgs) {
         auto methodData = ctx.owner.asMethodRef().data(ctx);
         bool inShadows = false;
         bool intrinsic = isIntrinsic(methodData);
@@ -841,7 +842,7 @@ private:
         }
     }
 
-    bool paramsMatch(core::MutableContext ctx, core::MethodRef method, const vector<core::ParsedArg> &parsedArgs) {
+    bool paramsMatch(core::MutableContext ctx, core::MethodRef method, const vector<core::ParsedParam> &parsedArgs) {
         auto sym = method.data(ctx)->dealiasMethod(ctx);
         return absl::c_equal(parsedArgs, sym.data(ctx)->arguments, [](const auto &methodArg, const auto &symArg) {
             return symArg.flags.isKeyword == methodArg.flags.isKeyword &&
@@ -851,7 +852,7 @@ private:
         });
     }
 
-    void paramMismatchErrors(core::MutableContext ctx, core::Loc loc, const vector<core::ParsedArg> &parsedArgs) {
+    void paramMismatchErrors(core::MutableContext ctx, core::Loc loc, const vector<core::ParsedParam> &parsedArgs) {
         auto sym = ctx.owner.dealias(ctx);
         if (!sym.isMethod()) {
             return;
@@ -1721,7 +1722,7 @@ class TreeSymbolizer {
         return squashNamesInner(ctx, owner, node, firstName);
     }
 
-    ast::ExpressionPtr arg2Symbol(int pos, const core::ParsedArg &parsedArg, ast::ExpressionPtr arg) {
+    ast::ExpressionPtr arg2Symbol(int pos, const core::ParsedParam &parsedArg, ast::ExpressionPtr arg) {
         ast::ExpressionPtr localExpr = ast::make_expression<ast::Local>(parsedArg.loc, parsedArg.local);
         if (parsedArg.flags.isDefault) {
             localExpr =
@@ -1777,7 +1778,7 @@ public:
     }
 #endif
 
-    ast::MethodDef::PARAMS_store fillInParams(const vector<core::ParsedArg> &parsedArgs,
+    ast::MethodDef::PARAMS_store fillInParams(const vector<core::ParsedParam> &parsedArgs,
                                               ast::MethodDef::PARAMS_store oldParams) {
         ast::MethodDef::PARAMS_store params;
         int i = -1;

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1777,8 +1777,8 @@ public:
     }
 #endif
 
-    ast::MethodDef::PARAMS_store fillInArgs(const vector<core::ParsedArg> &parsedArgs,
-                                            ast::MethodDef::PARAMS_store oldParams) {
+    ast::MethodDef::PARAMS_store fillInParams(const vector<core::ParsedArg> &parsedArgs,
+                                              ast::MethodDef::PARAMS_store oldParams) {
         ast::MethodDef::PARAMS_store params;
         int i = -1;
         for (auto &param : parsedArgs) {
@@ -1807,7 +1807,7 @@ public:
             ctx.state.lookupMethodSymbolWithHash(owner, method.name, ast::ArgParsing::hashArgs(ctx, parsedParams));
         ENFORCE(sym.exists());
         method.symbol = sym;
-        method.params = fillInArgs(move(parsedParams), std::move(method.params));
+        method.params = fillInParams(move(parsedParams), move(method.params));
     }
 
     void postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1777,25 +1777,25 @@ public:
     }
 #endif
 
-    ast::MethodDef::ARGS_store fillInArgs(const vector<core::ParsedArg> &parsedArgs,
-                                          ast::MethodDef::ARGS_store oldArgs) {
-        ast::MethodDef::ARGS_store args;
+    ast::MethodDef::PARAMS_store fillInArgs(const vector<core::ParsedArg> &parsedArgs,
+                                            ast::MethodDef::PARAMS_store oldParams) {
+        ast::MethodDef::PARAMS_store params;
         int i = -1;
-        for (auto &arg : parsedArgs) {
+        for (auto &param : parsedArgs) {
             i++;
-            auto localVariable = arg.local;
+            auto localVariable = param.local;
 
-            if (arg.flags.isShadow) {
-                auto localExpr = ast::make_expression<ast::Local>(arg.loc, localVariable);
-                args.emplace_back(move(localExpr));
+            if (param.flags.isShadow) {
+                auto localExpr = ast::make_expression<ast::Local>(param.loc, localVariable);
+                params.emplace_back(move(localExpr));
             } else {
-                ENFORCE(i < oldArgs.size());
-                auto expr = arg2Symbol(i, arg, move(oldArgs[i]));
-                args.emplace_back(move(expr));
+                ENFORCE(i < oldParams.size());
+                auto expr = arg2Symbol(i, param, move(oldParams[i]));
+                params.emplace_back(move(expr));
             }
         }
 
-        return args;
+        return params;
     }
 
     void preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -312,7 +312,7 @@ public:
         foundMethod.loc = method.loc;
         foundMethod.declLoc = method.declLoc;
         foundMethod.flags = method.flags;
-        foundMethod.parsedArgs = ast::ArgParsing::parseArgs(method.params);
+        foundMethod.parsedArgs = ast::ArgParsing::parseParams(method.params);
         foundMethod.arityHash = ast::ArgParsing::hashArgs(ctx, foundMethod.parsedArgs);
         auto def = foundDefs->addMethod(move(foundMethod));
 
@@ -1803,7 +1803,7 @@ public:
         auto &method = ast::cast_tree_nonnull<ast::MethodDef>(tree);
 
         auto owner = methodOwner(ctx, ctx.owner, method.flags.isSelfMethod);
-        auto parsedParams = ast::ArgParsing::parseArgs(method.params);
+        auto parsedParams = ast::ArgParsing::parseParams(method.params);
         auto sym =
             ctx.state.lookupMethodSymbolWithHash(owner, method.name, ast::ArgParsing::hashArgs(ctx, parsedParams));
         ENFORCE(sym.exists());

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -92,7 +92,7 @@ private:
     std::pair<std::unique_ptr<parser::Args>, core::NameRef /* enclosingBlockParamName */>
     translateParametersNode(pm_parameters_node *paramsNode);
 
-    std::tuple<ast::MethodDef::ARGS_store, ast::InsSeq::STATS_store, bool>
+    std::tuple<ast::MethodDef::PARAMS_store, ast::InsSeq::STATS_store, bool>
     desugarParametersNode(NodeVec &params, bool attemptToDesugarParams);
 
     NodeVec translateArguments(pm_arguments_node *node, pm_node *blockArgumentNode = nullptr);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3214,7 +3214,7 @@ private:
     static ast::Local const *getArgLocal(core::Context ctx, const core::ArgInfo &argSym, const ast::MethodDef &mdef,
                                          int pos, bool isOverloaded) {
         if (!isOverloaded) {
-            return ast::MK::arg2Local(mdef.args[pos]);
+            return ast::MK::arg2Local(mdef.params[pos]);
         }
 
         // we cannot rely on method and symbol arguments being aligned, as method could have more arguments.
@@ -3224,7 +3224,7 @@ private:
                                              [&](const auto &arg) { return arg.name == internalNameToLookFor; });
         ENFORCE(originalArgIt != mdef.symbol.data(ctx)->arguments.end());
         auto realPos = originalArgIt - mdef.symbol.data(ctx)->arguments.begin();
-        return ast::MK::arg2Local(mdef.args[realPos]);
+        return ast::MK::arg2Local(mdef.params[realPos]);
     }
 
     static bool usesArgumentForwardingSyntax(core::Context ctx, core::MethodData methodInfo, const ast::MethodDef &mdef,
@@ -3283,7 +3283,7 @@ private:
                                                             core::LocOffsets exprLoc, ParsedSig &sig, bool isOverloaded,
                                                             const ast::MethodDef &mdef) {
         ENFORCE(isOverloaded || mdef.symbol == method);
-        ENFORCE(isOverloaded || method.data(ctx)->arguments.size() == mdef.args.size());
+        ENFORCE(isOverloaded || method.data(ctx)->arguments.size() == mdef.params.size());
 
         if (!sig.seen.returns.exists() && !sig.seen.void_.exists()) {
             if (auto e = ctx.beginError(exprLoc, core::errors::Resolver::InvalidMethodSignature)) {
@@ -3648,18 +3648,18 @@ private:
                         InlinedVector<OverloadedMethodSignature, 2> sigs;
                         for (auto &lastSig : lastSigs) {
                             auto sig = parseSig(ctx, sigOwner, *lastSig, mdef);
-                            vector<bool> argsToKeep;
+                            vector<bool> paramsToKeep;
                             if (isOverloaded) {
-                                for (auto &argTree : mdef.args) {
-                                    const auto local = ast::MK::arg2Local(argTree);
-                                    auto treeArgName = local->localVariable._name;
+                                for (auto &paramTree : mdef.params) {
+                                    const auto local = ast::MK::arg2Local(paramTree);
+                                    auto treeParamName = local->localVariable._name;
                                     ENFORCE(local != nullptr);
-                                    argsToKeep.emplace_back(absl::c_find_if(sig.argTypes, [&](auto &spec) {
-                                                                return spec.name == treeArgName;
-                                                            }) != sig.argTypes.end());
+                                    paramsToKeep.emplace_back(absl::c_find_if(sig.argTypes, [&](auto &spec) {
+                                                                  return spec.name == treeParamName;
+                                                              }) != sig.argTypes.end());
                                 }
                             }
-                            sigs.emplace_back(OverloadedMethodSignature{lastSig->loc, move(sig), move(argsToKeep)});
+                            sigs.emplace_back(OverloadedMethodSignature{lastSig->loc, move(sig), move(paramsToKeep)});
                         }
 
                         multiSignatureJobs.emplace_back(ResolveMultiSignatureJob{ctx.owner.asClassOrModuleRef(), &mdef,

--- a/rewriter/ClassNew.cc
+++ b/rewriter/ClassNew.cc
@@ -61,9 +61,9 @@ vector<ast::ExpressionPtr> ClassNew::run(core::MutableContext ctx, ast::Assign *
     ast::ClassDef::RHS_store body;
 
     auto *block = send->block();
-    if (block != nullptr && block->args.size() == 1) {
-        auto blockArg = move(block->args[0]);
-        body.emplace_back(ast::MK::Assign(blockArg.loc(), move(blockArg), asgn->lhs.deepCopy()));
+    if (block != nullptr && block->params.size() == 1) {
+        auto blockParam = move(block->params[0]);
+        body.emplace_back(ast::MK::Assign(blockParam.loc(), move(blockParam), asgn->lhs.deepCopy()));
     }
 
     if (block != nullptr) {

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -33,7 +33,7 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
     }
 
     int i = 0;
-    ast::MethodDef *call = nullptr;
+    ast::MethodDef *call = nullptr; // TODO: why is this called "call" not "def"?
     ast::ExpressionPtr *callptr = nullptr;
     auto instanceMethods = InlinedVector<pair<core::NameRef, core::LocOffsets>, 4>();
 
@@ -67,10 +67,10 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
             return;
         }
 
-        ast::MethodDef::PARAMS_store newArgs;
-        newArgs.reserve(call->args.size());
-        for (auto &arg : call->args) {
-            newArgs.emplace_back(arg.deepCopy());
+        ast::MethodDef::PARAMS_store newParams;
+        newParams.reserve(call->params.size());
+        for (auto &param : call->params) {
+            newParams.emplace_back(param.deepCopy());
         }
 
         // This method is only for type checking. It doesn't actually exist at runtime, and instead all
@@ -78,7 +78,7 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
         ast::MethodDef::Flags flags;
         flags.isSelfMethod = true;
         flags.discardDef = true;
-        auto selfCall = ast::MK::SyntheticMethod(call->loc, call->declLoc, call->name, std::move(newArgs),
+        auto selfCall = ast::MK::SyntheticMethod(call->loc, call->declLoc, call->name, std::move(newParams),
                                                  ast::MK::RaiseTypedUnimplemented(call->declLoc), flags);
 
         // We are now in the weird situation where we have an actual method that
@@ -88,7 +88,7 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
         // the location(s) on the non-synthetic method so that LSP only sees the
         // synthetic method.
         auto hiddenCall = ast::MK::Method(call->loc.copyWithZeroLength(), call->declLoc.copyWithZeroLength(),
-                                          call->name, std::move(call->args), std::move(call->rhs), call->flags);
+                                          call->name, std::move(call->params), std::move(call->rhs), call->flags);
 
         // We need to make sure we assign into `callptr` prior to inserting into
         // `klass->rhs`, otherwise our pointer might not be live anymore.

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -67,7 +67,7 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
             return;
         }
 
-        ast::MethodDef::ARGS_store newArgs;
+        ast::MethodDef::PARAMS_store newArgs;
         newArgs.reserve(call->args.size());
         for (auto &arg : call->args) {
             newArgs.emplace_back(arg.deepCopy());

--- a/rewriter/Data.cc
+++ b/rewriter/Data.cc
@@ -68,7 +68,7 @@ vector<ast::ExpressionPtr> Data::run(core::MutableContext ctx, ast::Assign *asgn
 
     auto loc = asgn->loc;
 
-    ast::MethodDef::ARGS_store newArgs;
+    ast::MethodDef::PARAMS_store newArgs;
     ast::Send::ARGS_store sigArgs;
     ast::ClassDef::RHS_store body;
 

--- a/rewriter/DefDelegator.cc
+++ b/rewriter/DefDelegator.cc
@@ -19,12 +19,12 @@ void generateStub(vector<ast::ExpressionPtr> &methodStubs, const core::LocOffset
     methodStubs.push_back(ast::MK::Sig(loc, std::move(sigArgs), ast::MK::Untyped(loc)));
 
     // def $methodName(*arg0, &blk); end
-    ast::MethodDef::ARGS_store args;
-    args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
-    args.emplace_back(ast::make_expression<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
+    ast::MethodDef::PARAMS_store params;
+    params.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
+    params.emplace_back(ast::make_expression<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
 
     methodStubs.push_back(
-        ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::RaiseUnimplemented(loc)));
+        ast::MK::SyntheticMethod(loc, loc, methodName, std::move(params), ast::MK::RaiseUnimplemented(loc)));
 }
 
 /// Handle #def_delegator for a single delegate method

--- a/rewriter/Delegate.cc
+++ b/rewriter/Delegate.cc
@@ -108,11 +108,11 @@ vector<ast::ExpressionPtr> Delegate::run(core::MutableContext ctx, const ast::Se
         methodStubs.push_back(ast::MK::Sig(loc, std::move(sigArgs), ast::MK::Untyped(loc)));
 
         // def $methodName(*arg0, &blk); end
-        ast::MethodDef::ARGS_store args;
-        args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
-        args.emplace_back(ast::make_expression<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
+        ast::MethodDef::PARAMS_store params;
+        params.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
+        params.emplace_back(ast::make_expression<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
 
-        methodStubs.push_back(ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::EmptyTree()));
+        methodStubs.push_back(ast::MK::SyntheticMethod(loc, loc, methodName, std::move(params), ast::MK::EmptyTree()));
     }
 
     return methodStubs;

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -271,7 +271,7 @@ core::NameRef nameForTestHelperMethod(core::MutableContext ctx, const ast::Send 
 }
 
 ast::ExpressionPtr prepareTestEachBody(core::MutableContext ctx, core::NameRef eachName, ast::ExpressionPtr body,
-                                       const ast::MethodDef::ARGS_store &args,
+                                       const ast::MethodDef::PARAMS_store &args,
                                        absl::Span<const ast::ExpressionPtr> destructuringStmts,
                                        ast::ExpressionPtr &iteratee, bool insideDescribe);
 
@@ -292,7 +292,7 @@ ast::ExpressionPtr invalidUnderTestEach(core::MutableContext ctx, core::NameRef 
 // otherwise flag an error about it
 ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName,
                                 absl::Span<const ast::ExpressionPtr> destructuringStmts, ast::ExpressionPtr stmt,
-                                const ast::MethodDef::ARGS_store &args, ast::ExpressionPtr &iteratee,
+                                const ast::MethodDef::PARAMS_store &args, ast::ExpressionPtr &iteratee,
                                 bool insideDescribe) {
     // this statement must be a send
     auto send = ast::cast_tree<ast::Send>(stmt);
@@ -327,7 +327,7 @@ ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName
         }
 
         // pull the arg and the iteratee in and synthesize `iterate.each { |arg| body }`
-        ast::MethodDef::ARGS_store new_args;
+        ast::MethodDef::PARAMS_store new_args;
         for (auto &arg : args) {
             new_args.emplace_back(arg.deepCopy());
         }
@@ -362,7 +362,8 @@ ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName
     return invalidUnderTestEach(ctx, eachName, move(stmt));
 }
 
-bool isDestructuringArg(core::GlobalState &gs, const ast::MethodDef::ARGS_store &args, const ast::ExpressionPtr &expr) {
+bool isDestructuringArg(core::GlobalState &gs, const ast::MethodDef::PARAMS_store &args,
+                        const ast::ExpressionPtr &expr) {
     auto local = ast::cast_tree<ast::UnresolvedIdent>(expr);
     if (local == nullptr || local->kind != ast::UnresolvedIdent::Kind::Local) {
         return false;
@@ -398,7 +399,7 @@ bool isDestructuringArg(core::GlobalState &gs, const ast::MethodDef::ARGS_store 
 //
 // Because this case is so common, we have special handling to detect "contains only valid it-blocks
 // plus desugared destruturing assignments."
-bool isDestructuringInsSeq(core::GlobalState &gs, const ast::MethodDef::ARGS_store &args, ast::InsSeq *body) {
+bool isDestructuringInsSeq(core::GlobalState &gs, const ast::MethodDef::PARAMS_store &args, ast::InsSeq *body) {
     return absl::c_all_of(body->stats, [&gs, &args](auto &stat) {
         auto insSeq = ast::cast_tree<ast::InsSeq>(stat);
         if (insSeq == nullptr) {
@@ -412,7 +413,7 @@ bool isDestructuringInsSeq(core::GlobalState &gs, const ast::MethodDef::ARGS_sto
 
 // this just walks the body of a `test_each` and tries to transform every statement
 ast::ExpressionPtr prepareTestEachBody(core::MutableContext ctx, core::NameRef eachName, ast::ExpressionPtr body,
-                                       const ast::MethodDef::ARGS_store &args,
+                                       const ast::MethodDef::PARAMS_store &args,
                                        absl::Span<const ast::ExpressionPtr> destructuringStmts,
                                        ast::ExpressionPtr &iteratee, bool insideDescribe) {
     if (auto bodySeq = ast::cast_tree<ast::InsSeq>(body)) {

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -300,7 +300,7 @@ ast::ExpressionPtr runUnderEach(core::MutableContext ctx, core::NameRef eachName
         return invalidUnderTestEach(ctx, eachName, move(stmt));
     }
 
-    if (!send->hasBlock() || send->block()->args.size() != 0) {
+    if (!send->hasBlock() || send->block()->params.size() != 0) {
         return invalidUnderTestEach(ctx, eachName, move(stmt));
     }
 
@@ -493,12 +493,12 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
                 return nullptr;
             }
 
-            if ((send->fun == core::Names::testEach() && block->args.size() < 1) ||
-                (send->fun == core::Names::testEachHash() && block->args.size() != 2)) {
+            if ((send->fun == core::Names::testEach() && block->params.size() < 1) ||
+                (send->fun == core::Names::testEachHash() && block->params.size() != 2)) {
                 if (auto e = ctx.beginIndexerError(block->loc, core::errors::Rewriter::BadTestEach)) {
                     e.setHeader("Wrong number of parameters for `{}` block: expected `{}`, got `{}`",
                                 send->fun.show(ctx), send->fun == core::Names::testEach() ? "at least 1" : "2",
-                                block->args.size());
+                                block->params.size());
                 }
                 return nullptr;
             }
@@ -507,11 +507,11 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, ast::Send *
             // we can freely copy into methoddef scope
             auto iteratee = getIteratee(send->getPosArg(0));
             // and then reconstruct the send but with a modified body
-            auto body =
-                prepareTestEachBody(ctx, send->fun, std::move(block->body), block->args, {}, iteratee, insideDescribe);
+            auto body = prepareTestEachBody(ctx, send->fun, std::move(block->body), block->params, {}, iteratee,
+                                            insideDescribe);
             return ast::MK::Send(send->loc, ast::MK::Self(send->recv.loc()), send->fun, send->funLoc, 1,
-                                 ast::MK::SendArgs(move(send->getPosArg(0)),
-                                                   ast::MK::Block(block->loc, std::move(body), std::move(block->args))),
+                                 ast::MK::SendArgs(move(send->getPosArg(0)), ast::MK::Block(block->loc, std::move(body),
+                                                                                            std::move(block->params))),
                                  send->flags);
         }
 

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -135,10 +135,10 @@ vector<ast::ExpressionPtr> ModuleFunction::run(core::MutableContext ctx, ast::Se
 
             stats.emplace_back(ast::MK::Send1(loc, ast::MK::Self(loc), core::Names::private_(),
                                               loc.copyWithZeroLength(), lit->deepCopy()));
-            ast::MethodDef::ARGS_store args;
-            args.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
-            args.emplace_back(ast::make_expression<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
-            auto methodDef = ast::MK::SyntheticMethod(loc, loc, methodName, std::move(args), ast::MK::EmptyTree());
+            ast::MethodDef::PARAMS_store params;
+            params.emplace_back(ast::MK::RestArg(loc, ast::MK::Local(loc, core::Names::arg0())));
+            params.emplace_back(ast::make_expression<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
+            auto methodDef = ast::MK::SyntheticMethod(loc, loc, methodName, std::move(params), ast::MK::EmptyTree());
             ast::cast_tree_nonnull<ast::MethodDef>(methodDef).flags.isSelfMethod = true;
             stats.emplace_back(std::move(methodDef));
         } else {

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -611,9 +611,9 @@ vector<ast::ExpressionPtr> processProp(core::MutableContext ctx, PropInfo &prop,
 
 vector<ast::ExpressionPtr> mkTypedInitialize(core::MutableContext ctx, core::LocOffsets klassLoc,
                                              core::LocOffsets klassDeclLoc, const vector<PropInfo> &props) {
-    ast::MethodDef::ARGS_store args;
+    ast::MethodDef::PARAMS_store params;
     ast::Send::ARGS_store sigArgs;
-    args.reserve(props.size());
+    params.reserve(props.size());
     sigArgs.reserve(props.size() * 2);
 
     // add all the required props first.
@@ -622,7 +622,7 @@ vector<ast::ExpressionPtr> mkTypedInitialize(core::MutableContext ctx, core::Loc
             continue;
         }
         auto loc = prop.loc;
-        args.emplace_back(ast::MK::KeywordArg(loc, prop.name));
+        params.emplace_back(ast::MK::KeywordArg(loc, prop.name));
         sigArgs.emplace_back(ast::MK::Symbol(loc, prop.name));
         sigArgs.emplace_back(prop.type.deepCopy());
     }
@@ -633,7 +633,7 @@ vector<ast::ExpressionPtr> mkTypedInitialize(core::MutableContext ctx, core::Loc
             continue;
         }
         auto loc = prop.loc;
-        args.emplace_back(ast::MK::OptionalArg(loc, ast::MK::KeywordArg(loc, prop.name), prop.default_.deepCopy()));
+        params.emplace_back(ast::MK::OptionalArg(loc, ast::MK::KeywordArg(loc, prop.name), prop.default_.deepCopy()));
         sigArgs.emplace_back(ast::MK::Symbol(loc, prop.name));
         sigArgs.emplace_back(prop.type.deepCopy());
     }
@@ -649,8 +649,8 @@ vector<ast::ExpressionPtr> mkTypedInitialize(core::MutableContext ctx, core::Loc
 
     vector<ast::ExpressionPtr> result;
     result.emplace_back(ast::MK::SigVoid(klassDeclLoc, std::move(sigArgs)));
-    result.emplace_back(
-        ast::MK::SyntheticMethod(klassLoc, klassDeclLoc, core::Names::initialize(), std::move(args), std::move(body)));
+    result.emplace_back(ast::MK::SyntheticMethod(klassLoc, klassDeclLoc, core::Names::initialize(), std::move(params),
+                                                 std::move(body)));
     return result;
 }
 

--- a/rewriter/Struct.cc
+++ b/rewriter/Struct.cc
@@ -77,7 +77,7 @@ vector<ast::ExpressionPtr> Struct::run(core::MutableContext ctx, ast::Assign *as
 
     auto loc = asgn->loc;
 
-    ast::MethodDef::ARGS_store newArgs;
+    ast::MethodDef::PARAMS_store newArgs;
     ast::Send::ARGS_store sigArgs;
     ast::ClassDef::RHS_store body;
 

--- a/rewriter/util/Util.cc
+++ b/rewriter/util/Util.cc
@@ -339,7 +339,7 @@ ast::ExpressionPtr ASTUtil::thunkBody(core::MutableContext ctx, ast::ExpressionP
         return nullptr;
     }
     auto *block = send->block();
-    if (!block->args.empty()) {
+    if (!block->params.empty()) {
         return nullptr;
     }
     return std::move(block->body);

--- a/test/cli/phases/test.out
+++ b/test/cli/phases/test.out
@@ -124,7 +124,7 @@ ClassDef{
     MethodDef{
       flags = {self}
       name = <U <static-init>><<N <U <static-init>> $CENSORED>>
-      args = [Local{
+      params = [Local{
           localVariable = <U <blk>>
         }]
       rhs = Literal{ value = 1 }
@@ -152,7 +152,7 @@ ClassDef{
     MethodDef{
       flags = {self}
       name = <U <static-init>><<N <U <static-init>> $CENSORED>>
-      args = [Local{
+      params = [Local{
           localVariable = <U <blk>>
         }]
       rhs = Literal{ value = 1 }
@@ -254,10 +254,10 @@ class <C <U <root>>> < <C <U Object>> ()
 < 
 <           localVariable = <U <blk>>
 <         }]
-<       args = [Local{
 <       flags = {self}
 <       name = <U <static-init>><<N <U <static-init>> $CENSORED>>
 <       orig = nullptr
+<       params = [Local{
 <       rhs = Literal{ value = 1 }
 <       symbol = (class ::<todo sym>)
 <     1

--- a/test/hello-test.cc
+++ b/test/hello-test.cc
@@ -127,13 +127,13 @@ TEST_CASE("CountTrees") {
     auto empty = vector<core::SymbolRef>();
     auto argumentSym = core::LocalVariable(name, 0);
     auto rhs(ast::MK::Int(loc.offsets(), 5));
-    auto arg = ast::make_expression<ast::Local>(loc.offsets(), argumentSym);
-    ast::MethodDef::ARGS_store args;
-    args.emplace_back(std::move(arg));
+    auto param = ast::make_expression<ast::Local>(loc.offsets(), argumentSym);
+    ast::MethodDef::PARAMS_store params;
+    params.emplace_back(std::move(param));
 
     ast::MethodDef::Flags flags;
     auto methodDef = ast::make_expression<ast::MethodDef>(loc.offsets(), loc.offsets(), methodSym, name,
-                                                          std::move(args), std::move(rhs), flags);
+                                                          std::move(params), std::move(rhs), flags);
     auto emptyTree = ast::MK::EmptyTree();
     auto cnst = ast::make_expression<ast::UnresolvedConstantLit>(loc.offsets(), std::move(emptyTree), name);
 

--- a/test/prism_regression/assign_to_constant.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/assign_to_constant.rb.desugar-tree-raw.exp
@@ -361,7 +361,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U method1><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -605,7 +605,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U method2><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/call_all_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_all_params.rb.desugar-tree-raw.exp
@@ -88,7 +88,7 @@ ClassDef{
       }
       fun = <U <call-with-splat>>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U a>
@@ -184,7 +184,7 @@ ClassDef{
       }
       fun = <U <call-with-splat>>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U a>

--- a/test/prism_regression/call_block_param.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_block_param.rb.desugar-tree-raw.exp
@@ -12,7 +12,7 @@ ClassDef{
       recv = Self
       fun = <U foo>
       block = Block {
-        args = [
+        params = [
         ]
         body = EmptyTree
       }
@@ -26,7 +26,7 @@ ClassDef{
       recv = Self
       fun = <U foo>
       block = Block {
-        args = [
+        params = [
         ]
         body = EmptyTree
       }
@@ -40,7 +40,7 @@ ClassDef{
       recv = Self
       fun = <U foo>
       block = Block {
-        args = [
+        params = [
         ]
         body = Literal{ value = "inline block" }
       }
@@ -54,7 +54,7 @@ ClassDef{
       recv = Self
       fun = <U foo>
       block = Block {
-        args = [
+        params = [
         ]
         body = Literal{ value = "do-end block" }
       }
@@ -68,7 +68,7 @@ ClassDef{
       recv = Self
       fun = <U foo>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U positional>
@@ -94,7 +94,7 @@ ClassDef{
       recv = Self
       fun = <U foo>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U positional>
@@ -120,7 +120,7 @@ ClassDef{
       recv = Self
       fun = <U foo>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U positional>
@@ -226,7 +226,7 @@ ClassDef{
       recv = Self
       fun = <U foo>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U bar>
@@ -252,7 +252,7 @@ ClassDef{
       recv = Self
       fun = <U foo>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U positional>
@@ -366,7 +366,7 @@ ClassDef{
       recv = Self
       fun = <U foo>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U bar>
@@ -470,7 +470,7 @@ ClassDef{
           }
           fun = <U bar>
           block = Block {
-            args = [
+            params = [
             ]
             body = EmptyTree
           }
@@ -486,7 +486,7 @@ ClassDef{
       recv = Self
       fun = <U foo>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <D <U <destructure>> $9>
@@ -569,7 +569,7 @@ ClassDef{
       recv = Self
       fun = <U foo>
       block = Block {
-        args = [
+        params = [
           RestArg{ expr = UnresolvedIdent{
             kind = Local
             name = <U args>

--- a/test/prism_regression/call_forwarding_param.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_forwarding_param.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [RestArg{ expr = UnresolvedIdent{
+      params = [RestArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <fwd-args>>
         } }, RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{

--- a/test/prism_regression/call_kw_rest_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_kw_rest_params.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U has_named_kwargs><<U <todo method>>>
-      args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
+      params = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U kwargs>
         } } }, BlockArg{ expr = UnresolvedIdent{
@@ -61,7 +61,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U has_anonymous_kwargs><<U <todo method>>>
-      args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
+      params = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <P <U **> $2>
         } } }, BlockArg{ expr = UnresolvedIdent{

--- a/test/prism_regression/call_rest_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_rest_params.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U has_named_rest_args><<U <todo method>>>
-      args = [RestArg{ expr = UnresolvedIdent{
+      params = [RestArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U args>
         } }, BlockArg{ expr = UnresolvedIdent{
@@ -53,7 +53,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U has_anonymous_rest_args><<U <todo method>>>
-      args = [RestArg{ expr = UnresolvedIdent{
+      params = [RestArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U *>
         } }, BlockArg{ expr = UnresolvedIdent{

--- a/test/prism_regression/def.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -20,7 +20,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U bar><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/def_all_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_all_params.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [UnresolvedIdent{
+      params = [UnresolvedIdent{
           kind = Local
           name = <U a>
         }, OptionalArg{
@@ -44,7 +44,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [RestArg{ expr = UnresolvedIdent{
+      params = [RestArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U *>
         } }, RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{

--- a/test/prism_regression/def_block_param.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_block_param.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U my_block_param>
         } }]
@@ -20,7 +20,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <P <U &> $2>
         } }]

--- a/test/prism_regression/def_forwarding_param.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_forwarding_param.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [RestArg{ expr = UnresolvedIdent{
+      params = [RestArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <fwd-args>>
         } }, RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{

--- a/test/prism_regression/def_kw_rest_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_kw_rest_params.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
+      params = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U a>
         } } }, BlockArg{ expr = UnresolvedIdent{
@@ -23,7 +23,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
+      params = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <P <U **> $2>
         } } }, BlockArg{ expr = UnresolvedIdent{
@@ -36,7 +36,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/def_optional_kw_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_optional_kw_params.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [OptionalArg{
+      params = [OptionalArg{
           expr = KeywordArg{ expr = UnresolvedIdent{
             kind = Local
             name = <U a>
@@ -26,7 +26,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U bar><<U <todo method>>>
-      args = [OptionalArg{
+      params = [OptionalArg{
           expr = KeywordArg{ expr = UnresolvedIdent{
             kind = Local
             name = <U a>

--- a/test/prism_regression/def_optional_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_optional_params.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [OptionalArg{
+      params = [OptionalArg{
           expr = UnresolvedIdent{
             kind = Local
             name = <U a>
@@ -26,7 +26,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U bar><<U <todo method>>>
-      args = [OptionalArg{
+      params = [OptionalArg{
           expr = UnresolvedIdent{
             kind = Local
             name = <U a>

--- a/test/prism_regression/def_required_kw_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_required_kw_params.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [KeywordArg{ expr = UnresolvedIdent{
+      params = [KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U a>
         } }, BlockArg{ expr = UnresolvedIdent{
@@ -23,7 +23,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U bar><<U <todo method>>>
-      args = [KeywordArg{ expr = UnresolvedIdent{
+      params = [KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U a>
         } }, KeywordArg{ expr = UnresolvedIdent{

--- a/test/prism_regression/def_required_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_required_params.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [UnresolvedIdent{
+      params = [UnresolvedIdent{
           kind = Local
           name = <U a>
         }, BlockArg{ expr = UnresolvedIdent{
@@ -23,7 +23,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U bar><<U <todo method>>>
-      args = [UnresolvedIdent{
+      params = [UnresolvedIdent{
           kind = Local
           name = <U a>
         }, UnresolvedIdent{

--- a/test/prism_regression/def_rest_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_rest_params.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [RestArg{ expr = UnresolvedIdent{
+      params = [RestArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U a>
         } }, BlockArg{ expr = UnresolvedIdent{
@@ -23,7 +23,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [RestArg{ expr = UnresolvedIdent{
+      params = [RestArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U *>
         } }, BlockArg{ expr = UnresolvedIdent{
@@ -36,7 +36,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [RestArg{ expr = UnresolvedIdent{
+      params = [RestArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U a>
         } }, UnresolvedIdent{

--- a/test/prism_regression/def_singleton.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_singleton.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {self}
       name = <U foo><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -20,7 +20,7 @@ ClassDef{
     MethodDef{
       flags = {self}
       name = <U foo><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -30,7 +30,7 @@ ClassDef{
     MethodDef{
       flags = {self}
       name = <U foo><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U blk>
         } }]

--- a/test/prism_regression/def_with_body.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_with_body.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U one_statement><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -20,7 +20,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U two_statements><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -35,7 +35,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U three_statements><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -51,7 +51,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U begin_block><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/ensure.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/ensure.rb.desugar-tree-raw.exp
@@ -34,7 +34,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U method_with_ensure><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -55,7 +55,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U empty_method_with_ensure><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -71,7 +71,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U method_with_begin_and_ensure><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/error_recovery/assign.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/error_recovery/assign.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U test_bad_assign><<U <todo method>>>
-      args = [UnresolvedIdent{
+      params = [UnresolvedIdent{
           kind = Local
           name = <U x>
         }, BlockArg{ expr = UnresolvedIdent{

--- a/test/prism_regression/for_loop.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/for_loop.rb.desugar-tree-raw.exp
@@ -20,7 +20,7 @@ ClassDef{
       }
       fun = <U each>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U x>
@@ -46,7 +46,7 @@ ClassDef{
       }
       fun = <U each>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U x>
@@ -72,7 +72,7 @@ ClassDef{
       }
       fun = <U each>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U x>
@@ -103,7 +103,7 @@ ClassDef{
       }
       fun = <U each>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U x>
@@ -129,7 +129,7 @@ ClassDef{
       }
       fun = <U each>
       block = Block {
-        args = [
+        params = [
         ]
         body = InsSeq{
           stats = [

--- a/test/prism_regression/keyword_it.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/keyword_it.rb.desugar-tree-raw.exp
@@ -15,7 +15,7 @@ ClassDef{
       }
       fun = <U new>
       block = Block {
-        args = [
+        params = [
         ]
         body = Send{
           flags = {privateOk}
@@ -40,7 +40,7 @@ ClassDef{
       }
       fun = <U new>
       block = Block {
-        args = [
+        params = [
         ]
         body = InsSeq{
           stats = [

--- a/test/prism_regression/lambda.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/lambda.rb.desugar-tree-raw.exp
@@ -15,7 +15,7 @@ ClassDef{
       }
       fun = <U lambda>
       block = Block {
-        args = [
+        params = [
         ]
         body = Literal{ value = 123 }
       }
@@ -32,7 +32,7 @@ ClassDef{
       }
       fun = <U lambda>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U param>
@@ -56,7 +56,7 @@ ClassDef{
       }
       fun = <U lambda>
       block = Block {
-        args = [
+        params = [
           OptionalArg{
             expr = UnresolvedIdent{
               kind = Local
@@ -85,7 +85,7 @@ ClassDef{
         }
         fun = <U lambda>
         block = Block {
-          args = [
+          params = [
           ]
           body = Literal{ value = 456 }
         }
@@ -105,7 +105,7 @@ ClassDef{
       recv = Self
       fun = <U lambda>
       block = Block {
-        args = [
+        params = [
         ]
         body = Literal{ value = 789 }
       }
@@ -119,7 +119,7 @@ ClassDef{
       recv = Self
       fun = <U lambda>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U param>
@@ -151,7 +151,7 @@ ClassDef{
           }
           fun = <U lambda>
           block = Block {
-            args = [
+            params = [
             ]
             body = Literal{ value = 123 }
           }
@@ -170,7 +170,7 @@ ClassDef{
       }
       fun = <U lambda>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U _1>
@@ -217,7 +217,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U method_returning_lambda><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -229,7 +229,7 @@ ClassDef{
             }
             fun = <U lambda>
             block = Block {
-              args = [
+              params = [
               ]
               body = Literal{ value = 123 }
             }
@@ -249,7 +249,7 @@ ClassDef{
       }
       fun = <U lambda>
       block = Block {
-        args = [
+        params = [
         ]
         body = Send{
           flags = {}

--- a/test/prism_regression/literal_array.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/literal_array.rb.desugar-tree-raw.exp
@@ -55,7 +55,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U has_named_rest_args><<U <todo method>>>
-      args = [RestArg{ expr = UnresolvedIdent{
+      params = [RestArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U args>
         } }, BlockArg{ expr = UnresolvedIdent{
@@ -115,7 +115,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U has_anonymous_rest_args><<U <todo method>>>
-      args = [RestArg{ expr = UnresolvedIdent{
+      params = [RestArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U *>
         } }, BlockArg{ expr = UnresolvedIdent{

--- a/test/prism_regression/literal_hash.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/literal_hash.rb.desugar-tree-raw.exp
@@ -37,7 +37,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U has_named_kwargs><<U <todo method>>>
-      args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
+      params = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U kwargs>
         } } }, BlockArg{ expr = UnresolvedIdent{
@@ -133,7 +133,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U has_anonymous_kwargs><<U <todo method>>>
-      args = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
+      params = [RestArg{ expr = KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <P <U **> $2>
         } } }, BlockArg{ expr = UnresolvedIdent{

--- a/test/prism_regression/multi_target.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/multi_target.rb.desugar-tree-raw.exp
@@ -178,7 +178,7 @@ ClassDef{
       }
       fun = <U new>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U p1>
@@ -292,7 +292,7 @@ ClassDef{
       }
       fun = <U each>
       block = Block {
-        args = [
+        params = [
         ]
         body = InsSeq{
           stats = [
@@ -1224,7 +1224,7 @@ ClassDef{
       }
       fun = <U each>
       block = Block {
-        args = [
+        params = [
         ]
         body = InsSeq{
           stats = [

--- a/test/prism_regression/numbered_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/numbered_params.rb.desugar-tree-raw.exp
@@ -12,7 +12,7 @@ ClassDef{
       recv = Self
       fun = <U proc>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U _1>
@@ -52,7 +52,7 @@ ClassDef{
       }
       fun = <U lambda>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U _1>

--- a/test/prism_regression/range.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/range.rb.desugar-tree-raw.exp
@@ -53,7 +53,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -83,7 +83,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U bar><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/rescue.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/rescue.rb.desugar-tree-raw.exp
@@ -35,7 +35,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U method_with_rescue><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -427,7 +427,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U index><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/super.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/super.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U m><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -52,7 +52,7 @@ ClassDef{
             recv = Self
             fun = <U <super>>
             block = Block {
-              args = [
+              params = [
               ]
               body = Send{
                 flags = {}
@@ -77,7 +77,7 @@ ClassDef{
           recv = Self
           fun = <U <super>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}

--- a/test/testdata/cfg/rescue.rb.desugar-tree-raw.exp
+++ b/test/testdata/cfg/rescue.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U main><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -67,7 +67,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U a><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -77,7 +77,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U b><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -87,7 +87,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U c><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -97,7 +97,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U d><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/testdata/cfg/retry.rb.desugar-tree-raw.exp
+++ b/test/testdata/cfg/retry.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U main><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/testdata/desugar/numbered_parameters.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/numbered_parameters.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -22,7 +22,7 @@ ClassDef{
       recv = Self
       fun = <U foo>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U _1>
@@ -43,7 +43,7 @@ ClassDef{
       recv = Self
       fun = <U foo>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U _1>
@@ -96,7 +96,7 @@ ClassDef{
       recv = Self
       fun = <U foo>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U _1>
@@ -133,7 +133,7 @@ ClassDef{
       recv = Self
       fun = <U foo>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U _1>
@@ -154,7 +154,7 @@ ClassDef{
       recv = Self
       fun = <U foo>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U _1>
@@ -207,7 +207,7 @@ ClassDef{
       recv = Self
       fun = <U foo>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U _1>
@@ -247,7 +247,7 @@ ClassDef{
       }
       fun = <U lambda>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U _1>
@@ -271,7 +271,7 @@ ClassDef{
       }
       fun = <U lambda>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U _1>
@@ -327,7 +327,7 @@ ClassDef{
       }
       fun = <U lambda>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U _1>
@@ -364,7 +364,7 @@ ClassDef{
       recv = Self
       fun = <U foo>
       block = Block {
-        args = [
+        params = [
           UnresolvedIdent{
             kind = Local
             name = <U _1>

--- a/test/testdata/desugar/opasgn_accessor.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/opasgn_accessor.rb.desugar-tree-raw.exp
@@ -41,7 +41,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}

--- a/test/testdata/desugar/range.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/range.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/testdata/infer/attached_class_self_new.rb
+++ b/test/testdata/infer/attached_class_self_new.rb
@@ -32,7 +32,7 @@ class PosArgs
   end
 end
 
-class NamedArgs
+class NamedParams
   extend T::Sig
 
   sig {params(x: Integer, y: String).void}
@@ -40,12 +40,12 @@ class NamedArgs
 
   sig {returns(T.attached_class)}
   def self.make
-    T.reveal_type(self.new(x: 10, y: "foo")) # error: Revealed type: `T.attached_class (of NamedArgs)`
+    T.reveal_type(self.new(x: 10, y: "foo")) # error: Revealed type: `T.attached_class (of NamedParams)`
 
     # Not matching initialize
     T.reveal_type(self.new(x: 10))
     #                      ^^^^^ error: Missing required keyword argument `y`
-  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Revealed type: `T.attached_class (of NamedArgs)`
+  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Revealed type: `T.attached_class (of NamedParams)`
   end
 end
 

--- a/test/testdata/infer/yield_multiple.rb.desugar-tree-raw.exp
+++ b/test/testdata/infer/yield_multiple.rb.desugar-tree-raw.exp
@@ -29,7 +29,7 @@ ClassDef{
       recv = Self
       fun = <U sig>
       block = Block {
-        args = [
+        params = [
         ]
         body = Send{
           flags = {}
@@ -100,7 +100,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U yield_two><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U blk>
         } }]

--- a/test/testdata/local_vars/z_super_args.rb.index-tree-raw.exp
+++ b/test/testdata/local_vars/z_super_args.rb.index-tree-raw.exp
@@ -22,7 +22,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_positional><<U <todo method>>>
-          args = [Local{
+          params = [Local{
               localVariable = <U arg0>
             }, BlockArg{ expr = Local{
               localVariable = <U <blk>>
@@ -44,7 +44,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_keyword><<U <todo method>>>
-          args = [KeywordArg{ expr = Local{
+          params = [KeywordArg{ expr = Local{
               localVariable = <U arg0>
             } }, BlockArg{ expr = Local{
               localVariable = <U <blk>>
@@ -66,7 +66,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_two_keyword><<U <todo method>>>
-          args = [KeywordArg{ expr = Local{
+          params = [KeywordArg{ expr = Local{
               localVariable = <U arg0>
             } }, KeywordArg{ expr = Local{
               localVariable = <U arg1>
@@ -106,7 +106,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_positional_then_keyword><<U <todo method>>>
-          args = [Local{
+          params = [Local{
               localVariable = <U arg0>
             }, KeywordArg{ expr = Local{
               localVariable = <U arg1>
@@ -146,7 +146,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_rest><<U <todo method>>>
-          args = [RestArg{ expr = Local{
+          params = [RestArg{ expr = Local{
               localVariable = <U args>
             } }, BlockArg{ expr = Local{
               localVariable = <U <blk>>
@@ -168,7 +168,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_keyword_rest><<U <todo method>>>
-          args = [RestArg{ expr = KeywordArg{ expr = Local{
+          params = [RestArg{ expr = KeywordArg{ expr = Local{
               localVariable = <U args>
             } } }, BlockArg{ expr = Local{
               localVariable = <U <blk>>
@@ -190,7 +190,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_block><<U <todo method>>>
-          args = [BlockArg{ expr = Local{
+          params = [BlockArg{ expr = Local{
               localVariable = <U blk>
             } }]
           rhs = Send{
@@ -210,7 +210,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U zsuper_inside_block><<U <todo method>>>
-          args = [BlockArg{ expr = Local{
+          params = [BlockArg{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = EmptyTree
@@ -249,7 +249,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_positional><<U <todo method>>>
-          args = [Local{
+          params = [Local{
               localVariable = <U arg0>
             }, BlockArg{ expr = Local{
               localVariable = <U <blk>>
@@ -279,7 +279,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_keyword><<U <todo method>>>
-          args = [KeywordArg{ expr = Local{
+          params = [KeywordArg{ expr = Local{
               localVariable = <U arg0>
             } }, BlockArg{ expr = Local{
               localVariable = <U <blk>>
@@ -310,7 +310,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_two_keyword><<U <todo method>>>
-          args = [KeywordArg{ expr = Local{
+          params = [KeywordArg{ expr = Local{
               localVariable = <U arg0>
             } }, KeywordArg{ expr = Local{
               localVariable = <U arg1>
@@ -347,7 +347,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_positional_then_keyword><<U <todo method>>>
-          args = [Local{
+          params = [Local{
               localVariable = <U arg0>
             }, KeywordArg{ expr = Local{
               localVariable = <U arg1>
@@ -383,7 +383,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_rest><<U <todo method>>>
-          args = [RestArg{ expr = Local{
+          params = [RestArg{ expr = Local{
               localVariable = <U args>
             } }, BlockArg{ expr = Local{
               localVariable = <U <blk>>
@@ -438,7 +438,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_keyword_rest><<U <todo method>>>
-          args = [RestArg{ expr = KeywordArg{ expr = Local{
+          params = [RestArg{ expr = KeywordArg{ expr = Local{
               localVariable = <U args>
             } } }, BlockArg{ expr = Local{
               localVariable = <U <blk>>
@@ -480,7 +480,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_block><<U <todo method>>>
-          args = [BlockArg{ expr = Local{
+          params = [BlockArg{ expr = Local{
               localVariable = <U blk>
             } }]
           rhs = Send{
@@ -505,7 +505,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U zsuper_inside_block><<U <todo method>>>
-          args = [BlockArg{ expr = Local{
+          params = [BlockArg{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -513,7 +513,7 @@ ClassDef{
             recv = Literal{ value = 1 }
             fun = <U times>
             block = Block {
-              args = [
+              params = [
                 Local{
                   localVariable = <U i>$1
                 }
@@ -572,7 +572,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U super_inside_module><<U <todo method>>>
-          args = [BlockArg{ expr = Local{
+          params = [BlockArg{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{

--- a/test/testdata/local_vars/z_super_args_splats_blocks.rb.index-tree-raw.exp
+++ b/test/testdata/local_vars/z_super_args_splats_blocks.rb.index-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -53,7 +53,7 @@ ClassDef{
           recv = Self
           fun = <U <untypedSuper>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -85,7 +85,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U possplat><<U <todo method>>>
-      args = [RestArg{ expr = Local{
+      params = [RestArg{ expr = Local{
           localVariable = <U foo>
         } }, BlockArg{ expr = Local{
           localVariable = <U <blk>>
@@ -146,7 +146,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -199,7 +199,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U possplat_pos><<U <todo method>>>
-      args = [RestArg{ expr = Local{
+      params = [RestArg{ expr = Local{
           localVariable = <U foo>
         } }, Local{
           localVariable = <U p>
@@ -282,7 +282,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -353,7 +353,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_possplat><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -441,7 +441,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -515,7 +515,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_possplat_pos><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -625,7 +625,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -717,7 +717,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_blk><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -760,7 +760,7 @@ ClassDef{
           recv = Self
           fun = <U <untypedSuper>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -792,7 +792,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U possplat_blk><<U <todo method>>>
-      args = [RestArg{ expr = Local{
+      params = [RestArg{ expr = Local{
           localVariable = <U foo>
         } }, BlockArg{ expr = Local{
           localVariable = <U blk>
@@ -853,7 +853,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -906,7 +906,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U possplat_pos_blk><<U <todo method>>>
-      args = [RestArg{ expr = Local{
+      params = [RestArg{ expr = Local{
           localVariable = <U foo>
         } }, Local{
           localVariable = <U p>
@@ -989,7 +989,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -1060,7 +1060,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_possplat_blk><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -1148,7 +1148,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -1222,7 +1222,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_possplat_pos_blk><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -1332,7 +1332,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -1424,7 +1424,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_kw><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -1479,7 +1479,7 @@ ClassDef{
           recv = Self
           fun = <U <untypedSuper>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -1519,7 +1519,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U possplat_kw><<U <todo method>>>
-      args = [RestArg{ expr = Local{
+      params = [RestArg{ expr = Local{
           localVariable = <U foo>
         } }, KeywordArg{ expr = Local{
           localVariable = <U j>
@@ -1595,7 +1595,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -1659,7 +1659,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U possplat_pos_kw><<U <todo method>>>
-      args = [RestArg{ expr = Local{
+      params = [RestArg{ expr = Local{
           localVariable = <U foo>
         } }, Local{
           localVariable = <U p>
@@ -1757,7 +1757,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -1839,7 +1839,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_possplat_kw><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -1942,7 +1942,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -2027,7 +2027,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_possplat_pos_kw><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -2152,7 +2152,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -2255,7 +2255,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_kwsplat><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -2315,7 +2315,7 @@ ClassDef{
           recv = Self
           fun = <U <untypedSuper>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -2362,7 +2362,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U possplat_kwsplat><<U <todo method>>>
-      args = [RestArg{ expr = Local{
+      params = [RestArg{ expr = Local{
           localVariable = <U foo>
         } }, RestArg{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
@@ -2443,7 +2443,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -2514,7 +2514,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U possplat_pos_kwsplat><<U <todo method>>>
-      args = [RestArg{ expr = Local{
+      params = [RestArg{ expr = Local{
           localVariable = <U foo>
         } }, Local{
           localVariable = <U p>
@@ -2617,7 +2617,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -2706,7 +2706,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_possplat_kwsplat><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -2814,7 +2814,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -2906,7 +2906,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_possplat_pos_kwsplat><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -3036,7 +3036,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -3146,7 +3146,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_kw_kwsplat><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -3234,7 +3234,7 @@ ClassDef{
           recv = Self
           fun = <U <untypedSuper>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -3305,7 +3305,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U possplat_kw_kwsplat><<U <todo method>>>
-      args = [RestArg{ expr = Local{
+      params = [RestArg{ expr = Local{
           localVariable = <U foo>
         } }, KeywordArg{ expr = Local{
           localVariable = <U j>
@@ -3414,7 +3414,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -3509,7 +3509,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U possplat_pos_kw_kwsplat><<U <todo method>>>
-      args = [RestArg{ expr = Local{
+      params = [RestArg{ expr = Local{
           localVariable = <U foo>
         } }, Local{
           localVariable = <U p>
@@ -3640,7 +3640,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -3753,7 +3753,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_possplat_kw_kwsplat><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -3889,7 +3889,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -4005,7 +4005,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_possplat_pos_kw_kwsplat><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -4163,7 +4163,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -4297,7 +4297,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_kw_blk><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -4352,7 +4352,7 @@ ClassDef{
           recv = Self
           fun = <U <untypedSuper>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -4392,7 +4392,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U possplat_kw_blk><<U <todo method>>>
-      args = [RestArg{ expr = Local{
+      params = [RestArg{ expr = Local{
           localVariable = <U foo>
         } }, KeywordArg{ expr = Local{
           localVariable = <U j>
@@ -4468,7 +4468,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -4532,7 +4532,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U possplat_pos_kw_blk><<U <todo method>>>
-      args = [RestArg{ expr = Local{
+      params = [RestArg{ expr = Local{
           localVariable = <U foo>
         } }, Local{
           localVariable = <U p>
@@ -4630,7 +4630,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -4712,7 +4712,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_possplat_kw_blk><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -4815,7 +4815,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -4900,7 +4900,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_possplat_pos_kw_blk><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -5025,7 +5025,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -5128,7 +5128,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_kwsplat_blk><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -5188,7 +5188,7 @@ ClassDef{
           recv = Self
           fun = <U <untypedSuper>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -5235,7 +5235,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U possplat_kwsplat_blk><<U <todo method>>>
-      args = [RestArg{ expr = Local{
+      params = [RestArg{ expr = Local{
           localVariable = <U foo>
         } }, RestArg{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
@@ -5316,7 +5316,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -5387,7 +5387,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U possplat_pos_kwsplat_blk><<U <todo method>>>
-      args = [RestArg{ expr = Local{
+      params = [RestArg{ expr = Local{
           localVariable = <U foo>
         } }, Local{
           localVariable = <U p>
@@ -5490,7 +5490,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -5579,7 +5579,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_possplat_kwsplat_blk><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -5687,7 +5687,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -5779,7 +5779,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_possplat_pos_kwsplat_blk><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -5909,7 +5909,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -6019,7 +6019,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_kw_kwsplat_blk><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -6107,7 +6107,7 @@ ClassDef{
           recv = Self
           fun = <U <untypedSuper>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -6178,7 +6178,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U possplat_kw_kwsplat_blk><<U <todo method>>>
-      args = [RestArg{ expr = Local{
+      params = [RestArg{ expr = Local{
           localVariable = <U foo>
         } }, KeywordArg{ expr = Local{
           localVariable = <U j>
@@ -6287,7 +6287,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -6382,7 +6382,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U possplat_pos_kw_kwsplat_blk><<U <todo method>>>
-      args = [RestArg{ expr = Local{
+      params = [RestArg{ expr = Local{
           localVariable = <U foo>
         } }, Local{
           localVariable = <U p>
@@ -6513,7 +6513,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -6626,7 +6626,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_possplat_kw_kwsplat_blk><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -6762,7 +6762,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -6878,7 +6878,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U pos_possplat_pos_kw_kwsplat_blk><<U <todo method>>>
-      args = [Local{
+      params = [Local{
           localVariable = <U x>
         }, Local{
           localVariable = <U y>
@@ -7036,7 +7036,7 @@ ClassDef{
           }
           fun = <U <call-with-splat>>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}

--- a/test/testdata/local_vars/z_super_args_strict.rb.index-tree-raw.exp
+++ b/test/testdata/local_vars/z_super_args_strict.rb.index-tree-raw.exp
@@ -24,7 +24,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -57,7 +57,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_positional><<U <todo method>>>
-          args = [Local{
+          params = [Local{
               localVariable = <U arg0>
             }, BlockArg{ expr = Local{
               localVariable = <U <blk>>
@@ -81,7 +81,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -114,7 +114,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_keyword><<U <todo method>>>
-          args = [KeywordArg{ expr = Local{
+          params = [KeywordArg{ expr = Local{
               localVariable = <U arg0>
             } }, BlockArg{ expr = Local{
               localVariable = <U <blk>>
@@ -138,7 +138,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -176,7 +176,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_two_keyword><<U <todo method>>>
-          args = [KeywordArg{ expr = Local{
+          params = [KeywordArg{ expr = Local{
               localVariable = <U arg0>
             } }, KeywordArg{ expr = Local{
               localVariable = <U arg1>
@@ -218,7 +218,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -256,7 +256,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_positional_then_keyword><<U <todo method>>>
-          args = [Local{
+          params = [Local{
               localVariable = <U arg0>
             }, KeywordArg{ expr = Local{
               localVariable = <U arg1>
@@ -298,7 +298,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -339,7 +339,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_rest><<U <todo method>>>
-          args = [RestArg{ expr = Local{
+          params = [RestArg{ expr = Local{
               localVariable = <U args>
             } }, BlockArg{ expr = Local{
               localVariable = <U <blk>>
@@ -363,7 +363,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -404,7 +404,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_keyword_rest><<U <todo method>>>
-          args = [RestArg{ expr = KeywordArg{ expr = Local{
+          params = [RestArg{ expr = KeywordArg{ expr = Local{
               localVariable = <U args>
             } } }, BlockArg{ expr = Local{
               localVariable = <U <blk>>
@@ -428,7 +428,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -477,7 +477,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_block><<U <todo method>>>
-          args = [BlockArg{ expr = Local{
+          params = [BlockArg{ expr = Local{
               localVariable = <U blk>
             } }]
           rhs = Send{
@@ -499,7 +499,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -519,7 +519,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U zsuper_inside_block><<U <todo method>>>
-          args = [BlockArg{ expr = Local{
+          params = [BlockArg{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = EmptyTree
@@ -577,7 +577,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -610,7 +610,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_positional><<U <todo method>>>
-          args = [Local{
+          params = [Local{
               localVariable = <U arg0>
             }, BlockArg{ expr = Local{
               localVariable = <U <blk>>
@@ -634,7 +634,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -667,7 +667,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_keyword><<U <todo method>>>
-          args = [KeywordArg{ expr = Local{
+          params = [KeywordArg{ expr = Local{
               localVariable = <U arg0>
             } }, BlockArg{ expr = Local{
               localVariable = <U <blk>>
@@ -692,7 +692,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -730,7 +730,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_two_keyword><<U <todo method>>>
-          args = [KeywordArg{ expr = Local{
+          params = [KeywordArg{ expr = Local{
               localVariable = <U arg0>
             } }, KeywordArg{ expr = Local{
               localVariable = <U arg1>
@@ -761,7 +761,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -799,7 +799,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_positional_then_keyword><<U <todo method>>>
-          args = [Local{
+          params = [Local{
               localVariable = <U arg0>
             }, KeywordArg{ expr = Local{
               localVariable = <U arg1>
@@ -829,7 +829,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -870,7 +870,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_rest><<U <todo method>>>
-          args = [RestArg{ expr = Local{
+          params = [RestArg{ expr = Local{
               localVariable = <U args>
             } }, BlockArg{ expr = Local{
               localVariable = <U <blk>>
@@ -924,7 +924,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -965,7 +965,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_keyword_rest><<U <todo method>>>
-          args = [RestArg{ expr = KeywordArg{ expr = Local{
+          params = [RestArg{ expr = KeywordArg{ expr = Local{
               localVariable = <U args>
             } } }, BlockArg{ expr = Local{
               localVariable = <U <blk>>
@@ -1001,7 +1001,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -1050,7 +1050,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_block><<U <todo method>>>
-          args = [BlockArg{ expr = Local{
+          params = [BlockArg{ expr = Local{
               localVariable = <U blk>
             } }]
           rhs = Send{
@@ -1077,7 +1077,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -1097,7 +1097,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U zsuper_inside_block><<U <todo method>>>
-          args = [BlockArg{ expr = Local{
+          params = [BlockArg{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -1105,7 +1105,7 @@ ClassDef{
             recv = Literal{ value = 1 }
             fun = <U times>
             block = Block {
-              args = [
+              params = [
                 Local{
                   localVariable = <U i>$1
                 }
@@ -1158,7 +1158,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -1178,7 +1178,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U super_inside_module><<U <todo method>>>
-          args = [BlockArg{ expr = Local{
+          params = [BlockArg{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{

--- a/test/testdata/namer/arguments.rb.desugar-tree-raw.exp
+++ b/test/testdata/namer/arguments.rb.desugar-tree-raw.exp
@@ -22,7 +22,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U take_arguments><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U a>
             }, OptionalArg{
@@ -97,7 +97,7 @@ ClassDef{
               recv = Self
               fun = <U proc>
               block = Block {
-                args = [
+                params = [
                   UnresolvedIdent{
                     kind = Local
                     name = <U a>

--- a/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
+++ b/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
@@ -14,7 +14,7 @@ InsSeq{
         MethodDef{
           flags = {self}
           name = <U <static-init>><<N <U <static-init>> $CENSORED>>
-          args = [Local{
+          params = [Local{
               localVariable = <U <blk>>
             }]
           rhs = EmptyTree
@@ -39,7 +39,7 @@ InsSeq{
         MethodDef{
           flags = {}
           name = <U take_arguments><<U take_arguments>>
-          args = [Local{
+          params = [Local{
               localVariable = <U a>
             }, OptionalArg{
               expr = Local{
@@ -99,7 +99,7 @@ InsSeq{
               recv = Self
               fun = <U proc>
               block = Block {
-                args = [
+                params = [
                   Local{
                     localVariable = <U a>$1
                   }
@@ -170,7 +170,7 @@ InsSeq{
         MethodDef{
           flags = {self}
           name = <U <static-init>><<U <static-init>>>
-          args = [Local{
+          params = [Local{
               localVariable = <U <blk>>
             }]
           rhs = <runtime method definition of take_arguments>

--- a/test/testdata/resolver/field.rb.flatten-tree-raw.exp
+++ b/test/testdata/resolver/field.rb.flatten-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U foo>>
-      args = [Local{
+      params = [Local{
           localVariable = <U a>
         }, Local{
           localVariable = <U <blk>>
@@ -29,7 +29,7 @@ ClassDef{
     MethodDef{
       flags = {self}
       name = <U <static-init>><<N <U <static-init>> $CENSORED>>
-      args = [Local{
+      params = [Local{
           localVariable = <U <blk>>
         }]
       rhs = <runtime method definition of foo>

--- a/test/testdata/resolver/resolve_tree_printing.rb.flatten-tree-raw.exp
+++ b/test/testdata/resolver/resolve_tree_printing.rb.flatten-tree-raw.exp
@@ -14,7 +14,7 @@ InsSeq{
         MethodDef{
           flags = {self}
           name = <U <static-init>><<N <U <static-init>> $CENSORED>>
-          args = [Local{
+          params = [Local{
               localVariable = <U <blk>>
             }]
           rhs = EmptyTree
@@ -39,7 +39,7 @@ InsSeq{
         MethodDef{
           flags = {}
           name = <U has_while><<U has_while>>
-          args = [Local{
+          params = [Local{
               localVariable = <U <blk>>
             }]
           rhs = While{
@@ -59,7 +59,7 @@ InsSeq{
         MethodDef{
           flags = {}
           name = <U has_constant_with_resolution_scope><<U has_constant_with_resolution_scope>>
-          args = [Local{
+          params = [Local{
               localVariable = <U <blk>>
             }]
           rhs = ConstantLit{
@@ -75,7 +75,7 @@ InsSeq{
         MethodDef{
           flags = {}
           name = <U has_global_field><<U has_global_field>>
-          args = [Local{
+          params = [Local{
               localVariable = <U <blk>>
             }]
           rhs = UnresolvedIdent{
@@ -87,7 +87,7 @@ InsSeq{
         MethodDef{
           flags = {}
           name = <U has_class_field><<U has_class_field>>
-          args = [Local{
+          params = [Local{
               localVariable = <U <blk>>
             }]
           rhs = UnresolvedIdent{
@@ -99,7 +99,7 @@ InsSeq{
         MethodDef{
           flags = {}
           name = <U has_next><<U has_next>>
-          args = [Local{
+          params = [Local{
               localVariable = <U <blk>>
             }]
           rhs = Send{
@@ -107,7 +107,7 @@ InsSeq{
             recv = Self
             fun = <U loop>
             block = Block {
-              args = [
+              params = [
               ]
               body = Next{ expr = EmptyTree }
             }
@@ -120,7 +120,7 @@ InsSeq{
         MethodDef{
           flags = {}
           name = <U has_break><<U has_break>>
-          args = [Local{
+          params = [Local{
               localVariable = <U <blk>>
             }]
           rhs = Send{
@@ -128,7 +128,7 @@ InsSeq{
             recv = Self
             fun = <U loop>
             block = Block {
-              args = [
+              params = [
               ]
               body = Break{ expr = EmptyTree }
             }
@@ -141,7 +141,7 @@ InsSeq{
         MethodDef{
           flags = {}
           name = <U has_return><<U has_return>>
-          args = [Local{
+          params = [Local{
               localVariable = <U <blk>>
             }]
           rhs = Return{ expr = Literal{ value = 1 } }
@@ -150,7 +150,7 @@ InsSeq{
         MethodDef{
           flags = {}
           name = <U has_cast><<U has_cast>>
-          args = [Local{
+          params = [Local{
               localVariable = <U <blk>>
             }]
           rhs = Cast{
@@ -186,7 +186,7 @@ InsSeq{
         MethodDef{
           flags = {self}
           name = <U <static-init>><<U <static-init>>>
-          args = [Local{
+          params = [Local{
               localVariable = <U <blk>>
             }]
           rhs = InsSeq{

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U main><<U <todo method>>>
-      args = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -1076,7 +1076,7 @@ ClassDef{
         MethodDef{
           flags = {self}
           name = <U prop><<U <todo method>>>
-          args = [RestArg{ expr = UnresolvedIdent{
+          params = [RestArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U args>
             } }, BlockArg{ expr = UnresolvedIdent{
@@ -1332,7 +1332,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -1356,7 +1356,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U foo><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -1383,7 +1383,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -1420,7 +1420,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U foo=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -1447,7 +1447,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {privateOk}
@@ -1483,7 +1483,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U foo2><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -1528,7 +1528,7 @@ ClassDef{
           recv = Self
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -1565,7 +1565,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U foo2=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -1678,7 +1678,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -1702,7 +1702,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U default><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -1729,7 +1729,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -1766,7 +1766,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U default=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -1796,7 +1796,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -1832,7 +1832,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U t_nilable><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -1859,7 +1859,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -1920,7 +1920,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U t_nilable=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -1950,7 +1950,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -1974,7 +1974,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U array><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2001,7 +2001,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -2038,7 +2038,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U array=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -2068,7 +2068,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -2107,7 +2107,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U t_array><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2134,7 +2134,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -2201,7 +2201,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U t_array=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -2231,7 +2231,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -2274,7 +2274,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U hash_of><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2301,7 +2301,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -2376,7 +2376,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U hash_of=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -2406,7 +2406,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -2430,7 +2430,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U const_explicit><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2457,7 +2457,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -2481,7 +2481,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U const><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2508,7 +2508,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -2532,7 +2532,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U enum_prop><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2559,7 +2559,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -2596,7 +2596,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U enum_prop=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -2626,7 +2626,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -2650,7 +2650,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U foreign><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2677,7 +2677,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -2714,7 +2714,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U foreign=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -2744,7 +2744,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -2808,7 +2808,7 @@ ClassDef{
         MethodDef{
           flags = {rewriterSynthesized}
           name = <U foreign_><<U <todo method>>>
-          args = [OptionalArg{
+          params = [OptionalArg{
               expr = KeywordArg{ expr = UnresolvedIdent{
                 kind = Local
                 name = <U allow_direct_mutation>
@@ -2841,7 +2841,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -2893,7 +2893,7 @@ ClassDef{
         MethodDef{
           flags = {rewriterSynthesized}
           name = <U foreign_!><<U <todo method>>>
-          args = [OptionalArg{
+          params = [OptionalArg{
               expr = KeywordArg{ expr = UnresolvedIdent{
                 kind = Local
                 name = <U allow_direct_mutation>
@@ -2926,7 +2926,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -2950,7 +2950,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U foreign_lazy><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2977,7 +2977,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -3014,7 +3014,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U foreign_lazy=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -3044,7 +3044,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -3108,7 +3108,7 @@ ClassDef{
         MethodDef{
           flags = {rewriterSynthesized}
           name = <U foreign_lazy_><<U <todo method>>>
-          args = [OptionalArg{
+          params = [OptionalArg{
               expr = KeywordArg{ expr = UnresolvedIdent{
                 kind = Local
                 name = <U allow_direct_mutation>
@@ -3141,7 +3141,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -3193,7 +3193,7 @@ ClassDef{
         MethodDef{
           flags = {rewriterSynthesized}
           name = <U foreign_lazy_!><<U <todo method>>>
-          args = [OptionalArg{
+          params = [OptionalArg{
               expr = KeywordArg{ expr = UnresolvedIdent{
                 kind = Local
                 name = <U allow_direct_mutation>
@@ -3226,7 +3226,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -3250,7 +3250,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U foreign_proc><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -3277,7 +3277,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -3314,7 +3314,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U foreign_proc=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -3344,7 +3344,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -3408,7 +3408,7 @@ ClassDef{
         MethodDef{
           flags = {rewriterSynthesized}
           name = <U foreign_proc_><<U <todo method>>>
-          args = [OptionalArg{
+          params = [OptionalArg{
               expr = KeywordArg{ expr = UnresolvedIdent{
                 kind = Local
                 name = <U allow_direct_mutation>
@@ -3441,7 +3441,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -3493,7 +3493,7 @@ ClassDef{
         MethodDef{
           flags = {rewriterSynthesized}
           name = <U foreign_proc_!><<U <todo method>>>
-          args = [OptionalArg{
+          params = [OptionalArg{
               expr = KeywordArg{ expr = UnresolvedIdent{
                 kind = Local
                 name = <U allow_direct_mutation>
@@ -3526,7 +3526,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -3550,7 +3550,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U foreign_invalid><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -3577,7 +3577,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -3614,7 +3614,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U foreign_invalid=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -3644,7 +3644,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -3704,7 +3704,7 @@ ClassDef{
         MethodDef{
           flags = {rewriterSynthesized}
           name = <U foreign_invalid_><<U <todo method>>>
-          args = [OptionalArg{
+          params = [OptionalArg{
               expr = KeywordArg{ expr = UnresolvedIdent{
                 kind = Local
                 name = <U allow_direct_mutation>
@@ -3737,7 +3737,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -3797,7 +3797,7 @@ ClassDef{
         MethodDef{
           flags = {rewriterSynthesized}
           name = <U foreign_invalid_!><<U <todo method>>>
-          args = [OptionalArg{
+          params = [OptionalArg{
               expr = KeywordArg{ expr = UnresolvedIdent{
                 kind = Local
                 name = <U allow_direct_mutation>
@@ -3830,7 +3830,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -3854,7 +3854,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U ifunset><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -3881,7 +3881,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -3918,7 +3918,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U ifunset=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -3948,7 +3948,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -3984,7 +3984,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U ifunset_nilable><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4011,7 +4011,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -4072,7 +4072,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U ifunset_nilable=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -4102,7 +4102,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -4126,7 +4126,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U empty_hash_rules><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4153,7 +4153,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -4190,7 +4190,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U empty_hash_rules=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -4220,7 +4220,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -4244,7 +4244,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U hash_rules><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4271,7 +4271,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -4308,7 +4308,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U hash_rules=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -4597,7 +4597,7 @@ ClassDef{
               }
               fun = <U lambda>
               block = Block {
-                args = [
+                params = [
                 ]
                 body = UnresolvedConstantLit{
                   cnst = <C <U ForeignClass>>
@@ -4633,7 +4633,7 @@ ClassDef{
               recv = Self
               fun = <U proc>
               block = Block {
-                args = [
+                params = [
                 ]
                 body = UnresolvedConstantLit{
                   cnst = <C <U ForeignClass>>
@@ -4669,7 +4669,7 @@ ClassDef{
               recv = Self
               fun = <U proc>
               block = Block {
-                args = [
+                params = [
                 ]
                 body = Literal{ value = :not_a_type }
               }
@@ -4810,7 +4810,7 @@ ClassDef{
         MethodDef{
           flags = {self}
           name = <U token_prop><<U <todo method>>>
-          args = [OptionalArg{
+          params = [OptionalArg{
               expr = UnresolvedIdent{
                 kind = Local
                 name = <U opts>
@@ -4829,7 +4829,7 @@ ClassDef{
         MethodDef{
           flags = {self}
           name = <U created_prop><<U <todo method>>>
-          args = [OptionalArg{
+          params = [OptionalArg{
               expr = UnresolvedIdent{
                 kind = Local
                 name = <U opts>
@@ -4853,7 +4853,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -4877,7 +4877,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U token><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4904,7 +4904,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -4941,7 +4941,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U token=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -4971,7 +4971,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -4995,7 +4995,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U created><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -5022,7 +5022,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -5059,7 +5059,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U created=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -5147,7 +5147,7 @@ ClassDef{
         MethodDef{
           flags = {self}
           name = <U timestamped_token_prop><<U <todo method>>>
-          args = [OptionalArg{
+          params = [OptionalArg{
               expr = UnresolvedIdent{
                 kind = Local
                 name = <U opts>
@@ -5166,7 +5166,7 @@ ClassDef{
         MethodDef{
           flags = {self}
           name = <U created_prop><<U <todo method>>>
-          args = [OptionalArg{
+          params = [OptionalArg{
               expr = UnresolvedIdent{
                 kind = Local
                 name = <U opts>
@@ -5190,7 +5190,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -5214,7 +5214,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U token><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -5241,7 +5241,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -5278,7 +5278,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U token=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -5308,7 +5308,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -5332,7 +5332,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U created><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -5474,7 +5474,7 @@ ClassDef{
         MethodDef{
           flags = {self}
           name = <U encrypted_prop><<U <todo method>>>
-          args = [OptionalArg{
+          params = [OptionalArg{
               expr = UnresolvedIdent{
                 kind = Local
                 name = <U opts>
@@ -5498,7 +5498,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -5534,7 +5534,7 @@ ClassDef{
         MethodDef{
           flags = {rewriterSynthesized}
           name = <U foo><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -5573,7 +5573,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -5624,7 +5624,7 @@ ClassDef{
         MethodDef{
           flags = {rewriterSynthesized}
           name = <U encrypted_foo><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -5663,7 +5663,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -5724,7 +5724,7 @@ ClassDef{
         MethodDef{
           flags = {rewriterSynthesized}
           name = <U foo=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -5766,7 +5766,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -5857,7 +5857,7 @@ ClassDef{
         MethodDef{
           flags = {rewriterSynthesized}
           name = <U encrypted_foo=><<U <todo method>>>
-          args = [UnresolvedIdent{
+          params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
             }, BlockArg{ expr = UnresolvedIdent{
@@ -5899,7 +5899,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -5935,7 +5935,7 @@ ClassDef{
         MethodDef{
           flags = {rewriterSynthesized}
           name = <U bar><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -5974,7 +5974,7 @@ ClassDef{
           }
           fun = <U sig>
           block = Block {
-            args = [
+            params = [
             ]
             body = Send{
               flags = {}
@@ -6025,7 +6025,7 @@ ClassDef{
         MethodDef{
           flags = {rewriterSynthesized}
           name = <U encrypted_bar><<U <todo method>>>
-          args = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]


### PR DESCRIPTION
### Motivation

Part of #9325

This name is pretty extensive, so I did it bit by bit. Rather than trying to cram it all in a single gigantic PR, I propose doing it in several steps. That introduces some inconsistency in the meantime, but inconsistent is the baseline, soooo anywhere is up from here.

This PR only tackles `MethodDef::ARGS_store`, instances of it, and code immediately near instances of it. Renaming parser types (e.g. `parser::Blockarg`, `parser::RestArg`, etc. will be a separate PR.

### Test plan

Pure refactor.