### PR TITLE
Partially revert ivar warning changes

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/abstract/data.rb
+++ b/gems/sorbet-runtime/lib/types/private/abstract/data.rb
@@ -12,7 +12,7 @@
 # modules that override the `hash` method with something completely broken.
 module T::Private::Abstract::Data
   def self.get(mod, key)
-    mod.instance_variable_get("@opus_abstract__#{key}") if key?(mod, key)
+    mod.instance_variable_get("@opus_abstract__#{key}")
   end
 
   def self.set(mod, key, value)

--- a/gems/sorbet-runtime/lib/types/private/sealed.rb
+++ b/gems/sorbet-runtime/lib/types/private/sealed.rb
@@ -70,7 +70,7 @@ module T::Private::Sealed
 
   def self.validate_inheritance(caller_loc, parent, child, verb)
     this_file = caller_loc&.path
-    decl_file = parent.instance_variable_get(:@sorbet_sealed_module_decl_file) if sealed_module?(parent)
+    decl_file = parent.instance_variable_get(:@sorbet_sealed_module_decl_file)
 
     if !this_file
       raise "Could not use backtrace to determine file for #{verb} child #{child}"

--- a/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
+++ b/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
@@ -37,7 +37,7 @@ module T::Props
 
     sig { returns(T::Boolean) }
     def self.lazy_evaluation_enabled?
-      !defined?(@lazy_evaluation_disabled) || !@lazy_evaluation_disabled
+      !@lazy_evaluation_disabled
     end
 
     module DecoratorMethods

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -121,8 +121,8 @@ module T::Props::Serializable
   private def with_existing_hash(changed_props, existing_hash:)
     serialized = existing_hash
     new_val = self.class.from_hash(serialized.merge(recursive_stringify_keys(changed_props)))
-    old_extra = self.instance_variable_get(:@_extra_props) if self.instance_variable_defined?(:@_extra_props)
-    new_extra = new_val.instance_variable_get(:@_extra_props) if new_val.instance_variable_defined?(:@_extra_props)
+    old_extra = self.instance_variable_get(:@_extra_props)
+    new_extra = new_val.instance_variable_get(:@_extra_props)
     if old_extra != new_extra
       difference =
         if old_extra
@@ -137,8 +137,7 @@ module T::Props::Serializable
 
   # Asserts if this property is missing during strict serialize
   private def required_prop_missing_from_serialize(prop)
-    if defined?(@_required_props_missing_from_deserialize) &&
-       @_required_props_missing_from_deserialize&.include?(prop)
+    if @_required_props_missing_from_deserialize&.include?(prop)
       # If the prop was already missing during deserialization, that means the application
       # code already had to deal with a nil value, which means we wouldn't be accomplishing
       # much by raising here (other than causing an unnecessary breakage).
@@ -353,11 +352,7 @@ module T::Props::Serializable::DecoratorMethods
   private_constant :EMPTY_EXTRA_PROPS
 
   def extra_props(instance)
-    if instance.instance_variable_defined?(:@_extra_props)
-      instance.instance_variable_get(:@_extra_props) || EMPTY_EXTRA_PROPS
-    else
-      EMPTY_EXTRA_PROPS
-    end
+    instance.instance_variable_get(:@_extra_props) || EMPTY_EXTRA_PROPS
   end
 
   # adds to the default result of T::Props::PrettyPrintable


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Partially reverts e0bea1895c14584d3b5b3c0855c79cc945980b94

See #6992 for the motivation, but the idea is that the instance variable
warnings were removed from Ruby as of 3.0

<https://github.com/ruby/ruby/commit/01b7d5acc702df22d306ae95f1a9c3096e63e624>

And sorbet-runtime no longer support <3.0: #9228


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests