### PR TITLE
Use `<Magic>.requires_ancestor`

### DIFF
--- a/rewriter/RequiresAncestorKernel.cc
+++ b/rewriter/RequiresAncestorKernel.cc
@@ -35,18 +35,13 @@ void RequiresAncestorKernel::run(core::MutableContext ctx, ast::ClassDef *klass)
         return;
     }
 
-    auto loc = klass->loc;
-    auto locZero = loc.copyWithZeroLength();
-
-    // Add extend T::Helpers
-    klass->rhs.emplace_back(ast::MK::Send1(loc, ast::MK::Self(loc), core::Names::extend(), locZero,
-                                           ast::MK::Constant(loc, core::Symbols::T_Helpers())));
+    auto locZero = klass->declLoc.copyEndWithZeroLength();
 
     // Add requires_ancestor { Kernel }
-    auto kernelConstant = ast::MK::Constant(loc, core::Symbols::Kernel());
-    auto block = ast::MK::Block0(loc, std::move(kernelConstant));
-    auto requiresAncestorSend =
-        ast::MK::Send0Block(loc, ast::MK::Self(loc), core::Names::requiresAncestor(), loc, std::move(block));
+    auto kernelConstant = ast::MK::Constant(locZero, core::Symbols::Kernel());
+    auto block = ast::MK::Block0(locZero, std::move(kernelConstant));
+    auto requiresAncestorSend = ast::MK::Send0Block(locZero, ast::MK::Magic(locZero), core::Names::requiresAncestor(),
+                                                    locZero, std::move(block));
 
     klass->rhs.emplace_back(std::move(requiresAncestorSend));
 }

--- a/test/testdata/lsp/requires_ancestor_ab.rb.symbol-table.exp
+++ b/test/testdata/lsp/requires_ancestor_ab.rb.symbol-table.exp
@@ -11,7 +11,7 @@ class ::<root> < ::Object ()
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/lsp/requires_ancestor_ab.rb start=??? end=???}
     method ::A#only_on_a (<blk>) @ test/testdata/lsp/requires_ancestor_ab.rb:7
       argument <blk><block> @ Loc {file=test/testdata/lsp/requires_ancestor_ab.rb start=??? end=???}
-  class ::<Class:A> < ::Module (Helpers, Sig) @ test/testdata/lsp/requires_ancestor_ab.rb:4
+  class ::<Class:A> < ::Module (Sig) @ test/testdata/lsp/requires_ancestor_ab.rb:4
     method ::<Class:A>#<static-init> (<blk>) @ test/testdata/lsp/requires_ancestor_ab.rb:4
       argument <blk><block> @ Loc {file=test/testdata/lsp/requires_ancestor_ab.rb start=??? end=???}
   module ::B < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/lsp/requires_ancestor_ab.rb:13
@@ -23,7 +23,7 @@ class ::<root> < ::Object ()
       argument <blk><block> -> T.untyped @ Loc {file=test/testdata/lsp/requires_ancestor_ab.rb start=??? end=???}
     method ::B#only_on_b (<blk>) @ test/testdata/lsp/requires_ancestor_ab.rb:16
       argument <blk><block> @ Loc {file=test/testdata/lsp/requires_ancestor_ab.rb start=??? end=???}
-  class ::<Class:B> < ::Module (Helpers, Sig) @ test/testdata/lsp/requires_ancestor_ab.rb:13
+  class ::<Class:B> < ::Module (Sig) @ test/testdata/lsp/requires_ancestor_ab.rb:13
     method ::<Class:B>#<static-init> (<blk>) @ test/testdata/lsp/requires_ancestor_ab.rb:13
       argument <blk><block> @ Loc {file=test/testdata/lsp/requires_ancestor_ab.rb start=??? end=???}
   class ::C < ::Object (Target) @ test/testdata/lsp/requires_ancestor_ab.rb:35

--- a/test/testdata/rewriter/requires_ancestor_kernel.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/requires_ancestor_kernel.rb.rewrite-tree.exp
@@ -6,9 +6,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of some_method>
 
-    <self>.extend(::T::Helpers)
-
-    <self>.requires_ancestor() do ||
+    ::<Magic>.requires_ancestor() do ||
       ::Kernel
     end
   end
@@ -70,9 +68,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C Mine>::<C Kernel><<C <todo sym>>> < ()
-    <self>.extend(::T::Helpers)
-
-    <self>.requires_ancestor() do ||
+    ::<Magic>.requires_ancestor() do ||
       ::Kernel
     end
   end
@@ -81,9 +77,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     module <emptyTree>::<C Kernel><<C <todo sym>>> < ()
     end
 
-    <self>.extend(::T::Helpers)
-
-    <self>.requires_ancestor() do ||
+    ::<Magic>.requires_ancestor() do ||
       ::Kernel
     end
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It is **never** okay to insert an `include` or an `extend` in a rewriter
pass to get a Sorbet-specific helper method like
`mixes_in_class_methods`, `abstract!`, `requires_ancestor`, etc.
defined.

Doing so masks valid errors: e.g. had someone went to define `abstract!`
in this class, they would be met with runtime-only missing methods
errors, because `extend T::Helpers` is not in the ancestor hierarchy at
runtime.


cc @elliottt @paracycle

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.