### PR TITLE
Improve argsLoc now that we have `this->block->loc`

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -1014,7 +1014,7 @@ struct DispatchArgs {
     }
 
     // Attempts to compute a loc that you could use to insert an arg at the beginning end of the current list of args.
-    Loc argsLoc() const;
+    Loc argsLoc(const GlobalState &gs) const;
 
     Loc blockLoc(const GlobalState &gs) const {
         return core::Loc(locs.file, block->loc);

--- a/core/Types.h
+++ b/core/Types.h
@@ -1020,21 +1020,24 @@ struct DispatchArgs {
             return core::Loc(locs.file, locs.args.front().join(locs.args.back()));
         }
 
+        Loc result;
         if (this->block != nullptr) {
             if (!this->block->loc.exists()) {
-                return callLoc().copyEndWithZeroLength();
+                result = callLoc().copyEndWithZeroLength();
             } else if (!locs.fun.exists()) {
-                return core::Loc(locs.file, this->block->loc.copyWithZeroLength());
+                result = core::Loc(locs.file, this->block->loc.copyWithZeroLength());
             } else {
-                return core::Loc(locs.file, funLoc().endPos(), this->block->loc.beginPos());
+                result = core::Loc(locs.file, funLoc().endPos(), this->block->loc.beginPos());
             }
         } else {
             if (locs.fun.exists()) {
-                return core::Loc(locs.file, locs.fun.endPos(), locs.call.endPos());
+                result = core::Loc(locs.file, locs.fun.endPos(), locs.call.endPos());
             } else {
-                return callLoc().copyEndWithZeroLength();
+                result = callLoc().copyEndWithZeroLength();
             }
         }
+
+        return result;
     }
     Loc blockLoc(const GlobalState &gs) const {
         return core::Loc(locs.file, block->loc);

--- a/core/Types.h
+++ b/core/Types.h
@@ -1014,31 +1014,8 @@ struct DispatchArgs {
     }
 
     // Attempts to compute a loc that you could use to insert an arg at the beginning end of the current list of args.
-    Loc argsLoc() const {
-        if (!locs.args.empty()) {
-            // Note: there are some limitations here when the args themselves are parenthesized
-            return core::Loc(locs.file, locs.args.front().join(locs.args.back()));
-        }
+    Loc argsLoc() const;
 
-        Loc result;
-        if (this->block != nullptr) {
-            if (!this->block->loc.exists()) {
-                result = callLoc().copyEndWithZeroLength();
-            } else if (!locs.fun.exists()) {
-                result = core::Loc(locs.file, this->block->loc.copyWithZeroLength());
-            } else {
-                result = core::Loc(locs.file, funLoc().endPos(), this->block->loc.beginPos());
-            }
-        } else {
-            if (locs.fun.exists()) {
-                result = core::Loc(locs.file, locs.fun.endPos(), locs.call.endPos());
-            } else {
-                result = callLoc().copyEndWithZeroLength();
-            }
-        }
-
-        return result;
-    }
     Loc blockLoc(const GlobalState &gs) const {
         return core::Loc(locs.file, block->loc);
     }

--- a/core/Types.h
+++ b/core/Types.h
@@ -1023,9 +1023,7 @@ struct DispatchArgs {
         if (this->block != nullptr) {
             if (!this->block->loc.exists()) {
                 return callLoc().copyEndWithZeroLength();
-            }
-
-            if (!locs.fun.exists()) {
+            } else if (!locs.fun.exists()) {
                 return core::Loc(locs.file, this->block->loc.copyWithZeroLength());
             } else {
                 return core::Loc(locs.file, funLoc().endPos(), this->block->loc.beginPos());
@@ -1033,9 +1031,9 @@ struct DispatchArgs {
         } else {
             if (locs.fun.exists()) {
                 return core::Loc(locs.file, locs.fun.endPos(), locs.call.endPos());
+            } else {
+                return callLoc().copyEndWithZeroLength();
             }
-
-            return callLoc().copyEndWithZeroLength();
         }
     }
     Loc blockLoc(const GlobalState &gs) const {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1282,7 +1282,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
 
     if (pit != pend) {
         if (!(pit->flags.isKeyword || pit->flags.isDefault || pit->flags.isRepeated || pit->flags.isBlock)) {
-            if (auto e = gs.beginError(args.argsLoc(), errors::Infer::MethodArgumentCountMismatch)) {
+            if (auto e = gs.beginError(args.argsLoc(gs), errors::Infer::MethodArgumentCountMismatch)) {
                 if (args.fullType.type != args.thisType) {
                     e.setHeader("Not enough arguments provided for method `{}` on `{}` component of `{}`. "
                                 "Expected: `{}`, got: `{}`",
@@ -1366,7 +1366,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 if (arg == hash->keys.end()) {
                     if (!kwParam.flags.isDefault) {
                         if (auto e =
-                                missingArg(gs, args.argsLoc(), args.receiverLoc(), method, kwParam, symbol, targs)) {
+                                missingArg(gs, args.argsLoc(gs), args.receiverLoc(), method, kwParam, symbol, targs)) {
                             result.main.errors.emplace_back(std::move(e));
                         }
                     }
@@ -1441,7 +1441,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 if (!param.flags.isKeyword || param.flags.isDefault || param.flags.isRepeated) {
                     continue;
                 }
-                if (auto e = missingArg(gs, args.argsLoc(), args.receiverLoc(), method, param, symbol, targs)) {
+                if (auto e = missingArg(gs, args.argsLoc(gs), args.receiverLoc(), method, param, symbol, targs)) {
                     result.main.errors.emplace_back(std::move(e));
                 }
             }

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -1133,29 +1133,29 @@ DispatchArgs::DispatchArgs(NameRef name, const CallLocs &locs, uint16_t numPosAr
       suppressErrors(suppressErrors), enclosingMethodForSuper(enclosingMethodForSuper) {}
 
 Loc DispatchArgs::argsLoc() const {
-        if (!locs.args.empty()) {
-            // Note: there are some limitations here when the args themselves are parenthesized
-            return core::Loc(locs.file, locs.args.front().join(locs.args.back()));
-        }
+    if (!locs.args.empty()) {
+        // Note: there are some limitations here when the args themselves are parenthesized
+        return core::Loc(locs.file, locs.args.front().join(locs.args.back()));
+    }
 
-        Loc result;
-        if (this->block != nullptr) {
-            if (!this->block->loc.exists()) {
-                result = callLoc().copyEndWithZeroLength();
-            } else if (!locs.fun.exists()) {
-                result = core::Loc(locs.file, this->block->loc.copyWithZeroLength());
-            } else {
-                result = core::Loc(locs.file, funLoc().endPos(), this->block->loc.beginPos());
-            }
+    Loc result;
+    if (this->block != nullptr) {
+        if (!this->block->loc.exists()) {
+            result = callLoc().copyEndWithZeroLength();
+        } else if (!locs.fun.exists()) {
+            result = core::Loc(locs.file, this->block->loc.copyWithZeroLength());
         } else {
-            if (locs.fun.exists()) {
-                result = core::Loc(locs.file, locs.fun.endPos(), locs.call.endPos());
-            } else {
-                result = callLoc().copyEndWithZeroLength();
-            }
+            result = core::Loc(locs.file, funLoc().endPos(), this->block->loc.beginPos());
         }
+    } else {
+        if (locs.fun.exists()) {
+            result = core::Loc(locs.file, locs.fun.endPos(), locs.call.endPos());
+        } else {
+            result = callLoc().copyEndWithZeroLength();
+        }
+    }
 
-        return result;
+    return result;
 }
 
 DispatchArgs DispatchArgs::withSelfAndThisRef(const TypePtr &newSelfRef) const {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -1132,6 +1132,32 @@ DispatchArgs::DispatchArgs(NameRef name, const CallLocs &locs, uint16_t numPosAr
       thisType(thisType), block(block), originForUninitialized(originForUninitialized), isPrivateOk(isPrivateOk),
       suppressErrors(suppressErrors), enclosingMethodForSuper(enclosingMethodForSuper) {}
 
+Loc DispatchArgs::argsLoc() const {
+        if (!locs.args.empty()) {
+            // Note: there are some limitations here when the args themselves are parenthesized
+            return core::Loc(locs.file, locs.args.front().join(locs.args.back()));
+        }
+
+        Loc result;
+        if (this->block != nullptr) {
+            if (!this->block->loc.exists()) {
+                result = callLoc().copyEndWithZeroLength();
+            } else if (!locs.fun.exists()) {
+                result = core::Loc(locs.file, this->block->loc.copyWithZeroLength());
+            } else {
+                result = core::Loc(locs.file, funLoc().endPos(), this->block->loc.beginPos());
+            }
+        } else {
+            if (locs.fun.exists()) {
+                result = core::Loc(locs.file, locs.fun.endPos(), locs.call.endPos());
+            } else {
+                result = callLoc().copyEndWithZeroLength();
+            }
+        }
+
+        return result;
+}
+
 DispatchArgs DispatchArgs::withSelfAndThisRef(const TypePtr &newSelfRef) const {
     return DispatchArgs{name,        locs,           numPosArgs,
                         args,        newSelfRef,     fullType,

--- a/test/testdata/infer/arg_matching.rb
+++ b/test/testdata/infer/arg_matching.rb
@@ -22,11 +22,11 @@ class TestArgs
     required {}
     #       ^ error: Not enough arguments
     required()
-    #       ^^ error: Not enough arguments
+    #        ^ error: Not enough arguments
     required( )
-    #       ^^^ error: Not enough arguments
+    #        ^ error: Not enough arguments
     required() {}
-    #       ^ error: Not enough arguments
+    #        ^ error: Not enough arguments
     required(0) {}
     #        ^ error: Not enough arguments
     required(0, )
@@ -144,17 +144,17 @@ class TestArgs
     #             ^ error: Not enough arguments
     #             ^ error: Missing required keyword argument
     requires_mixed()
-    #             ^^ error: Not enough arguments
-    #             ^^ error: Missing required keyword argument
+    #              ^ error: Not enough arguments
+    #              ^ error: Missing required keyword argument
     requires_mixed( )
-    #             ^^^ error: Not enough arguments
-    #             ^^^ error: Missing required keyword argument
+    #              ^ error: Not enough arguments
+    #              ^ error: Missing required keyword argument
     requires_mixed() {}
-    #             ^ error: Not enough arguments
-    #             ^ error: Missing required keyword argument
+    #              ^ error: Not enough arguments
+    #              ^ error: Missing required keyword argument
     requires_mixed(  ) {}
-    #             ^ error: Not enough arguments
-    #             ^ error: Missing required keyword argument
+    #              ^^ error: Not enough arguments
+    #              ^^ error: Missing required keyword argument
     requires_mixed(0)
     #              ^ error: Not enough arguments
     #              ^ error: Missing required keyword argument

--- a/test/testdata/infer/arg_matching.rb
+++ b/test/testdata/infer/arg_matching.rb
@@ -16,6 +16,27 @@ class TestArgs
     required(1, 2)
     required(1, 2, 3)
     #              ^ error: Expected: `2`, got: `3`
+
+    required
+    #       ^ error: Not enough arguments
+    required {}
+    #       ^ error: Not enough arguments
+    required()
+    #       ^^ error: Not enough arguments
+    required( )
+    #       ^^^ error: Not enough arguments
+    required() {}
+    #       ^ error: Not enough arguments
+    required(0) {}
+    #        ^ error: Not enough arguments
+    required(0, )
+    #        ^ error: Not enough arguments
+    required(any:)
+    #        ^^^^ error: Not enough arguments
+    required(any:,)
+    #        ^^^^ error: Not enough arguments
+    required((0))
+    #         ^ error: Not enough arguments
   end
 
   def optional(a, b=1)
@@ -112,4 +133,50 @@ class TestArgs
     #     ^^^^^^^    error: Missing required keyword argument `u` for method `TestArgs#optkw`
     #           ^ error: Too many positional arguments provided for method `TestArgs#optkw`. Expected: `1..2`, got: `3`
   end
+
+  def requires_mixed(a, b, c:); end
+
+  def call_requires_three
+    requires_mixed
+    #             ^ error: Not enough arguments
+    #             ^ error: Missing required keyword argument
+    requires_mixed {}
+    #             ^ error: Not enough arguments
+    #             ^ error: Missing required keyword argument
+    requires_mixed()
+    #             ^^ error: Not enough arguments
+    #             ^^ error: Missing required keyword argument
+    requires_mixed( )
+    #             ^^^ error: Not enough arguments
+    #             ^^^ error: Missing required keyword argument
+    requires_mixed() {}
+    #             ^ error: Not enough arguments
+    #             ^ error: Missing required keyword argument
+    requires_mixed(  ) {}
+    #             ^ error: Not enough arguments
+    #             ^ error: Missing required keyword argument
+    requires_mixed(0)
+    #              ^ error: Not enough arguments
+    #              ^ error: Missing required keyword argument
+    requires_mixed(0, )
+    #              ^ error: Not enough arguments
+    #              ^ error: Missing required keyword argument
+    requires_mixed(any:)
+    #              ^^^^ error: Not enough arguments
+    #              ^^^^ error: Missing required keyword argument
+    requires_mixed(any:,)
+    #              ^^^^ error: Not enough arguments
+    #              ^^^^ error: Missing required keyword argument
+    requires_mixed((0))
+    #               ^ error: Not enough arguments
+    #               ^ error: Missing required keyword argument
+    requires_mixed((0), (1))
+    #               ^^^^^^ error: Missing required keyword argument
+    requires_mixed(0, (1))
+    #              ^^^^^ error: Missing required keyword argument
+    requires_mixed((0), 1)
+    #               ^^^^^ error: Missing required keyword argument
+  end
+
+
 end

--- a/test/testdata/infer/arg_matching.rb.autocorrects.exp
+++ b/test/testdata/infer/arg_matching.rb.autocorrects.exp
@@ -23,11 +23,11 @@ class TestArgs
     required {}
     #       ^ error: Not enough arguments
     required()
-    #       ^^ error: Not enough arguments
+    #        ^ error: Not enough arguments
     required( )
-    #       ^^^ error: Not enough arguments
+    #        ^ error: Not enough arguments
     required() {}
-    #       ^ error: Not enough arguments
+    #        ^ error: Not enough arguments
     required(0) {}
     #        ^ error: Not enough arguments
     required(0, )
@@ -145,17 +145,17 @@ class TestArgs
     #             ^ error: Not enough arguments
     #             ^ error: Missing required keyword argument
     requires_mixed()
-    #             ^^ error: Not enough arguments
-    #             ^^ error: Missing required keyword argument
+    #              ^ error: Not enough arguments
+    #              ^ error: Missing required keyword argument
     requires_mixed( )
-    #             ^^^ error: Not enough arguments
-    #             ^^^ error: Missing required keyword argument
+    #              ^ error: Not enough arguments
+    #              ^ error: Missing required keyword argument
     requires_mixed() {}
-    #             ^ error: Not enough arguments
-    #             ^ error: Missing required keyword argument
+    #              ^ error: Not enough arguments
+    #              ^ error: Missing required keyword argument
     requires_mixed(  ) {}
-    #             ^ error: Not enough arguments
-    #             ^ error: Missing required keyword argument
+    #              ^^ error: Not enough arguments
+    #              ^^ error: Missing required keyword argument
     requires_mixed(0)
     #              ^ error: Not enough arguments
     #              ^ error: Missing required keyword argument

--- a/test/testdata/infer/arg_matching.rb.autocorrects.exp
+++ b/test/testdata/infer/arg_matching.rb.autocorrects.exp
@@ -17,6 +17,27 @@ class TestArgs
     required(1, 2)
     required(1, 2)
     #              ^ error: Expected: `2`, got: `3`
+
+    required
+    #       ^ error: Not enough arguments
+    required {}
+    #       ^ error: Not enough arguments
+    required()
+    #       ^^ error: Not enough arguments
+    required( )
+    #       ^^^ error: Not enough arguments
+    required() {}
+    #       ^ error: Not enough arguments
+    required(0) {}
+    #        ^ error: Not enough arguments
+    required(0, )
+    #        ^ error: Not enough arguments
+    required(any:)
+    #        ^^^^ error: Not enough arguments
+    required(any:,)
+    #        ^^^^ error: Not enough arguments
+    required((0))
+    #         ^ error: Not enough arguments
   end
 
   def optional(a, b=1)
@@ -113,5 +134,51 @@ class TestArgs
     #     ^^^^^^^    error: Missing required keyword argument `u` for method `TestArgs#optkw`
     #           ^ error: Too many positional arguments provided for method `TestArgs#optkw`. Expected: `1..2`, got: `3`
   end
+
+  def requires_mixed(a, b, c:); end
+
+  def call_requires_three
+    requires_mixed
+    #             ^ error: Not enough arguments
+    #             ^ error: Missing required keyword argument
+    requires_mixed {}
+    #             ^ error: Not enough arguments
+    #             ^ error: Missing required keyword argument
+    requires_mixed()
+    #             ^^ error: Not enough arguments
+    #             ^^ error: Missing required keyword argument
+    requires_mixed( )
+    #             ^^^ error: Not enough arguments
+    #             ^^^ error: Missing required keyword argument
+    requires_mixed() {}
+    #             ^ error: Not enough arguments
+    #             ^ error: Missing required keyword argument
+    requires_mixed(  ) {}
+    #             ^ error: Not enough arguments
+    #             ^ error: Missing required keyword argument
+    requires_mixed(0)
+    #              ^ error: Not enough arguments
+    #              ^ error: Missing required keyword argument
+    requires_mixed(0, )
+    #              ^ error: Not enough arguments
+    #              ^ error: Missing required keyword argument
+    requires_mixed(any:)
+    #              ^^^^ error: Not enough arguments
+    #              ^^^^ error: Missing required keyword argument
+    requires_mixed(any:,)
+    #              ^^^^ error: Not enough arguments
+    #              ^^^^ error: Missing required keyword argument
+    requires_mixed((0))
+    #               ^ error: Not enough arguments
+    #               ^ error: Missing required keyword argument
+    requires_mixed((0), (1))
+    #               ^^^^^^ error: Missing required keyword argument
+    requires_mixed(0, (1))
+    #              ^^^^^ error: Missing required keyword argument
+    requires_mixed((0), 1)
+    #               ^^^^^ error: Missing required keyword argument
+  end
+
+
 end
 # ------------------------------

--- a/test/testdata/infer/attached_class_self_new.rb
+++ b/test/testdata/infer/attached_class_self_new.rb
@@ -27,7 +27,7 @@ class PosArgs
 
     # Not matching initialize
     T.reveal_type(self.new())
-    #                     ^^ error: Not enough arguments provided
+    #                      ^ error: Not enough arguments provided
   # ^^^^^^^^^^^^^^^^^^^^^^^^^ error: Revealed type: `T.attached_class (of PosArgs)`
   end
 end

--- a/test/testdata/infer/must_because.rb
+++ b/test/testdata/infer/must_because.rb
@@ -6,7 +6,7 @@ def test_must_because # error: does not have a `sig`
 
   T.must_because(x) {'reason'}
   T.must_because()
-  #             ^^ error: Not enough arguments
+  #              ^ error: Not enough arguments
   #               ^ error: requires a block parameter
 
   T.must_because(x) # error: requires a block parameter

--- a/test/testdata/lsp/completion/empty_parens.rb
+++ b/test/testdata/lsp/completion/empty_parens.rb
@@ -17,12 +17,12 @@ end
 sig {params(m: M, a: Integer, b: Integer).void}
 def AAA_example1(m, a, b)
   AAA_example1()
-  #           ^^ error: Not enough arguments
+  #            ^ error: Not enough arguments
   #            ^ completion: a, b, m, AAA_example1, ...
 
   # No locals here because !isPrivateOk 🙃
   m.aaa_only_on_m()
-  #              ^^ error: Not enough arguments
+  #               ^ error: Not enough arguments
   #               ^ completion: aaa_only_on_m, ...
 
   # In addition to the above wonkiness, this case is even wonkier, because of
@@ -30,12 +30,12 @@ def AAA_example1(m, a, b)
   # block.
 
   AAA_example1() {}
-  #           ^ error: Not enough arguments
+  #            ^ error: Not enough arguments
   #            ^ completion: (nothing)
   #               ^ completion: (nothing)
 
   m.aaa_only_on_m() {}
-  #              ^ error: Not enough arguments
+  #               ^ error: Not enough arguments
   #               ^ completion: (nothing)
   #                  ^ completion: (nothing)
 end

--- a/test/testdata/resolver/missing_type_combinator_args.rb
+++ b/test/testdata/resolver/missing_type_combinator_args.rb
@@ -10,6 +10,6 @@ T.let(1)
 #     ^ error: Not enough arguments provided for method
 T.let(1, 2, 3) # error: Unsupported literal in type syntax
 T.reveal_type()
-#            ^^ error: Not enough arguments provided for method
+#             ^ error: Not enough arguments provided for method
 T.reveal_type(1, 2)
 #                ^ error: Too many arguments provided for method


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Stacked on #9411.

Before that change, we were computing `blockLoc()` using `argsLoc()`, so it
would have been a cycle to attempt to compute `argsLoc()` using `blockLoc()`.

Now that we're not, we can improve the `argsLoc` when we have nowhere to point.

Also, I figured we may as well attempt to do a little better for the common case
of leading and trailing `()` and `[]`. I'm particularly interested in that case,
because in a future change I want to have some autocorrects that will work by
inserting arguments, and it's bad if we attempt to insert arguments outside the
`()` list.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tests show the before+after