### PR TITLE
Improve selectivity of `LanguageClient`'s documentSelector

### DIFF
--- a/vscode_extension/CHANGELOG.md
+++ b/vscode_extension/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Version history
 
+## 0.3.46
+- Exclude Ruby files outside the target workspace from triggering IntelliSense events.
+
 ## 0.3.45
 - `Copy Symbol to Clipboard` is enabled and visible only when a workspace is open.
 

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.45",
+  "version": "0.3.46",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -33,9 +33,10 @@ export function createClient(
     ...Object.entries(initializationOptions).map(([k, v]) => `${k}:${v}`),
   );
 
+  const pattern = workspaceFolder ? `${workspaceFolder.uri}/**/*.rb` : undefined;
   const client = new CustomLanguageClient("ruby", "Sorbet", serverOptions, {
     documentSelector: [
-      { language: "ruby", scheme: "file" },
+      { language: "ruby", scheme: "file", pattern },
       // Support queries on generated files with sorbet:// URIs that do not exist editor-side.
       { language: "ruby", scheme: "sorbet" },
     ],

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -33,7 +33,9 @@ export function createClient(
     ...Object.entries(initializationOptions).map(([k, v]) => `${k}:${v}`),
   );
 
-  const pattern = workspaceFolder ? `${workspaceFolder.uri.path}/**/*` : undefined;
+  const pattern = workspaceFolder
+    ? `${workspaceFolder.uri.path}/**/*`
+    : undefined;
   const client = new CustomLanguageClient("ruby", "Sorbet", serverOptions, {
     documentSelector: [
       { language: "ruby", scheme: "file", pattern },

--- a/vscode_extension/src/languageClient.ts
+++ b/vscode_extension/src/languageClient.ts
@@ -33,7 +33,7 @@ export function createClient(
     ...Object.entries(initializationOptions).map(([k, v]) => `${k}:${v}`),
   );
 
-  const pattern = workspaceFolder ? `${workspaceFolder.uri}/**/*.rb` : undefined;
+  const pattern = workspaceFolder ? `${workspaceFolder.uri.path}/**/*` : undefined;
   const client = new CustomLanguageClient("ruby", "Sorbet", serverOptions, {
     documentSelector: [
       { language: "ruby", scheme: "file", pattern },


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Improve selectivity of `LanguageClient`'s documentSelector so no IntelliSense requests on files not belonging to current workspace are routed to Sorbet.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Remove spurious requests that lead to errors similar to these when a Ruby file that does not belong to the workspace Sorbet is active in editor:

```
[Error - 9:56:40 AM] Request textDocument/definition failed.
  Message: Did not find file at uri file:///Users/damolina/test.rb in textDocument/definition
  Code: -32602 
msg="Unrecognized URI received from client" uri="file:///Users/damolina/test.rb"
[Error - 9:56:40 AM] Request textDocument/hover failed.
  Message: Did not find file at uri file:///Users/damolina/test.rb in textDocument/hover
  Code: -32602 
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
