### PR TITLE
Don't export instance variables

### DIFF
--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -232,6 +232,7 @@ public:
         bool isStaticFieldTypeAlias : 1;
         bool isStaticFieldPrivate : 1;
 
+        // Can only export a static field
         bool isExported : 1;
 
         constexpr static uint8_t NUMBER_OF_FLAGS = 5;

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -141,6 +141,9 @@ class PropagateVisibility final {
 
             case core::SymbolRef::Kind::FieldOrStaticField: {
                 auto fieldData = sym.asFieldRef().data(ctx);
+                if (!fieldData->flags.isStaticField) {
+                    break;
+                }
 
                 if (setExportedTo) {
                     checkDuplicateExport(ctx, currentExportLineSym, currentExportLineLoc, sym,

--- a/test/testdata/packager/export_conflicts/__package.rb
+++ b/test/testdata/packager/export_conflicts/__package.rb
@@ -7,4 +7,6 @@ class MyPackage < PackageSpec
   export MyPackage::A::C
 # ^^^^^^^^^^^^^^^^^^^^^^ error: Cannot export `MyPackage::A::C` because another exported name `MyPackage::A` is a prefix of it
   export MyPackage::A
+
+  export MyPackage::HasSingletonIvar # error: Cannot export `T.class_of(MyPackage::HasSingletonIvar::Nested)#@nested` because another exported name `MyPackage::HasSingletonIvar` is a prefix of it
 end

--- a/test/testdata/packager/export_conflicts/__package.rb
+++ b/test/testdata/packager/export_conflicts/__package.rb
@@ -8,5 +8,5 @@ class MyPackage < PackageSpec
 # ^^^^^^^^^^^^^^^^^^^^^^ error: Cannot export `MyPackage::A::C` because another exported name `MyPackage::A` is a prefix of it
   export MyPackage::A
 
-  export MyPackage::HasSingletonIvar # error: Cannot export `T.class_of(MyPackage::HasSingletonIvar::Nested)#@nested` because another exported name `MyPackage::HasSingletonIvar` is a prefix of it
+  export MyPackage::HasSingletonIvar
 end

--- a/test/testdata/packager/export_conflicts/has_singleton_ivar.rb
+++ b/test/testdata/packager/export_conflicts/has_singleton_ivar.rb
@@ -1,0 +1,11 @@
+# typed: strict
+
+module MyPackage
+  class HasSingletonIvar
+    @outside = T.let(0, Integer)
+
+    class Nested
+      @nested = T.let(0, Integer)
+    end
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes a bug on Stripe's codebase introduced by #9342

- The old version didn't have this bug, because duplicate exports were reported
  only at the level of what showed up in the `vector<vector<NameRef>>` capturing
  the list of exports. So duplicate exports error reporting never looked at the
  symbol table, because that phase ran before the symbol table had even been
  populated.

- The old version **did** actually mark instance variables as exported. Somehow
  this only causes a duplicate export error if the instance variable shows up
  inside of some other, nested class or module, not if it's an instance variable
  at the top level (i.e., only `@nested`, not `@outside`)

  This didn't matter in practice, because we never read the value of
  `isExported` for fields--we would only read it during
  `postTransformConstantLiteral`, which mean that we would only read it for
  `class-or-module` or `static-field` symbols.

  My apologies to @neilparikh, to whom I said the opposite in a meeting earlier
  today (that we don't mark fields exported). It turns out we do, but it didn't
  matter because we don't read that bit.

We can solve it by simply only exporting static fields.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.