### PR TITLE
Stop suggesting `T.must` sometimes

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2533,7 +2533,7 @@ class Magic_callWithBlockPass : public IntrinsicMethod {
 
 private:
     static TypePtr typeToProc(const GlobalState &gs, const TypeAndOrigins &blockType, core::FileRef file,
-                              LocOffsets receiverLoc, Loc originForUninitialized, bool suppressErrors) {
+                              LocOffsets blockArgLoc, Loc originForUninitialized, bool suppressErrors) {
         auto nonNilBlockType = blockType;
         auto typeIsNilable = false;
         if (blockType.type.isUntyped()) {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -764,7 +764,9 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 e.addErrorNote("For help fixing `{}` errors: {}", "super", "https://sorbet.org/docs/typed-super");
             } else if (args.receiverLoc().exists() &&
                        (gs.suggestUnsafe.has_value() ||
-                        (args.fullType.type != args.thisType && symbol == Symbols::NilClass()))) {
+                        (args.fullType.type != args.thisType && symbol == Symbols::NilClass() &&
+                         // Don't suggest T.must if the suggestion will produce bottom
+                         !Types::dropNil(gs, args.fullType.type).isBottom()))) {
                 auto wrapInFn = gs.suggestUnsafe.value_or("T.must");
                 if (args.receiverLoc().empty()) {
                     auto shortName = args.name.shortName(gs);
@@ -847,6 +849,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                     }
                 }
 
+                canSkipFuzzyMatch = canSkipFuzzyMatch || !args.funLoc().exists() || args.funLoc().empty();
                 if (!canSkipFuzzyMatch) {
                     auto alternatives = symbol.data(gs)->findMemberFuzzyMatch(gs, targetName);
                     for (auto alternative : alternatives) {
@@ -2530,8 +2533,7 @@ class Magic_callWithBlockPass : public IntrinsicMethod {
 
 private:
     static TypePtr typeToProc(const GlobalState &gs, const TypeAndOrigins &blockType, core::FileRef file,
-                              LocOffsets callLoc, LocOffsets receiverLoc, LocOffsets funLoc, Loc originForUninitialized,
-                              bool suppressErrors) {
+                              LocOffsets receiverLoc, Loc originForUninitialized, bool suppressErrors) {
         auto nonNilBlockType = blockType;
         auto typeIsNilable = false;
         if (blockType.type.isUntyped()) {
@@ -2553,7 +2555,13 @@ private:
 
         InlinedVector<const TypeAndOrigins *, 2> sendArgs;
         InlinedVector<LocOffsets, 2> sendArgLocs;
-        CallLocs sendLocs{file, callLoc, receiverLoc, funLoc, sendArgLocs};
+        CallLocs sendLocs{
+            .file = file,
+            .call = blockArgLoc,
+            .receiver = blockArgLoc,
+            .fun = blockArgLoc.copyWithZeroLength(),
+            .args = sendArgLocs,
+        };
         DispatchArgs innerArgs{core::Names::toProc(),
                                sendLocs,
                                0,
@@ -2761,9 +2769,8 @@ public:
         CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], args.locs.fun, sendArgLocs};
 
         auto &blockArgTpo = *args.args[2];
-        auto finalBlockType =
-            Magic_callWithBlockPass::typeToProc(gs, blockArgTpo, args.locs.file, args.locs.call, args.locs.args[2],
-                                                args.locs.fun, args.originForUninitialized, args.suppressErrors);
+        auto finalBlockType = Magic_callWithBlockPass::typeToProc(gs, blockArgTpo, args.locs.file, args.locs.args[2],
+                                                                  args.originForUninitialized, args.suppressErrors);
         optional<int> blockArity = Magic_callWithBlockPass::getArityForBlock(finalBlockType);
         core::SendAndBlockLink link{fn, Magic_callWithBlockPass::paramInfoByArity(blockArity)};
         res.main.constr = make_unique<TypeConstraint>();
@@ -2877,9 +2884,8 @@ public:
         CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], args.locs.fun, sendArgLocs};
 
         auto &blockArgTpo = *args.args[4];
-        auto finalBlockType =
-            Magic_callWithBlockPass::typeToProc(gs, blockArgTpo, args.locs.file, args.locs.call, args.locs.args[4],
-                                                args.locs.fun, args.originForUninitialized, args.suppressErrors);
+        auto finalBlockType = Magic_callWithBlockPass::typeToProc(gs, blockArgTpo, args.locs.file, args.locs.args[4],
+                                                                  args.originForUninitialized, args.suppressErrors);
         optional<int> blockArity = Magic_callWithBlockPass::getArityForBlock(finalBlockType);
         core::SendAndBlockLink link{fn, Magic_callWithBlockPass::paramInfoByArity(blockArity)};
         res.main.constr = make_unique<TypeConstraint>();

--- a/test/cli/autocorrect-t-combinator-kwargs/test.out
+++ b/test/cli/autocorrect-t-combinator-kwargs/test.out
@@ -77,9 +77,6 @@ autocorrect-t-combinator-kwargs.rb:14: Method `to_hash` does not exist on `T::Ar
     autocorrect-t-combinator-kwargs.rb:14:
     14 |      splat: T.class_of(**TYPES),
                                 ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#L1424: Did you mean: `Array#hash`
-    1424 |  def hash; end
-            ^^^^^^^^
 
 autocorrect-t-combinator-kwargs.rb:15: Method `to_hash` does not exist on `T::Array[T.any(T.class_of(Integer), T.class_of(String))]` https://srb.help/7003
     15 |      pos_and_splat: T.class_of(Float, **TYPES),
@@ -88,9 +85,6 @@ autocorrect-t-combinator-kwargs.rb:15: Method `to_hash` does not exist on `T::Ar
     autocorrect-t-combinator-kwargs.rb:15:
     15 |      pos_and_splat: T.class_of(Float, **TYPES),
                                                ^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/array.rbi#L1424: Did you mean: `Array#hash`
-    1424 |  def hash; end
-            ^^^^^^^^
 Errors: 14
 
 --------------------------------------------------------------------------

--- a/test/cli/for-block-argument/test.out
+++ b/test/cli/for-block-argument/test.out
@@ -76,23 +76,12 @@ test.rb:23: Expected `T.proc.void` but found `T.nilable(T.proc.returns(NilClass)
 
 test.rb:32: Method `to_proc` does not exist on `NilClass` component of `T.all(NilClass, T.type_parameter(:U) (of Object#example_with_generics))` https://srb.help/7003
     32 |  takes_block(&x)
-          ^^^^^^^^^^^
+                       ^
   Got `T.all(NilClass, T.type_parameter(:U) (of Object#example_with_generics))` originating from:
     test.rb:31:
     31 |def example_with_generics(x)
                                   ^
-  Autocorrect: Done
-    test.rb:32: Replaced with `T.must(x)`
-    32 |  takes_block(&x)
-                       ^
-
-test.rb:36: This code is unreachable https://srb.help/7006
-    36 |    takes_block(&T.must(x))
-            ^^^^^^^^^^^^^^^^^^^^^^^
-    test.rb:36: This expression always raises or can never be computed
-    36 |    takes_block(&T.must(x))
-                         ^^^^^^^^^
-Errors: 6
+Errors: 5
 
 --------------------------------------------------------------------------
 
@@ -127,11 +116,6 @@ sig {
     .void
 }
 def example_with_generics(x)
-  takes_block(&T.must(x))
-
-  # ^ It's unclear whether we actually want an autocorrect there, because if you accept it, you get this, but the situation is really rare anyways.
-  if T.unsafe(nil)
-    takes_block(&T.must(x))
-  end
+  takes_block(&x)
 end
 

--- a/test/cli/for-block-argument/test.rb
+++ b/test/cli/for-block-argument/test.rb
@@ -30,10 +30,5 @@ sig {
 }
 def example_with_generics(x)
   takes_block(&x)
-
-  # ^ It's unclear whether we actually want an autocorrect there, because if you accept it, you get this, but the situation is really rare anyways.
-  if T.unsafe(nil)
-    takes_block(&T.must(x))
-  end
 end
 

--- a/test/cli/suggest_t_must/suggest_t_must.rb
+++ b/test/cli/suggest_t_must/suggest_t_must.rb
@@ -23,3 +23,16 @@ end
 
 x, y = [1, T.let('', T.nilable(String))]
 y.split
+
+class B
+  extend T::Sig
+
+  sig {
+    type_parameters(:U)
+      .params(x: T.all(NilClass, T.type_parameter(:U)))
+      .void
+  }
+  def nil_type_parameter(x)
+    x.foo
+  end
+end

--- a/test/cli/suggest_t_must/test.out
+++ b/test/cli/suggest_t_must/test.out
@@ -73,10 +73,6 @@ suggest_t_must.rb:36: Method `foo` does not exist on `NilClass` component of `T.
     suggest_t_must.rb:35:
     35 |  def nil_type_parameter(x)
                                  ^
-  Autocorrect: Done
-    suggest_t_must.rb:36: Replaced with `T.must(x)`
-    36 |    x.foo
-            ^
 
 suggest_t_must.rb:36: Call to method `foo` on generic type `T.type_parameter(:U) (of B#nil_type_parameter)` component of `T.all(NilClass, T.type_parameter(:U) (of B#nil_type_parameter))` https://srb.help/7038
     36 |    x.foo
@@ -126,6 +122,6 @@ class B
       .void
   }
   def nil_type_parameter(x)
-    T.must(x).foo
+    x.foo
   end
 end

--- a/test/cli/suggest_t_must/test.out
+++ b/test/cli/suggest_t_must/test.out
@@ -65,7 +65,29 @@ suggest_t_must.rb:20: Expected `Integer` but found `T.nilable(Integer)` for fiel
     suggest_t_must.rb:20: Replaced with `T.must(xs[i])`
     20 |    @result = xs[i]
                       ^^^^^
-Errors: 5
+
+suggest_t_must.rb:36: Method `foo` does not exist on `NilClass` component of `T.all(NilClass, T.type_parameter(:U) (of B#nil_type_parameter))` https://srb.help/7003
+    36 |    x.foo
+              ^^^
+  Got `T.all(NilClass, T.type_parameter(:U) (of B#nil_type_parameter))` originating from:
+    suggest_t_must.rb:35:
+    35 |  def nil_type_parameter(x)
+                                 ^
+  Autocorrect: Done
+    suggest_t_must.rb:36: Replaced with `T.must(x)`
+    36 |    x.foo
+            ^
+
+suggest_t_must.rb:36: Call to method `foo` on generic type `T.type_parameter(:U) (of B#nil_type_parameter)` component of `T.all(NilClass, T.type_parameter(:U) (of B#nil_type_parameter))` https://srb.help/7038
+    36 |    x.foo
+              ^^^
+  Got `T.all(NilClass, T.type_parameter(:U) (of B#nil_type_parameter))` originating from:
+    suggest_t_must.rb:35:
+    35 |  def nil_type_parameter(x)
+                                 ^
+  Note:
+    Consider using `T.all(T.type_parameter(:U), Constraint)` to place a constraint on this type
+Errors: 7
 
 --------------------------------------------------------------------------
 
@@ -94,3 +116,16 @@ end
 
 x, y = [1, T.let('', T.nilable(String))]
 T.must(y).split
+
+class B
+  extend T::Sig
+
+  sig {
+    type_parameters(:U)
+      .params(x: T.all(NilClass, T.type_parameter(:U)))
+      .void
+  }
+  def nil_type_parameter(x)
+    T.must(x).foo
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

- Don't suggest `T.must` if it would produce `T.noreturn`

  All the other places that we call `dropNil` also check for bottom. It
  was just this one place in the receiver that we're not using the
  `maybeAutocorrect` helper (because we want a little more flexibility,
  e.g. maybe we want to expand the `&:foo` into a proper block like
  `{ T.must(_1).foo }`), but the `maybeAutocorrect` also checks for
  bottom here.

- Don't suggest did you mean if the `funLoc` doesn't exist or is
  empty--that almost certainly means it was synthetic, or at least that
  our suggestion of an alternative name isn't good (e.g., no funLoc for
  `x[0]`, but we shouldn't suggest a "did you mean" there anyways).

These are kind of unrelated changes but I grouped them together because
they feel small enough.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tests show before+after