### PR TITLE
Treat module singleton classes as final for flow-sensitive checking

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -507,10 +507,13 @@ bool isSingleton(core::Context ctx, const core::TypePtr &ty, bool includeSinglet
     }
 
     // attachedClass on untyped symbol is defined to return itself
-    if (includeSingletonClasses && sym != core::Symbols::untyped() && data->attachedClass(ctx).exists() &&
-        data->flags.isFinal) {
-        // This is a Ruby singleton class object
-        return true;
+    if (includeSingletonClasses && sym != core::Symbols::untyped()) {
+        // Check for Ruby singleton class objects
+        auto attachedClass = data->attachedClass(ctx);
+        if (attachedClass.exists() && (data->flags.isFinal || attachedClass.data(ctx)->flags.isModule)) {
+            // module singleton classes are final even if not declared `final!` because of how the Ruby VM works
+            return true;
+        }
     }
 
     // The Ruby stdlib has a Singleton module which lets people invent their own singletons.

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -499,20 +499,22 @@ bool isSingleton(core::Context ctx, const core::TypePtr &ty, bool includeSinglet
         return true;
     }
 
+    auto data = sym.data(ctx);
+
     // T::Enum values are modeled as singletons of their own fake class.
-    if (sym.data(ctx)->name.isTEnumName(ctx)) {
+    if (data->name.isTEnumName(ctx)) {
         return true;
     }
 
     // attachedClass on untyped symbol is defined to return itself
-    if (includeSingletonClasses && sym != core::Symbols::untyped() && sym.data(ctx)->attachedClass(ctx).exists() &&
-        sym.data(ctx)->flags.isFinal) {
+    if (includeSingletonClasses && sym != core::Symbols::untyped() && data->attachedClass(ctx).exists() &&
+        data->flags.isFinal) {
         // This is a Ruby singleton class object
         return true;
     }
 
     // The Ruby stdlib has a Singleton module which lets people invent their own singletons.
-    return (sym.data(ctx)->derivesFrom(ctx, core::Symbols::Singleton()) && sym.data(ctx)->flags.isFinal);
+    return (data->derivesFrom(ctx, core::Symbols::Singleton()) && data->flags.isFinal);
 }
 
 } // namespace

--- a/test/testdata/infer/singleton_class_update_knowledge.rb
+++ b/test/testdata/infer/singleton_class_update_knowledge.rb
@@ -72,6 +72,8 @@ end
 
 module E; extend T::Helpers; final!; end
 module F; extend T::Helpers; final!; end
+# module singleton classes are implicitly final
+module G; end
 
 sig {params(x: T.any(T.class_of(E), T.class_of(F))).void}
 def test7(x)
@@ -91,11 +93,30 @@ def test8(x)
   end
 end
 
+sig { params(x: T.any(T.class_of(G), T.class_of(E))).void }
+def test9(x)
+  if x == G
+    T.reveal_type(x) # error: `T.class_of(G)`
+  elsif x == E
+    T.reveal_type(x) # error: `T.class_of(E)`
+  else
+    T.absurd(x) # error: the type `T.class_of(G)` wasn't handled
+  end
+
+  if G == x
+    T.reveal_type(x) # error: `T.class_of(G)`
+  elsif E == x
+    T.reveal_type(x) # error: `T.class_of(E)`
+  else
+    T.absurd(x) # error: the type `T.class_of(G)` wasn't handled
+  end
+end
+
 class Parent; end
 class Child < Parent; end
 
 sig {params(x: T.class_of(Parent)).void}
-def test9(x)
+def test10(x)
   if x == Parent
     T.reveal_type(x) # error: `T.class_of(Parent)`
   else
@@ -105,7 +126,7 @@ def test9(x)
 end
 
 sig {params(x: T.class_of(Parent)).void}
-def test10(x)
+def test11(x)
   if Parent == x
     T.reveal_type(x) # error: `T.class_of(Parent)`
   else

--- a/test/testdata/infer/singleton_class_update_knowledge.rb
+++ b/test/testdata/infer/singleton_class_update_knowledge.rb
@@ -100,7 +100,7 @@ def test9(x)
   elsif x == E
     T.reveal_type(x) # error: `T.class_of(E)`
   else
-    T.absurd(x) # error: the type `T.class_of(G)` wasn't handled
+    T.absurd(x)
   end
 
   if G == x
@@ -108,7 +108,7 @@ def test9(x)
   elsif E == x
     T.reveal_type(x) # error: `T.class_of(E)`
   else
-    T.absurd(x) # error: the type `T.class_of(G)` wasn't handled
+    T.absurd(x)
   end
 end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Brought up by a user

For more context: [module singleton classes are final](https://blog.jez.io/inheritance-in-ruby/#the-include-operator)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.