### PR TITLE
Make "bad parameter" errors localized to the error

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3460,7 +3460,7 @@ private:
                     (sig.seen.params.exists() || sig.seen.returns.exists() || sig.seen.void_.exists())) {
                     // Only error if we have any types
                     if (auto e = ctx.state.beginError(param.loc, core::errors::Resolver::InvalidMethodSignature)) {
-                        e.setHeader("Malformed `{}`. Type not specified for argument `{}`", "sig",
+                        e.setHeader("Malformed `{}`. Type not specified for parameter `{}`", "sig",
                                     param.parameterName(ctx.state));
                         e.addErrorLine(ctx.locAt(exprLoc), "Signature");
                     }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3458,11 +3458,14 @@ private:
                 // We silence the "type not specified" error when a sig does not mention the synthesized block arg.
                 if (!isOverloaded && !isSyntheticBlkArg &&
                     (sig.seen.params.exists() || sig.seen.returns.exists() || sig.seen.void_.exists())) {
-                    // Only error if we have any types
-                    if (auto e = ctx.state.beginError(param.loc, core::errors::Resolver::InvalidMethodSignature)) {
+                    if (auto e = ctx.beginError(local->loc, core::errors::Resolver::InvalidMethodSignature)) {
                         e.setHeader("Malformed `{}`. Type not specified for parameter `{}`", "sig",
-                                    param.parameterName(ctx.state));
-                        e.addErrorLine(ctx.locAt(exprLoc), "Signature");
+                                    param.parameterName(ctx));
+                        if (sig.seen.params.exists()) {
+                            e.addErrorLine(ctx.locAt(sig.seen.params), "Add it to the signature's `{}` here", "params");
+                        } else {
+                            e.addErrorLine(ctx.locAt(exprLoc), "Add it to the signature here");
+                        }
                     }
                 }
             }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3482,7 +3482,7 @@ private:
         for (const auto &spec : sig.argTypes) {
             info.allArgsMatched = false;
             if (auto e = ctx.beginError(spec.nameLoc, core::errors::Resolver::InvalidMethodSignature)) {
-                e.setHeader("Unknown argument name `{}`", spec.name.show(ctx));
+                e.setHeader("Unknown parameter name `{}`", spec.name.show(ctx));
             }
         }
 

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3483,6 +3483,7 @@ private:
             info.allArgsMatched = false;
             if (auto e = ctx.beginError(spec.nameLoc, core::errors::Resolver::InvalidMethodSignature)) {
                 e.setHeader("Unknown parameter name `{}`", spec.name.show(ctx));
+                e.addErrorLine(ctx.locAt(mdef.declLoc), "Parameter not in method definition here");
             }
         }
 

--- a/test/cli/autocorrect-kwargs/test.out
+++ b/test/cli/autocorrect-kwargs/test.out
@@ -28,14 +28,14 @@ autocorrect-kwargs.rb:21: `params` expects keyword arguments https://srb.help/50
     21 |sig {params({a: Integer, b: String}).void}
                     ^^^^^^^^^^^^^^^^^^^^^^^
 
-autocorrect-kwargs.rb:22: Malformed `sig`. Type not specified for argument `a` https://srb.help/5003
+autocorrect-kwargs.rb:22: Malformed `sig`. Type not specified for parameter `a` https://srb.help/5003
     22 |def test3(a, b)
                   ^
     autocorrect-kwargs.rb:21: Signature
     21 |sig {params({a: Integer, b: String}).void}
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-autocorrect-kwargs.rb:22: Malformed `sig`. Type not specified for argument `b` https://srb.help/5003
+autocorrect-kwargs.rb:22: Malformed `sig`. Type not specified for parameter `b` https://srb.help/5003
     22 |def test3(a, b)
                      ^
     autocorrect-kwargs.rb:21: Signature

--- a/test/cli/incremental-resolver/test.out
+++ b/test/cli/incremental-resolver/test.out
@@ -3,14 +3,14 @@ No errors! Great job.
 ----- test/cli/incremental-resolver/type-template.rb ---------------------
 No errors! Great job.
 ----- test/cli/incremental-resolver/expect-failures/abstract_impl.rb ---------------------
-test/cli/incremental-resolver/expect-failures/abstract_impl.rb:5: Malformed `sig`. Type not specified for argument `foo` https://srb.help/5003
+test/cli/incremental-resolver/expect-failures/abstract_impl.rb:5: Malformed `sig`. Type not specified for parameter `foo` https://srb.help/5003
      5 |  def foo(*foo)end
                    ^^^
     test/cli/incremental-resolver/expect-failures/abstract_impl.rb:4: Signature
      4 |  sig { overridable.void }
           ^^^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/incremental-resolver/expect-failures/abstract_impl.rb:123: Malformed `sig`. Type not specified for argument `foo` https://srb.help/5003
+test/cli/incremental-resolver/expect-failures/abstract_impl.rb:123: Malformed `sig`. Type not specified for parameter `foo` https://srb.help/5003
      123 |  def foo(*foo)end
                      ^^^
     test/cli/incremental-resolver/expect-failures/abstract_impl.rb:122: Signature
@@ -78,14 +78,14 @@ test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:3: Unused type an
      4 |  sig {void}
           ^^^^^^^^^^
 
-test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:5: Malformed `sig`. Type not specified for argument `f` https://srb.help/5003
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:5: Malformed `sig`. Type not specified for parameter `f` https://srb.help/5003
      5 |  def-f
               ^
     test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:3: Signature
      3 |  sig {void}
           ^^^^^^^^^^
 
-test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:5: Malformed `sig`. Type not specified for argument `f` https://srb.help/5003
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:5: Malformed `sig`. Type not specified for parameter `f` https://srb.help/5003
      5 |  def-f
               ^
     test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:4: Signature
@@ -99,14 +99,14 @@ test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:68: Unused type a
     69 |  sig {void}
           ^^^^^^^^^^
 
-test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:70: Malformed `sig`. Type not specified for argument `f` https://srb.help/5003
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:70: Malformed `sig`. Type not specified for parameter `f` https://srb.help/5003
     70 |  def-f
               ^
     test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:68: Signature
     68 |  sig {void}
           ^^^^^^^^^^
 
-test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:70: Malformed `sig`. Type not specified for argument `f` https://srb.help/5003
+test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:70: Malformed `sig`. Type not specified for parameter `f` https://srb.help/5003
     70 |  def-f
               ^
     test/cli/incremental-resolver/expect-failures/multiple_sigs.rb:69: Signature

--- a/test/testdata/lsp/fast_path/method_add_argument.2.rbupdate
+++ b/test/testdata/lsp/fast_path/method_add_argument.2.rbupdate
@@ -2,7 +2,7 @@
 # assert-fast-path: method_add_argument.rb
 
 class A extend T::Sig
-  sig {params(x: Integer, y: Integer).returns(String)} # error: Unknown argument name `y`
+  sig {params(x: Integer, y: Integer).returns(String)} # error: Unknown parameter name `y`
   def bar(x)
     res = x.to_s
     puts(y) # error: Method `y` does not exist on `A`

--- a/test/testdata/namer/duplicate_field_error.rb
+++ b/test/testdata/namer/duplicate_field_error.rb
@@ -6,7 +6,7 @@ class A
   extend T::Sig
   sig { params(x: Integer, x: String).void }
                          # ^ error: Hash key `x` is duplicated
-                         # ^ error: Unknown argument name `x`
+                         # ^ error: Unknown parameter name `x`
   def initialize(x:, x: nil)
                    # ^^ error: Malformed `sig`
                    # ^^^^^^ error: duplicate argument name x

--- a/test/testdata/namer/toplevel_attr_writer.rb
+++ b/test/testdata/namer/toplevel_attr_writer.rb
@@ -3,4 +3,4 @@
 extend T::Sig
 
 sig {returns(T.untyped)}
-attr_writer :foo # error: Malformed `sig`. Type not specified for argument `foo`
+attr_writer :foo # error: Malformed `sig`. Type not specified for parameter `foo`

--- a/test/testdata/parser/error_recovery/lonely_def_02.rb
+++ b/test/testdata/parser/error_recovery/lonely_def_02.rb
@@ -2,7 +2,7 @@
 class A
   extend T::Sig
   sig {params(x: Integer).void}
-  #           ^ error: Unknown argument name `x`
+  #           ^ error: Unknown parameter name `x`
   def
 # ^^^ error: Hint: this "def" token might not be followed by a method name
 # ^^^ error: Hint: this "def" token might not be properly closed

--- a/test/testdata/parser/error_recovery/lonely_def_08.rb
+++ b/test/testdata/parser/error_recovery/lonely_def_08.rb
@@ -2,6 +2,6 @@
 class A
   extend T::Sig
   sig {params(x: Integer).void}
-  #           ^ error: Unknown argument name `x`
+  #           ^ error: Unknown parameter name `x`
   def self # error: Hint: this "def" token might not be properly closed
 end # error: unexpected token "end of file"

--- a/test/testdata/parser/error_recovery/lonely_def_09.rb
+++ b/test/testdata/parser/error_recovery/lonely_def_09.rb
@@ -2,7 +2,7 @@
 class A
   extend T::Sig
   sig {params(x: Integer).void}
-  #           ^ error: Unknown argument name `x`
+  #           ^ error: Unknown parameter name `x`
   def self.
 # ^^^ error: Hint: this "def" token might not be properly closed
   #       ^ error: Hint: this "." token might not be followed by a method name

--- a/test/testdata/parser/error_recovery/pos_after_kw_1.rb
+++ b/test/testdata/parser/error_recovery/pos_after_kw_1.rb
@@ -5,7 +5,7 @@ sig do
     type
   # ^^^^ error: positional arg "type" after keyword arg
   # ^^^^ error: Malformed type declaration. Unknown type syntax. Expected a ClassName or T.<func>
-  # ^^^^ error: Unknown argument name `type`
+  # ^^^^ error: Unknown parameter name `type`
     filter: T.nilable(String),
   )
   .returns(T::Array[String])

--- a/test/testdata/rbs/signatures_defs.rb
+++ b/test/testdata/rbs/signatures_defs.rb
@@ -42,7 +42,7 @@ def sig_mismatch1(p1, p2); end
 
 #: (foo: P1) -> void
 #   ^^^^^^^ error: Argument kind mismatch for `p1`, method declares `positional`, but RBS signature declares `keyword`
-#   ^^^ error: Unknown argument name `foo`
+#   ^^^ error: Unknown parameter name `foo`
 def sig_mismatch2(p1); end
 #                 ^^ error: Malformed `sig`. Type not specified for argument `p1`
 
@@ -155,14 +155,14 @@ method11("foo")
 method11(42) # error: Expected `String` but found `Integer(42)` for argument `x`
 
 #: (String x) -> String
-#          ^ error: Unknown argument name `x`
+#          ^ error: Unknown parameter name `x`
 def named_args2(y)
   #             ^ error: Malformed `sig`. Type not specified for argument `y`
   T.reveal_type(y) # error: Revealed type: `T.untyped`
 end
 
 #: (String foo) -> String
-#          ^^^ error: Unknown argument name `foo`
+#          ^^^ error: Unknown parameter name `foo`
 def method12(y)
   #          ^ error: Malformed `sig`. Type not specified for argument `y`
   T.reveal_type(y) # error: Revealed type: `T.untyped`

--- a/test/testdata/rbs/signatures_defs.rb
+++ b/test/testdata/rbs/signatures_defs.rb
@@ -38,13 +38,13 @@ end
 
 #: (P1) -> void
 def sig_mismatch1(p1, p2); end
-#                     ^^ error: Malformed `sig`. Type not specified for argument `p2`
+#                     ^^ error: Malformed `sig`. Type not specified for parameter `p2`
 
 #: (foo: P1) -> void
 #   ^^^^^^^ error: Argument kind mismatch for `p1`, method declares `positional`, but RBS signature declares `keyword`
 #   ^^^ error: Unknown parameter name `foo`
 def sig_mismatch2(p1); end
-#                 ^^ error: Malformed `sig`. Type not specified for argument `p1`
+#                 ^^ error: Malformed `sig`. Type not specified for parameter `p1`
 
 #: (P1, P2, P3) -> void # error: RBS signature has more parameters than in the method definition
 def sig_mismatch3; end # error: The method `sig_mismatch3` does not have a `sig`
@@ -157,14 +157,14 @@ method11(42) # error: Expected `String` but found `Integer(42)` for argument `x`
 #: (String x) -> String
 #          ^ error: Unknown parameter name `x`
 def named_args2(y)
-  #             ^ error: Malformed `sig`. Type not specified for argument `y`
+  #             ^ error: Malformed `sig`. Type not specified for parameter `y`
   T.reveal_type(y) # error: Revealed type: `T.untyped`
 end
 
 #: (String foo) -> String
 #          ^^^ error: Unknown parameter name `foo`
 def method12(y)
-  #          ^ error: Malformed `sig`. Type not specified for argument `y`
+  #          ^ error: Malformed `sig`. Type not specified for parameter `y`
   T.reveal_type(y) # error: Revealed type: `T.untyped`
 end
 

--- a/test/testdata/rbs/signatures_defs_multiline.rb
+++ b/test/testdata/rbs/signatures_defs_multiline.rb
@@ -32,7 +32,7 @@ def parse_error3; T.unsafe(nil); end # error: The method `parse_error3` does not
 #|   String x ) -> String
 #           ^ error: Unknown parameter name `x`
 def named_args1(y)
-  #             ^ error: Malformed `sig`. Type not specified for argument `y`
+  #             ^ error: Malformed `sig`. Type not specified for parameter `y`
   T.reveal_type(y) # error: Revealed type: `T.untyped`
 end
 
@@ -41,7 +41,7 @@ end
 #| x ) -> String
 #  ^ error: Unknown parameter name `x`
 def named_args2(y)
-  #             ^ error: Malformed `sig`. Type not specified for argument `y`
+  #             ^ error: Malformed `sig`. Type not specified for parameter `y`
   T.reveal_type(y) # error: Revealed type: `T.untyped`
 end
 

--- a/test/testdata/rbs/signatures_defs_multiline.rb
+++ b/test/testdata/rbs/signatures_defs_multiline.rb
@@ -30,7 +30,7 @@ def parse_error3; T.unsafe(nil); end # error: The method `parse_error3` does not
 
 #: (
 #|   String x ) -> String
-#           ^ error: Unknown argument name `x`
+#           ^ error: Unknown parameter name `x`
 def named_args1(y)
   #             ^ error: Malformed `sig`. Type not specified for argument `y`
   T.reveal_type(y) # error: Revealed type: `T.untyped`
@@ -39,7 +39,7 @@ end
 #: (
 #|   String
 #| x ) -> String
-#  ^ error: Unknown argument name `x`
+#  ^ error: Unknown parameter name `x`
 def named_args2(y)
   #             ^ error: Malformed `sig`. Type not specified for argument `y`
   T.reveal_type(y) # error: Revealed type: `T.untyped`

--- a/test/testdata/resolver/abstract_validation.rb
+++ b/test/testdata/resolver/abstract_validation.rb
@@ -100,15 +100,15 @@ class AnonArgParent
   abstract!
   sig { abstract.void }
   def foo(*); end
-#         ^ error: Malformed `sig`. Type not specified for argument `*`
+#         ^ error: Malformed `sig`. Type not specified for parameter `*`
 
   sig { abstract.void }
   def bar(**); end
-#         ^^ error: Malformed `sig`. Type not specified for argument `**`
+#         ^^ error: Malformed `sig`. Type not specified for parameter `**`
 
   sig { abstract.void }
   def baz(&); end
-#         ^ error: Malformed `sig`. Type not specified for argument `&`
+#         ^ error: Malformed `sig`. Type not specified for parameter `&`
 end
 
 class AnonArgChild < AnonArgParent

--- a/test/testdata/resolver/bad_parameters.rb
+++ b/test/testdata/resolver/bad_parameters.rb
@@ -1,0 +1,31 @@
+# typed: true
+
+extend T::Sig
+
+sig { params(name: String).returns(T.nilable(String)) }
+#            ^^^^ error: Malformed `sig`. Type not specified for argument `name`
+def foo(name)
+end
+
+
+sig { params(other_name: String).returns(T.nilable(String)) }
+#            ^^^^^^^^^^ error: Unknown argument name `other_name`
+def foo(name)
+end
+
+def bar(name)
+end
+
+sig { params(other_name: String).returns(T.nilable(String)) }
+#            ^^^^^^^^^^ error: Unknown argument name `other_name`
+def bar(name)
+#       ^^^^ error: Malformed `sig`. Type not specified for argument `name`
+end
+
+def qux(name)
+end
+
+sig { returns(T.nilable(String)) }
+def qux(name)
+#       ^^^^ error: Malformed `sig`. Type not specified for argument `name`
+end

--- a/test/testdata/resolver/bad_parameters.rb
+++ b/test/testdata/resolver/bad_parameters.rb
@@ -3,23 +3,23 @@
 extend T::Sig
 
 sig { params(name: String).returns(T.nilable(String)) }
-#            ^^^^ error: Malformed `sig`. Type not specified for argument `name`
 def foo(name)
 end
 
 
 sig { params(other_name: String).returns(T.nilable(String)) }
-#            ^^^^^^^^^^ error: Unknown argument name `other_name`
+#            ^^^^^^^^^^ error: Unknown parameter name `other_name`
 def foo(name)
+#       ^^^^ error: Malformed `sig`. Type not specified for parameter `name`
 end
 
 def bar(name)
 end
 
 sig { params(other_name: String).returns(T.nilable(String)) }
-#            ^^^^^^^^^^ error: Unknown argument name `other_name`
+#            ^^^^^^^^^^ error: Unknown parameter name `other_name`
 def bar(name)
-#       ^^^^ error: Malformed `sig`. Type not specified for argument `name`
+#       ^^^^ error: Malformed `sig`. Type not specified for parameter `name`
 end
 
 def qux(name)
@@ -27,5 +27,5 @@ end
 
 sig { returns(T.nilable(String)) }
 def qux(name)
-#       ^^^^ error: Malformed `sig`. Type not specified for argument `name`
+#       ^^^^ error: Malformed `sig`. Type not specified for parameter `name`
 end

--- a/test/testdata/resolver/overloads_test.rb
+++ b/test/testdata/resolver/overloads_test.rb
@@ -35,10 +35,10 @@ class Wrap1
 
   sig {params(x: Integer, y: String).void}
 #             ^ error: Overloaded functions cannot have keyword arguments
-#                         ^ error: Unknown argument name
+#                         ^ error: Unknown parameter name
   sig {params(x: Integer, y: String, blk: T.proc.returns(Integer)).void}
 #             ^ error: Overloaded functions cannot have keyword arguments
-#                         ^ error: Unknown argument name
+#                         ^ error: Unknown parameter name
   def arg_in_sig_but_not_method(x:, &blk); end # error: against an overloaded signature
 
   sig {params(x: Integer, y: String).void} # error-with-dupes: Overloaded functions cannot have keyword arguments

--- a/test/testdata/resolver/sig_arg_types.rb
+++ b/test/testdata/resolver/sig_arg_types.rb
@@ -8,21 +8,21 @@ class A
 
   sig {void}
   def test_arg_type_not_specified(foo); end
-                                # ^^^ error: Malformed `sig`. Type not specified for argument `foo`
+                                # ^^^ error: Malformed `sig`. Type not specified for parameter `foo`
 
   sig {params(foo: Integer).void}
   def test_kwarg_type_specified(foo:); end
 
   sig {void}
   def test_kwarg_type_not_specified(foo:); end
-                                  # ^^^^ error: Malformed `sig`. Type not specified for argument `foo`
+                                  # ^^^^ error: Malformed `sig`. Type not specified for parameter `foo`
 
   sig {params(blk: T.proc.void).void}
   def test_block_type_specified(&blk); end
 
   sig {void}
   def test_block_type_not_specified(&blk); end
-                                   # ^^^ error: Malformed `sig`. Type not specified for argument `blk`
+                                   # ^^^ error: Malformed `sig`. Type not specified for parameter `blk`
 
   sig {void}
   def test_yield
@@ -35,5 +35,5 @@ end
 
 class A
   def test_block_type_not_specified_later(&my_custom_block_name); end
-                                         # ^^^^^^^^^^^^^^^^^^^^ error: Malformed `sig`. Type not specified for argument `my_custom_block_name`
+                                         # ^^^^^^^^^^^^^^^^^^^^ error: Malformed `sig`. Type not specified for parameter `my_custom_block_name`
 end

--- a/test/testdata/resolver/sig_misc.rb
+++ b/test/testdata/resolver/sig_misc.rb
@@ -35,7 +35,7 @@ class A
     T2.new
   end
 
-  sig {params(x: T1).returns(T1)} # error: Unknown argument name `x`
+  sig {params(x: T1).returns(T1)} # error: Unknown parameter name `x`
   def f3
     T1.new
   end

--- a/test/testdata/resolver/sig_misc.rb
+++ b/test/testdata/resolver/sig_misc.rb
@@ -26,7 +26,7 @@ class A
   sig {params(types).returns(T1)}
             # ^^^^^ error: Method `types` does not exist
      # ^^^^^^^^^^^^^ error: `params` expects keyword arguments
-  def f1(x) # error: Type not specified for argument
+  def f1(x) # error: Type not specified for parameter
     T1.new
   end
 
@@ -80,7 +80,7 @@ class A
 
   sig { override.void }
   def test_implementation(x) # error: Method `A#test_implementation` is marked `override` but does not override anything
-                        # ^ error: Malformed `sig`. Type not specified for argument
+                        # ^ error: Malformed `sig`. Type not specified for parameter
   end
 
   sig {override.returns(T1)}

--- a/test/testdata/resolver/sig_void.rb
+++ b/test/testdata/resolver/sig_void.rb
@@ -24,7 +24,7 @@ class Main
     end
 
     sig {void}
-    def self.missing_arg(my_arg) # error: Type not specified for argument `my_arg`
+    def self.missing_arg(my_arg) # error: Type not specified for parameter `my_arg`
     end
 end
 

--- a/test/testdata/rewriter/initializer_local.rb
+++ b/test/testdata/rewriter/initializer_local.rb
@@ -4,7 +4,7 @@ class A
   extend T::Sig
 
   sig {params(y: T.nilable(String)).void}
-  #           ^ error: Unknown argument name `y`
+  #           ^ error: Unknown parameter name `y`
   def initialize
     y = 1
     @y = y # error: The instance variable `@y` must be declared

--- a/test/testdata/rewriter/initializer_no_arg_with_local.rb
+++ b/test/testdata/rewriter/initializer_no_arg_with_local.rb
@@ -6,7 +6,7 @@ class A
   # At one point, the parser would produce local variables inside the method,
   # but no corresponding argument in the method definition.
   sig {params(x: Integer, y: T.nilable(String)).void}
-  #                       ^ error: Unknown argument name `y`
+  #                       ^ error: Unknown parameter name `y`
   def initialize(x, y=nil, )
                 # ^ error: unexpected token ","
     @x = x


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sometimes when reporting "bad parameter" errors (either "type not specified", or
"unknown parameter name"), we were using the locations from the symbol table,
instead of from the tree. Since there might be multiple definitions of a method,
we need to use the locations from the tree, so that we report the errors on the
specific bad AST that has the problems. Otherwise, we might report an error
somewhere else entirely, making it hard for the author to track down where the
real source of the bug is.

### Commit summary


- **Add test showing old behavior** (eebac7d8c2)


- **fastmod 'Unknown argument name' 'Unknown parameter name'** (b705d4307b)


- **Show error line for method definition parameters** (beaed0e673)


- **fastmoda 'specified for argument' 'specified for parameter'** (e700c8622f)


- **Use the tree locs for errors, not the symbol locs** (6eadb9d5d1)

  The ParamInfo's loc for a method definition gets updated the first time 
  that its type is set, which moves the loc of the ParamInfo for `name` 
  from a loc in the MethodDef declLoc to a loc in the signature. When 
  parsing the second signature, since it can't find the parameter, it was 
  printing the location using `param.loc`, which came from the symbol 
  table, and thus was pointing to the first location, where `name` 
  successfully had been defined.

  These fillInInfoFromSig errors should be more local/syntactic, so now 
  all the errors we report are from the current signature or MethodDef 
  node, instead of from the symbol table (though we do use the location 
  from the symbol table to figure that out, c.f. the `.contains` call 
  below)

- **Show changes to the test** (34db99b979)




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tests show the before+after.

I also took the liberty to change `argument` → `parameter` in these error
messages, because that's more accurate.