### PR TITLE
Rename "args" to "params" where appropriate (part 7)

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -121,7 +121,7 @@ public:
         return make_expression<ast::RestParam>(loc, std::move(inner));
     }
 
-    static ExpressionPtr BlockArg(core::LocOffsets loc, ExpressionPtr inner) {
+    static ExpressionPtr BlockParam(core::LocOffsets loc, ExpressionPtr inner) {
         return make_expression<ast::BlockParam>(loc, std::move(inner));
     }
 

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -122,7 +122,7 @@ public:
     }
 
     static ExpressionPtr BlockArg(core::LocOffsets loc, ExpressionPtr inner) {
-        return make_expression<ast::BlockArg>(loc, std::move(inner));
+        return make_expression<ast::BlockParam>(loc, std::move(inner));
     }
 
     static ExpressionPtr ShadowArg(core::LocOffsets loc, ExpressionPtr inner) {
@@ -247,9 +247,9 @@ public:
     static ExpressionPtr Method(core::LocOffsets loc, core::LocOffsets declLoc, core::NameRef name,
                                 MethodDef::PARAMS_store params, ExpressionPtr rhs,
                                 MethodDef::Flags flags = MethodDef::Flags()) {
-        if (params.empty() || (!isa_tree<ast::Local>(params.back()) && !isa_tree<ast::BlockArg>(params.back()))) {
+        if (params.empty() || (!isa_tree<ast::Local>(params.back()) && !isa_tree<ast::BlockParam>(params.back()))) {
             auto blkLoc = core::LocOffsets::none();
-            params.emplace_back(make_expression<ast::BlockArg>(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
+            params.emplace_back(make_expression<ast::BlockParam>(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
         }
         return make_expression<MethodDef>(loc, declLoc, core::Symbols::todoMethod(), name, std::move(params),
                                           std::move(rhs), flags);
@@ -629,7 +629,7 @@ public:
                 *cursor, [&](const class RestParam &rest) { cursor = &rest.expr; },
                 [&](const class KeywordArg &kw) { cursor = &kw.expr; },
                 [&](const class OptionalParam &opt) { cursor = &opt.expr; },
-                [&](const class BlockArg &blk) { cursor = &blk.expr; },
+                [&](const class BlockParam &blk) { cursor = &blk.expr; },
                 [&](const class ShadowArg &shadow) { cursor = &shadow.expr; },
                 // ENFORCES are last so that we don't pay the price of casting in the fast path.
                 [&](const ast::Local &opt) { ENFORCE(false, "Should only be called before local_vars.cc"); },
@@ -650,7 +650,7 @@ public:
                 *cursor, [&](const class RestParam &rest) { cursor = &rest.expr; },
                 [&](const class KeywordArg &kw) { cursor = &kw.expr; },
                 [&](const class OptionalParam &opt) { cursor = &opt.expr; },
-                [&](const class BlockArg &blk) { cursor = &blk.expr; },
+                [&](const class BlockParam &blk) { cursor = &blk.expr; },
                 [&](const class ShadowArg &shadow) { cursor = &shadow.expr; },
                 // ENFORCES are last so that we don't pay the price of casting in the fast path.
                 [&](const UnresolvedIdent &opt) { ENFORCE(false, "Namer should have created a Local for this arg."); },

--- a/ast/ParamParsing.cc
+++ b/ast/ParamParsing.cc
@@ -27,7 +27,7 @@ core::ParsedParam parseParam(const ast::ExpressionPtr &param) {
                 parsedParam.flags.isDefault = true;
                 cursor = &opt.expr;
             },
-            [&](const ast::BlockArg &blk) {
+            [&](const ast::BlockParam &blk) {
                 parsedParam.flags.isBlock = true;
                 cursor = &blk.expr;
             },
@@ -56,7 +56,7 @@ ExpressionPtr getDefaultValue(ExpressionPtr param) {
                 cursor = &opt.default_;
                 done = true;
             },
-            [&](ast::BlockArg &blk) { cursor = &blk.expr; }, [&](ast::ShadowArg &shadow) { cursor = &shadow.expr; },
+            [&](ast::BlockParam &blk) { cursor = &blk.expr; }, [&](ast::ShadowArg &shadow) { cursor = &shadow.expr; },
             [&](ast::Local &local) {
                 ENFORCE(false, "shouldn't reach a local variable for arg");
                 done = true;

--- a/ast/TreeCopying.cc
+++ b/ast/TreeCopying.cc
@@ -117,9 +117,9 @@ ExpressionPtr deepCopy(const void *avoid, const Tag tag, const void *tree, bool 
             return make_expression<OptionalParam>(exp->loc, deepCopy(avoid, exp->expr), deepCopy(avoid, exp->default_));
         }
 
-        case Tag::BlockArg: {
-            auto *exp = reinterpret_cast<const BlockArg *>(tree);
-            return make_expression<BlockArg>(exp->loc, deepCopy(avoid, exp->expr));
+        case Tag::BlockParam: {
+            auto *exp = reinterpret_cast<const BlockParam *>(tree);
+            return make_expression<BlockParam>(exp->loc, deepCopy(avoid, exp->expr));
         }
 
         case Tag::ShadowArg: {
@@ -239,7 +239,7 @@ COPY_IMPL(UnresolvedIdent);
 COPY_IMPL(RestParam);
 COPY_IMPL(KeywordArg);
 COPY_IMPL(OptionalParam);
-COPY_IMPL(BlockArg);
+COPY_IMPL(BlockParam);
 COPY_IMPL(ShadowArg);
 COPY_IMPL(Assign);
 COPY_IMPL(Cast);

--- a/ast/TreeEquality.cc
+++ b/ast/TreeEquality.cc
@@ -196,9 +196,9 @@ bool compareTrees(const core::GlobalState &gs, const void *avoid, const Tag tag,
                    Comparator::compareNodes(gs, avoid, a->default_, b->default_, file);
         }
 
-        case Tag::BlockArg: {
-            auto *a = reinterpret_cast<const BlockArg *>(tree);
-            auto *b = reinterpret_cast<const BlockArg *>(other);
+        case Tag::BlockParam: {
+            auto *a = reinterpret_cast<const BlockParam *>(tree);
+            auto *b = reinterpret_cast<const BlockParam *>(other);
             return Comparator::compareNodes(gs, avoid, a->expr, b->expr, file);
         }
 
@@ -476,7 +476,7 @@ EQUAL_IMPL(UnresolvedIdent);
 EQUAL_IMPL(RestParam);
 EQUAL_IMPL(KeywordArg);
 EQUAL_IMPL(OptionalParam);
-EQUAL_IMPL(BlockArg);
+EQUAL_IMPL(BlockParam);
 EQUAL_IMPL(ShadowArg);
 EQUAL_IMPL(Assign);
 EQUAL_IMPL(Cast);

--- a/ast/TreeSanityChecks.cc
+++ b/ast/TreeSanityChecks.cc
@@ -31,7 +31,7 @@ void ExpressionPtr::_sanityCheck() const {
         SANITY_CHECK(RestParam)
         SANITY_CHECK(KeywordArg)
         SANITY_CHECK(OptionalParam)
-        SANITY_CHECK(BlockArg)
+        SANITY_CHECK(BlockParam)
         SANITY_CHECK(ShadowArg)
         SANITY_CHECK(Assign)
         SANITY_CHECK(Cast)
@@ -67,7 +67,7 @@ void Block::_sanityCheck() {
     ENFORCE(body);
 }
 
-void BlockArg::_sanityCheck() {
+void BlockParam::_sanityCheck() {
     ENFORCE(expr);
     ENFORCE(!isa_tree<OptionalParam>(expr), "OptionalParams must be at the top-level of an arg.");
 }
@@ -157,7 +157,7 @@ void Local::_sanityCheck() {
 void MethodDef::_sanityCheck() {
     ENFORCE(name.exists());
     ENFORCE(!params.empty(), "Every method should have at least one param (the block param).\n");
-    ENFORCE(isa_tree<BlockArg>(params.back()) || isa_tree<Local>(params.back()),
+    ENFORCE(isa_tree<BlockParam>(params.back()) || isa_tree<Local>(params.back()),
             "Last param must be a block param (or a local, if block param has already been removed).");
     for (auto &node : params) {
         ENFORCE(node);

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -35,7 +35,7 @@ namespace sorbet::ast {
         CASE_STATEMENT(CASE_BODY, RestParam)               \
         CASE_STATEMENT(CASE_BODY, KeywordArg)              \
         CASE_STATEMENT(CASE_BODY, OptionalParam)           \
-        CASE_STATEMENT(CASE_BODY, BlockArg)                \
+        CASE_STATEMENT(CASE_BODY, BlockParam)              \
         CASE_STATEMENT(CASE_BODY, ShadowArg)               \
         CASE_STATEMENT(CASE_BODY, Assign)                  \
         CASE_STATEMENT(CASE_BODY, Cast)                    \
@@ -139,7 +139,7 @@ void ExpressionPtr::resetToEmpty(EmptyTree *expr) noexcept {
 
 bool isa_reference(const ExpressionPtr &what) {
     return isa_tree<Local>(what) || isa_tree<UnresolvedIdent>(what) || isa_tree<RestParam>(what) ||
-           isa_tree<KeywordArg>(what) || isa_tree<OptionalParam>(what) || isa_tree<BlockArg>(what) ||
+           isa_tree<KeywordArg>(what) || isa_tree<OptionalParam>(what) || isa_tree<BlockParam>(what) ||
            isa_tree<ShadowArg>(what) || isa_tree<Self>(what);
 }
 
@@ -300,7 +300,7 @@ ShadowArg::ShadowArg(core::LocOffsets loc, ExpressionPtr expr) : loc(loc), expr(
     _sanityCheck();
 }
 
-BlockArg::BlockArg(core::LocOffsets loc, ExpressionPtr expr) : loc(loc), expr(std::move(expr)) {
+BlockParam::BlockParam(core::LocOffsets loc, ExpressionPtr expr) : loc(loc), expr(std::move(expr)) {
     categoryCounterInc("trees", "blockarg");
     _sanityCheck();
 }
@@ -1305,7 +1305,7 @@ string ShadowArg::toStringWithTabs(const core::GlobalState &gs, int tabs) const 
     return this->expr.toStringWithTabs(gs, tabs);
 }
 
-string BlockArg::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
+string BlockParam::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     return "&" + this->expr.toStringWithTabs(gs, tabs);
 }
 
@@ -1480,7 +1480,7 @@ string ShadowArg::showRaw(const core::GlobalState &gs, int tabs) const {
     return fmt::format("{}{{ expr = {} }}", nodeName(), expr.showRaw(gs, tabs));
 }
 
-string BlockArg::showRaw(const core::GlobalState &gs, int tabs) const {
+string BlockParam::showRaw(const core::GlobalState &gs, int tabs) const {
     return fmt::format("{}{{ expr = {} }}", nodeName(), expr.showRaw(gs, tabs));
 }
 
@@ -1488,8 +1488,8 @@ string_view ShadowArg::nodeName() const {
     return "ShadowArg";
 }
 
-string_view BlockArg::nodeName() const {
-    return "BlockArg";
+string_view BlockParam::nodeName() const {
+    return "BlockParam";
 }
 
 string_view RuntimeMethodDefinition::nodeName() const {
@@ -1931,7 +1931,7 @@ string Cast::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, in
     return fmt::to_string(buf);
 }
 
-string BlockArg::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
+string BlockParam::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, int tabs) const {
     return fmt::format("{}{{ loc = {}, expr = {} }}", nodeName(), core::Loc(file, this->loc).fileShortPosToString(gs),
                        expr.showRawWithLocs(gs, file, tabs));
 }

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -53,7 +53,7 @@ enum class Tag {
     RestParam,
     KeywordArg,
     OptionalParam,
-    BlockArg,
+    BlockParam,
     ShadowArg,
     Assign,
     Cast,
@@ -761,13 +761,13 @@ public:
 };
 CheckSize(OptionalParam, 24, 8);
 
-EXPRESSION(BlockArg) {
+EXPRESSION(BlockParam) {
 public:
     const core::LocOffsets loc;
 
     ExpressionPtr expr;
 
-    BlockArg(core::LocOffsets loc, ExpressionPtr expr);
+    BlockParam(core::LocOffsets loc, ExpressionPtr expr);
 
     ExpressionPtr deepCopy() const;
     bool structurallyEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
@@ -780,7 +780,7 @@ public:
 
     void _sanityCheck();
 };
-CheckSize(BlockArg, 16, 8);
+CheckSize(BlockParam, 16, 8);
 
 EXPRESSION(ShadowArg) {
 public:

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -116,7 +116,7 @@ pair<MethodDef::PARAMS_store, InsSeq::STATS_store> desugarParams(DesugarContext 
                 params.emplace_back(MK::RestParam(fargs->loc, MK::KeywordArg(fargs->loc, core::Names::fwdKwargs())));
 
                 // add `&<fwd-block>`
-                params.emplace_back(MK::BlockArg(fargs->loc, MK::Local(fargs->loc, core::Names::fwdBlock())));
+                params.emplace_back(MK::BlockParam(fargs->loc, MK::Local(fargs->loc, core::Names::fwdBlock())));
             } else {
                 params.emplace_back(node2TreeImpl(dctx, arg));
             }
@@ -373,7 +373,7 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
 
     if (params.empty() || !isa_tree<BlockParam>(params.back())) {
         auto blkLoc = core::LocOffsets::none();
-        params.emplace_back(MK::BlockArg(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
+        params.emplace_back(MK::BlockParam(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
     }
 
     const auto &blockParam = cast_tree<BlockParam>(params.back());
@@ -1532,7 +1532,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = move(res);
             },
             [&](parser::BlockParam *param) {
-                ExpressionPtr res = MK::BlockArg(loc, MK::Local(loc, param->name));
+                ExpressionPtr res = MK::BlockParam(loc, MK::Local(loc, param->name));
                 result = move(res);
             },
             [&](parser::Kwoptarg *arg) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1529,8 +1529,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 ExpressionPtr res = MK::KeywordArg(loc, arg->name);
                 result = move(res);
             },
-            [&](parser::BlockParam *arg) {
-                ExpressionPtr res = MK::BlockArg(loc, MK::Local(loc, arg->name));
+            [&](parser::BlockParam *param) {
+                ExpressionPtr res = MK::BlockArg(loc, MK::Local(loc, param->name));
                 result = move(res);
             },
             [&](parser::Kwoptarg *arg) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -43,7 +43,7 @@ struct DesugarContext final {
     }
 };
 
-core::NameRef blockArg2Name(DesugarContext dctx, const BlockArg &blkArg) {
+core::NameRef blockArg2Name(DesugarContext dctx, const BlockParam &blkArg) {
     auto blkIdent = cast_tree<UnresolvedIdent>(blkArg.expr);
     ENFORCE(blkIdent != nullptr, "BlockArg must wrap UnresolvedIdent in desugar.");
     return blkIdent->name;
@@ -371,12 +371,12 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
                          inModule, dctx.preserveConcreteSyntax);
     auto [params, destructures] = desugarParams(dctx1, loc, argnode);
 
-    if (params.empty() || !isa_tree<BlockArg>(params.back())) {
+    if (params.empty() || !isa_tree<BlockParam>(params.back())) {
         auto blkLoc = core::LocOffsets::none();
         params.emplace_back(MK::BlockArg(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
     }
 
-    const auto &blkArg = cast_tree<BlockArg>(params.back());
+    const auto &blkArg = cast_tree<BlockParam>(params.back());
     ENFORCE(blkArg != nullptr, "Every method's last arg must be a block arg by now.");
     auto enclosingBlockParamName = blockArg2Name(dctx, *blkArg);
 

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -2016,10 +2016,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
 
                 ExpressionPtr recv;
                 if (dctx.enclosingBlockParamName.exists()) {
-                    // we always want to report an error if we're using yield with a synthesized name in
-                    // strict mode
-                    auto blockArgName = dctx.enclosingBlockParamName;
-                    if (blockArgName == core::Names::blkArg()) {
+                    // we always want to report an error if we're using yield with a synthesized name in strict mode
+                    if (dctx.enclosingBlockParamName == core::Names::blkArg()) {
                         if (auto e = dctx.ctx.beginIndexerError(dctx.enclosingMethodLoc,
                                                                 core::errors::Desugar::UnnamedBlockParameter)) {
                             e.setHeader("Method `{}` uses `{}` but does not mention a block parameter",

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -43,9 +43,9 @@ struct DesugarContext final {
     }
 };
 
-core::NameRef blockArg2Name(DesugarContext dctx, const BlockParam &blkArg) {
-    auto blkIdent = cast_tree<UnresolvedIdent>(blkArg.expr);
-    ENFORCE(blkIdent != nullptr, "BlockArg must wrap UnresolvedIdent in desugar.");
+core::NameRef blockParam2Name(DesugarContext dctx, const BlockParam &blockParam) {
+    auto blkIdent = cast_tree<UnresolvedIdent>(blockParam.expr);
+    ENFORCE(blkIdent != nullptr, "BlockParam must wrap UnresolvedIdent in desugar.");
     return blkIdent->name;
 }
 
@@ -376,9 +376,9 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
         params.emplace_back(MK::BlockArg(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
     }
 
-    const auto &blkArg = cast_tree<BlockParam>(params.back());
-    ENFORCE(blkArg != nullptr, "Every method's last arg must be a block arg by now.");
-    auto enclosingBlockParamName = blockArg2Name(dctx, *blkArg);
+    const auto &blockParam = cast_tree<BlockParam>(params.back());
+    ENFORCE(blockParam != nullptr, "Every method's last param must be a block param by now.");
+    auto enclosingBlockParamName = blockParam2Name(dctx, *blockParam);
 
     DesugarContext dctx2(dctx1.ctx, dctx1.uniqueCounter, enclosingBlockParamName, declLoc, name, dctx.inAnyBlock,
                          inModule, dctx.preserveConcreteSyntax);

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -24,17 +24,17 @@ namespace {
 struct DesugarContext final {
     core::MutableContext ctx;
     uint32_t &uniqueCounter;
-    core::NameRef enclosingBlockArg;
+    core::NameRef enclosingBlockParamName;
     core::LocOffsets enclosingMethodLoc;
     core::NameRef enclosingMethodName;
     bool inAnyBlock;
     bool inModule;
     bool preserveConcreteSyntax;
 
-    DesugarContext(core::MutableContext ctx, uint32_t &uniqueCounter, core::NameRef enclosingBlockArg,
+    DesugarContext(core::MutableContext ctx, uint32_t &uniqueCounter, core::NameRef enclosingBlockParamName,
                    core::LocOffsets enclosingMethodLoc, core::NameRef enclosingMethodName, bool inAnyBlock,
                    bool inModule, bool preserveConcreteSyntax)
-        : ctx(ctx), uniqueCounter(uniqueCounter), enclosingBlockArg(enclosingBlockArg),
+        : ctx(ctx), uniqueCounter(uniqueCounter), enclosingBlockParamName(enclosingBlockParamName),
           enclosingMethodLoc(enclosingMethodLoc), enclosingMethodName(enclosingMethodName), inAnyBlock(inAnyBlock),
           inModule(inModule), preserveConcreteSyntax(preserveConcreteSyntax){};
 
@@ -202,7 +202,7 @@ ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, core::LocO
     checkBlockRestParam(dctx, Params);
 
     auto inBlock = true;
-    DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,
+    DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockParamName, dctx.enclosingMethodLoc,
                          dctx.enclosingMethodName, inBlock, dctx.inModule, dctx.preserveConcreteSyntax);
     auto desugaredBody = desugarBody(dctx1, loc, blockBody, move(destructures));
 
@@ -367,8 +367,8 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
     // Reset uniqueCounter within this scope (to keep numbers small)
     uint32_t uniqueCounter = 1;
     auto inModule = dctx.inModule && !isSelf;
-    DesugarContext dctx1(dctx.ctx, uniqueCounter, dctx.enclosingBlockArg, declLoc, name, dctx.inAnyBlock, inModule,
-                         dctx.preserveConcreteSyntax);
+    DesugarContext dctx1(dctx.ctx, uniqueCounter, dctx.enclosingBlockParamName, declLoc, name, dctx.inAnyBlock,
+                         inModule, dctx.preserveConcreteSyntax);
     auto [params, destructures] = desugarParams(dctx1, loc, argnode);
 
     if (params.empty() || !isa_tree<BlockArg>(params.back())) {
@@ -378,10 +378,10 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
 
     const auto &blkArg = cast_tree<BlockArg>(params.back());
     ENFORCE(blkArg != nullptr, "Every method's last arg must be a block arg by now.");
-    auto enclosingBlockArg = blockArg2Name(dctx, *blkArg);
+    auto enclosingBlockParamName = blockArg2Name(dctx, *blkArg);
 
-    DesugarContext dctx2(dctx1.ctx, dctx1.uniqueCounter, enclosingBlockArg, declLoc, name, dctx.inAnyBlock, inModule,
-                         dctx.preserveConcreteSyntax);
+    DesugarContext dctx2(dctx1.ctx, dctx1.uniqueCounter, enclosingBlockParamName, declLoc, name, dctx.inAnyBlock,
+                         inModule, dctx.preserveConcreteSyntax);
     ExpressionPtr desugaredBody = desugarBody(dctx2, loc, body, move(destructures));
     desugaredBody = validateRBIBody(dctx2, move(desugaredBody));
 
@@ -569,7 +569,7 @@ ClassDef::RHS_store scopeNodeToBody(DesugarContext dctx, unique_ptr<parser::Node
     uint32_t uniqueCounter = 1;
     // Blocks never persist across a class/module boundary
     auto inAnyBlock = false;
-    DesugarContext dctx1(dctx.ctx, uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,
+    DesugarContext dctx1(dctx.ctx, uniqueCounter, dctx.enclosingBlockParamName, dctx.enclosingMethodLoc,
                          dctx.enclosingMethodName, inAnyBlock, dctx.inModule, dctx.preserveConcreteSyntax);
     if (auto *begin = parser::cast_node<parser::Begin>(node.get())) {
         body.reserve(begin->stmts.size());
@@ -935,8 +935,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         }
                     }
 
-                    if (send->method == core::Names::blockGiven_p() && dctx.enclosingBlockArg.exists()) {
-                        auto if_ = MK::If(loc, MK::Local(loc, dctx.enclosingBlockArg), move(res), MK::False(loc));
+                    if (send->method == core::Names::blockGiven_p() && dctx.enclosingBlockParamName.exists()) {
+                        auto if_ = MK::If(loc, MK::Local(loc, dctx.enclosingBlockParamName), move(res), MK::False(loc));
                         result = move(if_);
                     } else {
                         result = move(res);
@@ -1492,16 +1492,18 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
             },
             [&](parser::Kwbegin *kwbegin) { result = desugarBegin(dctx, loc, kwbegin->stmts); },
             [&](parser::Module *module) {
-                DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,
-                                     dctx.enclosingMethodName, dctx.inAnyBlock, true, dctx.preserveConcreteSyntax);
+                DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockParamName,
+                                     dctx.enclosingMethodLoc, dctx.enclosingMethodName, dctx.inAnyBlock, true,
+                                     dctx.preserveConcreteSyntax);
                 ClassDef::RHS_store body = scopeNodeToBody(dctx1, move(module->body));
                 ExpressionPtr res =
                     MK::Module(module->loc, module->declLoc, node2TreeImpl(dctx, module->name), move(body));
                 result = move(res);
             },
             [&](parser::Class *klass) {
-                DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,
-                                     dctx.enclosingMethodName, dctx.inAnyBlock, false, dctx.preserveConcreteSyntax);
+                DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockParamName,
+                                     dctx.enclosingMethodLoc, dctx.enclosingMethodName, dctx.inAnyBlock, false,
+                                     dctx.preserveConcreteSyntax);
                 ClassDef::RHS_store body = scopeNodeToBody(dctx1, move(klass->body));
                 ClassDef::ANCESTORS_store ancestors;
                 if (klass->superclass == nullptr) {
@@ -1584,8 +1586,9 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     return;
                 }
 
-                DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,
-                                     dctx.enclosingMethodName, dctx.inAnyBlock, false, dctx.preserveConcreteSyntax);
+                DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockParamName,
+                                     dctx.enclosingMethodLoc, dctx.enclosingMethodName, dctx.inAnyBlock, false,
+                                     dctx.preserveConcreteSyntax);
                 ClassDef::RHS_store body = scopeNodeToBody(dctx1, move(sclass->body));
                 ClassDef::ANCESTORS_store emptyAncestors;
                 ExpressionPtr res =
@@ -2012,10 +2015,10 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 };
 
                 ExpressionPtr recv;
-                if (dctx.enclosingBlockArg.exists()) {
+                if (dctx.enclosingBlockParamName.exists()) {
                     // we always want to report an error if we're using yield with a synthesized name in
                     // strict mode
-                    auto blockArgName = dctx.enclosingBlockArg;
+                    auto blockArgName = dctx.enclosingBlockParamName;
                     if (blockArgName == core::Names::blkArg()) {
                         if (auto e = dctx.ctx.beginIndexerError(dctx.enclosingMethodLoc,
                                                                 core::errors::Desugar::UnnamedBlockParameter)) {
@@ -2025,7 +2028,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         }
                     }
 
-                    recv = MK::Local(loc, dctx.enclosingBlockArg);
+                    recv = MK::Local(loc, dctx.enclosingBlockParamName);
                 } else {
                     // No enclosing block arg can happen when e.g. yield is called in a class / at the top-level.
                     recv = MK::RaiseUnimplemented(loc);

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1529,7 +1529,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 ExpressionPtr res = MK::KeywordArg(loc, arg->name);
                 result = move(res);
             },
-            [&](parser::Blockarg *arg) {
+            [&](parser::BlockParam *arg) {
                 ExpressionPtr res = MK::BlockArg(loc, MK::Local(loc, arg->name));
                 result = move(res);
             },

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -31,17 +31,17 @@ namespace {
 struct DesugarContext final {
     core::MutableContext ctx;
     uint32_t &uniqueCounter;
-    core::NameRef enclosingBlockArg;
+    core::NameRef enclosingBlockParamName;
     core::LocOffsets enclosingMethodLoc;
     core::NameRef enclosingMethodName;
     bool inAnyBlock;
     bool inModule;
     bool preserveConcreteSyntax;
 
-    DesugarContext(core::MutableContext ctx, uint32_t &uniqueCounter, core::NameRef enclosingBlockArg,
+    DesugarContext(core::MutableContext ctx, uint32_t &uniqueCounter, core::NameRef enclosingBlockParamName,
                    core::LocOffsets enclosingMethodLoc, core::NameRef enclosingMethodName, bool inAnyBlock,
                    bool inModule, bool preserveConcreteSyntax)
-        : ctx(ctx), uniqueCounter(uniqueCounter), enclosingBlockArg(enclosingBlockArg),
+        : ctx(ctx), uniqueCounter(uniqueCounter), enclosingBlockParamName(enclosingBlockParamName),
           enclosingMethodLoc(enclosingMethodLoc), enclosingMethodName(enclosingMethodName), inAnyBlock(inAnyBlock),
           inModule(inModule), preserveConcreteSyntax(preserveConcreteSyntax){};
 
@@ -169,7 +169,7 @@ ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, core::LocO
     checkBlockRestParam(dctx, params);
 
     auto inBlock = true;
-    DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,
+    DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockParamName, dctx.enclosingMethodLoc,
                          dctx.enclosingMethodName, inBlock, dctx.inModule, dctx.preserveConcreteSyntax);
     auto desugaredBody = desugarBody(dctx1, loc, blockBody, move(destructures));
 
@@ -334,8 +334,8 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
     // Reset uniqueCounter within this scope (to keep numbers small)
     uint32_t uniqueCounter = 1;
     auto inModule = dctx.inModule && !isSelf;
-    DesugarContext dctx1(dctx.ctx, uniqueCounter, dctx.enclosingBlockArg, declLoc, name, dctx.inAnyBlock, inModule,
-                         dctx.preserveConcreteSyntax);
+    DesugarContext dctx1(dctx.ctx, uniqueCounter, dctx.enclosingBlockParamName, declLoc, name, dctx.inAnyBlock,
+                         inModule, dctx.preserveConcreteSyntax);
     auto [params, destructures] = desugarParams(dctx1, loc, argnode);
 
     if (params.empty() || !isa_tree<BlockArg>(params.back())) {
@@ -345,10 +345,10 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
 
     const auto &blkArg = cast_tree<BlockArg>(params.back());
     ENFORCE(blkArg != nullptr, "Every method's last arg must be a block arg by now.");
-    auto enclosingBlockArg = blockArg2Name(dctx, *blkArg);
+    auto enclosingBlockParamName = blockArg2Name(dctx, *blkArg);
 
-    DesugarContext dctx2(dctx1.ctx, dctx1.uniqueCounter, enclosingBlockArg, declLoc, name, dctx.inAnyBlock, inModule,
-                         dctx.preserveConcreteSyntax);
+    DesugarContext dctx2(dctx1.ctx, dctx1.uniqueCounter, enclosingBlockParamName, declLoc, name, dctx.inAnyBlock,
+                         inModule, dctx.preserveConcreteSyntax);
     ExpressionPtr desugaredBody = desugarBody(dctx2, loc, body, move(destructures));
     desugaredBody = validateRBIBody(dctx2, move(desugaredBody));
 
@@ -521,7 +521,7 @@ ClassDef::RHS_store scopeNodeToBody(DesugarContext dctx, unique_ptr<parser::Node
     uint32_t uniqueCounter = 1;
     // Blocks never persist across a class/module boundary
     auto inAnyBlock = false;
-    DesugarContext dctx1(dctx.ctx, uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,
+    DesugarContext dctx1(dctx.ctx, uniqueCounter, dctx.enclosingBlockParamName, dctx.enclosingMethodLoc,
                          dctx.enclosingMethodName, inAnyBlock, dctx.inModule, dctx.preserveConcreteSyntax);
     if (auto *begin = parser::NodeWithExpr::cast_node<parser::Begin>(node.get())) {
         body.reserve(begin->stmts.size());
@@ -891,8 +891,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         }
                     }
 
-                    if (send->method == core::Names::blockGiven_p() && dctx.enclosingBlockArg.exists()) {
-                        auto if_ = MK::If(loc, MK::Local(loc, dctx.enclosingBlockArg), move(res), MK::False(loc));
+                    if (send->method == core::Names::blockGiven_p() && dctx.enclosingBlockParamName.exists()) {
+                        auto if_ = MK::If(loc, MK::Local(loc, dctx.enclosingBlockParamName), move(res), MK::False(loc));
                         result = move(if_);
                     } else {
                         result = move(res);
@@ -1440,16 +1440,18 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
             [&](parser::Cbase *cbase) { desugaredByPrismTranslator(cbase); },
             [&](parser::Kwbegin *kwbegin) { result = desugarBegin(dctx, loc, kwbegin->stmts); },
             [&](parser::Module *module) {
-                DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,
-                                     dctx.enclosingMethodName, dctx.inAnyBlock, true, dctx.preserveConcreteSyntax);
+                DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockParamName,
+                                     dctx.enclosingMethodLoc, dctx.enclosingMethodName, dctx.inAnyBlock, true,
+                                     dctx.preserveConcreteSyntax);
                 ClassDef::RHS_store body = scopeNodeToBody(dctx1, move(module->body));
                 ExpressionPtr res =
                     MK::Module(module->loc, module->declLoc, node2TreeImpl(dctx, module->name), move(body));
                 result = move(res);
             },
             [&](parser::Class *klass) {
-                DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,
-                                     dctx.enclosingMethodName, dctx.inAnyBlock, false, dctx.preserveConcreteSyntax);
+                DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockParamName,
+                                     dctx.enclosingMethodLoc, dctx.enclosingMethodName, dctx.inAnyBlock, false,
+                                     dctx.preserveConcreteSyntax);
                 ClassDef::RHS_store body = scopeNodeToBody(dctx1, move(klass->body));
                 ClassDef::ANCESTORS_store ancestors;
                 if (klass->superclass == nullptr) {
@@ -1523,8 +1525,9 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     return;
                 }
 
-                DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockArg, dctx.enclosingMethodLoc,
-                                     dctx.enclosingMethodName, dctx.inAnyBlock, false, dctx.preserveConcreteSyntax);
+                DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockParamName,
+                                     dctx.enclosingMethodLoc, dctx.enclosingMethodName, dctx.inAnyBlock, false,
+                                     dctx.preserveConcreteSyntax);
                 ClassDef::RHS_store body = scopeNodeToBody(dctx1, move(sclass->body));
                 ClassDef::ANCESTORS_store emptyAncestors;
                 ExpressionPtr res =
@@ -1842,10 +1845,10 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 };
 
                 ExpressionPtr recv;
-                if (dctx.enclosingBlockArg.exists()) {
+                if (dctx.enclosingBlockParamName.exists()) {
                     // we always want to report an error if we're using yield with a synthesized name in
                     // strict mode
-                    auto blockArgName = dctx.enclosingBlockArg;
+                    auto blockArgName = dctx.enclosingBlockParamName;
                     if (blockArgName == core::Names::blkArg()) {
                         if (auto e = dctx.ctx.beginIndexerError(dctx.enclosingMethodLoc,
                                                                 core::errors::Desugar::UnnamedBlockParameter)) {
@@ -1855,7 +1858,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         }
                     }
 
-                    recv = MK::Local(loc, dctx.enclosingBlockArg);
+                    recv = MK::Local(loc, dctx.enclosingBlockParamName);
                 } else {
                     // No enclosing block arg can happen when e.g. yield is called in a class / at the top-level.
                     recv = MK::RaiseUnimplemented(loc);

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -1471,8 +1471,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = move(res);
             },
             [&](parser::Kwarg *arg) { desugaredByPrismTranslator(arg); },
-            [&](parser::BlockParam *arg) {
-                ExpressionPtr res = MK::BlockArg(loc, MK::Local(loc, arg->name));
+            [&](parser::BlockParam *param) {
+                ExpressionPtr res = MK::BlockArg(loc, MK::Local(loc, param->name));
                 result = move(res);
             },
             [&](parser::Kwoptarg *arg) {

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -1471,7 +1471,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = move(res);
             },
             [&](parser::Kwarg *arg) { desugaredByPrismTranslator(arg); },
-            [&](parser::Blockarg *arg) {
+            [&](parser::BlockParam *arg) {
                 ExpressionPtr res = MK::BlockArg(loc, MK::Local(loc, arg->name));
                 result = move(res);
             },

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -50,9 +50,9 @@ struct DesugarContext final {
     }
 };
 
-core::NameRef blockArg2Name(DesugarContext dctx, const BlockParam &blkArg) {
-    auto blkIdent = cast_tree<UnresolvedIdent>(blkArg.expr);
-    ENFORCE(blkIdent != nullptr, "BlockArg must wrap UnresolvedIdent in desugar.");
+core::NameRef blockParam2Name(DesugarContext dctx, const BlockParam &blockParam) {
+    auto blkIdent = cast_tree<UnresolvedIdent>(blockParam.expr);
+    ENFORCE(blkIdent != nullptr, "BlockParam must wrap UnresolvedIdent in desugar.");
     return blkIdent->name;
 }
 
@@ -343,9 +343,9 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
         params.emplace_back(MK::BlockArg(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
     }
 
-    const auto &blkArg = cast_tree<BlockParam>(params.back());
-    ENFORCE(blkArg != nullptr, "Every method's last arg must be a block arg by now.");
-    auto enclosingBlockParamName = blockArg2Name(dctx, *blkArg);
+    const auto &blockParam = cast_tree<BlockParam>(params.back());
+    ENFORCE(blockParam != nullptr, "Every method's last param must be a block param by now.");
+    auto enclosingBlockParamName = blockParam2Name(dctx, *blockParam);
 
     DesugarContext dctx2(dctx1.ctx, dctx1.uniqueCounter, enclosingBlockParamName, declLoc, name, dctx.inAnyBlock,
                          inModule, dctx.preserveConcreteSyntax);

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -50,7 +50,7 @@ struct DesugarContext final {
     }
 };
 
-core::NameRef blockArg2Name(DesugarContext dctx, const BlockArg &blkArg) {
+core::NameRef blockArg2Name(DesugarContext dctx, const BlockParam &blkArg) {
     auto blkIdent = cast_tree<UnresolvedIdent>(blkArg.expr);
     ENFORCE(blkIdent != nullptr, "BlockArg must wrap UnresolvedIdent in desugar.");
     return blkIdent->name;
@@ -338,12 +338,12 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
                          inModule, dctx.preserveConcreteSyntax);
     auto [params, destructures] = desugarParams(dctx1, loc, argnode);
 
-    if (params.empty() || !isa_tree<BlockArg>(params.back())) {
+    if (params.empty() || !isa_tree<BlockParam>(params.back())) {
         auto blkLoc = core::LocOffsets::none();
         params.emplace_back(MK::BlockArg(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
     }
 
-    const auto &blkArg = cast_tree<BlockArg>(params.back());
+    const auto &blkArg = cast_tree<BlockParam>(params.back());
     ENFORCE(blkArg != nullptr, "Every method's last arg must be a block arg by now.");
     auto enclosingBlockParamName = blockArg2Name(dctx, *blkArg);
 

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -1846,10 +1846,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
 
                 ExpressionPtr recv;
                 if (dctx.enclosingBlockParamName.exists()) {
-                    // we always want to report an error if we're using yield with a synthesized name in
-                    // strict mode
-                    auto blockArgName = dctx.enclosingBlockParamName;
-                    if (blockArgName == core::Names::blkArg()) {
+                    // we always want to report an error if we're using yield with a synthesized name in strict mode
+                    if (dctx.enclosingBlockParamName == core::Names::blkArg()) {
                         if (auto e = dctx.ctx.beginIndexerError(dctx.enclosingMethodLoc,
                                                                 core::errors::Desugar::UnnamedBlockParameter)) {
                             e.setHeader("Method `{}` uses `{}` but does not mention a block parameter",

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -84,7 +84,7 @@ pair<MethodDef::PARAMS_store, InsSeq::STATS_store> desugarParams(DesugarContext 
                 params.emplace_back(MK::RestParam(fargs->loc, MK::KeywordArg(fargs->loc, core::Names::fwdKwargs())));
 
                 // add `&<fwd-block>`
-                params.emplace_back(MK::BlockArg(fargs->loc, MK::Local(fargs->loc, core::Names::fwdBlock())));
+                params.emplace_back(MK::BlockParam(fargs->loc, MK::Local(fargs->loc, core::Names::fwdBlock())));
             } else {
                 params.emplace_back(node2TreeImpl(dctx, arg));
             }
@@ -340,7 +340,7 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
 
     if (params.empty() || !isa_tree<BlockParam>(params.back())) {
         auto blkLoc = core::LocOffsets::none();
-        params.emplace_back(MK::BlockArg(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
+        params.emplace_back(MK::BlockParam(blkLoc, MK::Local(blkLoc, core::Names::blkArg())));
     }
 
     const auto &blockParam = cast_tree<BlockParam>(params.back());
@@ -1474,7 +1474,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
             },
             [&](parser::Kwarg *arg) { desugaredByPrismTranslator(arg); },
             [&](parser::BlockParam *param) {
-                ExpressionPtr res = MK::BlockArg(loc, MK::Local(loc, param->name));
+                ExpressionPtr res = MK::BlockParam(loc, MK::Local(loc, param->name));
                 result = move(res);
             },
             [&](parser::Kwoptarg *arg) {

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -33,7 +33,7 @@ private:
         while (arg != nullptr) {
             typecase(
                 *arg, [&](RestParam &rest) { arg = &rest.expr; }, [&](KeywordArg &kw) { arg = &kw.expr; },
-                [&](OptionalParam &opt) { arg = &opt.expr; }, [&](BlockArg &opt) { arg = &opt.expr; },
+                [&](OptionalParam &opt) { arg = &opt.expr; }, [&](BlockParam &opt) { arg = &opt.expr; },
                 [&](ShadowArg &opt) { arg = &opt.expr; },
                 [&](Local &local) {
                     local.localVariable._name = subst.substitute(local.localVariable._name);

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -33,7 +33,7 @@ private:
         while (arg != nullptr) {
             typecase(
                 *arg, [&](RestParam &rest) { arg = &rest.expr; }, [&](KeywordArg &kw) { arg = &kw.expr; },
-                [&](OptionalParam &opt) { arg = &opt.expr; }, [&](BlockParam &opt) { arg = &opt.expr; },
+                [&](OptionalParam &opt) { arg = &opt.expr; }, [&](BlockParam &param) { arg = &param.expr; },
                 [&](ShadowArg &opt) { arg = &opt.expr; },
                 [&](Local &local) {
                     local.localVariable._name = subst.substitute(local.localVariable._name);

--- a/ast/treemap/treemap.h
+++ b/ast/treemap/treemap.h
@@ -644,7 +644,7 @@ private:
                     Exception::raise("should never happen. Forgot to add new tree kind? {}", what.nodeName());
                     break;
 
-                case Tag::BlockArg:
+                case Tag::BlockParam:
                     Exception::raise("should never happen. Forgot to add new tree kind? {}", what.nodeName());
                     break;
 

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1433,8 +1433,8 @@ void SerializerImpl::pickle(Pickler &p, const ast::ExpressionPtr &what) {
             break;
         }
 
-        case ast::Tag::BlockArg: {
-            auto &a = ast::cast_tree_nonnull<ast::BlockArg>(what);
+        case ast::Tag::BlockParam: {
+            auto &a = ast::cast_tree_nonnull<ast::BlockParam>(what);
             pickle(p, a.loc);
             pickle(p, a.expr);
             break;
@@ -1733,10 +1733,10 @@ ast::ExpressionPtr SerializerImpl::unpickleExpr(serialize::UnPickler &p, const G
             auto ref = unpickleExpr(p, gs);
             return ast::make_expression<ast::ShadowArg>(loc, std::move(ref));
         }
-        case ast::Tag::BlockArg: {
+        case ast::Tag::BlockParam: {
             auto loc = unpickleLocOffsets(p);
             auto ref = unpickleExpr(p, gs);
-            return ast::make_expression<ast::BlockArg>(loc, std::move(ref));
+            return ast::make_expression<ast::BlockParam>(loc, std::move(ref));
         }
         case ast::Tag::OptionalParam: {
             auto loc = unpickleLocOffsets(p);

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -100,7 +100,7 @@ class LocalNameInserter {
                     cursor = &kw.expr;
                 },
                 [&](ast::OptionalParam &opt) { cursor = &opt.expr; },
-                [&](ast::BlockArg &blk) {
+                [&](ast::BlockParam &blk) {
                     named.flags.block = true;
                     cursor = &blk.expr;
                 },

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -582,7 +582,7 @@ public:
             nm = gs_.freshNameUnique(core::UniqueNameKind::Parser, core::Names::ampersand(), ++uniqueCounter_);
         }
 
-        return make_unique<Blockarg>(loc, nm);
+        return make_unique<BlockParam>(loc, nm);
     }
 
     unique_ptr<Node> callLambda(const token *lambda) {
@@ -1762,7 +1762,7 @@ public:
                 hasDuplicateParam(optParam->name, optParam->loc, map);
             } else if (auto *restParam = parser::cast_node<RestParam>(thisParam.get())) {
                 hasDuplicateParam(restParam->name, restParam->loc, map);
-            } else if (auto *blockarg = parser::cast_node<Blockarg>(thisParam.get())) {
+            } else if (auto *blockarg = parser::cast_node<BlockParam>(thisParam.get())) {
                 hasDuplicateParam(blockarg->name, blockarg->loc, map);
             } else if (auto *kwarg = parser::cast_node<Kwarg>(thisParam.get())) {
                 if (hasDuplicateParam(kwarg->name, kwarg->loc, map)) {

--- a/parser/NodeCopying.cc
+++ b/parser/NodeCopying.cc
@@ -50,8 +50,8 @@ std::unique_ptr<Node> deepCopy(const Node *node) {
             result = std::make_unique<Block>(block->loc, deepCopy(block->send.get()), deepCopy(block->params.get()),
                                              deepCopy(block->body.get()));
         },
-        [&](const parser::BlockParam *blockarg) {
-            result = std::make_unique<BlockParam>(blockarg->loc, blockarg->name);
+        [&](const parser::BlockParam *blockParam) {
+            result = std::make_unique<BlockParam>(blockParam->loc, blockParam->name);
         },
         [&](const parser::BlockPass *blockPass) {
             result = std::make_unique<BlockPass>(blockPass->loc, deepCopy(blockPass->block.get()));

--- a/parser/NodeCopying.cc
+++ b/parser/NodeCopying.cc
@@ -50,7 +50,9 @@ std::unique_ptr<Node> deepCopy(const Node *node) {
             result = std::make_unique<Block>(block->loc, deepCopy(block->send.get()), deepCopy(block->params.get()),
                                              deepCopy(block->body.get()));
         },
-        [&](const parser::Blockarg *blockarg) { result = std::make_unique<Blockarg>(blockarg->loc, blockarg->name); },
+        [&](const parser::BlockParam *blockarg) {
+            result = std::make_unique<BlockParam>(blockarg->loc, blockarg->name);
+        },
         [&](const parser::BlockPass *blockPass) {
             result = std::make_unique<BlockPass>(blockPass->loc, deepCopy(blockPass->block.get()));
         },

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -2792,7 +2792,7 @@ Translator::translateParametersNode(pm_parameters_node *paramsNode) {
         // Drop the `&` before the name of the block parameter.
         blockParamLoc = core::LocOffsets{blockParamLoc.beginPos() + 1, blockParamLoc.endPos()};
 
-        auto blockParamExpr = MK::BlockArg(blockParamLoc, MK::Local(blockParamLoc, enclosingBlockParamName));
+        auto blockParamExpr = MK::BlockParam(blockParamLoc, MK::Local(blockParamLoc, enclosingBlockParamName));
         auto blockParamNode =
             make_node_with_expr<parser::BlockParam>(move(blockParamExpr), blockParamLoc, enclosingBlockParamName);
 
@@ -2848,7 +2848,7 @@ Translator::desugarParametersNode(NodeVec &params, bool attemptToDesugarParams) 
             paramsStore.emplace_back(MK::RestParam(loc, MK::KeywordArg(loc, core::Names::fwdKwargs())));
 
             // add `&<fwd-block>`
-            paramsStore.emplace_back(MK::BlockArg(loc, MK::Local(loc, core::Names::fwdBlock())));
+            paramsStore.emplace_back(MK::BlockParam(loc, MK::Local(loc, core::Names::fwdBlock())));
         } else {
             paramsStore.emplace_back(param->takeDesugaredExpr());
         }

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -2794,7 +2794,7 @@ Translator::translateParametersNode(pm_parameters_node *paramsNode) {
 
         auto blockParamExpr = MK::BlockArg(blockParamLoc, MK::Local(blockParamLoc, enclosingBlockParamName));
         auto blockParamNode =
-            make_node_with_expr<parser::Blockarg>(move(blockParamExpr), blockParamLoc, enclosingBlockParamName);
+            make_node_with_expr<parser::BlockParam>(move(blockParamExpr), blockParamLoc, enclosingBlockParamName);
 
         params.emplace_back(move(blockParamNode));
     } else {

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -95,10 +95,10 @@ NodeDef nodes[] = {
         "block",
         vector<FieldDef>({{"send", FieldType::Node}, {"params", FieldType::Node}, {"body", FieldType::Node}}),
     },
-    // Wraps a `&foo` argument in an argument list
+    // Wraps a `&foo` parameter in a parameter list
     {
-        "Blockarg",
-        "blockarg",
+        "BlockParam",
+        "blockparam",
         vector<FieldDef>({{"name", FieldType::Name}}),
     },
     //  e.g. map(&:token)

--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -166,7 +166,7 @@ core::NameRef nodeName(const parser::Node *node) {
 
     typecase(
         node, [&](const parser::Param *p) { name = p->name; }, [&](const parser::RestParam *p) { name = p->name; },
-        [&](const parser::Kwarg *p) { name = p->name; }, [&](const parser::Blockarg *p) { name = p->name; },
+        [&](const parser::Kwarg *p) { name = p->name; }, [&](const parser::BlockParam *p) { name = p->name; },
         [&](const parser::Kwoptarg *p) { name = p->name; }, [&](const parser::OptParam *p) { name = p->name; },
         [&](const parser::Kwrestarg *p) { name = p->name; }, [&](const parser::Shadowarg *p) { name = p->name; },
         [&](const parser::Symbol *s) { name = s->val; },
@@ -206,7 +206,7 @@ string nodeKindToString(const parser::Node *node) {
         [&](const parser::Kwarg *_p) { kind = "keyword"; },
         [&](const parser::Kwoptarg *_p) { kind = "optional keyword"; },
         [&](const parser::Kwrestarg *_p) { kind = "rest keyword"; },
-        [&](const parser::Blockarg *_p) { kind = "block"; },
+        [&](const parser::BlockParam *_p) { kind = "block"; },
         [&](const parser::Node *other) {
             Exception::raise("Unexpected expression type: {}", ((parser::Node *)node)->nodeName());
         });
@@ -216,7 +216,7 @@ string nodeKindToString(const parser::Node *node) {
 
 optional<core::AutocorrectSuggestion> autocorrectArg(core::MutableContext ctx, const parser::Node *methodArg,
                                                      RBSArg arg, unique_ptr<parser::Node> type) {
-    if (arg.kind == RBSArg::Kind::Block || parser::isa_node<parser::Blockarg>((parser::Node *)methodArg)) {
+    if (arg.kind == RBSArg::Kind::Block || parser::isa_node<parser::BlockParam>((parser::Node *)methodArg)) {
         // Block arguments are not autocorrected
         return nullopt;
     }
@@ -300,7 +300,7 @@ bool checkParameterKindMatch(const RBSArg &arg, const parser::Node *methodArg) {
         [&](const parser::Kwarg *_p) { kindMatch = arg.kind == RBSArg::Kind::Keyword; },
         [&](const parser::Kwoptarg *_p) { kindMatch = arg.kind == RBSArg::Kind::OptionalKeyword; },
         [&](const parser::Kwrestarg *_p) { kindMatch = arg.kind == RBSArg::Kind::RestKeyword; },
-        [&](const parser::Blockarg *_p) { kindMatch = arg.kind == RBSArg::Kind::Block; },
+        [&](const parser::BlockParam *_p) { kindMatch = arg.kind == RBSArg::Kind::Block; },
         [&](const parser::Node *other) { Exception::raise("Unexpected expression type: {}", methodArg->nodeName()); });
 
     return kindMatch;

--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -214,9 +214,9 @@ string nodeKindToString(const parser::Node *node) {
     return kind;
 }
 
-optional<core::AutocorrectSuggestion> autocorrectArg(core::MutableContext ctx, const parser::Node *methodArg,
+optional<core::AutocorrectSuggestion> autocorrectArg(core::MutableContext ctx, const parser::Node *methodParam,
                                                      RBSArg arg, unique_ptr<parser::Node> type) {
-    if (arg.kind == RBSArg::Kind::Block || parser::isa_node<parser::BlockParam>((parser::Node *)methodArg)) {
+    if (arg.kind == RBSArg::Kind::Block || parser::isa_node<parser::BlockParam>((parser::Node *)methodParam)) {
         // Block arguments are not autocorrected
         return nullopt;
     }
@@ -226,7 +226,7 @@ optional<core::AutocorrectSuggestion> autocorrectArg(core::MutableContext ctx, c
     auto typeString = source.substr(type->loc.beginPos(), type->loc.endPos() - type->loc.beginPos());
 
     typecase(
-        methodArg,
+        methodParam,
         // Should be: `Type name`
         [&](const parser::Param *p) {
             if (arg.name) {
@@ -290,18 +290,20 @@ optional<core::AutocorrectSuggestion> autocorrectArg(core::MutableContext ctx, c
                                        {core::AutocorrectSuggestion::Edit{ctx.locAt(loc), corrected}}};
 }
 
-bool checkParameterKindMatch(const RBSArg &arg, const parser::Node *methodArg) {
+bool checkParameterKindMatch(const RBSArg &arg, const parser::Node *methodParam) {
     auto kindMatch = false;
 
     typecase(
-        methodArg, [&](const parser::Param *_p) { kindMatch = arg.kind == RBSArg::Kind::Positional; },
+        methodParam, [&](const parser::Param *_p) { kindMatch = arg.kind == RBSArg::Kind::Positional; },
         [&](const parser::OptParam *_p) { kindMatch = arg.kind == RBSArg::Kind::OptionalPositional; },
         [&](const parser::RestParam *_p) { kindMatch = arg.kind == RBSArg::Kind::RestPositional; },
         [&](const parser::Kwarg *_p) { kindMatch = arg.kind == RBSArg::Kind::Keyword; },
         [&](const parser::Kwoptarg *_p) { kindMatch = arg.kind == RBSArg::Kind::OptionalKeyword; },
         [&](const parser::Kwrestarg *_p) { kindMatch = arg.kind == RBSArg::Kind::RestKeyword; },
         [&](const parser::BlockParam *_p) { kindMatch = arg.kind == RBSArg::Kind::Block; },
-        [&](const parser::Node *other) { Exception::raise("Unexpected expression type: {}", methodArg->nodeName()); });
+        [&](const parser::Node *other) {
+            Exception::raise("Unexpected expression type: {}", methodParam->nodeName());
+        });
 
     return kindMatch;
 }

--- a/rewriter/DefDelegator.cc
+++ b/rewriter/DefDelegator.cc
@@ -21,7 +21,7 @@ void generateStub(vector<ast::ExpressionPtr> &methodStubs, const core::LocOffset
     // def $methodName(*arg0, &blk); end
     ast::MethodDef::PARAMS_store params;
     params.emplace_back(ast::MK::RestParam(loc, ast::MK::Local(loc, core::Names::arg0())));
-    params.emplace_back(ast::make_expression<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
+    params.emplace_back(ast::make_expression<ast::BlockParam>(loc, ast::MK::Local(loc, core::Names::blkArg())));
 
     methodStubs.push_back(
         ast::MK::SyntheticMethod(loc, loc, methodName, std::move(params), ast::MK::RaiseUnimplemented(loc)));

--- a/rewriter/Delegate.cc
+++ b/rewriter/Delegate.cc
@@ -110,7 +110,7 @@ vector<ast::ExpressionPtr> Delegate::run(core::MutableContext ctx, const ast::Se
         // def $methodName(*arg0, &blk); end
         ast::MethodDef::PARAMS_store params;
         params.emplace_back(ast::MK::RestParam(loc, ast::MK::Local(loc, core::Names::arg0())));
-        params.emplace_back(ast::make_expression<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
+        params.emplace_back(ast::make_expression<ast::BlockParam>(loc, ast::MK::Local(loc, core::Names::blkArg())));
 
         methodStubs.push_back(ast::MK::SyntheticMethod(loc, loc, methodName, std::move(params), ast::MK::EmptyTree()));
     }

--- a/rewriter/ModuleFunction.cc
+++ b/rewriter/ModuleFunction.cc
@@ -137,7 +137,7 @@ vector<ast::ExpressionPtr> ModuleFunction::run(core::MutableContext ctx, ast::Se
                                               loc.copyWithZeroLength(), lit->deepCopy()));
             ast::MethodDef::PARAMS_store params;
             params.emplace_back(ast::MK::RestParam(loc, ast::MK::Local(loc, core::Names::arg0())));
-            params.emplace_back(ast::make_expression<ast::BlockArg>(loc, ast::MK::Local(loc, core::Names::blkArg())));
+            params.emplace_back(ast::make_expression<ast::BlockParam>(loc, ast::MK::Local(loc, core::Names::blkArg())));
             auto methodDef = ast::MK::SyntheticMethod(loc, loc, methodName, std::move(params), ast::MK::EmptyTree());
             ast::cast_tree_nonnull<ast::MethodDef>(methodDef).flags.isSelfMethod = true;
             stats.emplace_back(std::move(methodDef));

--- a/test/prism_regression/assign_to_constant.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/assign_to_constant.rb.desugar-tree-raw.exp
@@ -397,7 +397,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U method1><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -660,7 +660,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U method2><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -693,7 +693,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U method3><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/call_all_args.parse-tree.exp
+++ b/test/prism_regression/call_all_args.parse-tree.exp
@@ -139,7 +139,7 @@ Begin {
           Kwarg {
             name = <U f>
           }
-          Blockarg {
+          BlockParam {
             name = <U block>
           }
         ]
@@ -224,7 +224,7 @@ Begin {
           Kwarg {
             name = <U f>
           }
-          Blockarg {
+          BlockParam {
             name = <U block>
           }
         ]

--- a/test/prism_regression/call_all_args.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_all_args.rb.desugar-tree-raw.exp
@@ -113,7 +113,7 @@ ClassDef{
             kind = Local
             name = <U f>
           } }
-          BlockArg{ expr = UnresolvedIdent{
+          BlockParam{ expr = UnresolvedIdent{
             kind = Local
             name = <U block>
           } }
@@ -209,7 +209,7 @@ ClassDef{
             kind = Local
             name = <U f>
           } }
-          BlockArg{ expr = UnresolvedIdent{
+          BlockParam{ expr = UnresolvedIdent{
             kind = Local
             name = <U block>
           } }

--- a/test/prism_regression/call_block_param.parse-tree.exp
+++ b/test/prism_regression/call_block_param.parse-tree.exp
@@ -59,7 +59,7 @@ Begin {
           Kwarg {
             name = <U kwarg>
           }
-          Blockarg {
+          BlockParam {
             name = <U block>
           }
         ]
@@ -83,7 +83,7 @@ Begin {
           Kwarg {
             name = <U kwarg>
           }
-          Blockarg {
+          BlockParam {
             name = <U block>
           }
         ]

--- a/test/prism_regression/call_block_param.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_block_param.rb.desugar-tree-raw.exp
@@ -77,7 +77,7 @@ ClassDef{
             kind = Local
             name = <U kwarg>
           } }
-          BlockArg{ expr = UnresolvedIdent{
+          BlockParam{ expr = UnresolvedIdent{
             kind = Local
             name = <U block>
           } }
@@ -103,7 +103,7 @@ ClassDef{
             kind = Local
             name = <U kwarg>
           } }
-          BlockArg{ expr = UnresolvedIdent{
+          BlockParam{ expr = UnresolvedIdent{
             kind = Local
             name = <U block>
           } }

--- a/test/prism_regression/call_forwarding_param.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_forwarding_param.rb.desugar-tree-raw.exp
@@ -16,7 +16,7 @@ ClassDef{
         } }, RestParam{ expr = KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <fwd-kwargs>>
-        } } }, BlockArg{ expr = UnresolvedIdent{
+        } } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <fwd-block>>
         } }]

--- a/test/prism_regression/call_kw_rest_args.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_kw_rest_args.rb.desugar-tree-raw.exp
@@ -13,7 +13,7 @@ ClassDef{
       params = [RestParam{ expr = KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U kwargs>
-        } } }, BlockArg{ expr = UnresolvedIdent{
+        } } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -64,7 +64,7 @@ ClassDef{
       params = [RestParam{ expr = KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <P <U **> $2>
-        } } }, BlockArg{ expr = UnresolvedIdent{
+        } } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/call_rest_args.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_rest_args.rb.desugar-tree-raw.exp
@@ -13,7 +13,7 @@ ClassDef{
       params = [RestParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U args>
-        } }, BlockArg{ expr = UnresolvedIdent{
+        } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -56,7 +56,7 @@ ClassDef{
       params = [RestParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U *>
-        } }, BlockArg{ expr = UnresolvedIdent{
+        } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/def.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -20,7 +20,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U bar><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/def_all_params.parse-tree.exp
+++ b/test/prism_regression/def_all_params.parse-tree.exp
@@ -28,7 +28,7 @@ Begin {
           Kwrestarg {
             name = <U f>
           }
-          Blockarg {
+          BlockParam {
             name = <U blk>
           }
         ]
@@ -45,7 +45,7 @@ Begin {
           Kwrestarg {
             name = <P <U **> $2>
           }
-          Blockarg {
+          BlockParam {
             name = <P <U &> $3>
           }
         ]

--- a/test/prism_regression/def_all_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_all_params.rb.desugar-tree-raw.exp
@@ -34,7 +34,7 @@ ClassDef{
         }, RestParam{ expr = KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U f>
-        } } }, BlockArg{ expr = UnresolvedIdent{
+        } } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U blk>
         } }]
@@ -50,7 +50,7 @@ ClassDef{
         } }, RestParam{ expr = KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <P <U **> $2>
-        } } }, BlockArg{ expr = UnresolvedIdent{
+        } } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <P <U &> $3>
         } }]

--- a/test/prism_regression/def_block_param.parse-tree.exp
+++ b/test/prism_regression/def_block_param.parse-tree.exp
@@ -4,7 +4,7 @@ Begin {
       name = <U foo>
       params = Params {
         params = [
-          Blockarg {
+          BlockParam {
             name = <U my_block_param>
           }
         ]
@@ -15,7 +15,7 @@ Begin {
       name = <U foo>
       params = Params {
         params = [
-          Blockarg {
+          BlockParam {
             name = <P <U &> $2>
           }
         ]

--- a/test/prism_regression/def_block_param.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_block_param.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U my_block_param>
         } }]
@@ -20,7 +20,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <P <U &> $2>
         } }]

--- a/test/prism_regression/def_forwarding_param.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_forwarding_param.rb.desugar-tree-raw.exp
@@ -16,7 +16,7 @@ ClassDef{
         } }, RestParam{ expr = KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U <fwd-kwargs>>
-        } } }, BlockArg{ expr = UnresolvedIdent{
+        } } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <fwd-block>>
         } }]

--- a/test/prism_regression/def_kw_rest_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_kw_rest_params.rb.desugar-tree-raw.exp
@@ -13,7 +13,7 @@ ClassDef{
       params = [RestParam{ expr = KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U a>
-        } } }, BlockArg{ expr = UnresolvedIdent{
+        } } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -26,7 +26,7 @@ ClassDef{
       params = [RestParam{ expr = KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <P <U **> $2>
-        } } }, BlockArg{ expr = UnresolvedIdent{
+        } } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -36,7 +36,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/def_optional_kw_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_optional_kw_params.rb.desugar-tree-raw.exp
@@ -16,7 +16,7 @@ ClassDef{
             name = <U a>
           } }
           default_ = Literal{ value = 1 }
-        }, BlockArg{ expr = UnresolvedIdent{
+        }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -38,7 +38,7 @@ ClassDef{
             name = <U b>
           } }
           default_ = Literal{ value = 2 }
-        }, BlockArg{ expr = UnresolvedIdent{
+        }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/def_optional_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_optional_params.rb.desugar-tree-raw.exp
@@ -16,7 +16,7 @@ ClassDef{
             name = <U a>
           }
           default_ = Literal{ value = 1 }
-        }, BlockArg{ expr = UnresolvedIdent{
+        }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -38,7 +38,7 @@ ClassDef{
             name = <U b>
           }
           default_ = Literal{ value = 2 }
-        }, BlockArg{ expr = UnresolvedIdent{
+        }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/def_required_kw_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_required_kw_params.rb.desugar-tree-raw.exp
@@ -13,7 +13,7 @@ ClassDef{
       params = [KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U a>
-        } }, BlockArg{ expr = UnresolvedIdent{
+        } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -29,7 +29,7 @@ ClassDef{
         } }, KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U b>
-        } }, BlockArg{ expr = UnresolvedIdent{
+        } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/def_required_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_required_params.rb.desugar-tree-raw.exp
@@ -13,7 +13,7 @@ ClassDef{
       params = [UnresolvedIdent{
           kind = Local
           name = <U a>
-        }, BlockArg{ expr = UnresolvedIdent{
+        }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -29,7 +29,7 @@ ClassDef{
         }, UnresolvedIdent{
           kind = Local
           name = <U b>
-        }, BlockArg{ expr = UnresolvedIdent{
+        }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/def_rest_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_rest_params.rb.desugar-tree-raw.exp
@@ -13,7 +13,7 @@ ClassDef{
       params = [RestParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U a>
-        } }, BlockArg{ expr = UnresolvedIdent{
+        } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -26,7 +26,7 @@ ClassDef{
       params = [RestParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U *>
-        } }, BlockArg{ expr = UnresolvedIdent{
+        } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -45,7 +45,7 @@ ClassDef{
         }, UnresolvedIdent{
           kind = Local
           name = <U c>
-        }, BlockArg{ expr = UnresolvedIdent{
+        }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/def_singleton.parse-tree.exp
+++ b/test/prism_regression/def_singleton.parse-tree.exp
@@ -24,7 +24,7 @@ Begin {
       name = <U foo>
       params = Params {
         params = [
-          Blockarg {
+          BlockParam {
             name = <U blk>
           }
         ]

--- a/test/prism_regression/def_singleton.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_singleton.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {self}
       name = <U foo><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -20,7 +20,7 @@ ClassDef{
     MethodDef{
       flags = {self}
       name = <U foo><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -30,7 +30,7 @@ ClassDef{
     MethodDef{
       flags = {self}
       name = <U foo><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U blk>
         } }]

--- a/test/prism_regression/def_with_body.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_with_body.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U one_statement><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -20,7 +20,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U two_statements><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -35,7 +35,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U three_statements><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -51,7 +51,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U begin_block><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/ensure.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/ensure.rb.desugar-tree-raw.exp
@@ -34,7 +34,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U method_with_ensure><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -55,7 +55,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U empty_method_with_ensure><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -71,7 +71,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U method_with_begin_and_ensure><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/error_recovery/assign.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/error_recovery/assign.rb.desugar-tree-raw.exp
@@ -13,7 +13,7 @@ ClassDef{
       params = [UnresolvedIdent{
           kind = Local
           name = <U x>
-        }, BlockArg{ expr = UnresolvedIdent{
+        }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/lambda.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/lambda.rb.desugar-tree-raw.exp
@@ -217,7 +217,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U method_returning_lambda><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]

--- a/test/prism_regression/literal_array.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/literal_array.rb.desugar-tree-raw.exp
@@ -58,7 +58,7 @@ ClassDef{
       params = [RestParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U args>
-        } }, BlockArg{ expr = UnresolvedIdent{
+        } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -118,7 +118,7 @@ ClassDef{
       params = [RestParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U *>
-        } }, BlockArg{ expr = UnresolvedIdent{
+        } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/literal_hash.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/literal_hash.rb.desugar-tree-raw.exp
@@ -40,7 +40,7 @@ ClassDef{
       params = [RestParam{ expr = KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <U kwargs>
-        } } }, BlockArg{ expr = UnresolvedIdent{
+        } } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -136,7 +136,7 @@ ClassDef{
       params = [RestParam{ expr = KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <P <U **> $2>
-        } } }, BlockArg{ expr = UnresolvedIdent{
+        } } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/range.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/range.rb.desugar-tree-raw.exp
@@ -53,7 +53,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -83,7 +83,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U bar><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/rescue.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/rescue.rb.desugar-tree-raw.exp
@@ -35,7 +35,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U method_with_rescue><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -427,7 +427,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U index><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/prism_regression/super.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/super.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U m><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/testdata/cfg/rescue.rb.desugar-tree-raw.exp
+++ b/test/testdata/cfg/rescue.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U main><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -67,7 +67,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U a><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -77,7 +77,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U b><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -87,7 +87,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U c><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -97,7 +97,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U d><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/testdata/cfg/retry.rb.desugar-tree-raw.exp
+++ b/test/testdata/cfg/retry.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U main><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/testdata/desugar/numbered_parameters.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/numbered_parameters.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/testdata/desugar/range.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/range.rb.desugar-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U foo><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]

--- a/test/testdata/infer/yield_multiple.rb.desugar-tree-raw.exp
+++ b/test/testdata/infer/yield_multiple.rb.desugar-tree-raw.exp
@@ -100,7 +100,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U yield_two><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U blk>
         } }]

--- a/test/testdata/local_vars/z_super_args.rb.index-tree-raw.exp
+++ b/test/testdata/local_vars/z_super_args.rb.index-tree-raw.exp
@@ -24,7 +24,7 @@ ClassDef{
           name = <U takes_positional><<U <todo method>>>
           params = [Local{
               localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
+            }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -46,7 +46,7 @@ ClassDef{
           name = <U takes_keyword><<U <todo method>>>
           params = [KeywordArg{ expr = Local{
               localVariable = <U arg0>
-            } }, BlockArg{ expr = Local{
+            } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -70,7 +70,7 @@ ClassDef{
               localVariable = <U arg0>
             } }, KeywordArg{ expr = Local{
               localVariable = <U arg1>
-            } }, BlockArg{ expr = Local{
+            } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = InsSeq{
@@ -110,7 +110,7 @@ ClassDef{
               localVariable = <U arg0>
             }, KeywordArg{ expr = Local{
               localVariable = <U arg1>
-            } }, BlockArg{ expr = Local{
+            } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = InsSeq{
@@ -148,7 +148,7 @@ ClassDef{
           name = <U takes_rest><<U <todo method>>>
           params = [RestParam{ expr = Local{
               localVariable = <U args>
-            } }, BlockArg{ expr = Local{
+            } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -170,7 +170,7 @@ ClassDef{
           name = <U takes_keyword_rest><<U <todo method>>>
           params = [RestParam{ expr = KeywordArg{ expr = Local{
               localVariable = <U args>
-            } } }, BlockArg{ expr = Local{
+            } } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -190,7 +190,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_block><<U <todo method>>>
-          params = [BlockArg{ expr = Local{
+          params = [BlockParam{ expr = Local{
               localVariable = <U blk>
             } }]
           rhs = Send{
@@ -210,7 +210,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U zsuper_inside_block><<U <todo method>>>
-          params = [BlockArg{ expr = Local{
+          params = [BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = EmptyTree
@@ -251,7 +251,7 @@ ClassDef{
           name = <U takes_positional><<U <todo method>>>
           params = [Local{
               localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
+            }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -281,7 +281,7 @@ ClassDef{
           name = <U takes_keyword><<U <todo method>>>
           params = [KeywordArg{ expr = Local{
               localVariable = <U arg0>
-            } }, BlockArg{ expr = Local{
+            } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -314,7 +314,7 @@ ClassDef{
               localVariable = <U arg0>
             } }, KeywordArg{ expr = Local{
               localVariable = <U arg1>
-            } }, BlockArg{ expr = Local{
+            } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -351,7 +351,7 @@ ClassDef{
               localVariable = <U arg0>
             }, KeywordArg{ expr = Local{
               localVariable = <U arg1>
-            } }, BlockArg{ expr = Local{
+            } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -385,7 +385,7 @@ ClassDef{
           name = <U takes_rest><<U <todo method>>>
           params = [RestParam{ expr = Local{
               localVariable = <U args>
-            } }, BlockArg{ expr = Local{
+            } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -440,7 +440,7 @@ ClassDef{
           name = <U takes_keyword_rest><<U <todo method>>>
           params = [RestParam{ expr = KeywordArg{ expr = Local{
               localVariable = <U args>
-            } } }, BlockArg{ expr = Local{
+            } } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -480,7 +480,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_block><<U <todo method>>>
-          params = [BlockArg{ expr = Local{
+          params = [BlockParam{ expr = Local{
               localVariable = <U blk>
             } }]
           rhs = Send{
@@ -505,7 +505,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U zsuper_inside_block><<U <todo method>>>
-          params = [BlockArg{ expr = Local{
+          params = [BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -572,7 +572,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U super_inside_module><<U <todo method>>>
-          params = [BlockArg{ expr = Local{
+          params = [BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{

--- a/test/testdata/local_vars/z_super_args_splats_blocks.rb.index-tree-raw.exp
+++ b/test/testdata/local_vars/z_super_args_splats_blocks.rb.index-tree-raw.exp
@@ -16,7 +16,7 @@ ClassDef{
           localVariable = <U y>
         }, Local{
           localVariable = <U z>
-        }, BlockArg{ expr = Local{
+        }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -87,7 +87,7 @@ ClassDef{
       name = <U possplat><<U <todo method>>>
       params = [RestParam{ expr = Local{
           localVariable = <U foo>
-        } }, BlockArg{ expr = Local{
+        } }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -205,7 +205,7 @@ ClassDef{
           localVariable = <U p>
         }, Local{
           localVariable = <U q>
-        }, BlockArg{ expr = Local{
+        }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -361,7 +361,7 @@ ClassDef{
           localVariable = <U z>
         }, RestParam{ expr = Local{
           localVariable = <U foo>
-        } }, BlockArg{ expr = Local{
+        } }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -527,7 +527,7 @@ ClassDef{
           localVariable = <U p>
         }, Local{
           localVariable = <U q>
-        }, BlockArg{ expr = Local{
+        }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -723,7 +723,7 @@ ClassDef{
           localVariable = <U y>
         }, Local{
           localVariable = <U z>
-        }, BlockArg{ expr = Local{
+        }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{
@@ -794,7 +794,7 @@ ClassDef{
       name = <U possplat_blk><<U <todo method>>>
       params = [RestParam{ expr = Local{
           localVariable = <U foo>
-        } }, BlockArg{ expr = Local{
+        } }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{
@@ -912,7 +912,7 @@ ClassDef{
           localVariable = <U p>
         }, Local{
           localVariable = <U q>
-        }, BlockArg{ expr = Local{
+        }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{
@@ -1068,7 +1068,7 @@ ClassDef{
           localVariable = <U z>
         }, RestParam{ expr = Local{
           localVariable = <U foo>
-        } }, BlockArg{ expr = Local{
+        } }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{
@@ -1234,7 +1234,7 @@ ClassDef{
           localVariable = <U p>
         }, Local{
           localVariable = <U q>
-        }, BlockArg{ expr = Local{
+        }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{
@@ -1434,7 +1434,7 @@ ClassDef{
           localVariable = <U j>
         } }, KeywordArg{ expr = Local{
           localVariable = <U k>
-        } }, BlockArg{ expr = Local{
+        } }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -1525,7 +1525,7 @@ ClassDef{
           localVariable = <U j>
         } }, KeywordArg{ expr = Local{
           localVariable = <U k>
-        } }, BlockArg{ expr = Local{
+        } }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -1669,7 +1669,7 @@ ClassDef{
           localVariable = <U j>
         } }, KeywordArg{ expr = Local{
           localVariable = <U k>
-        } }, BlockArg{ expr = Local{
+        } }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -1851,7 +1851,7 @@ ClassDef{
           localVariable = <U j>
         } }, KeywordArg{ expr = Local{
           localVariable = <U k>
-        } }, BlockArg{ expr = Local{
+        } }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -2043,7 +2043,7 @@ ClassDef{
           localVariable = <U j>
         } }, KeywordArg{ expr = Local{
           localVariable = <U k>
-        } }, BlockArg{ expr = Local{
+        } }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -2263,7 +2263,7 @@ ClassDef{
           localVariable = <U z>
         }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -2366,7 +2366,7 @@ ClassDef{
           localVariable = <U foo>
         } }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -2522,7 +2522,7 @@ ClassDef{
           localVariable = <U q>
         }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -2716,7 +2716,7 @@ ClassDef{
           localVariable = <U foo>
         } }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -2920,7 +2920,7 @@ ClassDef{
           localVariable = <U q>
         }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -3158,7 +3158,7 @@ ClassDef{
           localVariable = <U k>
         } }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -3313,7 +3313,7 @@ ClassDef{
           localVariable = <U k>
         } }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -3521,7 +3521,7 @@ ClassDef{
           localVariable = <U k>
         } }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -3767,7 +3767,7 @@ ClassDef{
           localVariable = <U k>
         } }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -4023,7 +4023,7 @@ ClassDef{
           localVariable = <U k>
         } }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U <blk>>
         } }]
       rhs = InsSeq{
@@ -4307,7 +4307,7 @@ ClassDef{
           localVariable = <U j>
         } }, KeywordArg{ expr = Local{
           localVariable = <U k>
-        } }, BlockArg{ expr = Local{
+        } }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{
@@ -4398,7 +4398,7 @@ ClassDef{
           localVariable = <U j>
         } }, KeywordArg{ expr = Local{
           localVariable = <U k>
-        } }, BlockArg{ expr = Local{
+        } }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{
@@ -4542,7 +4542,7 @@ ClassDef{
           localVariable = <U j>
         } }, KeywordArg{ expr = Local{
           localVariable = <U k>
-        } }, BlockArg{ expr = Local{
+        } }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{
@@ -4724,7 +4724,7 @@ ClassDef{
           localVariable = <U j>
         } }, KeywordArg{ expr = Local{
           localVariable = <U k>
-        } }, BlockArg{ expr = Local{
+        } }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{
@@ -4916,7 +4916,7 @@ ClassDef{
           localVariable = <U j>
         } }, KeywordArg{ expr = Local{
           localVariable = <U k>
-        } }, BlockArg{ expr = Local{
+        } }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{
@@ -5136,7 +5136,7 @@ ClassDef{
           localVariable = <U z>
         }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{
@@ -5239,7 +5239,7 @@ ClassDef{
           localVariable = <U foo>
         } }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{
@@ -5395,7 +5395,7 @@ ClassDef{
           localVariable = <U q>
         }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{
@@ -5589,7 +5589,7 @@ ClassDef{
           localVariable = <U foo>
         } }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{
@@ -5793,7 +5793,7 @@ ClassDef{
           localVariable = <U q>
         }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{
@@ -6031,7 +6031,7 @@ ClassDef{
           localVariable = <U k>
         } }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{
@@ -6186,7 +6186,7 @@ ClassDef{
           localVariable = <U k>
         } }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{
@@ -6394,7 +6394,7 @@ ClassDef{
           localVariable = <U k>
         } }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{
@@ -6640,7 +6640,7 @@ ClassDef{
           localVariable = <U k>
         } }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{
@@ -6896,7 +6896,7 @@ ClassDef{
           localVariable = <U k>
         } }, RestParam{ expr = KeywordArg{ expr = Local{
           localVariable = <U bar>
-        } } }, BlockArg{ expr = Local{
+        } } }, BlockParam{ expr = Local{
           localVariable = <U blk>
         } }]
       rhs = InsSeq{

--- a/test/testdata/local_vars/z_super_args_strict.rb.index-tree-raw.exp
+++ b/test/testdata/local_vars/z_super_args_strict.rb.index-tree-raw.exp
@@ -59,7 +59,7 @@ ClassDef{
           name = <U takes_positional><<U <todo method>>>
           params = [Local{
               localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
+            }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -116,7 +116,7 @@ ClassDef{
           name = <U takes_keyword><<U <todo method>>>
           params = [KeywordArg{ expr = Local{
               localVariable = <U arg0>
-            } }, BlockArg{ expr = Local{
+            } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -180,7 +180,7 @@ ClassDef{
               localVariable = <U arg0>
             } }, KeywordArg{ expr = Local{
               localVariable = <U arg1>
-            } }, BlockArg{ expr = Local{
+            } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = InsSeq{
@@ -260,7 +260,7 @@ ClassDef{
               localVariable = <U arg0>
             }, KeywordArg{ expr = Local{
               localVariable = <U arg1>
-            } }, BlockArg{ expr = Local{
+            } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = InsSeq{
@@ -341,7 +341,7 @@ ClassDef{
           name = <U takes_rest><<U <todo method>>>
           params = [RestParam{ expr = Local{
               localVariable = <U args>
-            } }, BlockArg{ expr = Local{
+            } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -406,7 +406,7 @@ ClassDef{
           name = <U takes_keyword_rest><<U <todo method>>>
           params = [RestParam{ expr = KeywordArg{ expr = Local{
               localVariable = <U args>
-            } } }, BlockArg{ expr = Local{
+            } } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -477,7 +477,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_block><<U <todo method>>>
-          params = [BlockArg{ expr = Local{
+          params = [BlockParam{ expr = Local{
               localVariable = <U blk>
             } }]
           rhs = Send{
@@ -519,7 +519,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U zsuper_inside_block><<U <todo method>>>
-          params = [BlockArg{ expr = Local{
+          params = [BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = EmptyTree
@@ -612,7 +612,7 @@ ClassDef{
           name = <U takes_positional><<U <todo method>>>
           params = [Local{
               localVariable = <U arg0>
-            }, BlockArg{ expr = Local{
+            }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -669,7 +669,7 @@ ClassDef{
           name = <U takes_keyword><<U <todo method>>>
           params = [KeywordArg{ expr = Local{
               localVariable = <U arg0>
-            } }, BlockArg{ expr = Local{
+            } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -734,7 +734,7 @@ ClassDef{
               localVariable = <U arg0>
             } }, KeywordArg{ expr = Local{
               localVariable = <U arg1>
-            } }, BlockArg{ expr = Local{
+            } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -803,7 +803,7 @@ ClassDef{
               localVariable = <U arg0>
             }, KeywordArg{ expr = Local{
               localVariable = <U arg1>
-            } }, BlockArg{ expr = Local{
+            } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -872,7 +872,7 @@ ClassDef{
           name = <U takes_rest><<U <todo method>>>
           params = [RestParam{ expr = Local{
               localVariable = <U args>
-            } }, BlockArg{ expr = Local{
+            } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -967,7 +967,7 @@ ClassDef{
           name = <U takes_keyword_rest><<U <todo method>>>
           params = [RestParam{ expr = KeywordArg{ expr = Local{
               localVariable = <U args>
-            } } }, BlockArg{ expr = Local{
+            } } }, BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -1050,7 +1050,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U takes_block><<U <todo method>>>
-          params = [BlockArg{ expr = Local{
+          params = [BlockParam{ expr = Local{
               localVariable = <U blk>
             } }]
           rhs = Send{
@@ -1097,7 +1097,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U zsuper_inside_block><<U <todo method>>>
-          params = [BlockArg{ expr = Local{
+          params = [BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
@@ -1178,7 +1178,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U super_inside_module><<U <todo method>>>
-          params = [BlockArg{ expr = Local{
+          params = [BlockParam{ expr = Local{
               localVariable = <U <blk>>
             } }]
           rhs = Send{

--- a/test/testdata/namer/arguments.rb.desugar-tree-raw.exp
+++ b/test/testdata/namer/arguments.rb.desugar-tree-raw.exp
@@ -46,7 +46,7 @@ ClassDef{
             }, RestParam{ expr = KeywordArg{ expr = UnresolvedIdent{
               kind = Local
               name = <U f>
-            } } }, BlockArg{ expr = UnresolvedIdent{
+            } } }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U g>
             } }]
@@ -128,7 +128,7 @@ ClassDef{
                     kind = Local
                     name = <U f>
                   } } }
-                  BlockArg{ expr = UnresolvedIdent{
+                  BlockParam{ expr = UnresolvedIdent{
                     kind = Local
                     name = <U g>
                   } }

--- a/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
+++ b/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
@@ -124,7 +124,7 @@ InsSeq{
                   RestParam{ expr = KeywordArg{ expr = Local{
                     localVariable = <U f>$1
                   } } }
-                  BlockArg{ expr = Local{
+                  BlockParam{ expr = Local{
                     localVariable = <U g>$1
                   } }
                   ShadowArg{ expr = Local{

--- a/test/testdata/parser/kwnil.parse-tree.exp
+++ b/test/testdata/parser/kwnil.parse-tree.exp
@@ -67,7 +67,7 @@ Begin {
         params = [
           Kwnilarg {
           }
-          Blockarg {
+          BlockParam {
             name = <U blk>
           }
         ]
@@ -89,7 +89,7 @@ Begin {
           }
           Kwnilarg {
           }
-          Blockarg {
+          BlockParam {
             name = <U blk>
           }
         ]
@@ -111,7 +111,7 @@ Begin {
           }
           Kwnilarg {
           }
-          Blockarg {
+          BlockParam {
             name = <U blk>
           }
         ]

--- a/test/testdata/parser/misc.rb.parse-tree.exp
+++ b/test/testdata/parser/misc.rb.parse-tree.exp
@@ -129,7 +129,7 @@ Begin {
       name = <U bfoo>
       params = Params {
         params = [
-          Blockarg {
+          BlockParam {
             name = <U x>
           }
         ]

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -10,7 +10,7 @@ ClassDef{
     MethodDef{
       flags = {}
       name = <U main><<U <todo method>>>
-      params = [BlockArg{ expr = UnresolvedIdent{
+      params = [BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
         } }]
@@ -1079,7 +1079,7 @@ ClassDef{
           params = [RestParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U args>
-            } }, BlockArg{ expr = UnresolvedIdent{
+            } }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -1356,7 +1356,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U foo><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -1423,7 +1423,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -1483,7 +1483,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U foo2><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -1568,7 +1568,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -1702,7 +1702,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U default><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -1769,7 +1769,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -1832,7 +1832,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U t_nilable><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -1923,7 +1923,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -1974,7 +1974,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U array><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2041,7 +2041,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2107,7 +2107,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U t_array><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2204,7 +2204,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2274,7 +2274,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U hash_of><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2379,7 +2379,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2430,7 +2430,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U const_explicit><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2481,7 +2481,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U const><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2532,7 +2532,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U enum_prop><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2599,7 +2599,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2650,7 +2650,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U foreign><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2717,7 +2717,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2814,7 +2814,7 @@ ClassDef{
                 name = <U allow_direct_mutation>
               } }
               default_ = Literal{ value = nil }
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2899,7 +2899,7 @@ ClassDef{
                 name = <U allow_direct_mutation>
               } }
               default_ = Literal{ value = nil }
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -2950,7 +2950,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U foreign_lazy><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -3017,7 +3017,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -3114,7 +3114,7 @@ ClassDef{
                 name = <U allow_direct_mutation>
               } }
               default_ = Literal{ value = nil }
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -3199,7 +3199,7 @@ ClassDef{
                 name = <U allow_direct_mutation>
               } }
               default_ = Literal{ value = nil }
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -3250,7 +3250,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U foreign_proc><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -3317,7 +3317,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -3414,7 +3414,7 @@ ClassDef{
                 name = <U allow_direct_mutation>
               } }
               default_ = Literal{ value = nil }
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -3499,7 +3499,7 @@ ClassDef{
                 name = <U allow_direct_mutation>
               } }
               default_ = Literal{ value = nil }
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -3550,7 +3550,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U foreign_invalid><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -3617,7 +3617,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -3710,7 +3710,7 @@ ClassDef{
                 name = <U allow_direct_mutation>
               } }
               default_ = Literal{ value = nil }
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -3803,7 +3803,7 @@ ClassDef{
                 name = <U allow_direct_mutation>
               } }
               default_ = Literal{ value = nil }
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -3854,7 +3854,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U ifunset><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -3921,7 +3921,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -3984,7 +3984,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U ifunset_nilable><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4075,7 +4075,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4126,7 +4126,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U empty_hash_rules><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4193,7 +4193,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4244,7 +4244,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U hash_rules><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4311,7 +4311,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4819,7 +4819,7 @@ ClassDef{
                 pairs = [
                 ]
               }
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4838,7 +4838,7 @@ ClassDef{
                 pairs = [
                 ]
               }
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4877,7 +4877,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U token><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4944,7 +4944,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -4995,7 +4995,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U created><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -5062,7 +5062,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -5156,7 +5156,7 @@ ClassDef{
                 pairs = [
                 ]
               }
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -5175,7 +5175,7 @@ ClassDef{
                 pairs = [
                 ]
               }
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -5214,7 +5214,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U token><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -5281,7 +5281,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -5332,7 +5332,7 @@ ClassDef{
         MethodDef{
           flags = {}
           name = <U created><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -5483,7 +5483,7 @@ ClassDef{
                 pairs = [
                 ]
               }
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -5534,7 +5534,7 @@ ClassDef{
         MethodDef{
           flags = {rewriterSynthesized}
           name = <U foo><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -5624,7 +5624,7 @@ ClassDef{
         MethodDef{
           flags = {rewriterSynthesized}
           name = <U encrypted_foo><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -5727,7 +5727,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -5860,7 +5860,7 @@ ClassDef{
           params = [UnresolvedIdent{
               kind = Local
               name = <U arg0>
-            }, BlockArg{ expr = UnresolvedIdent{
+            }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -5935,7 +5935,7 @@ ClassDef{
         MethodDef{
           flags = {rewriterSynthesized}
           name = <U bar><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -6025,7 +6025,7 @@ ClassDef{
         MethodDef{
           flags = {rewriterSynthesized}
           name = <U encrypted_bar><<U <todo method>>>
-          params = [BlockArg{ expr = UnresolvedIdent{
+          params = [BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]

--- a/test/whitequark/test_anonymous_blockarg_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_anonymous_blockarg_0.parse-tree-whitequark.exp
@@ -1,5 +1,5 @@
 s(:def, :foo,
   s(:params,
-    s(:blockarg, :&)),
+    s(:blockparam, :&)),
   s(:send, nil, :bar,
     s(:block_pass, nil)))

--- a/test/whitequark/test_arg_combinations_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_arg_combinations_0.parse-tree-whitequark.exp
@@ -4,4 +4,4 @@ s(:def, :f,
     s(:optparam, :o,
       s(:int, "1")),
     s(:restparam, :r),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_arg_combinations_1.parse-tree-whitequark.exp
+++ b/test/whitequark/test_arg_combinations_1.parse-tree-whitequark.exp
@@ -5,4 +5,4 @@ s(:def, :f,
       s(:int, "1")),
     s(:restparam, :r),
     s(:param, :p),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_arg_combinations_10.parse-tree-whitequark.exp
+++ b/test/whitequark/test_arg_combinations_10.parse-tree-whitequark.exp
@@ -3,4 +3,4 @@ s(:def, :f,
     s(:optparam, :o,
       s(:int, "1")),
     s(:param, :p),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_arg_combinations_11.parse-tree-whitequark.exp
+++ b/test/whitequark/test_arg_combinations_11.parse-tree-whitequark.exp
@@ -1,4 +1,4 @@
 s(:def, :f,
   s(:params,
     s(:restparam, :r),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_arg_combinations_12.parse-tree-whitequark.exp
+++ b/test/whitequark/test_arg_combinations_12.parse-tree-whitequark.exp
@@ -2,4 +2,4 @@ s(:def, :f,
   s(:params,
     s(:restparam, :r),
     s(:param, :p),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_arg_combinations_13.parse-tree-whitequark.exp
+++ b/test/whitequark/test_arg_combinations_13.parse-tree-whitequark.exp
@@ -1,3 +1,3 @@
 s(:def, :f,
   s(:params,
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_arg_combinations_2.parse-tree-whitequark.exp
+++ b/test/whitequark/test_arg_combinations_2.parse-tree-whitequark.exp
@@ -3,4 +3,4 @@ s(:def, :f,
     s(:param, :a),
     s(:optparam, :o,
       s(:int, "1")),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_arg_combinations_3.parse-tree-whitequark.exp
+++ b/test/whitequark/test_arg_combinations_3.parse-tree-whitequark.exp
@@ -4,4 +4,4 @@ s(:def, :f,
     s(:optparam, :o,
       s(:int, "1")),
     s(:param, :p),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_arg_combinations_4.parse-tree-whitequark.exp
+++ b/test/whitequark/test_arg_combinations_4.parse-tree-whitequark.exp
@@ -2,4 +2,4 @@ s(:def, :f,
   s(:params,
     s(:param, :a),
     s(:restparam, :r),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_arg_combinations_5.parse-tree-whitequark.exp
+++ b/test/whitequark/test_arg_combinations_5.parse-tree-whitequark.exp
@@ -3,4 +3,4 @@ s(:def, :f,
     s(:param, :a),
     s(:restparam, :r),
     s(:param, :p),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_arg_combinations_6.parse-tree-whitequark.exp
+++ b/test/whitequark/test_arg_combinations_6.parse-tree-whitequark.exp
@@ -1,4 +1,4 @@
 s(:def, :f,
   s(:params,
     s(:param, :a),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_arg_combinations_7.parse-tree-whitequark.exp
+++ b/test/whitequark/test_arg_combinations_7.parse-tree-whitequark.exp
@@ -3,4 +3,4 @@ s(:def, :f,
     s(:optparam, :o,
       s(:int, "1")),
     s(:restparam, :r),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_arg_combinations_8.parse-tree-whitequark.exp
+++ b/test/whitequark/test_arg_combinations_8.parse-tree-whitequark.exp
@@ -4,4 +4,4 @@ s(:def, :f,
       s(:int, "1")),
     s(:restparam, :r),
     s(:param, :p),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_arg_combinations_9.parse-tree-whitequark.exp
+++ b/test/whitequark/test_arg_combinations_9.parse-tree-whitequark.exp
@@ -2,4 +2,4 @@ s(:def, :f,
   s(:params,
     s(:optparam, :o,
       s(:int, "1")),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_arg_combinations_10.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_10.parse-tree-whitequark.exp
@@ -3,4 +3,4 @@ s(:block,
   s(:params,
     s(:param, :a),
     s(:restparam, :*),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_arg_combinations_13.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_13.parse-tree-whitequark.exp
@@ -2,4 +2,4 @@ s(:block,
   s(:send, nil, :f),
   s(:params,
     s(:restparam, :s),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_arg_combinations_14.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_14.parse-tree-whitequark.exp
@@ -2,4 +2,4 @@ s(:block,
   s(:send, nil, :f),
   s(:params,
     s(:restparam, :*),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_arg_combinations_17.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_17.parse-tree-whitequark.exp
@@ -1,4 +1,4 @@
 s(:block,
   s(:send, nil, :f),
   s(:params,
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_arg_combinations_18.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_18.parse-tree-whitequark.exp
@@ -7,4 +7,4 @@ s(:block,
     s(:optparam, :o1,
       s(:int, "2")),
     s(:restparam, :r),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_arg_combinations_19.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_19.parse-tree-whitequark.exp
@@ -6,4 +6,4 @@ s(:block,
       s(:int, "1")),
     s(:restparam, :r),
     s(:param, :p),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_arg_combinations_20.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_20.parse-tree-whitequark.exp
@@ -4,4 +4,4 @@ s(:block,
     s(:param, :a),
     s(:optparam, :o,
       s(:int, "1")),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_arg_combinations_21.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_21.parse-tree-whitequark.exp
@@ -5,4 +5,4 @@ s(:block,
     s(:optparam, :o,
       s(:int, "1")),
     s(:param, :p),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_arg_combinations_22.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_22.parse-tree-whitequark.exp
@@ -4,4 +4,4 @@ s(:block,
     s(:param, :a),
     s(:restparam, :r),
     s(:param, :p),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_arg_combinations_23.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_23.parse-tree-whitequark.exp
@@ -4,4 +4,4 @@ s(:block,
     s(:optparam, :o,
       s(:int, "1")),
     s(:restparam, :r),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_arg_combinations_24.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_24.parse-tree-whitequark.exp
@@ -5,4 +5,4 @@ s(:block,
       s(:int, "1")),
     s(:restparam, :r),
     s(:param, :p),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_arg_combinations_25.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_25.parse-tree-whitequark.exp
@@ -3,4 +3,4 @@ s(:block,
   s(:params,
     s(:optparam, :o,
       s(:int, "1")),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_arg_combinations_26.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_26.parse-tree-whitequark.exp
@@ -4,4 +4,4 @@ s(:block,
     s(:optparam, :o,
       s(:int, "1")),
     s(:param, :p),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_arg_combinations_27.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_27.parse-tree-whitequark.exp
@@ -3,4 +3,4 @@ s(:block,
   s(:params,
     s(:restparam, :r),
     s(:param, :p),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_arg_combinations_8.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_8.parse-tree-whitequark.exp
@@ -2,4 +2,4 @@ s(:block,
   s(:send, nil, :f),
   s(:params,
     s(:param, :a),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_arg_combinations_9.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_9.parse-tree-whitequark.exp
@@ -3,4 +3,4 @@ s(:block,
   s(:params,
     s(:param, :a),
     s(:restparam, :s),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_kwarg_combinations_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_kwarg_combinations_0.parse-tree-whitequark.exp
@@ -6,4 +6,4 @@ s(:block,
     s(:kwoptarg, :bar,
       s(:int, "2")),
     s(:kwrestarg, :baz),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_kwarg_combinations_1.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_kwarg_combinations_1.parse-tree-whitequark.exp
@@ -3,4 +3,4 @@ s(:block,
   s(:params,
     s(:kwoptarg, :foo,
       s(:int, "1")),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_kwarg_combinations_2.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_kwarg_combinations_2.parse-tree-whitequark.exp
@@ -2,4 +2,4 @@ s(:block,
   s(:send, nil, :f),
   s(:params,
     s(:kwrestarg, :baz),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_blockarg_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_blockarg_0.parse-tree-whitequark.exp
@@ -1,3 +1,3 @@
 s(:def, :f,
   s(:params,
-    s(:blockarg, :block)), nil)
+    s(:blockparam, :block)), nil)

--- a/test/whitequark/test_kwarg_combinations_0.parse-tree-whitequark.exp
+++ b/test/whitequark/test_kwarg_combinations_0.parse-tree-whitequark.exp
@@ -5,4 +5,4 @@ s(:def, :f,
     s(:kwoptarg, :bar,
       s(:int, "2")),
     s(:kwrestarg, :baz),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_kwarg_combinations_1.parse-tree-whitequark.exp
+++ b/test/whitequark/test_kwarg_combinations_1.parse-tree-whitequark.exp
@@ -2,4 +2,4 @@ s(:def, :f,
   s(:params,
     s(:kwoptarg, :foo,
       s(:int, "1")),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)

--- a/test/whitequark/test_kwarg_combinations_2.parse-tree-whitequark.exp
+++ b/test/whitequark/test_kwarg_combinations_2.parse-tree-whitequark.exp
@@ -1,4 +1,4 @@
 s(:def, :f,
   s(:params,
     s(:kwrestarg, :baz),
-    s(:blockarg, :b)), nil)
+    s(:blockparam, :b)), nil)


### PR DESCRIPTION
### Motivation

Part of #9325

This PR renames `Blockarg` to `BlockParam`

Changed the name of `core::Names::blkArg`, but left its value (`<blk>`) as-is.

### Test plan

Covered by existing tests. A number of them needed modification to account for the change in the printed name.
