### PR TITLE
Handle test-only packages in the condensation strata

### DIFF
--- a/core/FileRef.h
+++ b/core/FileRef.h
@@ -52,6 +52,11 @@ public:
     // file. This helper exposes that without tripping an ENFORCE.
     bool isPackage(const GlobalState &gs) const;
 
+    // Normally, using .data requires that the file have been read.
+    // But File::Flag data is populated when the File is created, before needing to read the
+    // file. This helper exposes that without tripping an ENFORCE.
+    bool isTestPackage(const GlobalState &gs) const;
+
 private:
     uint32_t _id;
 };

--- a/core/Files.cc
+++ b/core/Files.cc
@@ -165,6 +165,12 @@ bool FileRef::isPackage(const GlobalState &gs) const {
     return dataAllowingUnsafe(gs).isPackage(gs);
 }
 
+bool FileRef::isTestPackage(const GlobalState &gs) const {
+    ENFORCE(gs.files[_id]);
+    ENFORCE(gs.files[_id]->sourceType != File::Type::TombStone);
+    return dataAllowingUnsafe(gs).isTestPackage(gs);
+}
+
 string_view File::path() const {
     return this->path_;
 }
@@ -212,6 +218,15 @@ bool File::isPackage(const GlobalState &gs) const {
     // Checks `packageDB()` last because probably we have better locality on the `flags` for the
     // common case of this not being a `__package.rb` file.
     return hasPackageRbPath() && gs.packageDB().enabled();
+}
+
+bool File::isTestPackage(const GlobalState &gs) const {
+    // If the `__package.rb` file is at `typed: ignore`, then we haven't even parsed it.
+    // Any loop over "all package files" really only wants "all non-ignored package files."
+    //
+    // Checks `packageDB()` last because probably we have better locality on the `flags` for the
+    // common case of this not being a `__package.rb` file.
+    return hasPackageRbPath() && this->flags.isTestPath && gs.packageDB().enabled();
 }
 
 bool File::isOpenInClient() const {

--- a/core/Files.h
+++ b/core/Files.h
@@ -51,6 +51,7 @@ public:
 
     bool hasPackageRbPath() const;
     bool isPackage(const GlobalState &gs) const;
+    bool isTestPackage(const GlobalState &gs) const;
 
     // Whether the file is open in the LSP client. (Always false if not running under LSP.)
     bool isOpenInClient() const;


### PR DESCRIPTION
Packages that live in a `*/test/*` path will never have application code associated with them. As such, we don't need to copy and edit them when processing the application code for a package. This PR implements that change by ignoring test-only packages during SCC construction, and then setting their SCC id to their test SCC id.

All of this can go away once we have separated out test packages.

### Motivation
Unblocking rolling out package-directed type checking.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
