### PR TITLE
Improve Prism Direct Desugaring of PM_OR_NODE and PM_AND_NODE

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -336,6 +336,13 @@ pipeline_tests(
 
             # Minor differences in the parse tree lead to different exp files
             "testdata/rbs/assertions_heredoc.rb",
+
+            # Whitequark and Prism parsers disagree on inclusion of parentheses in the location.
+            # This is surfaced with PM_AND_NODE and PM_OR_NODE desugaring a right hand side enclosed in parentheses.
+            # See comment in PM_PARENTHESES_NODE in Translator.cc.
+            #   "Override the begin node location to be the parentheses location instead of the statements location"
+            # However, undoing that override leads to issues with nested parentheses handling.
+            "testdata/infer/control_flow/complex_implication_1.rb",
         ],
     ),
     "PrismPosTests",


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

- desugar non-reference expressions that create unique temporary names
- Add handling for checkAndAnd in PM_AND_NODE


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
