### PR TITLE
Add `--sorbet-packages` as an alias for `--stripe-packages`

### DIFF
--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -382,7 +382,7 @@ com::stripe::rubytyper::FileTable Proto::filesToProto(const GlobalState &gs,
                                                       const UnorderedMap<long, long> &untypedUsages, bool showFull) {
     com::stripe::rubytyper::FileTable files;
     const auto &packageDB = gs.packageDB();
-    auto stripePackages = packageDB.enabled();
+    auto sorbetPackages = packageDB.enabled();
     for (int i = 1; i < gs.filesUsed(); ++i) {
         core::FileRef file(i);
         if (file.data(gs).isPayload()) {
@@ -408,7 +408,7 @@ com::stripe::rubytyper::FileTable Proto::filesToProto(const GlobalState &gs,
             entry->set_untyped_usages(frefIdIt->second);
         }
 
-        if (stripePackages) {
+        if (sorbetPackages) {
             const auto &pkg = packageDB.getPackageNameForFile(file);
             if (pkg.exists()) {
                 entry->set_pkg(packageDB.getPackageInfo(pkg).show(gs));

--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -132,7 +132,7 @@ LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPC
         // path logic in LSPPreprocessor.
         ENFORCE(fref.exists());
         ENFORCE(updatedFile->getFileHash() != nullptr);
-        if (config.opts.cacheSensitiveOptions.stripePackages && updatedFile->isPackage(gs)) {
+        if (config.opts.cacheSensitiveOptions.sorbetPackages && updatedFile->isPackage(gs)) {
             // Only relevant in --stripe-packages mode. Package declarations do not have method
             // hashes. Instead we rely on recomputing packages if any __package.rb source
             // changes.
@@ -191,7 +191,7 @@ LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPC
             continue;
         }
 
-        if (config.opts.cacheSensitiveOptions.stripePackages && oldFile->isPackage(gs)) {
+        if (config.opts.cacheSensitiveOptions.sorbetPackages && oldFile->isPackage(gs)) {
             continue; // See note above about --stripe-packages.
         }
 

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -117,7 +117,7 @@ LSPIndexer::getTypecheckingPathInternal(const vector<shared_ptr<core::File>> &ch
         // Only relevant in `--stripe-packages` mode. This prevents LSP editing features like autocomplete from
         // working in `__package.rb` since every edit causes a slow path.
         // Note: We don't use File::isPackage because we have not necessarily set the packager options on initialGS yet
-        if (this->config->opts.cacheSensitiveOptions.stripePackages && oldFile.hasPackageRbPath() &&
+        if (this->config->opts.cacheSensitiveOptions.sorbetPackages && oldFile.hasPackageRbPath() &&
             oldFile.source() != f->source()) {
             logger.debug("Taking slow path because {} is a package file", f->path());
             prodCategoryCounterInc("lsp.slow_path_reason", "package_file");
@@ -275,7 +275,7 @@ void LSPIndexer::transferInitializeState(InitializedTask &task) {
     // indexer and typechecker's file tables will almost immediately diverge, but that's not an issue as we don't share
     // `core::FileRef` values between the two.
     auto typecheckerGS = std::exchange(
-        this->gs, this->gs->copyForIndex(this->config->opts.cacheSensitiveOptions.stripePackages,
+        this->gs, this->gs->copyForIndex(this->config->opts.cacheSensitiveOptions.sorbetPackages,
                                          this->config->opts.extraPackageFilesDirectoryUnderscorePrefixes,
                                          this->config->opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
                                          this->config->opts.extraPackageFilesDirectorySlashPrefixes,

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -281,7 +281,7 @@ void LSPIndexer::transferInitializeState(InitializedTask &task) {
                                          this->config->opts.extraPackageFilesDirectorySlashPrefixes,
                                          this->config->opts.packageSkipRBIExportEnforcementDirs,
                                          this->config->opts.allowRelaxedPackagerChecksFor,
-                                         this->config->opts.packagerLayers, this->config->opts.stripePackagesHint));
+                                         this->config->opts.packagerLayers, this->config->opts.sorbetPackagesHint));
 
     task.setGlobalState(std::move(typecheckerGS));
     task.setKeyValueStore(std::move(this->kvstore));

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -459,7 +459,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
                 Timer timeit(config->logger, "reIndexFromFileSystem");
 
                 auto workspaceFilesSpan = absl::MakeSpan(this->workspaceFiles);
-                if (this->config->opts.cacheSensitiveOptions.stripePackages) {
+                if (this->config->opts.cacheSensitiveOptions.sorbetPackages) {
                     auto numPackageFiles = pipeline::partitionPackageFiles(*this->gs, workspaceFilesSpan);
                     auto inputPackageFiles = workspaceFilesSpan.first(numPackageFiles);
                     workspaceFilesSpan = workspaceFilesSpan.subspan(numPackageFiles);

--- a/main/minimize/minimize.cc
+++ b/main/minimize/minimize.cc
@@ -424,7 +424,7 @@ void Minimize::indexAndResolveForMinimize(core::GlobalState &sourceGS, core::Glo
     auto foundHashes = nullptr;
     auto canceled = pipeline::name(rbiGS, absl::MakeSpan(rbiIndexed.result()), opts, workers, foundHashes);
     ENFORCE(!canceled, "Can only cancel in LSP mode");
-    // We explicitly disable `stripePackages` in realmain for this call, which makes the packager call a no-op here.
+    // We explicitly disable `sorbetPackages` in realmain for this call, which makes the packager call a no-op here.
     pipeline::package(rbiGS, absl::MakeSpan(rbiIndexed.result()), opts, workers);
 
     auto resolved = pipeline::resolve(rbiGS, std::move(rbiIndexed.result()), opts, workers);

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -37,7 +37,7 @@ enum class Group {
     LSP,
     LSP_FEATURE,
     PERFORMANCE,
-    STRIPE_PACKAGES_MODE,
+    SORBET_PACKAGES_MODE,
     STRIPE_AUTOGEN,
     DEBUGGING,
     INTERNAL,
@@ -62,8 +62,8 @@ string groupToString(Group group) {
             return "LSP FEATURE";
         case Group::PERFORMANCE:
             return "PERFORMANCE";
-        case Group::STRIPE_PACKAGES_MODE:
-            return "STRIPE PACKAGES MODE";
+        case Group::SORBET_PACKAGES_MODE:
+            return "SORBET PACKAGES MODE";
         case Group::STRIPE_AUTOGEN:
             return "STRIPE AUTOGEN";
         case Group::DEBUGGING:
@@ -80,7 +80,7 @@ string groupToString(Group group) {
 const vector<string> groupSections{
     groupToString(Group::INPUT),          groupToString(Group::OUTPUT),      groupToString(Group::AUTOCORRECT),
     groupToString(Group::ERROR),          groupToString(Group::METRIC),      groupToString(Group::LSP),
-    groupToString(Group::LSP_FEATURE),    groupToString(Group::PERFORMANCE), groupToString(Group::STRIPE_PACKAGES_MODE),
+    groupToString(Group::LSP_FEATURE),    groupToString(Group::PERFORMANCE), groupToString(Group::SORBET_PACKAGES_MODE),
     groupToString(Group::STRIPE_AUTOGEN), groupToString(Group::DEBUGGING),   groupToString(Group::INTERNAL),
     groupToString(Group::OTHER),
 };
@@ -620,11 +620,16 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     // }}}
 
     // ----- STRIPE PACKAGES ---------------------------------------------- {{{
-    section = groupToString(Group::STRIPE_PACKAGES_MODE);
+    section = groupToString(Group::SORBET_PACKAGES_MODE);
     options.add_options(section)("stripe-packages", "Enable support for Stripe's internal Ruby package system",
                                  cxxopts::value<bool>());
     options.add_options(section)("stripe-packages-hint-message",
                                  "Optional hint message to add to packaging related errors",
+                                 cxxopts::value<string>()->default_value(""));
+    options.add_options(section)("sorbet-packages", "Enable support for Sorbet's experimental Ruby package system",
+                                 cxxopts::value<bool>());
+    options.add_options(section)("sorbet-packages-hint-message",
+                                 "Optional hint message to add to all packaging related errors",
                                  cxxopts::value<string>()->default_value(""));
     options.add_options(section)("extra-package-files-directory-prefix-underscore",
                                  "Extra parent directories which contain package files. Files are associated to a "
@@ -1208,7 +1213,8 @@ void readOptions(Options &opts,
         opts.reserveTypeArgumentTableCapacity = raw["reserve-type-argument-table-capacity"].as<uint32_t>();
         opts.reserveTypeMemberTableCapacity = raw["reserve-type-member-table-capacity"].as<uint32_t>();
         opts.uniquelyDefinedBehavior = raw["uniquely-defined-behavior"].as<bool>();
-        opts.cacheSensitiveOptions.stripePackages = raw["stripe-packages"].as<bool>();
+        opts.cacheSensitiveOptions.sorbetPackages =
+            raw["sorbet-packages"].as<bool>() || raw["stripe-packages"].as<bool>();
 
         opts.packageDirected = raw["experimental-package-directed"].as<bool>();
         if (opts.packageDirected && !opts.cacheSensitiveOptions.stripePackages) {
@@ -1252,8 +1258,8 @@ void readOptions(Options &opts,
         }
 
         if (raw.count("allow-relaxed-packager-checks-for")) {
-            if (!opts.cacheSensitiveOptions.stripePackages) {
-                logger->error("--allow-relaxed-packager-checks-for can only be specified in --stripe-packages mode");
+            if (!opts.cacheSensitiveOptions.sorbetPackages) {
+                logger->error("--allow-relaxed-packager-checks-for can only be specified in --sorbet-packages mode");
                 throw EarlyReturnWithCode(1);
             }
             std::regex nsValid("[A-Z][a-zA-Z0-9:]+");
@@ -1268,7 +1274,7 @@ void readOptions(Options &opts,
         }
 
         if (raw.count("packager-layers")) {
-            if (opts.cacheSensitiveOptions.stripePackages) {
+            if (opts.cacheSensitiveOptions.sorbetPackages) {
                 // TODO(neil): This regex was picked on a whim, so open to changing to be more or less restrictive based
                 // on feedback/usecases.
                 std::regex layerValid("[a-zA-Z0-9]+");
@@ -1280,21 +1286,24 @@ void readOptions(Options &opts,
                     opts.packagerLayers.emplace_back(layer);
                 }
             } else {
-                logger->error("--packager-layers can only be specified in --stripe-packages mode");
+                logger->error("--packager-layers can only be specified in --sorbet-packages mode");
                 throw EarlyReturnWithCode(1);
             }
         }
 
-        opts.stripePackagesHint = raw["stripe-packages-hint-message"].as<string>();
-        if (!opts.stripePackagesHint.empty() && !opts.cacheSensitiveOptions.stripePackages) {
-            if (!opts.cacheSensitiveOptions.stripePackages) {
-                logger->error("--stripe-packages-hint-message can only be specified in --stripe-packages mode");
+        opts.sorbetPackagesHint = raw["sorbet-packages-hint-message"].as<string>();
+        if (opts.sorbetPackagesHint.empty()) {
+            opts.sorbetPackagesHint = raw["stripe-packages-hint-message"].as<string>();
+        }
+        if (!opts.sorbetPackagesHint.empty() && !opts.cacheSensitiveOptions.sorbetPackages) {
+            if (!opts.cacheSensitiveOptions.sorbetPackages) {
+                logger->error("--sorbet-packages-hint-message can only be specified in --sorbet-packages mode");
                 throw EarlyReturnWithCode(1);
             }
         }
 
         if (raw.count("package-skip-rbi-export-enforcement")) {
-            if (!opts.cacheSensitiveOptions.stripePackages) {
+            if (!opts.cacheSensitiveOptions.sorbetPackages) {
                 logger->error("--package-skip-rbi-export-enforcement can only be specified in --stripe-packages mode");
                 throw EarlyReturnWithCode(1);
             }

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -1217,7 +1217,7 @@ void readOptions(Options &opts,
             raw["sorbet-packages"].as<bool>() || raw["stripe-packages"].as<bool>();
 
         opts.packageDirected = raw["experimental-package-directed"].as<bool>();
-        if (opts.packageDirected && !opts.cacheSensitiveOptions.stripePackages) {
+        if (opts.packageDirected && !opts.cacheSensitiveOptions.sorbetPackages) {
             logger->error("--experimental-package-directed can only be specified in --stripe-packages mode");
             throw EarlyReturnWithCode(1);
         }

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -621,10 +621,10 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
 
     // ----- STRIPE PACKAGES ---------------------------------------------- {{{
     section = groupToString(Group::SORBET_PACKAGES_MODE);
-    options.add_options(section)("stripe-packages", "Enable support for Stripe's internal Ruby package system",
+    options.add_options(section)("stripe-packages", "Enable support for Sorbet's experimental Ruby package system",
                                  cxxopts::value<bool>());
     options.add_options(section)("stripe-packages-hint-message",
-                                 "Optional hint message to add to packaging related errors",
+                                 "Optional hint message to add to all packaging related errors",
                                  cxxopts::value<string>()->default_value(""));
     options.add_options(section)("sorbet-packages", "Enable support for Sorbet's experimental Ruby package system",
                                  cxxopts::value<bool>());
@@ -1218,7 +1218,7 @@ void readOptions(Options &opts,
 
         opts.packageDirected = raw["experimental-package-directed"].as<bool>();
         if (opts.packageDirected && !opts.cacheSensitiveOptions.sorbetPackages) {
-            logger->error("--experimental-package-directed can only be specified in --stripe-packages mode");
+            logger->error("--experimental-package-directed can only be specified in --sorbet-packages mode");
             throw EarlyReturnWithCode(1);
         }
 
@@ -1304,7 +1304,7 @@ void readOptions(Options &opts,
 
         if (raw.count("package-skip-rbi-export-enforcement")) {
             if (!opts.cacheSensitiveOptions.sorbetPackages) {
-                logger->error("--package-skip-rbi-export-enforcement can only be specified in --stripe-packages mode");
+                logger->error("--package-skip-rbi-export-enforcement can only be specified in --sorbet-packages mode");
                 throw EarlyReturnWithCode(1);
             }
             for (const string &ns : raw["package-skip-rbi-export-enforcement"].as<vector<string>>()) {

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -161,7 +161,7 @@ struct Options {
     int logLevel = 0; // number of time -v was passed
     int autogenVersion = 0;
     bool uniquelyDefinedBehavior = false;
-    std::string stripePackagesHint = "";
+    std::string sorbetPackagesHint = "";
     std::vector<std::string> extraPackageFilesDirectoryUnderscorePrefixes;
     std::vector<std::string> extraPackageFilesDirectorySlashDeprecatedPrefixes;
     std::vector<std::string> extraPackageFilesDirectorySlashPrefixes;
@@ -202,7 +202,7 @@ struct Options {
 
         bool runningUnderAutogen : 1;
 
-        bool stripePackages : 1;
+        bool sorbetPackages : 1;
 
         // HELLO! adding/removing MUST also change this number!!
         constexpr static uint8_t NUMBER_OF_FLAGS = 6;
@@ -210,7 +210,7 @@ struct Options {
         // In C++20 we can replace this with bit field initializers
         CacheSensitiveOptions()
             : noStdlib(false), typedSuper(true), rbsEnabled(false), requiresAncestorEnabled(false),
-              runningUnderAutogen(false), stripePackages(false) {}
+              runningUnderAutogen(false), sorbetPackages(false) {}
 
         constexpr static uint8_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
 

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -117,7 +117,7 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
         gs.setPackagerOptions(opts.extraPackageFilesDirectoryUnderscorePrefixes,
                               opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
                               opts.extraPackageFilesDirectorySlashPrefixes, opts.packageSkipRBIExportEnforcementDirs,
-                              opts.allowRelaxedPackagerChecksFor, opts.packagerLayers, opts.stripePackagesHint);
+                              opts.allowRelaxedPackagerChecksFor, opts.packagerLayers, opts.sorbetPackagesHint);
     }
 #endif
 }
@@ -132,7 +132,7 @@ unique_ptr<core::GlobalState> copyForSlowPath(const core::GlobalState &from, con
     auto result = from.copyForSlowPath(
         opts.extraPackageFilesDirectoryUnderscorePrefixes, opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
         opts.extraPackageFilesDirectorySlashPrefixes, opts.packageSkipRBIExportEnforcementDirs,
-        opts.allowRelaxedPackagerChecksFor, opts.packagerLayers, opts.stripePackagesHint);
+        opts.allowRelaxedPackagerChecksFor, opts.packagerLayers, opts.sorbetPackagesHint);
 
     core::serialize::Serializer::loadSymbolTable(*result, PAYLOAD_SYMBOL_TABLE);
 
@@ -704,7 +704,7 @@ ast::ParsedFilesOrCancelled indexSuppliedFiles(core::GlobalState &baseGs, absl::
         opts.cacheSensitiveOptions.sorbetPackages, opts.extraPackageFilesDirectoryUnderscorePrefixes,
         opts.extraPackageFilesDirectorySlashDeprecatedPrefixes, opts.extraPackageFilesDirectorySlashPrefixes,
         opts.packageSkipRBIExportEnforcementDirs, opts.allowRelaxedPackagerChecksFor, opts.packagerLayers,
-        opts.stripePackagesHint);
+        opts.sorbetPackagesHint);
 
     workers.multiplexJob("indexSuppliedFiles", [emptyGs, &opts, fileq, resultq, &kvstore, cancelable]() {
         Timer timeit(emptyGs->tracer(), "indexSuppliedFilesWorker");

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -111,7 +111,7 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
     gs.suggestUnsafe = opts.suggestUnsafe;
 
 #ifndef SORBET_REALMAIN_MIN
-    if (opts.cacheSensitiveOptions.stripePackages) {
+    if (opts.cacheSensitiveOptions.sorbetPackages) {
         core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(gs);
         core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = gs.unfreezePackages();
         gs.setPackagerOptions(opts.extraPackageFilesDirectoryUnderscorePrefixes,
@@ -701,7 +701,7 @@ ast::ParsedFilesOrCancelled indexSuppliedFiles(core::GlobalState &baseGs, absl::
     }
 
     shared_ptr<const core::GlobalState> emptyGs = baseGs.copyForIndex(
-        opts.cacheSensitiveOptions.stripePackages, opts.extraPackageFilesDirectoryUnderscorePrefixes,
+        opts.cacheSensitiveOptions.sorbetPackages, opts.extraPackageFilesDirectoryUnderscorePrefixes,
         opts.extraPackageFilesDirectorySlashDeprecatedPrefixes, opts.extraPackageFilesDirectorySlashPrefixes,
         opts.packageSkipRBIExportEnforcementDirs, opts.allowRelaxedPackagerChecksFor, opts.packagerLayers,
         opts.stripePackagesHint);
@@ -939,7 +939,7 @@ vector<CondensationStratumInfo> computePackageStrata(const core::GlobalState &gs
 void package(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
              WorkerPool &workers) {
 #ifndef SORBET_REALMAIN_MIN
-    if (!opts.cacheSensitiveOptions.stripePackages) {
+    if (!opts.cacheSensitiveOptions.sorbetPackages) {
         return;
     }
 
@@ -964,7 +964,7 @@ void package(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const opti
 void buildPackageDB(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
                     WorkerPool &workers) {
 #ifndef SORBET_REALMAIN_MIN
-    if (!opts.cacheSensitiveOptions.stripePackages) {
+    if (!opts.cacheSensitiveOptions.sorbetPackages) {
         return;
     }
 
@@ -989,7 +989,7 @@ void buildPackageDB(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, con
 void setPackageForSourceFiles(core::GlobalState &gs, absl::Span<core::FileRef> packageFiles,
                               const options::Options &opts) {
 #ifndef SORBET_REALMAIN_MIN
-    if (!opts.cacheSensitiveOptions.stripePackages) {
+    if (!opts.cacheSensitiveOptions.sorbetPackages) {
         return;
     }
 
@@ -1008,7 +1008,7 @@ void setPackageForSourceFiles(core::GlobalState &gs, absl::Span<core::FileRef> p
 void validatePackagedFiles(core::GlobalState &gs, absl::Span<ast::ParsedFile> what, const options::Options &opts,
                            WorkerPool &workers) {
 #ifndef SORBET_REALMAIN_MIN
-    if (!opts.cacheSensitiveOptions.stripePackages) {
+    if (!opts.cacheSensitiveOptions.sorbetPackages) {
         return;
     }
 
@@ -1171,7 +1171,7 @@ ast::ParsedFilesOrCancelled resolve(core::GlobalState &gs, vector<ast::ParsedFil
             }
 
 #ifndef SORBET_REALMAIN_MIN
-            if (opts.cacheSensitiveOptions.stripePackages) {
+            if (opts.cacheSensitiveOptions.sorbetPackages) {
                 Timer timeit(gs.tracer(), "visibility_checker");
                 what = packager::VisibilityChecker::run(gs, workers, std::move(what));
             }
@@ -1358,7 +1358,7 @@ incrementalResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
         }
 
 #ifndef SORBET_REALMAIN_MIN
-        if (opts.cacheSensitiveOptions.stripePackages) {
+        if (opts.cacheSensitiveOptions.sorbetPackages) {
             Timer timeit(gs.tracer(), "incremental_packager");
             // For simplicity, we still call Packager::runIncremental here, even though
             // pipeline::nameAndResolve no longer calls Packager::run.
@@ -1391,7 +1391,7 @@ incrementalResolve(core::GlobalState &gs, vector<ast::ParsedFile> what,
         }
 
 #ifndef SORBET_REALMAIN_MIN
-        if (opts.cacheSensitiveOptions.stripePackages) {
+        if (opts.cacheSensitiveOptions.sorbetPackages) {
             what = packager::VisibilityChecker::run(gs, workers, std::move(what));
         }
 #endif

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -563,7 +563,7 @@ int realmain(int argc, char *argv[]) {
 
         // ----- build the package DB -----
 
-        if (opts.cacheSensitiveOptions.stripePackages) {
+        if (opts.cacheSensitiveOptions.sorbetPackages) {
             auto numPackageFiles = pipeline::partitionPackageFiles(*gs, inputFilesSpan);
             auto inputPackageFiles = inputFilesSpan.first(numPackageFiles);
             inputFilesSpan = inputFilesSpan.subspan(numPackageFiles);
@@ -681,7 +681,7 @@ int realmain(int argc, char *argv[]) {
             auto optsForMinimize = opts.clone();
             // Explicitly turn off the packager, because it doesn't make sense when the whole
             // project is a single RBI file.
-            optsForMinimize.cacheSensitiveOptions.stripePackages = false;
+            optsForMinimize.cacheSensitiveOptions.sorbetPackages = false;
 
             unique_ptr<core::GlobalState> gsForMinimize = make_unique<core::GlobalState>(gs->errorQueue);
             auto kvstore = nullptr;

--- a/test/cli/help/test.out
+++ b/test/cli/help/test.out
@@ -94,7 +94,7 @@ Usage:
  LSP options:
  LSP FEATURE options:
  PERFORMANCE options:
- STRIPE PACKAGES MODE options:
+ SORBET PACKAGES MODE options:
  STRIPE AUTOGEN options:
  DEBUGGING options:
  INTERNAL options:

--- a/test/cli/packager-layers/test.out
+++ b/test/cli/packager-layers/test.out
@@ -18,7 +18,7 @@ __package.rb:5: Argument to `layer` must be one of: `a`, `b`, or `c` https://srb
      5 |  layer 'fake'
                 ^^^^^^
 Errors: 1
---packager-layers can only be specified in --stripe-packages mode
+--packager-layers can only be specified in --sorbet-packages mode
 __package.rb:4: Found `strict_dependencies` annotation, but `--packager-layers` was not passed https://srb.help/3724
      4 |  strict_dependencies 'false'
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/helpers/packages.cc
+++ b/test/helpers/packages.cc
@@ -41,7 +41,7 @@ string PackageHelpers::makePackageRB(string name, string strictDeps, string laye
 void PackageHelpers::makeDefaultPackagerGlobalState(core::GlobalState &gs, const vector<string> &packagerLayers) {
     gs.initEmpty();
     realmain::options::Options opts;
-    opts.cacheSensitiveOptions.stripePackages = true;
+    opts.cacheSensitiveOptions.sorbetPackages = true;
     opts.packagerLayers = packagerLayers;
     realmain::pipeline::setGlobalStateOptions(gs, opts);
 }

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -711,7 +711,7 @@ realmain::options::Options RangeAssertion::parseOptions(vector<shared_ptr<RangeA
         opts.suggestUnsafe = "T.unsafe";
     }
 
-    opts.cacheSensitiveOptions.stripePackages =
+    opts.cacheSensitiveOptions.sorbetPackages =
         BooleanPropertyAssertion::getValue("enable-packager", assertions).value_or(false);
     auto extraDirUnderscore =
         StringPropertyAssertion::getValue("extra-package-files-directory-prefix-underscore", assertions);

--- a/test/lsp/watchman_test_corpus.cc
+++ b/test/lsp/watchman_test_corpus.cc
@@ -123,7 +123,7 @@ TEST_CASE_FIXTURE(ProtocolTest, "MergesMultipleWatchmanUpdates") {
 
 TEST_CASE_FIXTURE(ProtocolTest, "ZeroingOutPackageFiles") {
     auto opts = make_shared<realmain::options::Options>();
-    opts->cacheSensitiveOptions.stripePackages = true;
+    opts->cacheSensitiveOptions.sorbetPackages = true;
     this->resetState(std::move(opts));
 
     writeFilesToFS({

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -605,7 +605,7 @@ TEST_CASE("LSPTest") {
             auto responses = getLSPResponsesFor(*lspWrapper, make_unique<LSPMessage>(make_unique<NotificationMessage>(
                                                                  "2.0", LSPMethod::TextDocumentDidOpen, move(params))));
             // Sorbet will complain about missing packages in packaging mode. Ignore them.
-            if (!lspWrapper->opts->cacheSensitiveOptions.stripePackages) {
+            if (!lspWrapper->opts->cacheSensitiveOptions.sorbetPackages) {
                 INFO("Should not receive any response to opening an empty file.");
                 CHECK_EQ(0, countNonTestMessages(responses));
             }

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -384,7 +384,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     auto assertions = RangeAssertion::parseAssertions(test.sourceFileContents);
     auto opts = RangeAssertion::parseOptions(assertions);
     opts.censorForSnapshotTests = true;
-    opts.stripePackagesHint = "PACKAGE_ERROR_HINT";
+    opts.sorbetPackagesHint = "PACKAGE_ERROR_HINT";
     opts.parser = sorbet::test::parser;
 
     auto logger = spdlog::stderr_color_mt("fixtures: " + inputPath);

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -429,7 +429,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     vector<ast::ParsedFile> trees;
     auto filesSpan = absl::Span<core::FileRef>(files);
-    if (opts.cacheSensitiveOptions.stripePackages) {
+    if (opts.cacheSensitiveOptions.sorbetPackages) {
         auto numPackageFiles = realmain::pipeline::partitionPackageFiles(*gs, filesSpan);
         auto inputPackageFiles = filesSpan.first(numPackageFiles);
         filesSpan = filesSpan.subspan(numPackageFiles);
@@ -485,7 +485,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         core::UnfreezeSymbolTable symbolTableAccess(*gs); // enters stubs
         trees = move(resolver::Resolver::run(*gs, move(trees), *workers).result());
 
-        if (opts.cacheSensitiveOptions.stripePackages) {
+        if (opts.cacheSensitiveOptions.sorbetPackages) {
             trees = packager::VisibilityChecker::run(*gs, *workers, move(trees));
         }
 
@@ -807,7 +807,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         }
     }
 
-    if (opts.cacheSensitiveOptions.stripePackages) {
+    if (opts.cacheSensitiveOptions.sorbetPackages) {
         absl::c_stable_partition(trees, [&](const auto &pf) { return pf.file.isPackage(*gs); });
         trees = packager::Packager::runIncremental(*gs, move(trees), *workers);
         for (auto &tree : trees) {
@@ -827,7 +827,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
                      .result());
     }
 
-    if (opts.cacheSensitiveOptions.stripePackages) {
+    if (opts.cacheSensitiveOptions.sorbetPackages) {
         trees = packager::VisibilityChecker::run(*gs, *workers, move(trees));
     }
 

--- a/test/pkg_autocorrects_test.cc
+++ b/test/pkg_autocorrects_test.cc
@@ -86,7 +86,7 @@ const vector<string> LAYERS_UTIL_LIB_APP = {"util", "lib", "app"};
 void makeDefaultPackagerGlobalState(core::GlobalState &gs, const vector<string> &packagerLayers = NO_LAYERS) {
     gs.initEmpty();
     realmain::options::Options opts;
-    opts.cacheSensitiveOptions.stripePackages = true;
+    opts.cacheSensitiveOptions.sorbetPackages = true;
     opts.packagerLayers = packagerLayers;
     realmain::pipeline::setGlobalStateOptions(gs, opts);
 }

--- a/website/docs/cli-ref.md
+++ b/website/docs/cli-ref.md
@@ -295,13 +295,19 @@ Usage:
 
 ```
 
-## STRIPE PACKAGES MODE options
+## SORBET PACKAGES MODE options
 
 ```plaintext
-      --stripe-packages         Enable support for Stripe's internal Ruby package system
+      --stripe-packages         Enable support for Sorbet's experimental Ruby package
+                                system
       --stripe-packages-hint-message arg
-                                Optional hint message to add to packaging related errors
-                                (default: "")
+                                Optional hint message to add to all packaging related
+                                errors (default: "")
+      --sorbet-packages         Enable support for Sorbet's experimental Ruby package
+                                system
+      --sorbet-packages-hint-message arg
+                                Optional hint message to add to all packaging related
+                                errors (default: "")
       --extra-package-files-directory-prefix-underscore <dir>
                                 Extra parent directories which contain package files.
                                 Files are associated to a package using a package's


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Eventually we want this to be more widely used than just Stripe, I figure it
will be nice to have it named something else.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests