### PR TITLE
Rearrange `PM_CALL_NODE` logic

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -575,9 +575,6 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
 
             // Regular send, e.g. `a.b`
 
-            auto hasKwargsHash = callNode->arguments != nullptr &&
-                                 PM_NODE_FLAG_P(callNode->arguments, PM_ARGUMENTS_NODE_FLAGS_CONTAINS_KEYWORDS);
-
             // Detect special arguments that will require the call to be desugared to magic call.
 
             // true if the call contains a forwarded argument like `foo(...)`
@@ -603,6 +600,9 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
                     }
                 }
             }
+
+            auto hasKwargsHash = callNode->arguments != nullptr &&
+                                 PM_NODE_FLAG_P(callNode->arguments, PM_ARGUMENTS_NODE_FLAGS_CONTAINS_KEYWORDS);
 
             // Method defs are really complex, and we're building support for different kinds of arguments bit
             // by bit. This bool is true when this particular method call is supported by our desugar logic.

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -580,17 +580,22 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
             }
 
             pm_node_t *prismBlock = callNode->block;
-            if (prismBlock && PM_NODE_TYPE_P(prismBlock, PM_BLOCK_ARGUMENT_NODE)) {
-                // PM_BLOCK_ARGUMENT_NODE models the `&b` in `a.map(&b)`,
-                // but not a literal block with `{ ... }` or `do ... end`
-                args.emplace_back(translate(prismBlock));
-            }
 
             unique_ptr<parser::Node> sendNode;
 
             auto name = ctx.state.enterNameUTF8(constantNameString);
 
-            if (PM_NODE_FLAG_P(callNode, PM_CALL_NODE_FLAGS_SAFE_NAVIGATION)) { // Handle conditional send, e.g. `a&.b`
+            if (PM_NODE_FLAG_P(callNode, PM_CALL_NODE_FLAGS_SAFE_NAVIGATION)) {
+                // Handle conditional send, e.g. `a&.b`
+
+                if (prismBlock && PM_NODE_TYPE_P(prismBlock, PM_BLOCK_ARGUMENT_NODE)) {
+                    // PM_BLOCK_ARGUMENT_NODE models the `&b` in `a.map(&b)`,
+                    // but not a literal block with `{ ... }` or `do ... end`
+
+                    auto blockPassNode = translate(prismBlock);
+                    args.emplace_back(move(blockPassNode));
+                }
+
                 sendNode = make_unique<parser::CSend>(loc, move(receiver), name, messageLoc, move(args));
 
                 // TODO: Direct desugaring support for conditional sends is not implemented yet.
@@ -621,6 +626,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
             unique_ptr<parser::Node> blockParameters; // e.g. `|x|` in `foo { |x| 123 }`
             ast::MethodDef::PARAMS_store blockParamsStore;
             ast::InsSeq::STATS_store blockStatsStore;
+            unique_ptr<parser::Node> blockPassNode;
             bool supportedBlock;
             if (prismBlock != nullptr) {
                 if (PM_NODE_TYPE_P(prismBlock, PM_BLOCK_NODE)) {
@@ -714,6 +720,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
                     }
                 } else {
                     // `PM_BLOCK_ARGUMENT_NODE` is not supported yet.
+                    blockPassNode = translate(prismBlock);
                     supportedBlock = false;
                 }
             } else {
@@ -724,6 +731,13 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
             supportedCallType &= supportedBlock;
 
             if (!supportedCallType) {
+                if (prismBlock && PM_NODE_TYPE_P(prismBlock, PM_BLOCK_ARGUMENT_NODE)) {
+                    // PM_BLOCK_ARGUMENT_NODE models the `&b` in `a.map(&b)`,
+                    // but not a literal block with `{ ... }` or `do ... end`
+
+                    args.emplace_back(move(blockPassNode));
+                }
+
                 sendNode = make_unique<parser::Send>(loc, move(receiver), name, messageLoc, move(args));
 
                 if (prismBlock != nullptr && PM_NODE_TYPE_P(prismBlock, PM_BLOCK_NODE)) {

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -253,7 +253,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
     auto location = translateLoc(node->location);
 
     switch (PM_NODE_TYPE(node)) {
-        case PM_ALIAS_GLOBAL_VARIABLE_NODE: { // // The `alias` keyword used for global vars, like `alias $new $old`
+        case PM_ALIAS_GLOBAL_VARIABLE_NODE: { // The `alias` keyword used for global vars, like `alias $new $old`
             auto aliasGlobalVariableNode = down_cast<pm_alias_global_variable_node>(node);
 
             auto newName = translate(aliasGlobalVariableNode->new_name);
@@ -2516,10 +2516,10 @@ Translator::desugarParametersNode(NodeVec &params, bool attemptToDesugarParams) 
                // These other block types don't have their own dedicated desugared
                // representation, so they won't be directly translated.
                // Instead, they have special desugar logic below.
-               parser::NodeWithExpr::isa_node<parser::Kwnilarg>(param.get()) ||         // `f(**nil)`
-               parser::NodeWithExpr::isa_node<parser::ForwardArg>(param.get()) ||       // `f(...)`
-               parser::NodeWithExpr::isa_node<parser::ForwardedRestArg>(param.get()) || // a splat like `f(*)`
-               parser::NodeWithExpr::isa_node<parser::Splat>(param.get());              // a splat like `f(*a)`
+               parser::NodeWithExpr::isa_node<parser::Kwnilarg>(param.get()) ||         // `def f(**nil)`
+               parser::NodeWithExpr::isa_node<parser::ForwardArg>(param.get()) ||       // `def f(...)`
+               parser::NodeWithExpr::isa_node<parser::ForwardedRestArg>(param.get()) || // a splat like `def foo(*)`
+               parser::NodeWithExpr::isa_node<parser::Splat>(param.get());              // a splat like `def foo(*a)`
     });
 
     if (!supportedParams) {

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -536,6 +536,11 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
                 return make_node_with_expr<parser::Integer>(move(sendNode), location, move(valueString));
             }
 
+            if (constantNameString == "[]" || constantNameString == "[]=") {
+                // Empty funLoc implies that errors should use the callLoc
+                messageLoc.endLoc = messageLoc.beginLoc;
+            }
+
             pm_node_t *prismBlock = callNode->block;
 
             NodeVec args;
@@ -545,11 +550,6 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
                 args = translateArguments(callNode->arguments, callNode->block);
             } else {
                 args = translateArguments(callNode->arguments);
-            }
-
-            if (constantNameString == "[]" || constantNameString == "[]=") {
-                // Empty funLoc implies that errors should use the callLoc
-                messageLoc.endLoc = messageLoc.beginLoc;
             }
 
             unique_ptr<parser::Node> sendNode;

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -143,6 +143,8 @@ private:
                                                   std::unique_ptr<parser::Node> ifTrue,
                                                   std::unique_ptr<parser::Node> ifFalse);
 
+    std::pair<core::NameRef, core::LocOffsets> translateSymbol(pm_symbol_node *symbol);
+
     // String interpolation desugaring
     sorbet::ast::ExpressionPtr desugarDString(core::LocOffsets loc, pm_node_list prismNodeList);
 


### PR DESCRIPTION
### Motivation

I'm about to make some sweeping changes to the `PM_CALL_NODE` logic to add support for blocks (#9349) and kwargs. To simplify that already-insane diff, I pulled these house-keeping changes out on their own.

It's really straight forward if you review commit-by-commit.

Part of #9065 

### Test plan

Pure refactor, covered by existing tests.