### PR TITLE
Add a builder for constructing package text in tests

### DIFF
--- a/test/helpers/packages.h
+++ b/test/helpers/packages.h
@@ -18,6 +18,48 @@ class PackageInfo;
 
 namespace sorbet::test {
 
+class PackageTextBuilder {
+    std::string name;
+    std::string strictDeps;
+    std::string layer;
+    std::vector<std::string> imports;
+    std::vector<std::string> testImports;
+    bool preludePackage;
+
+public:
+    PackageTextBuilder &withName(std::string name) {
+        this->name = std::move(name);
+        return *this;
+    }
+
+    PackageTextBuilder &withStrictDeps(std::string strictDeps) {
+        this->strictDeps = std::move(strictDeps);
+        return *this;
+    }
+
+    PackageTextBuilder &withLayer(std::string layer) {
+        this->layer = std::move(layer);
+        return *this;
+    }
+
+    PackageTextBuilder &withImports(std::vector<std::string> imports) {
+        this->imports = std::move(imports);
+        return *this;
+    }
+
+    PackageTextBuilder &withTestImports(std::vector<std::string> testImports) {
+        this->testImports = std::move(testImports);
+        return *this;
+    }
+
+    PackageTextBuilder &withPreludePackage() {
+        this->preludePackage = true;
+        return *this;
+    }
+
+    std::string build();
+};
+
 // Helpers for writing tests about the package DB.
 class PackageHelpers {
 public:


### PR DESCRIPTION
Add a builder to simplify constructing package text with different options.

### Motivation
Simplifying test creation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This is a test utility change, the existing pkg_autocorrects_test.cc and pkg_condensation_test.cc should be sufficient.
