### PR TITLE
Move export handling to VisibilityChecker

### DIFF
--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -33,11 +33,6 @@ Import Import::prelude(MangledName mangledName, core::LocOffsets declLoc) {
     return res;
 }
 
-bool Export::lexCmp(const Export &a, const Export &b) {
-    return absl::c_lexicographical_compare(a.parts(), b.parts(),
-                                           [](auto a, auto b) -> bool { return a.rawId() < b.rawId(); });
-}
-
 PackageInfo &PackageInfo::from(core::GlobalState &gs, MangledName pkg) {
     ENFORCE(pkg.exists());
     return *gs.packageDB().getPackageInfoNonConst(pkg);

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -23,10 +23,6 @@ string_view strictDependenciesLevelToString(StrictDependenciesLevel level) {
     }
 }
 
-string FullyQualifiedName::show(const core::GlobalState &gs) const {
-    return absl::StrJoin(parts, "::", NameFormatter(gs));
-}
-
 Import Import::prelude(MangledName mangledName, core::LocOffsets declLoc) {
     Import res{mangledName, ImportType::Normal, declLoc};
     res.isPrelude_ = true;

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -308,12 +308,13 @@ optional<core::AutocorrectSuggestion> PackageInfo::addImport(const core::GlobalS
 
 optional<core::AutocorrectSuggestion> PackageInfo::addExport(const core::GlobalState &gs,
                                                              const core::SymbolRef newExport) const {
+    auto exportLine = fmt::format("export {}", newExport.show(gs));
     auto pkgFile = loc.file();
     auto insertionLoc = core::Loc::none(pkgFile);
     if (!exports_.empty()) {
         core::LocOffsets exportToInsertAfter;
         for (auto &e : exports_) {
-            if (newExport.show(gs) > e.fqn.show(gs)) {
+            if (exportLine > core::Loc(pkgFile, e.loc).source(gs)) {
                 exportToInsertAfter = e.loc;
             }
         }
@@ -344,10 +345,9 @@ optional<core::AutocorrectSuggestion> PackageInfo::addExport(const core::GlobalS
     }
     ENFORCE(insertionLoc.exists());
 
-    auto strName = newExport.show(gs);
     core::AutocorrectSuggestion suggestion(
-        fmt::format("Export `{}` in package `{}`", strName, mangledName_.owner.show(gs)),
-        {{insertionLoc, fmt::format("\n  export {}", strName)}});
+        fmt::format("Add `{}` in package `{}`", exportLine, mangledName_.owner.show(gs)),
+        {{insertionLoc, fmt::format("\n  {}", exportLine)}});
     return {suggestion};
 }
 

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -299,7 +299,8 @@ optional<core::AutocorrectSuggestion> PackageInfo::addImport(const core::GlobalS
 
 optional<core::AutocorrectSuggestion> PackageInfo::addExport(const core::GlobalState &gs,
                                                              const core::SymbolRef newExport) const {
-    auto exportLine = fmt::format("export {}", newExport.show(gs));
+    auto newExportName = newExport.show(gs);
+    auto exportLine = fmt::format("export {}", newExportName);
     auto pkgFile = loc.file();
     auto insertionLoc = core::Loc::none(pkgFile);
     if (!exports_.empty()) {
@@ -337,7 +338,7 @@ optional<core::AutocorrectSuggestion> PackageInfo::addExport(const core::GlobalS
     ENFORCE(insertionLoc.exists());
 
     core::AutocorrectSuggestion suggestion(
-        fmt::format("Add `{}` in package `{}`", exportLine, mangledName_.owner.show(gs)),
+        fmt::format("Export `{}` in package `{}`", newExportName, mangledName_.owner.show(gs)),
         {{insertionLoc, fmt::format("\n  {}", exportLine)}});
     return {suggestion};
 }

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -43,21 +43,6 @@ enum class StrictDependenciesLevel {
 
 std::string_view strictDependenciesLevelToString(StrictDependenciesLevel level);
 
-struct FullyQualifiedName {
-    std::vector<core::NameRef> parts;
-
-    FullyQualifiedName() = default;
-    FullyQualifiedName(std::vector<core::NameRef> parts) : parts(parts) {}
-    explicit FullyQualifiedName(const FullyQualifiedName &) = default;
-    FullyQualifiedName(FullyQualifiedName &&) = default;
-    FullyQualifiedName &operator=(const FullyQualifiedName &) = delete;
-    FullyQualifiedName &operator=(FullyQualifiedName &&) = default;
-
-    std::string show(const core::GlobalState &gs) const;
-};
-
-class PackageInfo;
-
 struct Import {
     MangledName mangledName;
     ImportType type;

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -90,17 +90,9 @@ struct Import {
 };
 
 struct Export {
-    FullyQualifiedName fqn;
     core::LocOffsets loc;
 
-    explicit Export(FullyQualifiedName &&fqn, core::LocOffsets loc) : fqn(std::move(fqn)), loc(loc) {}
-
-    const std::vector<core::NameRef> &parts() const {
-        return fqn.parts;
-    }
-
-    // Lex sort by name.
-    static bool lexCmp(const Export &a, const Export &b);
+    explicit Export(core::LocOffsets loc) : loc(loc) {}
 };
 
 struct VisibleTo {

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -30,7 +30,7 @@ static core::SymbolRef getEnumClassForEnumValue(const core::GlobalState &gs, cor
 class PropagateVisibility final {
     const core::packages::PackageInfo &package;
 
-    void recursiveExportSymbol(core::GlobalState &gs, core::ClassOrModuleRef klass) {
+    void recursiveSetIsExported(core::GlobalState &gs, core::ClassOrModuleRef klass) {
         // Stop recursing at package boundary
         if (this->package.mangledName() != klass.data(gs)->package) {
             return;
@@ -44,7 +44,7 @@ class PropagateVisibility final {
                 continue;
             }
             if (child.isClassOrModule()) {
-                recursiveExportSymbol(gs, child.asClassOrModuleRef());
+                recursiveSetIsExported(gs, child.asClassOrModuleRef());
             } else if (child.isFieldOrStaticField()) {
                 child.asFieldRef().data(gs)->flags.isExported = true;
             }
@@ -146,7 +146,7 @@ public:
         if (litSymbol.isClassOrModule()) {
             auto sym = litSymbol.asClassOrModuleRef();
             checkExportPackage(ctx, send.loc, litSymbol);
-            recursiveExportSymbol(ctx, sym);
+            recursiveSetIsExported(ctx, sym);
 
             // When exporting a symbol, we also export its parent namespace. This is a bit of a hack, and it would be
             // great to remove this, but this was the behavior of the previous packager implementation.

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -30,7 +30,7 @@ static core::SymbolRef getEnumClassForEnumValue(const core::GlobalState &gs, cor
 class PropagateVisibility final {
     const core::packages::PackageInfo &package;
 
-    void recursiveExportSymbol(core::GlobalState &gs, bool firstSymbol, core::ClassOrModuleRef klass) {
+    void recursiveExportSymbol(core::GlobalState &gs, core::ClassOrModuleRef klass) {
         // Stop recursing at package boundary
         if (this->package.mangledName() != klass.data(gs)->package) {
             return;
@@ -44,7 +44,7 @@ class PropagateVisibility final {
                 continue;
             }
             if (child.isClassOrModule()) {
-                recursiveExportSymbol(gs, false, child.asClassOrModuleRef());
+                recursiveExportSymbol(gs, child.asClassOrModuleRef());
             } else if (child.isFieldOrStaticField()) {
                 child.asFieldRef().data(gs)->flags.isExported = true;
             }
@@ -146,7 +146,7 @@ public:
         if (litSymbol.isClassOrModule()) {
             auto sym = litSymbol.asClassOrModuleRef();
             checkExportPackage(ctx, send.loc, litSymbol);
-            recursiveExportSymbol(ctx, true, sym);
+            recursiveExportSymbol(ctx, sym);
 
             // When exporting a symbol, we also export its parent namespace. This is a bit of a hack, and it would be
             // great to remove this, but this was the behavior of the previous packager implementation.

--- a/test/cli/package-export-conflicts/test.out
+++ b/test/cli/package-export-conflicts/test.out
@@ -1,12 +1,12 @@
-__package.rb:6: Cannot export `MyPackage::A::C` because another exported name `MyPackage::A` is a prefix of it https://srb.help/3716
-     6 |  export MyPackage::A::C
+__package.rb:5: Cannot export `MyPackage::A::B` because another exported name `MyPackage::A` is a prefix of it https://srb.help/3716
+     5 |  export MyPackage::A::B
           ^^^^^^^^^^^^^^^^^^^^^^
     __package.rb:7: Prefix exported here
      7 |  export MyPackage::A
           ^^^^^^^^^^^^^^^^^^^
 
-__package.rb:5: Cannot export `MyPackage::A::B` because another exported name `MyPackage::A` is a prefix of it https://srb.help/3716
-     5 |  export MyPackage::A::B
+__package.rb:6: Cannot export `MyPackage::A::C` because another exported name `MyPackage::A` is a prefix of it https://srb.help/3716
+     6 |  export MyPackage::A::C
           ^^^^^^^^^^^^^^^^^^^^^^
     __package.rb:7: Prefix exported here
      7 |  export MyPackage::A


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Moving exports to VisibilityChecker

- Means that we don't need to create `FullyQualifiedName` objects to store the exports
- Sets us up to be able to take the fast path for changes to the list of exports, because VisibilityChecker already runs over files on the fast path.

This is the ~final step before we can enter package symbols in namer.


### Commit summary

The first ~6 commits are no-op commits that rename or reorganize things.

The next two are prework changes that are pretty mechanical that I thought might be nicer to have in their own commits, but it's kind of hard to understand their meaning except by looking forward to the last commit.

The second last commit is the real meat of the change.

- **no-op: Remove unused `firstSymbol` parameter** (3e033146de)


- **no-op: recursiveExportSymbol -> recursiveSetIsExported** (77e8363af0)


- **no-op: Accept `isExported` bool in `recursiveSetIsExported`** (fe7c1ebe2e)

  This way, we can use this function for recursively setting or unsetting 
  the `isExported` flag on a symbol.

- **no-op: Isolate base case and recursive case** (ef0abf36e9)

  Better ignoring whitespace.

  The old version of `recursiveSetIsExported` unfolded the recursive case 
  one level. That was ~fine before, when logic that needs to be done at 
  each level is trivial (e.g., `flags.isExported = true`).

  But I plan to add more logic here, and I didn't want to have to 
  duplicate it in both the base and recursive cases.

- **no-op: Only one switch statement over symbol kind** (58a9b82f5b)

  Looks better ignoring whitespace

- **no-op: gs-> ctx** (54ab6076bd)


- **prework: Add unsetAllExportedInPackage** (fdba108171)

  By moving from packager.cc to VisibilityChecker.cc, duplicate export 
  checking will now run on the fast path.

  The new algorithm, instead of being powered by sorting a deduplicating
  `FullyQualifiedName` objects for the exports, is going to be based on 
  whether a symbol is **already** exported by the time an `export` line 
  marks it as exported.

  That means that we have to start from a starting point where nothing in 
  the package is exported, so here's a helper that does that.

- **prework: Thread some variables through** (91586e8f88)


- **prework: Stop using FullyQualifiedName in addExport** (37310801f2)


- **Move export handling to VisibilityChecker** (b9296c6369)


- **Remove FullyQualifiedName** (ed0c428fe9)









### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.

None of the existing tests change, except one test which has a more pleasing order that errors are reported.