### PR TITLE
Prevent `Kernel` module from getting `requires_ancestor { Kernel }` injected

### DIFF
--- a/rewriter/RequiresAncestorKernel.cc
+++ b/rewriter/RequiresAncestorKernel.cc
@@ -25,6 +25,12 @@ void RequiresAncestorKernel::run(core::MutableContext ctx, ast::ClassDef *klass)
         return;
     }
 
+    // If the module is named Kernel and has no scope, don't add Kernel
+    auto id = ast::cast_tree<ast::UnresolvedConstantLit>(klass->name);
+    if (id && id->cnst == core::Names::Constants::Kernel() && ast::MK::isRootScope(id->scope)) {
+        return;
+    }
+
     if (hasAnyRequiresAncestorCall(ctx, klass)) {
         return;
     }

--- a/test/testdata/rewriter/requires_ancestor_kernel.rb
+++ b/test/testdata/rewriter/requires_ancestor_kernel.rb
@@ -1,14 +1,14 @@
 # typed: true
 # enable-experimental-requires-ancestor: true
 
-# Test case 1: Module without any requires_ancestor should get Kernel added
+# Module without any `requires_ancestor` should get `Kernel` added
 module TestModule1
   def some_method
     puts "hello"
   end
 end
 
-# Test case 2: Module with requires_ancestor { BasicObject } should NOT get Kernel added
+# Module with `requires_ancestor { BasicObject }` should NOT get `Kernel` added
 module TestModule2
   extend T::Helpers
   requires_ancestor { BasicObject }
@@ -18,7 +18,7 @@ module TestModule2
   end
 end
 
-# Test case 3: Module with requires_ancestor { Kernel } should NOT get another Kernel added
+# Module with `requires_ancestor { Kernel }` should NOT get another `Kernel` added
 module TestModule3
   extend T::Helpers
   requires_ancestor { Kernel }
@@ -28,19 +28,36 @@ module TestModule3
   end
 end
 
-# Test case 4: Class should NOT get requires_ancestor { Kernel } added
+# Class should NOT get `requires_ancestor { Kernel }` added
 class TestClass1
   def some_method
     puts "hello"
   end
 end
 
-# Test case 5: Module with other requires_ancestor should get Kernel added
+# Module with other `requires_ancestor` should get `Kernel` added
 module TestModule4
   extend T::Helpers
   requires_ancestor { Object }
 
   def some_method
     puts "hello"
+  end
+end
+
+# Unscoped `Kernel` modules should NOT get `Kernel` added
+module Kernel
+end
+
+module ::Kernel
+end
+
+# Scoped modules named `Kernel` should get `Kernel` added
+module Mine::Kernel
+end
+
+# Unfortunately, nested constants that are named Kernel will not get Kernel added
+module Mine
+  module Kernel
   end
 end

--- a/test/testdata/rewriter/requires_ancestor_kernel.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/requires_ancestor_kernel.rb.rewrite-tree.exp
@@ -62,4 +62,29 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of some_method>
   end
+
+  module <emptyTree>::<C Kernel><<C <todo sym>>> < ()
+  end
+
+  module ::<root>::<C Kernel><<C <todo sym>>> < ()
+  end
+
+  module <emptyTree>::<C Mine>::<C Kernel><<C <todo sym>>> < ()
+    <self>.extend(::T::Helpers)
+
+    <self>.requires_ancestor() do ||
+      ::Kernel
+    end
+  end
+
+  module <emptyTree>::<C Mine><<C <todo sym>>> < ()
+    module <emptyTree>::<C Kernel><<C <todo sym>>> < ()
+    end
+
+    <self>.extend(::T::Helpers)
+
+    <self>.requires_ancestor() do ||
+      ::Kernel
+    end
+  end
 end


### PR DESCRIPTION
Since a module cannot refer to itself within a `requires_ancestor` call, we should have excluded `Kernel` from getting any such `requires_ancestor { Kernel }` call injected.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This ends up being a problem in any RBI file from a gem that reopens `Kernel` to add methods, or similar.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
