### PR TITLE
Directly desugar `PM_ARRAY_NODE`

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -362,7 +362,74 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
 
             auto sorbetElements = translateMulti(arrayNode->elements);
 
-            return make_unique<parser::Array>(location, move(sorbetElements));
+            if (!directlyDesugar || !hasExpr(sorbetElements)) {
+                return make_unique<parser::Array>(location, move(sorbetElements));
+            }
+
+            auto locZeroLen = location.copyWithZeroLength();
+
+            ast::Array::ENTRY_store elems;
+            elems.reserve(sorbetElements.size());
+            ExpressionPtr lastMerge;
+            for (auto &stat : sorbetElements) {
+                if (parser::NodeWithExpr::isa_node<parser::Splat>(stat.get()) ||
+                    parser::NodeWithExpr::isa_node<parser::ForwardedRestArg>(stat.get())) {
+                    // Desugar [a, *x, remaining] into a.concat(<splat>(x)).concat(remaining)
+
+                    // The Splat was already desugared to Send{Magic.splat(arg)} with the splat's own location.
+                    // But for array literals, we want the splat to have the array's location to match
+                    // the legacy parser's behavior (important for error messages and hover).
+                    auto splatExpr = stat->takeDesugaredExpr();
+
+                    // The parser::Send case makes a fake parser::Array with locZeroLen to hide callWithSplat
+                    // methods from hover. Using the array's loc means that we will get a zero-length loc for
+                    // the Splat in that case, and non-zero if there was a real Array literal.
+                    if (auto send = ast::cast_tree<ast::Send>(splatExpr)) {
+                        ENFORCE(send->numPosArgs() == 1, "Splat Send should have exactly 1 argument");
+                        // Extract the argument from the old Send and create a new one with array's location
+                        splatExpr = MK::Splat(location, move(send->getPosArg(0)));
+                    }
+                    auto var = move(splatExpr);
+                    if (elems.empty()) {
+                        if (lastMerge != nullptr) {
+                            lastMerge =
+                                MK::Send1(location, move(lastMerge), core::Names::concat(), locZeroLen, move(var));
+                        } else {
+                            lastMerge = move(var);
+                        }
+                    } else {
+                        ExpressionPtr current = MK::Array(location, move(elems));
+                        /* reassign instead of clear to work around https://bugs.llvm.org/show_bug.cgi?id=37553 */
+                        elems = ast::Array::ENTRY_store();
+                        if (lastMerge != nullptr) {
+                            lastMerge =
+                                MK::Send1(location, move(lastMerge), core::Names::concat(), locZeroLen, move(current));
+                        } else {
+                            lastMerge = move(current);
+                        }
+                        lastMerge = MK::Send1(location, move(lastMerge), core::Names::concat(), locZeroLen, move(var));
+                    }
+                } else {
+                    elems.emplace_back(stat->takeDesugaredExpr());
+                }
+            };
+
+            ExpressionPtr res;
+            if (elems.empty()) {
+                if (lastMerge != nullptr) {
+                    res = move(lastMerge);
+                } else {
+                    // Empty array
+                    res = MK::Array(location, move(elems));
+                }
+            } else {
+                res = MK::Array(location, move(elems));
+                if (lastMerge != nullptr) {
+                    res = MK::Send1(location, move(lastMerge), core::Names::concat(), locZeroLen, move(res));
+                }
+            }
+
+            return make_node_with_expr<parser::Array>(move(res), location, move(sorbetElements));
         }
         case PM_ASSOC_NODE: { // A key-value pair in a Hash literal, e.g. the `a: 1` in `{ a: 1 }
             auto assocNode = down_cast<pm_assoc_node>(node);


### PR DESCRIPTION
Part of #9065 

Directly desugars `PM_ARRAY_NODE` in `Translator.cc`. 
There is special handling for splats, explained in comments, which are desugared in commit 0b79b57dd6c4f4022c747c96f3175150a2823252 of https://github.com/sorbet/sorbet/pull/9354. I will publish #9354 for review after this PR is merged. 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests