### PR TITLE
Simplify NamedLiteralType

### DIFF
--- a/ast/TreeEquality.cc
+++ b/ast/TreeEquality.cc
@@ -257,7 +257,7 @@ bool compareTrees(const core::GlobalState &gs, const void *avoid, const Tag tag,
             } else if (aType.tag() == core::TypePtr::Tag::NamedLiteralType) {
                 auto named_literal_a = core::cast_type_nonnull<core::NamedLiteralType>(aType);
                 auto named_literal_b = core::cast_type_nonnull<core::NamedLiteralType>(bType);
-                return named_literal_a.literalKind == named_literal_b.literalKind &&
+                return named_literal_a.kind == named_literal_b.kind &&
                        Comparator::compareNames(gs, named_literal_a.name, named_literal_b.name);
             } else if (aType.tag() == core::TypePtr::Tag::ClassType) {
                 auto class_type_a = core::cast_type_nonnull<core::ClassType>(aType);

--- a/ast/TreeEquality.cc
+++ b/ast/TreeEquality.cc
@@ -258,7 +258,7 @@ bool compareTrees(const core::GlobalState &gs, const void *avoid, const Tag tag,
                 auto named_literal_a = core::cast_type_nonnull<core::NamedLiteralType>(aType);
                 auto named_literal_b = core::cast_type_nonnull<core::NamedLiteralType>(bType);
                 return named_literal_a.literalKind == named_literal_b.literalKind &&
-                       Comparator::compareNames(gs, named_literal_a.asName(), named_literal_b.asName());
+                       Comparator::compareNames(gs, named_literal_a.name, named_literal_b.name);
             } else if (aType.tag() == core::TypePtr::Tag::ClassType) {
                 auto class_type_a = core::cast_type_nonnull<core::ClassType>(aType);
                 auto class_type_b = core::cast_type_nonnull<core::ClassType>(bType);

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1390,8 +1390,7 @@ core::NameRef Literal::asName() const {
 
 bool Literal::isSymbol() const {
     return core::isa_type<core::NamedLiteralType>(value) &&
-           core::cast_type_nonnull<core::NamedLiteralType>(value).literalKind ==
-               core::NamedLiteralType::LiteralTypeKind::Symbol;
+           core::cast_type_nonnull<core::NamedLiteralType>(value).kind == core::NamedLiteralType::Kind::Symbol;
 }
 
 bool Literal::isNil(const core::GlobalState &gs) const {
@@ -1400,8 +1399,7 @@ bool Literal::isNil(const core::GlobalState &gs) const {
 
 bool Literal::isString() const {
     return core::isa_type<core::NamedLiteralType>(value) &&
-           core::cast_type_nonnull<core::NamedLiteralType>(value).literalKind ==
-               core::NamedLiteralType::LiteralTypeKind::String;
+           core::cast_type_nonnull<core::NamedLiteralType>(value).kind == core::NamedLiteralType::Kind::String;
 }
 
 bool Literal::isName() const {

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1385,8 +1385,7 @@ core::NameRef Literal::asSymbol() const {
 core::NameRef Literal::asName() const {
     ENFORCE(isName());
     auto t = core::cast_type_nonnull<core::NamedLiteralType>(value);
-    core::NameRef res = t.asName();
-    return res;
+    return t.name;
 }
 
 bool Literal::isSymbol() const {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -406,7 +406,7 @@ ExpressionPtr symbol2Proc(DesugarContext dctx, ExpressionPtr expr) {
     auto lit = cast_tree<Literal>(expr);
     ENFORCE(lit && lit->isSymbol());
 
-    core::NameRef name = core::cast_type_nonnull<core::NamedLiteralType>(lit->value).asName();
+    core::NameRef name = lit->asSymbol();
     // `temp` does not refer to any specific source text, so give it a 0-length Loc so LSP ignores it.
     auto zeroLengthLoc = loc.copyWithZeroLength();
     auto recv = MK::Send1(zeroLengthLoc, MK::Local(zeroLengthLoc, temp), core::Names::squareBrackets(), zeroLengthLoc,

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -365,7 +365,7 @@ ExpressionPtr symbol2Proc(DesugarContext dctx, ExpressionPtr expr) {
     auto lit = cast_tree<Literal>(expr);
     ENFORCE(lit && lit->isSymbol());
 
-    core::NameRef name = core::cast_type_nonnull<core::NamedLiteralType>(lit->value).asName();
+    core::NameRef name = lit->asName();
     // `temp` does not refer to any specific source text, so give it a 0-length Loc so LSP ignores it.
     auto zeroLengthLoc = loc.copyWithZeroLength();
     auto recv = MK::Send1(zeroLengthLoc, MK::Local(zeroLengthLoc, temp), core::Names::squareBrackets(), zeroLengthLoc,

--- a/core/Types.h
+++ b/core/Types.h
@@ -549,18 +549,14 @@ template <> inline SelfType cast_type_nonnull<SelfType>(const TypePtr &what) {
 }
 
 TYPE_INLINED(NamedLiteralType) final {
-    const NameRef name;
-
 public:
+    const NameRef name;
     enum class LiteralTypeKind : uint8_t { String, Symbol };
     const LiteralTypeKind literalKind;
     NamedLiteralType(ClassOrModuleRef klass, NameRef val);
     TypePtr underlying(const GlobalState &gs) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
     DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
-    int64_t asInteger() const;
-    core::NameRef asName() const;
-    core::NameRef unsafeAsName() const;
 
     std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
     std::string show(const GlobalState &gs) const {

--- a/core/Types.h
+++ b/core/Types.h
@@ -551,8 +551,8 @@ template <> inline SelfType cast_type_nonnull<SelfType>(const TypePtr &what) {
 TYPE_INLINED(NamedLiteralType) final {
 public:
     const NameRef name;
-    enum class LiteralTypeKind : uint8_t { String, Symbol };
-    const LiteralTypeKind literalKind;
+    enum class Kind : uint8_t { String, Symbol };
+    const Kind kind;
     NamedLiteralType(ClassOrModuleRef klass, NameRef val);
     TypePtr underlying(const GlobalState &gs) const;
     bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
@@ -577,26 +577,24 @@ CheckSize(NamedLiteralType, 8, 8);
 template <>
 inline TypePtr make_type<NamedLiteralType, ClassOrModuleRef, NameRef &>(ClassOrModuleRef &&klass, NameRef &val) {
     NamedLiteralType type(klass, val);
-    return TypePtr(TypePtr::Tag::NamedLiteralType,
-                   (uint64_t(val.rawId()) << 8) | static_cast<uint64_t>(type.literalKind));
+    return TypePtr(TypePtr::Tag::NamedLiteralType, (uint64_t(val.rawId()) << 8) | static_cast<uint64_t>(type.kind));
 }
 
 template <>
 inline TypePtr make_type<NamedLiteralType, ClassOrModuleRef, NameRef>(ClassOrModuleRef &&klass, NameRef &&val) {
     NamedLiteralType type(klass, val);
-    return TypePtr(TypePtr::Tag::NamedLiteralType,
-                   (uint64_t(val.rawId()) << 8) | static_cast<uint64_t>(type.literalKind));
+    return TypePtr(TypePtr::Tag::NamedLiteralType, (uint64_t(val.rawId()) << 8) | static_cast<uint64_t>(type.kind));
 }
 
 template <> inline NamedLiteralType cast_type_nonnull<NamedLiteralType>(const TypePtr &what) {
     ENFORCE_NO_TIMER(isa_type<NamedLiteralType>(what));
     uint64_t tagged = what.inlinedValue();
     uint32_t id = static_cast<uint32_t>(tagged >> 8);
-    auto literalKind = static_cast<NamedLiteralType::LiteralTypeKind>(tagged & 0xff);
-    switch (literalKind) {
-        case NamedLiteralType::LiteralTypeKind::String:
+    auto kind = static_cast<NamedLiteralType::Kind>(tagged & 0xff);
+    switch (kind) {
+        case NamedLiteralType::Kind::String:
             return NamedLiteralType(Symbols::String(), NameRef::fromRawUnchecked(id));
-        case NamedLiteralType::LiteralTypeKind::Symbol:
+        case NamedLiteralType::Kind::Symbol:
             return NamedLiteralType(Symbols::Symbol(), NameRef::fromRawUnchecked(id));
     }
 }

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -171,11 +171,11 @@ com::stripe::rubytyper::Type::Literal Proto::toProto(const GlobalState &gs, cons
     switch (lit.literalKind) {
         case NamedLiteralType::LiteralTypeKind::String:
             proto.set_kind(com::stripe::rubytyper::Type::Literal::STRING);
-            proto.set_string(lit.asName().show(gs));
+            proto.set_string(lit.name.show(gs));
             break;
         case NamedLiteralType::LiteralTypeKind::Symbol:
             proto.set_kind(com::stripe::rubytyper::Type::Literal::SYMBOL);
-            proto.set_symbol(lit.asName().show(gs));
+            proto.set_symbol(lit.name.show(gs));
             break;
     }
     return proto;

--- a/core/proto/proto.cc
+++ b/core/proto/proto.cc
@@ -168,12 +168,12 @@ com::stripe::rubytyper::Symbol Proto::toProto(const GlobalState &gs, SymbolRef s
 com::stripe::rubytyper::Type::Literal Proto::toProto(const GlobalState &gs, const NamedLiteralType &lit) {
     com::stripe::rubytyper::Type::Literal proto;
 
-    switch (lit.literalKind) {
-        case NamedLiteralType::LiteralTypeKind::String:
+    switch (lit.kind) {
+        case NamedLiteralType::Kind::String:
             proto.set_kind(com::stripe::rubytyper::Type::Literal::STRING);
             proto.set_string(lit.name.show(gs));
             break;
-        case NamedLiteralType::LiteralTypeKind::Symbol:
+        case NamedLiteralType::Kind::Symbol:
             proto.set_kind(com::stripe::rubytyper::Type::Literal::SYMBOL);
             proto.set_symbol(lit.name.show(gs));
             break;

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -453,12 +453,7 @@ void SerializerImpl::pickle(Pickler &p, const TypePtr &what) {
         case TypePtr::Tag::NamedLiteralType: {
             auto c = cast_type_nonnull<NamedLiteralType>(what);
             p.putU1((uint8_t)c.literalKind);
-            switch (c.literalKind) {
-                case NamedLiteralType::LiteralTypeKind::Symbol:
-                case NamedLiteralType::LiteralTypeKind::String:
-                    p.putU4(c.unsafeAsName().rawId());
-                    break;
-            }
+            p.putU4(c.name.rawId());
             break;
         }
         case TypePtr::Tag::IntegerLiteralType: {

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -452,7 +452,7 @@ void SerializerImpl::pickle(Pickler &p, const TypePtr &what) {
         }
         case TypePtr::Tag::NamedLiteralType: {
             auto c = cast_type_nonnull<NamedLiteralType>(what);
-            p.putU1((uint8_t)c.literalKind);
+            p.putU1((uint8_t)c.kind);
             p.putU4(c.name.rawId());
             break;
         }
@@ -547,12 +547,12 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
         case TypePtr::Tag::OrType:
             return OrType::make_shared(unpickleType(p, gs), unpickleType(p, gs));
         case TypePtr::Tag::NamedLiteralType: {
-            auto kind = (core::NamedLiteralType::LiteralTypeKind)p.getU1();
+            auto kind = (core::NamedLiteralType::Kind)p.getU1();
             auto name = NameRef::fromRawUnchecked(p.getU4());
             switch (kind) {
-                case NamedLiteralType::LiteralTypeKind::String:
+                case NamedLiteralType::Kind::String:
                     return make_type<NamedLiteralType>(Symbols::String(), name);
-                case NamedLiteralType::LiteralTypeKind::Symbol:
+                case NamedLiteralType::Kind::Symbol:
                     return make_type<NamedLiteralType>(Symbols::Symbol(), name);
             }
             Exception::notImplemented();

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1090,7 +1090,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 auto &val = *kwit++;
                 keys.emplace_back(key->type);
                 values.emplace_back(val->type);
-                kwargLocs[cast_type_nonnull<NamedLiteralType>(key->type).asName()] = kwArgLoc;
+                kwargLocs[cast_type_nonnull<NamedLiteralType>(key->type).name] = kwArgLoc;
             }
         }
 
@@ -1330,7 +1330,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                             continue;
                         }
 
-                        NameRef arg = key.asName();
+                        NameRef arg = key.name;
                         if (consumed.contains(arg)) {
                             continue;
                         }
@@ -1357,7 +1357,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                     auto lit = cast_type_nonnull<NamedLiteralType>(litType);
                     auto underlying = lit.underlying(gs);
                     return cast_type_nonnull<ClassType>(underlying).symbol == Symbols::Symbol() &&
-                           lit.asName() == kwParam.name;
+                           lit.name == kwParam.name;
                 });
                 if (arg == hash->keys.end()) {
                     if (!kwParam.flags.isDefault) {
@@ -1409,13 +1409,13 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 auto key = cast_type_nonnull<NamedLiteralType>(keyType);
                 auto underlying = key.underlying(gs);
                 ClassOrModuleRef klass = cast_type_nonnull<ClassType>(underlying).symbol;
-                if (klass == Symbols::Symbol() && consumed.contains(key.asName())) {
+                if (klass == Symbols::Symbol() && consumed.contains(key.name)) {
                     continue;
                 }
-                NameRef arg = key.asName();
+                NameRef arg = key.name;
 
                 auto kwargErrLoc = kwargsLoc;
-                auto it = kwargLocs.find(key.asName());
+                auto it = kwargLocs.find(key.name);
                 // TODO(jez) This papers over some stuff around kwsplats which might get in our way
                 // of getting a loc for known keyword args. In those cases, we simply give up right now.
                 if (it != kwargLocs.end()) {
@@ -2457,7 +2457,7 @@ public:
             return;
         }
 
-        NameRef fn = lit.asName();
+        NameRef fn = lit.name;
 
         auto &receiver = args.args[0];
         if (receiver->type.isUntyped()) {
@@ -2719,7 +2719,7 @@ public:
             return;
         }
 
-        NameRef fn = lit.asName();
+        NameRef fn = lit.name;
         auto &receiver = args.args[0];
         if (receiver->type.isUntyped()) {
             auto what = core::errors::Infer::errorClassForUntyped(gs, args.locs.file, receiver->type);
@@ -2811,7 +2811,7 @@ public:
             return;
         }
 
-        NameRef fn = lit.asName();
+        NameRef fn = lit.name;
 
         auto &receiver = args.args[0];
         if (receiver->type.isUntyped()) {
@@ -2936,11 +2936,11 @@ public:
 
         if (auto e = gs.beginError(args.callLoc(), core::errors::Infer::UntypedFieldSuggestion)) {
             const auto &fieldKindTy = cast_type_nonnull<NamedLiteralType>(args.args[1]->type);
-            auto fieldKind = fieldKindTy.asName().show(gs);
+            auto fieldKind = fieldKindTy.name.show(gs);
             const auto &definingMethodNameTy = cast_type_nonnull<NamedLiteralType>(args.args[2]->type);
-            auto definingMethodName = definingMethodNameTy.asName();
+            auto definingMethodName = definingMethodNameTy.name;
             const auto &fieldNameTy = cast_type_nonnull<NamedLiteralType>(args.args[3]->type);
-            auto fieldName = fieldNameTy.asName().show(gs);
+            auto fieldName = fieldNameTy.name.show(gs);
 
             auto suggestType = res.returnType;
             if (definingMethodName != core::Names::initialize() && definingMethodName != core::Names::staticInit() &&
@@ -3050,7 +3050,7 @@ public:
         if (!lit.derivesFrom(gs, Symbols::Symbol())) {
             return;
         }
-        auto fun = lit.asName();
+        auto fun = lit.name;
 
         uint16_t numPosArgs = args.numPosArgs - 3;
 
@@ -3480,7 +3480,7 @@ public:
                     if (args.fullType.origins.size() == 1 && isa_type<NamedLiteralType>(arg)) {
                         auto argLit = cast_type_nonnull<NamedLiteralType>(arg);
                         if (argLit.literalKind == NamedLiteralType::LiteralTypeKind::Symbol) {
-                            auto key = argLit.asName();
+                            auto key = argLit.name;
                             auto loc = locOfValueForKey(gs, args.fullType.origins[0], key, expectedType);
 
                             if (loc.has_value() && loc->exists()) {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1077,8 +1077,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 // if the key isn't a symbol literal, break out as this is not a valid keyword
                 auto &key = *kwit++;
                 if (!isa_type<NamedLiteralType>(key->type) ||
-                    cast_type_nonnull<NamedLiteralType>(key->type).literalKind !=
-                        NamedLiteralType::LiteralTypeKind::Symbol) {
+                    cast_type_nonnull<NamedLiteralType>(key->type).kind != NamedLiteralType::Kind::Symbol) {
                     // it's not possible to tell if this is hash will be used as kwargs yet, so we can't raise a useful
                     // error here.
 
@@ -3479,7 +3478,7 @@ public:
 
                     if (args.fullType.origins.size() == 1 && isa_type<NamedLiteralType>(arg)) {
                         auto argLit = cast_type_nonnull<NamedLiteralType>(arg);
-                        if (argLit.literalKind == NamedLiteralType::LiteralTypeKind::Symbol) {
+                        if (argLit.kind == NamedLiteralType::Kind::Symbol) {
                             auto key = argLit.name;
                             auto loc = locOfValueForKey(gs, args.fullType.origins[0], key, expectedType);
 
@@ -3553,7 +3552,7 @@ public:
             }
 
             auto keylit = cast_type_nonnull<NamedLiteralType>(keyType);
-            if (keylit.literalKind != NamedLiteralType::LiteralTypeKind::Symbol) {
+            if (keylit.kind != NamedLiteralType::Kind::Symbol) {
                 return;
             }
 

--- a/core/types/hashing.cc
+++ b/core/types/hashing.cc
@@ -33,11 +33,7 @@ uint32_t NamedLiteralType::hash(const GlobalState &gs) const {
     ClassOrModuleRef undSymbol = cast_type_nonnull<ClassType>(underlying).symbol;
     result = mix(result, undSymbol.id());
 
-    switch (literalKind) {
-        case NamedLiteralType::LiteralTypeKind::String:
-        case NamedLiteralType::LiteralTypeKind::Symbol:
-            return mix(result, _hash(asName().shortName(gs)));
-    }
+    return mix(result, _hash(name.shortName(gs)));
 }
 
 uint32_t FloatLiteralType::hash(const GlobalState &gs) const {

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -78,10 +78,10 @@ string NamedLiteralType::show(const GlobalState &gs, ShowOptions options) const 
 }
 
 string NamedLiteralType::showValue(const GlobalState &gs) const {
-    switch (literalKind) {
-        case NamedLiteralType::LiteralTypeKind::String:
+    switch (kind) {
+        case NamedLiteralType::Kind::String:
             return fmt::format("\"{}\"", absl::CEscape(name.show(gs)));
-        case NamedLiteralType::LiteralTypeKind::Symbol: {
+        case NamedLiteralType::Kind::Symbol: {
             return name.showAsSymbolLiteral(gs);
         }
     }
@@ -179,7 +179,7 @@ string ShapeType::show(const GlobalState &gs, ShowOptions options) const {
         // properties beginning with $ need to be printed as :$prop => type.
         if (isa_type<NamedLiteralType>(key)) {
             const auto &keyLiteral = cast_type_nonnull<NamedLiteralType>(key);
-            if (keyLiteral.literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol &&
+            if (keyLiteral.kind == core::NamedLiteralType::Kind::Symbol &&
                 !absl::StartsWith(keyLiteral.name.shortName(gs), "$")) {
                 keyStr = keyLiteral.name.show(gs);
                 sepStr = ": ";

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -80,7 +80,7 @@ string NamedLiteralType::show(const GlobalState &gs, ShowOptions options) const 
 string NamedLiteralType::showValue(const GlobalState &gs) const {
     switch (literalKind) {
         case NamedLiteralType::LiteralTypeKind::String:
-            return fmt::format("\"{}\"", absl::CEscape(asName().show(gs)));
+            return fmt::format("\"{}\"", absl::CEscape(name.show(gs)));
         case NamedLiteralType::LiteralTypeKind::Symbol: {
             return name.showAsSymbolLiteral(gs);
         }
@@ -180,8 +180,8 @@ string ShapeType::show(const GlobalState &gs, ShowOptions options) const {
         if (isa_type<NamedLiteralType>(key)) {
             const auto &keyLiteral = cast_type_nonnull<NamedLiteralType>(key);
             if (keyLiteral.literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol &&
-                !absl::StartsWith(keyLiteral.asName().shortName(gs), "$")) {
-                keyStr = keyLiteral.asName().show(gs);
+                !absl::StartsWith(keyLiteral.name.shortName(gs), "$")) {
+                keyStr = keyLiteral.name.show(gs);
                 sepStr = ": ";
             } else {
                 keyStr = options.useValidSyntax ? keyLiteral.showValue(gs) : keyLiteral.show(gs, options);

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -397,7 +397,7 @@ void sanityCheckProxyType(const GlobalState &gs, TypePtr underlying) {
 } // namespace
 
 NamedLiteralType::NamedLiteralType(ClassOrModuleRef klass, NameRef val)
-    : name(val), literalKind(klass == Symbols::String() ? LiteralTypeKind::String : LiteralTypeKind::Symbol) {
+    : name(val), kind(klass == Symbols::String() ? Kind::String : Kind::Symbol) {
     if (klass == Symbols::String()) {
         recordAllocatedType("literaltype.string");
     } else {
@@ -407,10 +407,10 @@ NamedLiteralType::NamedLiteralType(ClassOrModuleRef klass, NameRef val)
 }
 
 TypePtr NamedLiteralType::underlying(const GlobalState &gs) const {
-    switch (literalKind) {
-        case LiteralTypeKind::String:
+    switch (kind) {
+        case Kind::String:
             return Types::String();
-        case LiteralTypeKind::Symbol:
+        case Kind::Symbol:
             return Types::Symbol();
     }
 }
@@ -445,7 +445,7 @@ void NamedLiteralType::_sanityCheck(const GlobalState &gs) const {
 }
 
 bool NamedLiteralType::equals(const NamedLiteralType &rhs) const {
-    if (this->literalKind != rhs.literalKind) {
+    if (this->kind != rhs.kind) {
         return false;
     }
 

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -406,16 +406,6 @@ NamedLiteralType::NamedLiteralType(ClassOrModuleRef klass, NameRef val)
     ENFORCE(klass == Symbols::String() || klass == Symbols::Symbol());
 }
 
-core::NameRef NamedLiteralType::asName() const {
-    ENFORCE_NO_TIMER(literalKind == LiteralTypeKind::Symbol || literalKind == LiteralTypeKind::String);
-    return name;
-}
-
-core::NameRef NamedLiteralType::unsafeAsName() const {
-    ENFORCE_NO_TIMER(literalKind == LiteralTypeKind::Symbol || literalKind == LiteralTypeKind::String);
-    return name;
-}
-
 TypePtr NamedLiteralType::underlying(const GlobalState &gs) const {
     switch (literalKind) {
         case LiteralTypeKind::String:
@@ -458,11 +448,8 @@ bool NamedLiteralType::equals(const NamedLiteralType &rhs) const {
     if (this->literalKind != rhs.literalKind) {
         return false;
     }
-    switch (this->literalKind) {
-        case LiteralTypeKind::Symbol:
-        case LiteralTypeKind::String:
-            return this->name == rhs.name;
-    }
+
+    return this->name == rhs.name;
 }
 
 void IntegerLiteralType::_sanityCheck(const GlobalState &gs) const {

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -104,7 +104,7 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
         if (inKwArgs) {
             if (core::isa_type<core::NamedLiteralType>(snd->args[i].type)) {
                 auto lit = core::cast_type_nonnull<core::NamedLiteralType>(snd->args[i].type);
-                if (lit.literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol) {
+                if (lit.kind == core::NamedLiteralType::Kind::Symbol) {
                     keyword = lit.name;
                 }
             }

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -105,7 +105,7 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
             if (core::isa_type<core::NamedLiteralType>(snd->args[i].type)) {
                 auto lit = core::cast_type_nonnull<core::NamedLiteralType>(snd->args[i].type);
                 if (lit.literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol) {
-                    keyword = lit.asName();
+                    keyword = lit.name;
                 }
             }
 

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1187,7 +1187,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                         ENFORCE(send.numPosArgs > 2, "Desugar invariant");
                         auto lit = core::cast_type_nonnull<core::NamedLiteralType>(args[1]->type);
                         ENFORCE(lit.literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol);
-                        fun = lit.asName();
+                        fun = lit.name;
                     }
                     core::lsp::QueryResponse::pushQueryResponse(
                         ctx, core::lsp::SendResponse(retainedResult, send.argLocs, fun, send.fun,

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1186,7 +1186,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                         fun == core::Names::callWithBlockPass() || fun == core::Names::callWithSplatAndBlockPass()) {
                         ENFORCE(send.numPosArgs > 2, "Desugar invariant");
                         auto lit = core::cast_type_nonnull<core::NamedLiteralType>(args[1]->type);
-                        ENFORCE(lit.literalKind == core::NamedLiteralType::LiteralTypeKind::Symbol);
+                        ENFORCE(lit.kind == core::NamedLiteralType::Kind::Symbol);
                         fun = lit.name;
                     }
                     core::lsp::QueryResponse::pushQueryResponse(

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2554,8 +2554,7 @@ class ResolveTypeMembersAndFieldsWalk {
             return;
         }
 
-        auto name = literal.asName();
-        auto shortName = name.shortName(ctx);
+        auto shortName = literal.name.shortName(ctx);
         if (shortName.empty()) {
             if (auto e = ctx.beginError(stringLoc, core::errors::Resolver::LazyResolve)) {
                 e.setHeader("The string given to `{}` must not be empty", method);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2549,7 +2549,7 @@ class ResolveTypeMembersAndFieldsWalk {
         }
 
         auto literal = core::cast_type_nonnull<core::NamedLiteralType>(literalNode->value);
-        if (literal.literalKind != core::NamedLiteralType::LiteralTypeKind::String) {
+        if (literal.kind != core::NamedLiteralType::Kind::String) {
             // Infer will report a type error
             return;
         }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I noticed that there were both `asName` and `unsafeAsName`, and I wasn't
sure what the difference was.

Turned out: they're identical. And also, in various places there were
still switch statements that were "unconditional," likely a relic from
back when there was only one LiteralType (now there are three, for
performance).

I took the liberty of simplifying some code.

I opted to delete the `asName()` function too, because it was asserting
that `literalKind` was either `Symbol` or `String`, but those are the
only two values left in the `LiteralKind` enumeration.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests