### PR TITLE
Include `Kernel` in `Delegator`

### DIFF
--- a/rbi/stdlib/delegator.rbi
+++ b/rbi/stdlib/delegator.rbi
@@ -38,6 +38,8 @@
 # Be advised, [`RDoc`](https://docs.ruby-lang.org/en/2.7.0/RDoc.html) will not
 # detect delegated methods.
 class Delegator < BasicObject
+  include ::Kernel
+
   # Pass in the *obj* to delegate method calls to. All methods supported by
   # *obj* will be delegated to.
   sig { params(obj: BasicObject).void }


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Even though it inherits from `BasicObject` `Delegator` it does effectively include `Kernel` https://github.com/ruby/ruby/blob/cdb9c2543415588c485282e460cdaba09452ab6a/lib/delegate.rb#L88-L89

This resolves bunch of `must include Kernel` errors for RBIs that utilize delegator https://github.com/Shopify/tapioca/issues/2393

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
