### PR TITLE
Two RSpec prework changes

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -797,6 +797,9 @@ void GlobalState::initEmpty() {
                  .untypedArg(Names::arg0())
                  .buildWithResult(Types::void_());
 
+    // Synthesize <Magic>.requires_ancestor(self: T.untyped) => Void
+    method = enterMethod(*this, Symbols::MagicSingleton(), Names::requiresAncestor()).buildWithResult(Types::void_());
+
     // Synthesize <Magic>.<check-match-array>(pattern: T.untyped, splatArray: T.untyped) => T.untyped
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::checkMatchArray())
                  .untypedArg(Names::arg0())

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -23,7 +23,7 @@ namespace sorbet::core {
 using namespace std;
 
 const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 215;
-const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 50;
+const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 51;
 const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 20;
 const int Symbols::MAX_SYNTHETIC_TYPEARGUMENT_SYMBOLS = 6;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 70;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1333,9 +1333,14 @@ public:
             }
         } else {
             auto recvAsConstantLit = ast::cast_tree<ast::ConstantLit>(send.recv);
-            if (recvAsConstantLit != nullptr && recvAsConstantLit->symbol() == core::Symbols::Magic() &&
-                send.fun == core::Names::mixesInClassMethods()) {
-                this->todoClassMethods_.emplace_back(ctx.file, ctx.owner, &send);
+            if (recvAsConstantLit != nullptr && recvAsConstantLit->symbol() == core::Symbols::Magic()) {
+                if (send.fun == core::Names::mixesInClassMethods()) {
+                    this->todoClassMethods_.emplace_back(ctx.file, ctx.owner, &send);
+                } else if (send.fun == core::Names::requiresAncestor()) {
+                    if (ctx.state.cacheSensitiveOptions.requiresAncestorEnabled) {
+                        this->todoRequiredAncestors_.emplace_back(ctx.file, ctx.owner.asClassOrModuleRef(), &send);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


- **no-op: Use a switch statement in runUnderEach** (8482df5caf)


- **prework: Add `<Magic>.requires_ancestor`** (fccad921f4)

  One of the RSpec rewriters gets better if it can use
  `requires_ancestor`, but we don't want to require or pretend that
  `extend T::Helpers` is in the ancestor hierarchy.

We're not using the `requires_ancestor` change yet, but it has run into
conflicts a couple of times on `Symbols.cc` as people add/remove well-known
SymbolRefs, so I'd like to just lock it in.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests