### PR TITLE
Set LC_COLLATE in update_testdata_exp.sh

### DIFF
--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -102,7 +102,7 @@ fi
 rb_src=()
 while IFS='' read -r line; do
   rb_src+=("$line")
-done < <(find "${paths[@]}" -name '*.rb*' | sort)
+done < <(find "${paths[@]}" -name '*.rb*' | LC_COLLATE=C sort)
 
 basename=
 srcs=()


### PR DESCRIPTION
    ❯ ( echo 'foo.bar'; echo 'foo_bar' ) | sort
    foo_bar
    foo.bar

    ❯ ( echo 'foo.bar'; echo 'foo_bar' ) | LC_COLLATE=C sort
    foo.bar
    foo_bar

    ❯ echo "LC_COLLATE=$LC_COLLATE"
    LC_COLLATE=

    ❯ echo "LC_ALL=$LC_ALL"
    LC_ALL=

    ❯ echo "LANG=$LANG"
    LANG=en_US.UTF-8

From `sort(1)`:

    ENVIRONMENT
         LC_COLLATE  Locale settings to be used to determine the collation for
                     sorting records.

         ...

         LANG        Used as a last resort to determine different kinds of locale-
                     specific behavior if neither the respective environment
                     variable, nor LC_ALL are set.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

UTF-8 was a mistake, we should have stopped at ASCII.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Required for some changes that I'm working on.

Note that we are already doing the `C` thing because the `operator<` on
`std::string` does does `char`-wise comparisons, and we explicitly `fast_sort`
by file path in `pipeline_test_runner.cc`.