### PR TITLE
Extract Array desugaring logic for reuse

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -430,10 +430,14 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
 
             ast::Array::ENTRY_store elems;
             elems.reserve(sorbetElements.size());
+
             ExpressionPtr lastMerge;
-            for (auto &stat : sorbetElements) {
-                if (parser::NodeWithExpr::isa_node<parser::Splat>(stat.get()) ||
-                    parser::NodeWithExpr::isa_node<parser::ForwardedRestArg>(stat.get())) {
+            ENFORCE(sorbetElements.size() == arrayNode->elements.size);
+            for (int i = 0; i < sorbetElements.size(); i++) {
+                auto *node = arrayNode->elements.nodes[i];
+                auto &stat = sorbetElements[i];
+
+                if (PM_NODE_TYPE_P(node, PM_SPLAT_NODE)) {
                     // Desugar [a, *x, remaining] into a.concat(<splat>(x)).concat(remaining)
 
                     // The Splat was already desugared to Send{Magic.splat(arg)} with the splat's own location.

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -436,74 +436,9 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
                 elements.emplace_back(move(expr));
             }
 
-            auto locZeroLen = location.copyWithZeroLength();
-
-            ast::Array::ENTRY_store elems;
-            elems.reserve(elements.size());
-
-            ExpressionPtr lastMerge;
-            ENFORCE(elements.size() == arrayNode->elements.size);
-            for (int i = 0; i < elements.size(); i++) {
-                auto *node = arrayNode->elements.nodes[i];
-                auto &stat = elements[i];
-
-                if (PM_NODE_TYPE_P(node, PM_SPLAT_NODE)) {
-                    // Desugar [a, *x, remaining] into a.concat(<splat>(x)).concat(remaining)
-
-                    // The Splat was already desugared to Send{Magic.splat(arg)} with the splat's own location.
-                    // But for array literals, we want the splat to have the array's location to match
-                    // the legacy parser's behavior (important for error messages and hover).
-                    auto splatExpr = move(stat);
-
-                    // The parser::Send case makes a fake parser::Array with locZeroLen to hide callWithSplat
-                    // methods from hover. Using the array's loc means that we will get a zero-length loc for
-                    // the Splat in that case, and non-zero if there was a real Array literal.
-                    if (auto send = ast::cast_tree<ast::Send>(splatExpr)) {
-                        ENFORCE(send->numPosArgs() == 1, "Splat Send should have exactly 1 argument");
-                        // Extract the argument from the old Send and create a new one with array's location
-                        splatExpr = MK::Splat(location, move(send->getPosArg(0)));
-                    }
-                    auto var = move(splatExpr);
-                    if (elems.empty()) {
-                        if (lastMerge != nullptr) {
-                            lastMerge =
-                                MK::Send1(location, move(lastMerge), core::Names::concat(), locZeroLen, move(var));
-                        } else {
-                            lastMerge = move(var);
-                        }
-                    } else {
-                        ExpressionPtr current = MK::Array(location, move(elems));
-                        /* reassign instead of clear to work around https://bugs.llvm.org/show_bug.cgi?id=37553 */
-                        elems = ast::Array::ENTRY_store();
-                        if (lastMerge != nullptr) {
-                            lastMerge =
-                                MK::Send1(location, move(lastMerge), core::Names::concat(), locZeroLen, move(current));
-                        } else {
-                            lastMerge = move(current);
-                        }
-                        lastMerge = MK::Send1(location, move(lastMerge), core::Names::concat(), locZeroLen, move(var));
-                    }
-                } else {
-                    elems.emplace_back(move(stat));
-                }
-            };
-
-            ExpressionPtr res;
-            if (elems.empty()) {
-                if (lastMerge != nullptr) {
-                    res = move(lastMerge);
-                } else {
-                    // Empty array
-                    res = MK::Array(location, move(elems));
-                }
-            } else {
-                res = MK::Array(location, move(elems));
-                if (lastMerge != nullptr) {
-                    res = MK::Send1(location, move(lastMerge), core::Names::concat(), locZeroLen, move(res));
-                }
-            }
-
-            return make_node_with_expr<parser::Array>(move(res), location, move(sorbetElements));
+            auto prismElements = absl::MakeSpan(arrayNode->elements.nodes, arrayNode->elements.size);
+            auto expr = desugarArray(location, prismElements, move(elements));
+            return make_node_with_expr<parser::Array>(move(expr), location, move(sorbetElements));
         }
         case PM_ASSOC_NODE: { // A key-value pair in a Hash literal, e.g. the `a: 1` in `{ a: 1 }
             auto assocNode = down_cast<pm_assoc_node>(node);
@@ -2945,6 +2880,76 @@ NodeVec Translator::translateArguments(pm_arguments_node *argsNode, pm_node *blo
     }
 
     return results;
+}
+
+ast::ExpressionPtr Translator::desugarArray(core::LocOffsets location, absl::Span<pm_node_t *> prismElements,
+                                            ast::Array::ENTRY_store elements) {
+    auto locZeroLen = location.copyWithZeroLength();
+
+    ast::Array::ENTRY_store elems;
+    elems.reserve(elements.size());
+
+    ExpressionPtr lastMerge;
+    ENFORCE(elements.size() == prismElements.size());
+    for (int i = 0; i < elements.size(); i++) {
+        auto *node = prismElements[i];
+        auto &stat = elements[i];
+
+        if (PM_NODE_TYPE_P(node, PM_SPLAT_NODE)) {
+            // Desugar [a, *x, remaining] into a.concat(<splat>(x)).concat(remaining)
+
+            // The Splat was already desugared to Send{Magic.splat(arg)} with the splat's own location.
+            // But for array literals, we want the splat to have the array's location to match
+            // the legacy parser's behavior (important for error messages and hover).
+            auto splatExpr = move(stat);
+
+            // The parser::Send case makes a fake parser::Array with locZeroLen to hide callWithSplat
+            // methods from hover. Using the array's loc means that we will get a zero-length loc for
+            // the Splat in that case, and non-zero if there was a real Array literal.
+            if (auto send = ast::cast_tree<ast::Send>(splatExpr)) {
+                ENFORCE(send->numPosArgs() == 1, "Splat Send should have exactly 1 argument");
+                // Extract the argument from the old Send and create a new one with array's location
+                splatExpr = MK::Splat(location, move(send->getPosArg(0)));
+            }
+            auto var = move(splatExpr);
+            if (elems.empty()) {
+                if (lastMerge != nullptr) {
+                    lastMerge = MK::Send1(location, move(lastMerge), core::Names::concat(), locZeroLen, move(var));
+                } else {
+                    lastMerge = move(var);
+                }
+            } else {
+                ExpressionPtr current = MK::Array(location, move(elems));
+                /* reassign instead of clear to work around https://bugs.llvm.org/show_bug.cgi?id=37553 */
+                elems = ast::Array::ENTRY_store();
+                if (lastMerge != nullptr) {
+                    lastMerge = MK::Send1(location, move(lastMerge), core::Names::concat(), locZeroLen, move(current));
+                } else {
+                    lastMerge = move(current);
+                }
+                lastMerge = MK::Send1(location, move(lastMerge), core::Names::concat(), locZeroLen, move(var));
+            }
+        } else {
+            elems.emplace_back(move(stat));
+        }
+    };
+
+    ExpressionPtr res;
+    if (elems.empty()) {
+        if (lastMerge != nullptr) {
+            res = move(lastMerge);
+        } else {
+            // Empty array
+            res = MK::Array(location, move(elems));
+        }
+    } else {
+        res = MK::Array(location, move(elems));
+        if (lastMerge != nullptr) {
+            res = MK::Send1(location, move(lastMerge), core::Names::concat(), locZeroLen, move(res));
+        }
+    }
+
+    return res;
 }
 
 // Translates the given Prism elements into a `NodeVec` of legacy parser nodes.

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -100,6 +100,8 @@ private:
     NodeVec translateArguments(pm_arguments_node *node, pm_node *blockArgumentNode = nullptr);
     parser::NodeVec translateKeyValuePairs(pm_node_list_t elements);
 
+    ast::ExpressionPtr desugarArray(core::LocOffsets location, absl::Span<pm_node_t *> prismElements,
+                                    ast::Array::ENTRY_store elements);
     ast::ExpressionPtr desugarHash(core::LocOffsets loc, NodeVec &kvPairs);
 
     std::unique_ptr<parser::Node> translateCallWithBlock(pm_node_t *prismBlockOrLambdaNode,


### PR DESCRIPTION
### Motivation

The desugar logic for `parser::Send` constructs a temporary `parser::Array` as a means of reusing the Array desugar logic:

https://github.com/sorbet/sorbet/blob/163ada82e2ff17f84b8a3dfa2bde4f2e80eafe5e/ast/desugar/Desugar.cc#L799-L800

Prism nodes are a fair bit more cumbersome to create, so I didn't want to port over this approach. Instead, this PR extracts a helper function that can be shared between `PM_ARRAY_NODE` and `PM_CALL_NODE` (#9389). This has the nice benefit of sparing an allocation of that temporary parser node, and the `switch` dispatch overhead.

Easiest to review commit-by-commit. Part of #9065

### Test plan

Pure refactor, that's covered by existing desugar tests.
