### PR TITLE
Add test for exported const and incremental namer

### DIFF
--- a/test/testdata/packager/incremental_fast_path_exported/__package.1.rbupdate
+++ b/test/testdata/packager/incremental_fast_path_exported/__package.1.rbupdate
@@ -1,6 +1,6 @@
 # typed: strict
 # enable-packager: true
-# spacer for exclude-from-file-update
+# exclude-from-file-update: true
 
 class Root < PackageSpec
   import Lib

--- a/test/testdata/packager/incremental_fast_path_exported/__package.2.rbupdate
+++ b/test/testdata/packager/incremental_fast_path_exported/__package.2.rbupdate
@@ -1,0 +1,7 @@
+# typed: strict
+# enable-packager: true
+# exclude-from-file-update: true
+
+class Root < PackageSpec
+  import Lib
+end

--- a/test/testdata/packager/incremental_fast_path_exported/__package.3.rbupdate
+++ b/test/testdata/packager/incremental_fast_path_exported/__package.3.rbupdate
@@ -1,0 +1,7 @@
+# typed: strict
+# enable-packager: true
+# exclude-from-file-update: true
+
+class Root < PackageSpec
+  import Lib
+end

--- a/test/testdata/packager/incremental_fast_path_exported/__package.rb
+++ b/test/testdata/packager/incremental_fast_path_exported/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# enable-packager: true
+
+class Root < PackageSpec
+  import Lib
+end

--- a/test/testdata/packager/incremental_fast_path_exported/lib/__package.1.rbupdate
+++ b/test/testdata/packager/incremental_fast_path_exported/lib/__package.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: strict
-# spacer for exclude-from-file-update
+# exclude-from-file-update: true
 
 class Lib < PackageSpec
   export Lib::MyStaticField

--- a/test/testdata/packager/incremental_fast_path_exported/lib/__package.2.rbupdate
+++ b/test/testdata/packager/incremental_fast_path_exported/lib/__package.2.rbupdate
@@ -1,0 +1,6 @@
+# typed: strict
+# exclude-from-file-update: true
+
+class Lib < PackageSpec
+  export Lib::MyStaticField # error: Unable to resolve
+end

--- a/test/testdata/packager/incremental_fast_path_exported/lib/__package.3.rbupdate
+++ b/test/testdata/packager/incremental_fast_path_exported/lib/__package.3.rbupdate
@@ -1,0 +1,6 @@
+# typed: strict
+# exclude-from-file-update: true
+
+class Lib < PackageSpec
+  export Lib::MyStaticField
+end

--- a/test/testdata/packager/incremental_fast_path_exported/lib/__package.rb
+++ b/test/testdata/packager/incremental_fast_path_exported/lib/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Lib < PackageSpec
+  export Lib::MyStaticField
+end

--- a/test/testdata/packager/incremental_fast_path_exported/lib/_impl.1.rbupdate
+++ b/test/testdata/packager/incremental_fast_path_exported/lib/_impl.1.rbupdate
@@ -1,9 +1,8 @@
 # typed: strict
-# assert-fast-path: lib/_impl.rb
+# assert-fast-path: lib/_impl.rb,main.rb
 
 module Lib
   MyStaticField = 1
 
-  # a comment
   MyPrivateStaticField = 2
 end

--- a/test/testdata/packager/incremental_fast_path_exported/lib/_impl.1.rbupdate
+++ b/test/testdata/packager/incremental_fast_path_exported/lib/_impl.1.rbupdate
@@ -1,0 +1,9 @@
+# typed: strict
+# assert-fast-path: lib/_impl.rb
+
+module Lib
+  MyStaticField = 1
+
+  # a comment
+  MyPrivateStaticField = 1
+end

--- a/test/testdata/packager/incremental_fast_path_exported/lib/_impl.1.rbupdate
+++ b/test/testdata/packager/incremental_fast_path_exported/lib/_impl.1.rbupdate
@@ -5,5 +5,5 @@ module Lib
   MyStaticField = 1
 
   # a comment
-  MyPrivateStaticField = 1
+  MyPrivateStaticField = 2
 end

--- a/test/testdata/packager/incremental_fast_path_exported/lib/_impl.2.rbupdate
+++ b/test/testdata/packager/incremental_fast_path_exported/lib/_impl.2.rbupdate
@@ -1,0 +1,8 @@
+# typed: strict
+# assert-fast-path: lib/__package.rb,lib/_impl.rb,__package.rb,main.rb
+
+module Lib
+  MyStaticField1 = 1
+
+  MyPrivateStaticField = 2
+end

--- a/test/testdata/packager/incremental_fast_path_exported/lib/_impl.3.rbupdate
+++ b/test/testdata/packager/incremental_fast_path_exported/lib/_impl.3.rbupdate
@@ -1,0 +1,8 @@
+# typed: strict
+# assert-fast-path: lib/__package.rb,lib/_impl.rb,__package.rb,main.rb
+
+module Lib
+  MyStaticField = 1
+
+  MyPrivateStaticField = 2
+end

--- a/test/testdata/packager/incremental_fast_path_exported/lib/_impl.rb
+++ b/test/testdata/packager/incremental_fast_path_exported/lib/_impl.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+module Lib
+  MyStaticField = 1
+
+  MyPrivateStaticField = 1
+end

--- a/test/testdata/packager/incremental_fast_path_exported/main.1.rbupdate
+++ b/test/testdata/packager/incremental_fast_path_exported/main.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: strict
-# spacer for exclude-from-file-update
+# exclude-from-file-update: true
 
 module Root
   class Main

--- a/test/testdata/packager/incremental_fast_path_exported/main.1.rbupdate
+++ b/test/testdata/packager/incremental_fast_path_exported/main.1.rbupdate
@@ -1,10 +1,12 @@
 # typed: strict
-# exclude-from-file-update: true
+# spacer for exclude-from-file-update
 
 module Root
   class Main
-    p(Lib::MyStaticField)
+    T.reveal_type(Lib::MyStaticField) # error: `Integer`
 
-    p(Lib::MyPrivateStaticField) # error: resolves but is not exported
+    T.reveal_type(Lib::MyPrivateStaticField)
+    #             ^^^^^^^^^^^^^^^^^^^^^^^^^ error: resolves but is not exported
+  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Integer`
   end
 end

--- a/test/testdata/packager/incremental_fast_path_exported/main.2.rbupdate
+++ b/test/testdata/packager/incremental_fast_path_exported/main.2.rbupdate
@@ -1,0 +1,12 @@
+# typed: strict
+# spacer for exclude-from-file-update
+
+module Root
+  class Main
+    T.reveal_type(Lib::MyStaticField) # error: `T.untyped`
+    #             ^^^^^^^^^^^^^^^^^^ error: Unable to resolve
+    T.reveal_type(Lib::MyPrivateStaticField)
+    #             ^^^^^^^^^^^^^^^^^^^^^^^^^ error: resolves but is not exported
+  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Integer`
+  end
+end

--- a/test/testdata/packager/incremental_fast_path_exported/main.3.rbupdate
+++ b/test/testdata/packager/incremental_fast_path_exported/main.3.rbupdate
@@ -1,0 +1,12 @@
+# typed: strict
+# spacer for exclude-from-file-update
+
+module Root
+  class Main
+    T.reveal_type(Lib::MyStaticField) # error: `Integer`
+
+    T.reveal_type(Lib::MyPrivateStaticField)
+    #             ^^^^^^^^^^^^^^^^^^^^^^^^^ error: resolves but is not exported
+  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Integer`
+  end
+end

--- a/test/testdata/packager/incremental_fast_path_exported/main.rb
+++ b/test/testdata/packager/incremental_fast_path_exported/main.rb
@@ -1,0 +1,9 @@
+# typed: strict
+
+module Root
+  class Main
+    p(Lib::MyStaticField)
+
+    p(Lib::MyPrivateStaticField) # error: resolves but is not exported
+  end
+end

--- a/test/testdata/packager/incremental_fast_path_exported/main.rb
+++ b/test/testdata/packager/incremental_fast_path_exported/main.rb
@@ -3,8 +3,10 @@
 
 module Root
   class Main
-    p(Lib::MyStaticField)
+    T.reveal_type(Lib::MyStaticField) # error: `Integer`
 
-    p(Lib::MyPrivateStaticField) # error: resolves but is not exported
+    T.reveal_type(Lib::MyPrivateStaticField)
+    #             ^^^^^^^^^^^^^^^^^^^^^^^^^ error: resolves but is not exported
+  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Integer`
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I was thinking through some edge cases in moving export handling from
packager.cc to PropagateVisibility, when I realized that it might have an edge
case with the incremental namer. Then after thinking more, I thought that the
same bug might be present on master.

I wrote this test to prove that actually master does not have this problem.

The hypothetical problem:

1.  Incremental namer notices that a symbol needs to be deleted and redefined
2.  That deletion wipes away the symbol's `isExported` bit
3.  `PropagateVisibility` does not re-run over the `__package.rb` file, so the
    nothing re-establishes the `isExported` bit

I suspected this flow might be a problem because the source of truth for setting
exports is **not** the contents of the `packageDB` but rather the contents of
the `__package.rb`'s resolved tree—that is already true on master, it's not
something that I'm trying to establish on my work-in-progress branch.

It turns out that's not a problem, because we add the `__package.rb` file to the
fast path set of files to update, which means that the exported status ends up
getting set on the new symbols, too.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

test-only change