### PR TITLE
Improve output of `prism_location_test.sh`

### DIFF
--- a/test/prism_location_test.sh
+++ b/test/prism_location_test.sh
@@ -18,8 +18,8 @@ root_dir="$(rlocation com_stripe_ruby_typer)"
 test_file="test/$1"
 
 # Temporary files to hold parser outputs
-sorbet_output_sorbet=$(mktemp -t "parser_original")
-sorbet_output_prism=$(mktemp  -t "parser_prism   ")
+sorbet_output_sorbet=$(mktemp -t "parser_original.XXXXXXXXXX")
+sorbet_output_prism=$(mktemp  -t "parser_prism   .XXXXXXXXXX")
 
 (
   cd "$root_dir"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These failing tests were hard to interpret.

cc @amomchilov

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Before:

```
FAIL: //test:prism_regression/call_location_test (see /private/var/tmp/_bazel_jez/491a13d243378e23690a7f8390a5c09f/execroot/com_stripe_ruby_typer/bazel-out/darwin_arm64-dbg/testlogs/test/prism_regression/call_location_test/test.log)
INFO: From Testing //test:prism_regression/call_location_test:
==================== Test output for //test:prism_regression/call_location_test:
Test failed for prism_regression/call.rb
Differences:
--- /var/folders/gt/3hq5tw5d62bfpr903pnnsdh80000gn/T/tmp.viJ51BdZL1     2025-09-17 22:55:45
+++ /var/folders/gt/3hq5tw5d62bfpr903pnnsdh80000gn/T/tmp.KmiLchijES     2025-09-17 22:55:46
@@ -62,7 +62,7 @@
         ]
       },
       "method" : "[]=",
-      "methodLoc" : "/private/var/tmp/_bazel_jez/491a13d243378e23690a7f8390a5c09f/execroot/com_stripe_ruby_typer/bazel-out/darwin_arm64-dbg/bin/test/prism_regression/call_location_test.runfiles/com_stripe_ruby_typer/test/prism_regression/call.rb:7:4-7:4",
+      "methodLoc" : "/private/var/tmp/_bazel_jez/491a13d243378e23690a7f8390a5c09f/execroot/com_stripe_ruby_typer/bazel-out/darwin_arm64-dbg/bin/test/prism_regression/call_location_test.runfiles/com_stripe_ruby_typer/test/prism_regression/call.rb:7:4-7:12",
       "args" : [
         {
           "type" : "Symbol",
================================================================================
```

After:

```
FAIL: //test:prism_regression/call_location_test (see /private/var/tmp/_bazel_jez/491a13d243378e23690a7f8390a5c09f/execroot/com_stripe_ruby_typer/bazel-out/darwin_arm64-dbg/testlogs/test/prism_regression/call_location_test/test.log)
INFO: From Testing //test:prism_regression/call_location_test:
==================== Test output for //test:prism_regression/call_location_test:
Running sorbet --print=parse-tree-json-with-locs produced different results for test/prism_regression/call.rb

--- parser_original.ARKUe1hGwe  2025-09-17 23:10:28
+++ parser_prism   .oIlrnRjFQz  2025-09-17 23:10:28
@@ -62,7 +62,7 @@
         ]
       },
       "method" : "[]=",
-      "methodLoc" : "test/prism_regression/call.rb:7:4-7:4",
+      "methodLoc" : "test/prism_regression/call.rb:7:4-7:12",
       "args" : [
         {
           "type" : "Symbol",
external/bazel_tools/tools/test/test-setup.sh: line 353: 62796 Killed: 9               sleep 10
================================================================================
```