### PR TITLE
Use parameter instead of argument in error messages in more places

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -303,7 +303,7 @@ unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Lo
             if (auto e = gs.beginError(argLoc, what)) {
                 e.setHeader("Argument passed to parameter `{}` is `{}`", argSym.parameterName(gs), "T.untyped");
                 auto for_ =
-                    ErrorColors::format("argument `{}` of method `{}`", argSym.parameterName(gs), method.show(gs));
+                    ErrorColors::format("parameter `{}` of method `{}`", argSym.parameterName(gs), method.show(gs));
                 e.addErrorSection(TypeAndOrigins::explainExpected(gs, expectedType, argSym.loc, for_));
                 TypeErrorDiagnostics::explainUntyped(gs, e, what, argTpe, originForUninitialized);
                 return e.build();
@@ -317,9 +317,9 @@ unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Lo
             e.setHeader("Assigning a value to `{}` that does not match expected type `{}`", argSym.parameterName(gs),
                         expectedType.show(gs));
         } else {
-            e.setHeader("Expected `{}` but found `{}` for argument `{}`", expectedType.show(gs), argTpe.type.show(gs),
+            e.setHeader("Expected `{}` but found `{}` for parameter `{}`", expectedType.show(gs), argTpe.type.show(gs),
                         argSym.parameterName(gs));
-            auto for_ = ErrorColors::format("argument `{}` of method `{}`", argSym.parameterName(gs), method.show(gs));
+            auto for_ = ErrorColors::format("parameter `{}` of method `{}`", argSym.parameterName(gs), method.show(gs));
             e.addErrorSection(TypeAndOrigins::explainExpected(gs, expectedType, argSym.loc, for_));
         }
         e.addErrorSection(argTpe.explainGot(gs, originForUninitialized));
@@ -339,7 +339,7 @@ unique_ptr<Error> missingArg(const GlobalState &gs, Loc argsLoc, Loc receiverLoc
         if (expectedType == nullptr) {
             expectedType = Types::untyped(method);
         }
-        e.addErrorLine(arg.loc, "Keyword argument `{}` declared to expect type `{}` here:", argName,
+        e.addErrorLine(arg.loc, "Keyword parameter `{}` declared to expect type `{}` here:", argName,
                        expectedType.show(gs));
         return e.build();
     }
@@ -1247,7 +1247,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                         if (auto e = gs.beginError(kwSplatArgLoc, errors::Infer::MethodArgumentMismatch)) {
                             e.setHeader("Expected `{}` for keyword parameter `{}` but found `{}` from keyword splat",
                                         kwParamType.show(gs), kwParam->parameterName(gs), kwSplatValueType.show(gs));
-                            auto for_ = ErrorColors::format("argument `{}` of method `{}`", kwParam->parameterName(gs),
+                            auto for_ = ErrorColors::format("parameter `{}` of method `{}`", kwParam->parameterName(gs),
                                                             method.show(gs));
                             e.addErrorSection(TypeAndOrigins::explainExpected(gs, kwParamType, kwParam->loc, for_));
                             e.addErrorSection(kwSplatTPO.explainGot(gs, args.originForUninitialized));

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -865,14 +865,14 @@ private:
                     // Subtracting 1 because of the block arg we added everywhere.
                     // Eventually we should be more principled about how we report this.
                     e.setHeader(
-                        "Method alias `{}` redefined without matching argument count. Expected: `{}`, got: `{}`",
+                        "Method alias `{}` redefined without matching parameter count. Expected: `{}`, got: `{}`",
                         ctx.owner.show(ctx), symMethod.data(ctx)->parameters.size() - 1, parsedParams.size() - 1);
                     e.addErrorLine(ctx.owner.loc(ctx), "Previous alias definition");
                     e.addErrorLine(symMethod.data(ctx)->loc(), "Dealiased definition");
                 } else {
                     // Subtracting 1 because of the block arg we added everywhere.
                     // Eventually we should be more principled about how we report this.
-                    e.setHeader("Method `{}` redefined without matching argument count. Expected: `{}`, got: `{}`",
+                    e.setHeader("Method `{}` redefined without matching parameter count. Expected: `{}`, got: `{}`",
                                 symMethod.show(ctx), symMethod.data(ctx)->parameters.size() - 1,
                                 parsedParams.size() - 1);
                     e.addErrorLine(symMethod.data(ctx)->loc(), "Previous definition");
@@ -886,12 +886,12 @@ private:
 
             if (symParam.flags.isKeyword != methodParam.flags.isKeyword) {
                 if (auto e = ctx.state.beginError(loc, core::errors::Namer::RedefinitionOfMethod)) {
-                    e.setHeader("Method `{}` redefined with argument `{}` as a {} argument", sym.show(ctx),
+                    e.setHeader("Method `{}` redefined with parameter `{}` as a {} parameter", sym.show(ctx),
                                 methodParam.local.toString(ctx),
                                 methodParam.flags.isKeyword ? "keyword" : "non-keyword");
                     e.addErrorLine(
                         sym.loc(ctx),
-                        "The corresponding argument `{}` in the previous definition was {}a keyword argument",
+                        "The corresponding parameter `{}` in the previous definition was {}a keyword parameter",
                         symParam.show(ctx), symParam.flags.isKeyword ? "" : "not ");
                 }
                 return;
@@ -907,18 +907,19 @@ private:
             ENFORCE(symParam.flags.isBlock == methodParam.flags.isBlock);
             if (symParam.flags.isRepeated != methodParam.flags.isRepeated) {
                 if (auto e = ctx.state.beginError(loc, core::errors::Namer::RedefinitionOfMethod)) {
-                    e.setHeader("Method `{}` redefined with argument `{}` as a {} argument", sym.show(ctx),
+                    e.setHeader("Method `{}` redefined with parameter `{}` as a {} parameter", sym.show(ctx),
                                 methodParam.local.toString(ctx), methodParam.flags.isRepeated ? "splat" : "non-splat");
-                    e.addErrorLine(sym.loc(ctx),
-                                   "The corresponding argument `{}` in the previous definition was {}a splat argument",
-                                   symParam.show(ctx), symParam.flags.isRepeated ? "" : "not ");
+                    e.addErrorLine(
+                        sym.loc(ctx),
+                        "The corresponding parameter `{}` in the previous definition was {}a splat parameter",
+                        symParam.show(ctx), symParam.flags.isRepeated ? "" : "not ");
                 }
                 return;
             }
             if (symParam.flags.isKeyword && symParam.name != methodParam.local._name) {
                 if (auto e = ctx.state.beginError(loc, core::errors::Namer::RedefinitionOfMethod)) {
                     e.setHeader(
-                        "Method `{}` redefined with mismatched keyword argument name. Expected: `{}`, got: `{}`",
+                        "Method `{}` redefined with mismatched keyword parameter name. Expected: `{}`, got: `{}`",
                         sym.show(ctx), symParam.name.show(ctx), methodParam.local._name.show(ctx));
                     e.addErrorLine(sym.loc(ctx), "Previous definition");
                 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Consistency.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
