### PR TITLE
Track blockLoc explicitly

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -173,7 +173,7 @@ void checkBlockRestParam(DesugarContext dctx, const MethodDef::PARAMS_store &arg
 
 ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, unique_ptr<parser::Node> &blockSend,
                            parser::Node *blockParams, unique_ptr<parser::Node> &blockBody) {
-    blockSend->loc = loc;
+    blockSend->loc = blockSend->loc.join(loc);
     auto recv = node2TreeImpl(dctx, blockSend);
     Send *send;
     ExpressionPtr res;
@@ -204,7 +204,6 @@ ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, unique_ptr
                          dctx.enclosingMethodName, inBlock, dctx.inModule, dctx.preserveConcreteSyntax);
     auto desugaredBody = desugarBody(dctx1, loc, blockBody, move(destructures));
 
-    // TODO the send->block's loc is too big and includes the whole send
     send->setBlock(MK::Block(loc, move(desugaredBody), move(Params)));
     return res;
 }

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -171,9 +171,8 @@ void checkBlockRestParam(DesugarContext dctx, const MethodDef::PARAMS_store &arg
     }
 }
 
-ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, core::LocOffsets blockLoc,
-                           unique_ptr<parser::Node> &blockSend, parser::Node *blockParams,
-                           unique_ptr<parser::Node> &blockBody) {
+ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, unique_ptr<parser::Node> &blockSend,
+                           parser::Node *blockParams, unique_ptr<parser::Node> &blockBody) {
     blockSend->loc = loc;
     auto recv = node2TreeImpl(dctx, blockSend);
     Send *send;
@@ -186,7 +185,7 @@ ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, core::LocO
         res = move(recv);
         auto is = cast_tree<InsSeq>(res);
         if (!is) {
-            if (auto e = dctx.ctx.beginIndexerError(blockLoc, core::errors::Desugar::UnsupportedNode)) {
+            if (auto e = dctx.ctx.beginIndexerError(loc, core::errors::Desugar::UnsupportedNode)) {
                 e.setHeader("No body in block");
             }
             return MK::EmptyTree();
@@ -1079,7 +1078,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 }
             },
             [&](parser::Block *block) {
-                result = desugarBlock(dctx, loc, block->loc, block->send, block->params.get(), block->body);
+                result = desugarBlock(dctx, loc, block->send, block->params.get(), block->body);
             },
             [&](parser::Begin *begin) { result = desugarBegin(dctx, loc, begin->stmts); },
             [&](parser::Assign *asgn) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -2408,8 +2408,8 @@ ExpressionPtr node2Tree(core::MutableContext ctx, unique_ptr<parser::Node> what,
         // We don't have an enclosing block arg to start off.
         DesugarContext dctx(ctx, uniqueCounter, core::NameRef::noName(), core::LocOffsets::none(),
                             core::NameRef::noName(), false, false, preserveConcreteSyntax);
-        auto loc = what->loc;
         auto result = node2TreeImpl(dctx, what);
+        auto loc = result.loc();
         result = liftTopLevel(dctx, loc, move(result));
         auto verifiedResult = Verifier::run(ctx, move(result));
         return verifiedResult;

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -90,8 +90,7 @@ ExpressionPtr numparamTree(DesugarContext dctx, int num, parser::NodeVec *decls)
 
 ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> &what);
 
-pair<MethodDef::PARAMS_store, InsSeq::STATS_store> desugarParams(DesugarContext dctx, core::LocOffsets loc,
-                                                                 parser::Node *anyParamsNode) {
+pair<MethodDef::PARAMS_store, InsSeq::STATS_store> desugarParams(DesugarContext dctx, parser::Node *anyParamsNode) {
     MethodDef::PARAMS_store params;
     InsSeq::STATS_store destructures;
 
@@ -197,7 +196,7 @@ ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, core::LocO
         send = cast_tree<Send>(iff->elsep);
         ENFORCE(send != nullptr, "DesugarBlock: failed to find Send");
     }
-    auto [Params, destructures] = desugarParams(dctx, loc, blockParams);
+    auto [Params, destructures] = desugarParams(dctx, blockParams);
 
     checkBlockRestParam(dctx, Params);
 
@@ -369,7 +368,7 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
     auto inModule = dctx.inModule && !isSelf;
     DesugarContext dctx1(dctx.ctx, uniqueCounter, dctx.enclosingBlockParamName, declLoc, name, dctx.inAnyBlock,
                          inModule, dctx.preserveConcreteSyntax);
-    auto [params, destructures] = desugarParams(dctx1, loc, argnode);
+    auto [params, destructures] = desugarParams(dctx1, argnode);
 
     if (params.empty() || !isa_tree<BlockParam>(params.back())) {
         auto blkLoc = core::LocOffsets::none();

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -2180,8 +2180,8 @@ ExpressionPtr node2Tree(core::MutableContext ctx, unique_ptr<parser::Node> what,
         // We don't have an enclosing block arg to start off.
         DesugarContext dctx(ctx, uniqueCounter, core::NameRef::noName(), core::LocOffsets::none(),
                             core::NameRef::noName(), false, false, preserveConcreteSyntax);
-        auto loc = what->loc;
         auto result = node2TreeImpl(dctx, what);
+        auto loc = result.loc();
         result = liftTopLevel(dctx, loc, move(result));
         auto verifiedResult = Verifier::run(ctx, move(result));
         return verifiedResult;

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -58,8 +58,7 @@ core::NameRef blockParam2Name(DesugarContext dctx, const BlockParam &blockParam)
 
 ExpressionPtr node2TreeImpl(DesugarContext dctx, unique_ptr<parser::Node> &what);
 
-pair<MethodDef::PARAMS_store, InsSeq::STATS_store> desugarParams(DesugarContext dctx, core::LocOffsets loc,
-                                                                 parser::Node *anyParamsNode) {
+pair<MethodDef::PARAMS_store, InsSeq::STATS_store> desugarParams(DesugarContext dctx, parser::Node *anyParamsNode) {
     MethodDef::PARAMS_store params;
     InsSeq::STATS_store destructures;
 
@@ -164,7 +163,7 @@ ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, core::LocO
         send = cast_tree<Send>(iff->elsep);
         ENFORCE(send != nullptr, "DesugarBlock: failed to find Send");
     }
-    auto [params, destructures] = desugarParams(dctx, loc, blockParams);
+    auto [params, destructures] = desugarParams(dctx, blockParams);
 
     checkBlockRestParam(dctx, params);
 
@@ -336,7 +335,7 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
     auto inModule = dctx.inModule && !isSelf;
     DesugarContext dctx1(dctx.ctx, uniqueCounter, dctx.enclosingBlockParamName, declLoc, name, dctx.inAnyBlock,
                          inModule, dctx.preserveConcreteSyntax);
-    auto [params, destructures] = desugarParams(dctx1, loc, argnode);
+    auto [params, destructures] = desugarParams(dctx1, argnode);
 
     if (params.empty() || !isa_tree<BlockParam>(params.back())) {
         auto blkLoc = core::LocOffsets::none();

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -2180,9 +2180,18 @@ ExpressionPtr node2Tree(core::MutableContext ctx, unique_ptr<parser::Node> what,
         // We don't have an enclosing block arg to start off.
         DesugarContext dctx(ctx, uniqueCounter, core::NameRef::noName(), core::LocOffsets::none(),
                             core::NameRef::noName(), false, false, preserveConcreteSyntax);
+        auto liftedClassDefLoc = what->loc;
         auto result = node2TreeImpl(dctx, what);
-        auto loc = result.loc();
-        result = liftTopLevel(dctx, loc, move(result));
+        if (result.loc().exists()) {
+            // If the desugared expression has a different loc, we want to use that. This can happen
+            // because (:block (:send)) desugars to (:send (:block)), but the (:block) node just has
+            // the loc of the `do ... end`, while the (:send) has the whole loc
+            //
+            // But if we desugared to EmptyTree (either intentionally or because there was an
+            // unsupported node type), we want to use the loc of the original node.
+            liftedClassDefLoc = result.loc();
+        }
+        result = liftTopLevel(dctx, liftedClassDefLoc, move(result));
         auto verifiedResult = Verifier::run(ctx, move(result));
         return verifiedResult;
     } catch (SorbetException &) {

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -138,9 +138,8 @@ void checkBlockRestParam(DesugarContext dctx, const MethodDef::PARAMS_store &arg
     }
 }
 
-ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, core::LocOffsets blockLoc,
-                           unique_ptr<parser::Node> &blockSend, parser::Node *blockParams,
-                           unique_ptr<parser::Node> &blockBody) {
+ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, unique_ptr<parser::Node> &blockSend,
+                           parser::Node *blockParams, unique_ptr<parser::Node> &blockBody) {
     blockSend->loc = loc;
     auto recv = node2TreeImpl(dctx, blockSend);
     Send *send;
@@ -153,7 +152,7 @@ ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, core::LocO
         res = move(recv);
         auto is = cast_tree<InsSeq>(res);
         if (!is) {
-            if (auto e = dctx.ctx.beginIndexerError(blockLoc, core::errors::Desugar::UnsupportedNode)) {
+            if (auto e = dctx.ctx.beginIndexerError(loc, core::errors::Desugar::UnsupportedNode)) {
                 e.setHeader("No body in block");
             }
             return MK::EmptyTree();
@@ -1036,7 +1035,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 }
             },
             [&](parser::Block *block) {
-                result = desugarBlock(dctx, loc, block->loc, block->send, block->params.get(), block->body);
+                result = desugarBlock(dctx, loc, block->send, block->params.get(), block->body);
             },
             [&](parser::Begin *begin) { result = desugarBegin(dctx, loc, begin->stmts); },
             [&](parser::Assign *asgn) {

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -140,7 +140,7 @@ void checkBlockRestParam(DesugarContext dctx, const MethodDef::PARAMS_store &arg
 
 ExpressionPtr desugarBlock(DesugarContext dctx, core::LocOffsets loc, unique_ptr<parser::Node> &blockSend,
                            parser::Node *blockParams, unique_ptr<parser::Node> &blockBody) {
-    blockSend->loc = loc;
+    blockSend->loc = blockSend->loc.join(loc);
     auto recv = node2TreeImpl(dctx, blockSend);
     Send *send;
     ExpressionPtr res;

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -425,6 +425,8 @@ public:
         core::LocOffsets loc;
         if (begin != nullptr) {
             loc = tokLoc(begin).join(tokLoc(end));
+        } else if (auto *block = parser::cast_node<Block>(body.get())) {
+            loc = block->send->loc.join(block->loc);
         } else {
             loc = body->loc;
         }
@@ -470,8 +472,14 @@ public:
             auto elseLoc = tokLoc(elseTok).join(maybe_loc(else_));
             else_stmts.emplace_back(std::move(else_));
             stmts.emplace_back(make_unique<Begin>(elseLoc, std::move(else_stmts)));
+            auto loc = collectionLoc(stmts);
+            if (!stmts.empty()) {
+                if (auto *block = parser::cast_node<Block>(body.get())) {
+                    loc = block->send->loc.join(loc);
+                }
+            }
 
-            body = make_unique<Begin>(collectionLoc(stmts), std::move(stmts));
+            body = make_unique<Begin>(loc, std::move(stmts));
         }
 
         if (ensure_tok != nullptr) {
@@ -686,8 +694,13 @@ public:
                 return nullptr;
             case 1:
                 return std::move(nodes.back());
-            default:
-                return make_unique<Begin>(collectionLoc(nodes), std::move(nodes));
+            default: {
+                auto loc = collectionLoc(nodes);
+                if (auto *block = parser::cast_node<Block>(nodes[0].get())) {
+                    loc = block->send->loc.join(loc);
+                }
+                return make_unique<Begin>(loc, std::move(nodes));
+            }
         }
     }
 

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -537,11 +537,11 @@ public:
             }
         }
 
+        auto blockLoc = tokLoc(begin).join(tokLoc(end));
         Node &n = *methodCall;
         const type_info &ty = typeid(n);
         if (ty == typeid(Send) || ty == typeid(CSend) || ty == typeid(Super) || ty == typeid(ZSuper)) {
-            return make_unique<Block>(methodCall->loc.join(tokLoc(end)), std::move(methodCall), std::move(args),
-                                      std::move(body));
+            return make_unique<Block>(blockLoc, std::move(methodCall), std::move(args), std::move(body));
         }
 
         sorbet::parser::NodeVec *exprs;
@@ -555,7 +555,6 @@ public:
             [&](Node *n) { Exception::raise("Unexpected send node: {}", n->nodeName()); });
 
         auto &send = exprs->front();
-        core::LocOffsets blockLoc = send->loc.join(tokLoc(end));
         unique_ptr<Node> block = make_unique<Block>(blockLoc, std::move(send), std::move(args), std::move(body));
         exprs->front().swap(block);
         return methodCall;

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -473,10 +473,8 @@ public:
             else_stmts.emplace_back(std::move(else_));
             stmts.emplace_back(make_unique<Begin>(elseLoc, std::move(else_stmts)));
             auto loc = collectionLoc(stmts);
-            if (!stmts.empty()) {
-                if (auto *block = parser::cast_node<Block>(body.get())) {
-                    loc = block->send->loc.join(loc);
-                }
+            if (auto *block = parser::cast_node<Block>(body.get())) {
+                loc = block->send->loc.join(loc);
             }
 
             body = make_unique<Begin>(loc, std::move(stmts));

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -3240,6 +3240,7 @@ unique_ptr<parser::Node> Translator::translateCallWithBlock(pm_node_t *prismBloc
                                                             unique_ptr<parser::Node> sendNode) {
     unique_ptr<parser::Node> parametersNode;
     unique_ptr<parser::Node> body;
+    auto blockLoc = translateLoc(prismBlockOrLambdaNode->location);
     if (PM_NODE_TYPE_P(prismBlockOrLambdaNode, PM_BLOCK_NODE)) {
         auto prismBlockNode = down_cast<pm_block_node>(prismBlockOrLambdaNode);
         parametersNode = translate(prismBlockNode->parameters);
@@ -3250,12 +3251,6 @@ unique_ptr<parser::Node> Translator::translateCallWithBlock(pm_node_t *prismBloc
         parametersNode = translate(prismLambdaNode->parameters);
         body = this->enterBlockContext().translate(prismLambdaNode->body);
     }
-
-    // There was a TODO in the original Desugarer: "the send->block's loc is too big and includes the whole send."
-    // We'll keep this behaviour for parity for now.
-    // TODO: Switch to using the fixed sendNode loc below after direct desugaring is complete
-    // https://github.com/Shopify/sorbet/issues/671
-    auto blockLoc = sendNode->loc;
 
     // Modify send node's endLoc to be position before first space
     // This fixes location for cases like:

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -393,7 +393,7 @@ void CommentsAssociator::walkNode(parser::Node *node) {
             consumeCommentsInsideNode(node, "begin");
         },
         [&](parser::Block *block) {
-            auto beginLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.beginPos()).line;
+            auto beginLine = core::Loc::pos2Detail(ctx.file.data(ctx), block->send->loc.beginPos()).line;
             consumeCommentsUntilLine(beginLine);
 
             associateAssertionCommentsToNode(node);

--- a/test/testdata/lsp/document_symbols_minitest.rb.document-symbols.exp
+++ b/test/testdata/lsp/document_symbols_minitest.rb.document-symbols.exp
@@ -49,7 +49,7 @@
                         },
                         "end": {
                             "line": 8,
-                            "character": 2
+                            "character": 29
                         }
                     },
                     "children": [
@@ -74,7 +74,7 @@
                                 },
                                 "end": {
                                     "line": 13,
-                                    "character": 4
+                                    "character": 23
                                 }
                             },
                             "children": []
@@ -100,7 +100,7 @@
                                 },
                                 "end": {
                                     "line": 16,
-                                    "character": 4
+                                    "character": 27
                                 }
                             },
                             "children": []

--- a/test/testdata/packager/invalid_imports_and_exports/__package.rb
+++ b/test/testdata/packager/invalid_imports_and_exports/__package.rb
@@ -34,7 +34,7 @@ class A < PackageSpec
   #                    ^^^^^^^^^^^^^^^^^^^^^ error: Expected `T.nilable(String)` but found `Symbol(:A_MYSTERIOUS_PURPOSE)`
   test_import C, only: "something else" # error: Invalid expression in package
   test_import C, only: -> { "naught" }
-  #                    ^^^^^^^^^^^^^^^ error: Invalid expression in package
+  #                       ^^^^^^^^^^^^ error: Invalid expression in package
   #                    ^^^^^^^^^^^^^^^ error: Expected `T.nilable(String)` but found `T.proc.returns(String)`
   test_import C, only: "test_rb", only: "test_rb" # error: Hash key `only` is duplicated
   test_import C, with: "cheese" # error: Unrecognized keyword argument

--- a/test/testdata/packager/invalid_imports_and_exports/pass.autocorrects.exp
+++ b/test/testdata/packager/invalid_imports_and_exports/pass.autocorrects.exp
@@ -35,7 +35,7 @@ class A < PackageSpec
   #                    ^^^^^^^^^^^^^^^^^^^^^ error: Expected `T.nilable(String)` but found `Symbol(:A_MYSTERIOUS_PURPOSE)`
   test_import C, only: "something else" # error: Invalid expression in package
   test_import C, only: -> { "naught" }
-  #                    ^^^^^^^^^^^^^^^ error: Invalid expression in package
+  #                       ^^^^^^^^^^^^ error: Invalid expression in package
   #                    ^^^^^^^^^^^^^^^ error: Expected `T.nilable(String)` but found `T.proc.returns(String)`
   test_import C, only: "test_rb", only: "test_rb" # error: Hash key `only` is duplicated
   test_import C, with: "cheese" # error: Unrecognized keyword argument

--- a/test/testdata/packager/invalid_package_control_flow/__package.rb
+++ b/test/testdata/packager/invalid_package_control_flow/__package.rb
@@ -30,13 +30,13 @@ class MyPackage < PackageSpec
 
   # Methods defs are not OK
   sig {void}
-# ^^^^^^^^^^ error: Invalid expression in package: `Block` not allowed
+  #   ^^^^^^ error: Invalid expression in package: `Block` not allowed
   def package_method; end
 # ^^^^^^^^^^^^^^^^^^^^^^^ error: Invalid expression in package: `MethodDef`
 # ^^^^^^^^^^^^^^^^^^      error: Invalid expression in package: `RuntimeMethodDefinition`
 
   sig {void}
-# ^^^^^^^^^^ error: Invalid expression in package: `Block` not allowed
+  #   ^^^^^^ error: Invalid expression in package: `Block` not allowed
   def self.static_method; end
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Invalid expression in package: `MethodDef`
 # ^^^^^^^^^^^^^^^^^^^^^^      error: Invalid expression in package: `RuntimeMethodDefinition`

--- a/test/testdata/packager/sorbet_min_typed_level/block/__package.rb
+++ b/test/testdata/packager/sorbet_min_typed_level/block/__package.rb
@@ -5,7 +5,7 @@
 
 class Block < PackageSpec
   sorbet min_typed_level: 'true', tests_min_typed_level: 'true' do end
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Invalid expression in package: `Block` not allowed
+  #                                                             ^^^^^^ error: Invalid expression in package: `Block` not allowed
   #                                                            ^^^^^^^ error: does not take a block
   strict_dependencies 'false'
   layer 'a'

--- a/test/testdata/packager/strict_dependencies/block/__package.rb
+++ b/test/testdata/packager/strict_dependencies/block/__package.rb
@@ -5,7 +5,7 @@
 
 class Block < PackageSpec
   strict_dependencies 'false' do end
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Invalid expression in package: `Block` not allowed
+  #                           ^^^^^^ error: Invalid expression in package: `Block` not allowed
   #                          ^^^^^^^ error: does not take a block
   layer 'a'
 end

--- a/test/testdata/packager/visibility/foo/__package.rb
+++ b/test/testdata/packager/visibility/foo/__package.rb
@@ -22,7 +22,7 @@ class Foo < PackageSpec
            # ^^^^^^ error: Unable to resolve constant `Nested`
   visible_to Nested::* {}
            # ^^^^^^^^^^^^ error: Argument to `visible_to` must be a constant or
-           # ^^^^^^^^^^^^ error: Invalid expression in package: `Block` not allowed
+           #           ^^ error: Invalid expression in package: `Block` not allowed
            # ^^^^^^ error: Unable to resolve constant `Nested`
 
   visible_to Nested::*::Blah


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It's annoying that we have to recompute it by looking at the source. We should just pay the extra bytes to allocate it.

This memory only lives as long as we're typechecking a single file, so it shouldn't meaningfully contribute to increased RSS.

This change comes with some annoying tradeoffs, because in various places Sorbet relied on the `Send` loc being at least as large as the `Block` loc (which was the case in the whitequark parser, because the `(:block ...)` node contains the `(:send ...)` node, paradoxically.

Breaking that assumption caused some tests to fail, and while I have fixed them, I think it is fair to be skeptical there are more things silently broken. The shape of bug was generally that things like the loc of an `InsSeq` (or the `<root>` ClassDef that wraps all code) would sometimes have as its loc the `beginPos()` of the first stmt and the `endPos()` of the last expr in cases when the `InsSeq` had been created without an explicit `begin ... end` keyword or `( ... )` token.

I have audited all the the places doing `make_unique<Begin>` in the Builder.cc to avoid that problem. To my knowledge, Prism _already_ worked the other way, so the prism Translator was already going to lengths to make sure that an `InsSeq` had the right locs.

When things broke, usually it was very benign—instead of reporting an error on the whole send loc, we would only show an error on the `{ ... }` portion of the send. That's bad, but that's not generally "crash the program" bad—I think that if somehow there are more examples of this, we can fix them forward.

The benefit of this is that there are some places in Sorbet that **only** want to operate on the `{ ... }` loc, and have to reconstruct it by scanning the source of the program to guess where that is, which leads to suboptimal errors.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests