### PR TITLE
Simplify conditional with always-false value

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1033,21 +1033,16 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
 
             sendNode = make_node_with_expr<parser::Send>(move(expr), loc, move(receiver), name, messageLoc, move(args));
 
-            if (prismBlock != nullptr) {
-                if (PM_NODE_TYPE_P(prismBlock, PM_BLOCK_NODE) || blockPassArgIsSymbol) {
-                    // In Prism, this is modeled by a `pm_call_node` with a `pm_block_node` as a child,
-                    // but the legacy parser inverts this, with a parent "Block" with a child "Send".
-                    //
-                    // Note: The legacy parser doesn't treat block pass arguments this way.
-                    //       It just puts them at the end of the arguments list,
-                    //       which is why we checked for `PM_BLOCK_NODE` specifically here.
+            if (prismBlock != nullptr && PM_NODE_TYPE_P(prismBlock, PM_BLOCK_NODE)) {
+                // In Prism, this is modeled by a `pm_call_node` with a `pm_block_node` as a child,
+                // but the legacy parser inverts this, with a parent "Block" with a child "Send".
+                //
+                // Note: The legacy parser doesn't treat block pass arguments this way.
+                //       It just puts them at the end of the arguments list,
+                //       which is why we checked for `PM_BLOCK_NODE` specifically here.
 
-                    return make_node_with_expr<parser::Block>(sendNode->takeDesugaredExpr(), sendNode->loc,
-                                                              move(sendNode), move(blockParameters), move(blockBody));
-                } else {
-                    unreachable("Found a {} block type, which is not implemented yet ",
-                                pm_node_type_to_str(PM_NODE_TYPE(prismBlock)));
-                }
+                return make_node_with_expr<parser::Block>(sendNode->takeDesugaredExpr(), sendNode->loc, move(sendNode),
+                                                          move(blockParameters), move(blockBody));
             }
 
             return sendNode;


### PR DESCRIPTION
### Motivation

The `blockPassArgIsSymbol` case is handled earlier, and always false here.

Part of #9065


### Test plan

Pure refactored covered by existing desugar tests.