### PR TITLE
Mark `initialize_copy` as `private`

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -491,7 +491,7 @@ module Kernel
   private def initialize_clone(*args); end
 
   sig {params(object: T.self_type).returns(T.self_type)}
-  def initialize_copy(object); end
+  private def initialize_copy(object); end
 
   private def initialize_dup(orig); end
 


### PR DESCRIPTION
It's private in `Kernel`:

    > class A; end

    > A.new.method(:initialize_copy)
    => #<Method: A(Kernel)#initialize_copy(_)>

    3> A.new.initialize_copy(A.new)
    (irb):3:in `<main>': private method `initialize_copy' called for an instance of A (NoMethodError)

    A.new.initialize_copy(A.new)
         ^^^^^^^^^^^^^^^^
            from <internal:kernel>:187:in `loop'
            from /Users/jez/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/irb-1.13.1/exe/irb:9:in `<top (required)>'
            from /Users/jez/.rbenv/versions/3.3.5/bin/irb:25:in `load'
            from /Users/jez/.rbenv/versions/3.3.5/bin/irb:25:in `<main>'

    4> A.method_defined?(:initialize_copy)
    => false

    5> A.private_method_defined?(:initialize_copy)
    => true

    6> Kernel.method_defined?(:initialize_copy)
    => false

    7> Kernel.private_method_defined?(:initialize_copy)
    => true


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

One day, I hope to fix `T.self_type` in parameters, but we should
probably not allow it in public instance methods for the same reason
that covariant type members are not allowed in public instance methods.
This is the only place in Sorbet's RBIs that has a `T.self_type` in an
input position, and we're lucky because this method is private (and
meant to be called privately).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a