### PR TITLE
Directly desugar regular expression nodes

### DIFF
--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -1732,41 +1732,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                                       move(excludeEnd));
                 result = move(send);
             },
-            [&](parser::Regexp *regexpNode) {
-                ExpressionPtr cnst = MK::Constant(loc, core::Symbols::Regexp());
-                auto pattern = desugarDString(dctx, loc, move(regexpNode->regex));
-                auto opts = node2TreeImpl(dctx, regexpNode->opts);
-                auto send = MK::Send2(loc, move(cnst), core::Names::new_(), locZeroLen, move(pattern), move(opts));
-                result = move(send);
-            },
-            [&](parser::Regopt *regopt) {
-                int flags = 0;
-                for (auto &chr : regopt->opts) {
-                    int flag = 0;
-                    switch (chr) {
-                        case 'i':
-                            flag = 1; // Regexp::IGNORECASE
-                            break;
-                        case 'x':
-                            flag = 2; // Regexp::EXTENDED
-                            break;
-                        case 'm':
-                            flag = 4; // Regexp::MULILINE
-                            break;
-                        case 'n':
-                        case 'e':
-                        case 's':
-                        case 'u':
-                            // Encoding options that should already be handled by the parser
-                            break;
-                        default:
-                            // The parser already yelled about this
-                            break;
-                    }
-                    flags |= flag;
-                }
-                result = MK::Int(loc, flags);
-            },
+            [&](parser::Regexp *regexpNode) { desugaredByPrismTranslator(regexpNode); },
+            [&](parser::Regopt *regopt) { desugaredByPrismTranslator(regopt); },
             [&](parser::Return *ret) {
                 if (ret->exprs.size() > 1) {
                     auto arrayLoc = ret->exprs.front()->loc.join(ret->exprs.back()->loc);

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -112,9 +112,9 @@ private:
     std::unique_ptr<parser::Node> translateStatements(pm_statements_node *stmtsNode, bool inlineIfSingle = true,
                                                       std::optional<pm_location_t> overrideLocation = std::nullopt);
 
-    std::unique_ptr<parser::Regopt> translateRegexpOptions(pm_location_t closingLoc);
-    std::unique_ptr<parser::Regexp> translateRegexp(pm_string_t unescaped, core::LocOffsets location,
-                                                    pm_location_t closingLoc);
+    std::unique_ptr<parser::Node> translateRegexpOptions(pm_location_t closingLoc);
+    std::unique_ptr<parser::Node> translateRegexp(pm_string_t unescaped, core::LocOffsets location,
+                                                  pm_location_t closingLoc);
 
     template <typename PrismNode> std::unique_ptr<parser::Mlhs> translateMultiTargetLhs(PrismNode *);
 


### PR DESCRIPTION
Part of #9065 

Desugars `PM_REGULAR_EXPRESSION_NODE` and `PM_INTERPOLATED_REGULAR_EXPRESSION_NODE` in `Translator.cc` as part of integrating Prism in Sorbet


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing tests
