### PR TITLE
give a better type to `Enumerator#with_object`

### DIFF
--- a/rbi/core/enumerator.rbi
+++ b/rbi/core/enumerator.rbi
@@ -461,7 +461,7 @@ class Enumerator < Object
       arg0: T.type_parameter(:U),
       blk: T.proc.params(arg0: Elem, arg1: T.type_parameter(:U)).returns(BasicObject)
     )
-                       .returns(T.untyped)
+                       .returns(T.type_parameter(:U))
   end
   sig do
     type_parameters(:U).params(


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Apparent this is just an alias for `each_with_object`, so it should have the same return type, which is the type of the object we passed in.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
