### PR TITLE
Directly desugar Symbol block pass arguments

### DIFF
--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -95,6 +95,8 @@ private:
     std::tuple<ast::MethodDef::PARAMS_store, ast::InsSeq::STATS_store, bool>
     desugarParametersNode(NodeVec &params, bool attemptToDesugarParams);
 
+    ast::ExpressionPtr desugarSymbolProc(pm_symbol_node *symbol);
+
     NodeVec translateArguments(pm_arguments_node *node, pm_node *blockArgumentNode = nullptr);
     parser::NodeVec translateKeyValuePairs(pm_node_list_t elements);
 


### PR DESCRIPTION
### Motivation

Part of #9065 and https://github.com/Shopify/sorbet/issues/461

This PR expands on the support for block pass arguments (#9349) to now include Symbol procs like `map(&:to_s)`.

### Test plan

Covered by existing desugar tests.