### PR TITLE
Fix bug in Prism method assignment locations

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -552,7 +552,8 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
 
                 messageLoc = translateLoc(adjustedLoc);
             } else if (constantNameString == "[]") { // Subscript operator, like `foo[i]`
-                messageLoc.endLoc = messageLoc.beginLoc;
+                // Sorbet's parser treats the subscript operator as zero-length.
+                messageLoc = messageLoc.copyWithZeroLength();
             }
 
             pm_node_t *prismBlock = callNode->block;

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -536,17 +536,6 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
                 return make_node_with_expr<parser::Integer>(move(sendNode), location, move(valueString));
             }
 
-            pm_node_t *prismBlock = callNode->block;
-
-            NodeVec args;
-            // PM_BLOCK_ARGUMENT_NODE models the `&b` in `a.map(&b)`,
-            // but not an explicit block with `{ ... }` or `do ... end`
-            if (prismBlock != nullptr && PM_NODE_TYPE_P(prismBlock, PM_BLOCK_ARGUMENT_NODE)) {
-                args = translateArguments(callNode->arguments, callNode->block);
-            } else {
-                args = translateArguments(callNode->arguments);
-            }
-
             if (PM_NODE_FLAG_P(callNode, PM_CALL_NODE_FLAGS_ATTRIBUTE_WRITE)) { // like `self.foo = 1`
                 // The `callNode->name` will be `foo=`, but the `message_loc` will be just the `foo` part,
                 // so we need to scan ahead to find the correct spot to end (just after the `=`).
@@ -566,6 +555,17 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
                 messageLoc.endLoc += 2;               // The message should include the closing bracket and equals sign
             } else if (constantNameString == "[]") {  // Subscript operator, like `foo[i]`
                 messageLoc.endLoc = messageLoc.beginLoc;
+            }
+
+            pm_node_t *prismBlock = callNode->block;
+
+            NodeVec args;
+            // PM_BLOCK_ARGUMENT_NODE models the `&b` in `a.map(&b)`,
+            // but not an explicit block with `{ ... }` or `do ... end`
+            if (prismBlock != nullptr && PM_NODE_TYPE_P(prismBlock, PM_BLOCK_ARGUMENT_NODE)) {
+                args = translateArguments(callNode->arguments, callNode->block);
+            } else {
+                args = translateArguments(callNode->arguments);
             }
 
             unique_ptr<parser::Node> sendNode;

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -551,9 +551,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
                 adjustedLoc.end++; // Bump the end to point just past the `=`.
 
                 messageLoc = translateLoc(adjustedLoc);
-            } else if (constantNameString == "[]=") { // Subscript assignment operator, like `foo[i] = 1`
-                messageLoc.endLoc += 2;               // The message should include the closing bracket and equals sign
-            } else if (constantNameString == "[]") {  // Subscript operator, like `foo[i]`
+            } else if (constantNameString == "[]") { // Subscript operator, like `foo[i]`
                 messageLoc.endLoc = messageLoc.beginLoc;
             }
 

--- a/test/prism_regression/assign_to_method_result.parse-tree.exp
+++ b/test/prism_regression/assign_to_method_result.parse-tree.exp
@@ -237,5 +237,61 @@ Begin {
         ]
       }
     }
+    Send {
+      receiver = Send {
+        receiver = NULL
+        method = <U receiver>
+        args = [
+        ]
+      }
+      method = <U method1=>
+      args = [
+        String {
+          val = <U value1>
+        }
+      ]
+    }
+    Send {
+      receiver = Send {
+        receiver = NULL
+        method = <U receiver>
+        args = [
+        ]
+      }
+      method = <U method2=>
+      args = [
+        String {
+          val = <U value2>
+        }
+      ]
+    }
+    Send {
+      receiver = Send {
+        receiver = NULL
+        method = <U receiver>
+        args = [
+        ]
+      }
+      method = <U method3=>
+      args = [
+        String {
+          val = <U value3>
+        }
+      ]
+    }
+    Send {
+      receiver = Send {
+        receiver = NULL
+        method = <U receiver>
+        args = [
+        ]
+      }
+      method = <U method4=>
+      args = [
+        String {
+          val = <U value4>
+        }
+      ]
+    }
   ]
 }

--- a/test/prism_regression/assign_to_method_result.rb
+++ b/test/prism_regression/assign_to_method_result.rb
@@ -23,3 +23,9 @@ self.m ||= 14
 # Multi-target assignment
 self.target1, self.target2 = 15, 16
 self&.target1, self&.target2 = 17, 18 # Not valid Ruby, but the parser needs to support it for the diagnostics to work
+
+# Test different locations
+receiver.method1 = "value1"
+receiver.method2   ="value2"
+receiver.method3=   "value3"
+receiver.method4="value4"

--- a/test/prism_regression/assign_to_method_result.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/assign_to_method_result.rb.desugar-tree-raw.exp
@@ -892,5 +892,81 @@ ClassDef{
         name = <D <U <assignTemp>> $19>
       }
     }
+
+    Send{
+      flags = {}
+      recv = Send{
+        flags = {privateOk}
+        recv = Self
+        fun = <U receiver>
+        block = nullptr
+        pos_args = 0
+        args = [
+        ]
+      }
+      fun = <U method1=>
+      block = nullptr
+      pos_args = 1
+      args = [
+        Literal{ value = "value1" }
+      ]
+    }
+
+    Send{
+      flags = {}
+      recv = Send{
+        flags = {privateOk}
+        recv = Self
+        fun = <U receiver>
+        block = nullptr
+        pos_args = 0
+        args = [
+        ]
+      }
+      fun = <U method2=>
+      block = nullptr
+      pos_args = 1
+      args = [
+        Literal{ value = "value2" }
+      ]
+    }
+
+    Send{
+      flags = {}
+      recv = Send{
+        flags = {privateOk}
+        recv = Self
+        fun = <U receiver>
+        block = nullptr
+        pos_args = 0
+        args = [
+        ]
+      }
+      fun = <U method3=>
+      block = nullptr
+      pos_args = 1
+      args = [
+        Literal{ value = "value3" }
+      ]
+    }
+
+    Send{
+      flags = {}
+      recv = Send{
+        flags = {privateOk}
+        recv = Self
+        fun = <U receiver>
+        block = nullptr
+        pos_args = 0
+        args = [
+        ]
+      }
+      fun = <U method4=>
+      block = nullptr
+      pos_args = 1
+      args = [
+        Literal{ value = "value4" }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
### Motivation

There is a bug in the logic that computes the message location for an assignment. It always looked one character before the first arg, which is correct for single spaces:

```ruby
target.field = abc
#      |^^^^^^|
```

... but wrong if there's more spaces, like so:

```ruby
target.field =      abc
#      |^^^^^^^^^^^|
```

The best way I found to fix this is by scanning to find the `=`. Rather than starting at the arg and scanning left, I opted to start at the message's end and scan right. This should be more reliable, because the message name should never include a `=` that _isn't_ the assignment `=`.

Part of #9065

### Test plan

Covered by new test lines in `assign_to_method_result.rb`.