### PR TITLE
Add `RequiresAncestorKernel` rewriter

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -975,6 +975,10 @@ void validateUselessRequiredAncestors(core::Context ctx, const core::ClassOrModu
     auto data = sym.data(ctx);
 
     for (auto req : data->requiredAncestors(ctx)) {
+        // Skip complaining for BasicObject: everything already derives from it by construction.
+        if (req.symbol == core::Symbols::BasicObject()) {
+            continue;
+        }
         if (data->derivesFrom(ctx, req.symbol)) {
             if (auto e = ctx.state.beginError(req.loc, core::errors::Resolver::UselessRequiredAncestor)) {
                 e.setHeader("`{}` is already {} by `{}`", req.symbol.show(ctx),

--- a/rewriter/RequiresAncestorKernel.cc
+++ b/rewriter/RequiresAncestorKernel.cc
@@ -1,0 +1,48 @@
+#include "rewriter/RequiresAncestorKernel.h"
+#include "ast/Helpers.h"
+#include "ast/ast.h"
+#include "core/Names.h"
+#include "core/core.h"
+
+using namespace std;
+
+namespace sorbet::rewriter {
+
+namespace {
+
+bool hasAnyRequiresAncestorCall(core::MutableContext ctx, ast::ClassDef *klass) {
+    return absl::c_any_of(klass->rhs, [](const auto &stat) {
+        auto send = ast::cast_tree<ast::Send>(stat);
+        return send && send->fun == core::Names::requiresAncestor() && send->recv.isSelfReference() &&
+               send->nonBlockArgs().empty() && send->hasBlock();
+    });
+}
+
+} // namespace
+
+void RequiresAncestorKernel::run(core::MutableContext ctx, ast::ClassDef *klass) {
+    if (klass->kind != ast::ClassDef::Kind::Module) {
+        return;
+    }
+
+    if (hasAnyRequiresAncestorCall(ctx, klass)) {
+        return;
+    }
+
+    auto loc = klass->loc;
+    auto locZero = loc.copyWithZeroLength();
+
+    // Add extend T::Helpers
+    klass->rhs.emplace_back(ast::MK::Send1(loc, ast::MK::Self(loc), core::Names::extend(), locZero,
+                                           ast::MK::Constant(loc, core::Symbols::T_Helpers())));
+
+    // Add requires_ancestor { Kernel }
+    auto kernelConstant = ast::MK::Constant(loc, core::Symbols::Kernel());
+    auto block = ast::MK::Block0(loc, std::move(kernelConstant));
+    auto requiresAncestorSend =
+        ast::MK::Send0Block(loc, ast::MK::Self(loc), core::Names::requiresAncestor(), loc, std::move(block));
+
+    klass->rhs.emplace_back(std::move(requiresAncestorSend));
+}
+
+} // namespace sorbet::rewriter

--- a/rewriter/RequiresAncestorKernel.h
+++ b/rewriter/RequiresAncestorKernel.h
@@ -1,0 +1,22 @@
+#ifndef SORBET_REWRITER_REQUIRES_ANCESTOR_KERNEL_H
+#define SORBET_REWRITER_REQUIRES_ANCESTOR_KERNEL_H
+#include "ast/ast.h"
+
+namespace sorbet::rewriter {
+
+/**
+ * This class adds `requires_ancestor { Kernel }` to Module definitions that:
+ * 1. Are Module definitions (not Class)
+ * 2. Have requires_ancestor feature enabled
+ * 3. Don't already have any `requires_ancestor` declarations
+ */
+class RequiresAncestorKernel final {
+public:
+    static void run(core::MutableContext ctx, ast::ClassDef *klass);
+
+    RequiresAncestorKernel() = delete;
+};
+
+} // namespace sorbet::rewriter
+
+#endif

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -25,6 +25,7 @@
 #include "rewriter/Private.h"
 #include "rewriter/Prop.h"
 #include "rewriter/Rails.h"
+#include "rewriter/RequiresAncestorKernel.h"
 #include "rewriter/Struct.h"
 #include "rewriter/TEnum.h"
 #include "rewriter/TestCase.h"
@@ -52,6 +53,10 @@ public:
         TypeMembers::run(ctx, classDef);
         Concern::run(ctx, classDef);
         TestCase::run(ctx, classDef);
+
+        if (ctx.state.cacheSensitiveOptions.requiresAncestorEnabled) {
+            RequiresAncestorKernel::run(ctx, classDef);
+        }
 
         PackageSpec::run(ctx, classDef);
 

--- a/test/testdata/lsp/requires_ancestor_ab.rb.symbol-table.exp
+++ b/test/testdata/lsp/requires_ancestor_ab.rb.symbol-table.exp
@@ -3,19 +3,27 @@ class ::<root> < ::Object ()
     method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/lsp/requires_ancestor_ab.rb:4
       argument <blk><block> @ Loc {file=test/testdata/lsp/requires_ancestor_ab.rb start=??? end=???}
   module ::A < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/lsp/requires_ancestor_ab.rb:4
+    method ::A#<required-ancestor-lin> (<arg>) -> [Kernel] @ test/testdata/lsp/requires_ancestor_ab.rb:4
+      argument <arg><> -> [A] @ Loc {file=??? start=??? end=???}
+    method ::A#<required-ancestor> (<arg>) -> [Kernel] @ test/testdata/lsp/requires_ancestor_ab.rb:4
+      argument <arg><> -> [A] @ Loc {file=??? start=??? end=???}
     method ::A#on_both_a_and_b (<blk>) -> Integer @ test/testdata/lsp/requires_ancestor_ab.rb:10
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/lsp/requires_ancestor_ab.rb start=??? end=???}
     method ::A#only_on_a (<blk>) @ test/testdata/lsp/requires_ancestor_ab.rb:7
       argument <blk><block> @ Loc {file=test/testdata/lsp/requires_ancestor_ab.rb start=??? end=???}
-  class ::<Class:A> < ::Module (Sig) @ test/testdata/lsp/requires_ancestor_ab.rb:4
+  class ::<Class:A> < ::Module (Helpers, Sig) @ test/testdata/lsp/requires_ancestor_ab.rb:4
     method ::<Class:A>#<static-init> (<blk>) @ test/testdata/lsp/requires_ancestor_ab.rb:4
       argument <blk><block> @ Loc {file=test/testdata/lsp/requires_ancestor_ab.rb start=??? end=???}
   module ::B < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/lsp/requires_ancestor_ab.rb:13
+    method ::B#<required-ancestor-lin> (<arg>) -> [Kernel] @ test/testdata/lsp/requires_ancestor_ab.rb:13
+      argument <arg><> -> [B] @ Loc {file=??? start=??? end=???}
+    method ::B#<required-ancestor> (<arg>) -> [Kernel] @ test/testdata/lsp/requires_ancestor_ab.rb:13
+      argument <arg><> -> [B] @ Loc {file=??? start=??? end=???}
     method ::B#on_both_a_and_b (<blk>) -> String @ test/testdata/lsp/requires_ancestor_ab.rb:19
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/lsp/requires_ancestor_ab.rb start=??? end=???}
     method ::B#only_on_b (<blk>) @ test/testdata/lsp/requires_ancestor_ab.rb:16
       argument <blk><block> @ Loc {file=test/testdata/lsp/requires_ancestor_ab.rb start=??? end=???}
-  class ::<Class:B> < ::Module (Sig) @ test/testdata/lsp/requires_ancestor_ab.rb:13
+  class ::<Class:B> < ::Module (Helpers, Sig) @ test/testdata/lsp/requires_ancestor_ab.rb:13
     method ::<Class:B>#<static-init> (<blk>) @ test/testdata/lsp/requires_ancestor_ab.rb:13
       argument <blk><block> @ Loc {file=test/testdata/lsp/requires_ancestor_ab.rb start=??? end=???}
   class ::C < ::Object (Target) @ test/testdata/lsp/requires_ancestor_ab.rb:35
@@ -26,8 +34,8 @@ class ::<root> < ::Object ()
     method ::<Class:C>#<static-init> (<blk>) @ test/testdata/lsp/requires_ancestor_ab.rb:35
       argument <blk><block> @ Loc {file=test/testdata/lsp/requires_ancestor_ab.rb start=??? end=???}
   module ::Target < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/lsp/requires_ancestor_ab.rb:22
-    method ::Target#<required-ancestor-lin> (<arg>) -> [A] @ test/testdata/lsp/requires_ancestor_ab.rb:25
-      argument <arg><> -> [Target] @ Loc {file=??? start=??? end=???}
+    method ::Target#<required-ancestor-lin> (<arg>) -> [A, Kernel] @ (test/testdata/lsp/requires_ancestor_ab.rb:25, test/testdata/lsp/requires_ancestor_ab.rb:4)
+      argument <arg><> -> [Target, A] @ Loc {file=??? start=??? end=???}
     method ::Target#<required-ancestor> (<arg>) -> [A] @ test/testdata/lsp/requires_ancestor_ab.rb:25
       argument <arg><> -> [Target] @ Loc {file=??? start=??? end=???}
     method ::Target#foo_b (<blk>) @ test/testdata/lsp/requires_ancestor_ab.rb:27

--- a/test/testdata/rewriter/requires_ancestor_kernel.rb
+++ b/test/testdata/rewriter/requires_ancestor_kernel.rb
@@ -1,0 +1,46 @@
+# typed: true
+# enable-experimental-requires-ancestor: true
+
+# Test case 1: Module without any requires_ancestor should get Kernel added
+module TestModule1
+  def some_method
+    puts "hello"
+  end
+end
+
+# Test case 2: Module with requires_ancestor { BasicObject } should NOT get Kernel added
+module TestModule2
+  extend T::Helpers
+  requires_ancestor { BasicObject }
+
+  def some_method
+    puts "hello" # error: Method `puts` does not exist on `TestModule2`
+  end
+end
+
+# Test case 3: Module with requires_ancestor { Kernel } should NOT get another Kernel added
+module TestModule3
+  extend T::Helpers
+  requires_ancestor { Kernel }
+
+  def some_method
+    puts "hello"
+  end
+end
+
+# Test case 4: Class should NOT get requires_ancestor { Kernel } added
+class TestClass1
+  def some_method
+    puts "hello"
+  end
+end
+
+# Test case 5: Module with other requires_ancestor should get Kernel added
+module TestModule4
+  extend T::Helpers
+  requires_ancestor { Object }
+
+  def some_method
+    puts "hello"
+  end
+end

--- a/test/testdata/rewriter/requires_ancestor_kernel.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/requires_ancestor_kernel.rb.rewrite-tree.exp
@@ -1,0 +1,65 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C TestModule1><<C <todo sym>>> < ()
+    def some_method<<todo method>>(&<blk>)
+      <self>.puts("hello")
+    end
+
+    <runtime method definition of some_method>
+
+    <self>.extend(::T::Helpers)
+
+    <self>.requires_ancestor() do ||
+      ::Kernel
+    end
+  end
+
+  module <emptyTree>::<C TestModule2><<C <todo sym>>> < ()
+    def some_method<<todo method>>(&<blk>)
+      <self>.puts("hello")
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Helpers>)
+
+    <self>.requires_ancestor() do ||
+      <emptyTree>::<C BasicObject>
+    end
+
+    <runtime method definition of some_method>
+  end
+
+  module <emptyTree>::<C TestModule3><<C <todo sym>>> < ()
+    def some_method<<todo method>>(&<blk>)
+      <self>.puts("hello")
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Helpers>)
+
+    <self>.requires_ancestor() do ||
+      <emptyTree>::<C Kernel>
+    end
+
+    <runtime method definition of some_method>
+  end
+
+  class <emptyTree>::<C TestClass1><<C <todo sym>>> < (::<todo sym>)
+    def some_method<<todo method>>(&<blk>)
+      <self>.puts("hello")
+    end
+
+    <runtime method definition of some_method>
+  end
+
+  module <emptyTree>::<C TestModule4><<C <todo sym>>> < ()
+    def some_method<<todo method>>(&<blk>)
+      <self>.puts("hello")
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Helpers>)
+
+    <self>.requires_ancestor() do ||
+      <emptyTree>::<C Object>
+    end
+
+    <runtime method definition of some_method>
+  end
+end


### PR DESCRIPTION
This PR adds a rewriter named `RequiresAncestorKernel` to add `requires_ancestor { Kernel }` to any module that is not specifically declaring that it `requires_ancestor { BasicObject }`. This is only done if the `--enable-experimental-requires-ancestor` flag is turned on, so that default behaviour is unchanged.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
By default Sorbet treats `Module`s as they could be mixed into any class, which includes classes that don't descend from `Kernel`, i.e. subclasses of `BasicObject`. While this is the correct way to treat modules in general, and is safe by default, this treatment makes it really difficult to work with modules in Ruby. In almost every case, the user intent is to mix a module into a class that descends from `Kernel`, and only seldomly is that expectation not true.

This PR makes that default expectation explicit when `requires_ancestor` feature is enabled. This is done by rewriting modules to include a `requires_ancestor { Kernel }` call, so that modules can refer to `Kernel` methods by default. If a module is meant for being mixed into a class that doesn't descend from `Kernel` the escape hatch is to mark it explicitly as `requires_ancestor { BasicObject }` in which case, this rewriter doesn't do anything.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
