### PR TITLE
Remove "either" from `include Kernel` error note

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -801,7 +801,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                                                                    fmt::format("{}.{}", ownerName, args.name.show(gs)))
                                              : ".";
 
-                        e.addErrorNote("`{}` is actually defined as a method on `{}`. To call it, either\n"
+                        e.addErrorNote("`{}` is actually defined as a method on `{}`. To call it,\n"
                                        "    `{}` in this module to ensure the method is always there{}",
                                        args.name.show(gs), ownerName, fmt::format("include {}", ownerName),
                                        suggestKernelDot);

--- a/test/cli/suggest-kernel/test.out
+++ b/test/cli/suggest-kernel/test.out
@@ -6,14 +6,14 @@ test/cli/suggest-kernel/suggest-kernel.rb:14: Method `is_a?` does not exist on `
     .. |def example(x)
                     ^
   Note:
-    `is_a?` is actually defined as a method on `Kernel`. To call it, either
+    `is_a?` is actually defined as a method on `Kernel`. To call it,
     `include Kernel` in this module to ensure the method is always there.
 
 test/cli/suggest-kernel/suggest-kernel.rb:4: Method `raise` does not exist on `Foo` https://srb.help/7003
      .. |    raise "hi"
             ^^^^^
   Note:
-    `raise` is actually defined as a method on `Kernel`. To call it, either
+    `raise` is actually defined as a method on `Kernel`. To call it,
     `include Kernel` in this module to ensure the method is always there, or
     call the method using `Kernel.raise` instead.
   Autocorrect: Use `-a` to autocorrect
@@ -25,7 +25,7 @@ test/cli/suggest-kernel/suggest-kernel.rb:5: Method `Integer` does not exist on 
      .. |    Integer(0)
             ^^^^^^^
   Note:
-    `Integer` is actually defined as a method on `Kernel`. To call it, either
+    `Integer` is actually defined as a method on `Kernel`. To call it,
     `include Kernel` in this module to ensure the method is always there, or
     call the method using `Kernel.Integer` instead.
   Autocorrect: Use `-a` to autocorrect
@@ -43,7 +43,7 @@ test/cli/suggest-kernel/suggest-kernel.rb:6: Method `Array` does not exist on `F
      .. |    Array(0)
             ^^^^^
   Note:
-    `Array` is actually defined as a method on `Kernel`. To call it, either
+    `Array` is actually defined as a method on `Kernel`. To call it,
     `include Kernel` in this module to ensure the method is always there, or
     call the method using `Kernel.Array` instead.
   Autocorrect: Use `-a` to autocorrect


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is not always an "either" because sometimes we omit the second
alternative when it won't actually be a solution. The sentence still
reads fine without the `either`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.