### PR TITLE
Use `autocorrectReceiver` helper in `dispatchCallSymbol`

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -171,26 +171,26 @@ DispatchResult TupleType::dispatchCall(const GlobalState &gs, const DispatchArgs
 namespace {
 void autocorrectReceiver(const core::GlobalState &gs, core::ErrorBuilder &e, const DispatchArgs &args,
                          string_view wrapInFn) {
-                if (args.receiverLoc().empty()) {
-                    auto shortName = args.name.shortName(gs);
-                    auto beginAdjust = -2;                     // (&
-                    auto endAdjust = 1 + shortName.size() + 1; // :foo)
-                    auto blockPassLoc = args.receiverLoc().adjust(gs, beginAdjust, endAdjust);
-                    if (blockPassLoc.exists()) {
-                        auto blockPassSource = blockPassLoc.source(gs).value();
-                        if (blockPassSource == fmt::format("(&:{})", shortName)) {
-                            e.replaceWith(fmt::format("Expand to block with `{}`", wrapInFn), blockPassLoc,
-                                          " {{ |x| {}(x).{} }}", wrapInFn, shortName);
-                        }
-                    }
-                } else if (args.errLoc() == args.funLoc() &&
-                           args.funLoc().source(gs) == absl::StrCat(args.name.shortName(gs), "=")) {
-                    e.replaceWith(fmt::format("Wrap in `{}`", wrapInFn), args.funLoc(), "= {}({}) {}", wrapInFn,
-                                  args.receiverLoc().source(gs).value(), args.name.shortName(gs));
-                } else {
-                    e.replaceWith(fmt::format("Wrap in `{}`", wrapInFn), args.receiverLoc(), "{}({})", wrapInFn,
-                                  args.receiverLoc().source(gs).value());
-                }
+    if (args.receiverLoc().empty()) {
+        auto shortName = args.name.shortName(gs);
+        auto beginAdjust = -2;                     // (&
+        auto endAdjust = 1 + shortName.size() + 1; // :foo)
+        auto blockPassLoc = args.receiverLoc().adjust(gs, beginAdjust, endAdjust);
+        if (blockPassLoc.exists()) {
+            auto blockPassSource = blockPassLoc.source(gs).value();
+            if (blockPassSource == fmt::format("(&:{})", shortName)) {
+                e.replaceWith(fmt::format("Expand to block with `{}`", wrapInFn), blockPassLoc, " {{ |x| {}(x).{} }}",
+                              wrapInFn, shortName);
+            }
+        }
+    } else if (args.errLoc() == args.funLoc() &&
+               args.funLoc().source(gs) == absl::StrCat(args.name.shortName(gs), "=")) {
+        e.replaceWith(fmt::format("Wrap in `{}`", wrapInFn), args.funLoc(), "= {}({}) {}", wrapInFn,
+                      args.receiverLoc().source(gs).value(), args.name.shortName(gs));
+    } else {
+        e.replaceWith(fmt::format("Wrap in `{}`", wrapInFn), args.receiverLoc(), "{}({})", wrapInFn,
+                      args.receiverLoc().source(gs).value());
+    }
 }
 
 void addUnconstrainedIsaGenericNote(const GlobalState &gs, ErrorBuilder &e, SymbolRef definition, NameRef methodName,

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -169,27 +169,28 @@ DispatchResult TupleType::dispatchCall(const GlobalState &gs, const DispatchArgs
 }
 
 namespace {
-void autocorrectReceiver(const core::GlobalState &gs, core::ErrorBuilder &e, core::Loc receiverLoc,
-                         core::NameRef methodName) {
-    if (receiverLoc.exists() && (gs.suggestUnsafe.has_value())) {
-        auto wrapInFn = gs.suggestUnsafe.value();
-        if (receiverLoc.empty()) {
-            auto shortName = methodName.shortName(gs);
-            auto beginAdjust = -2;                     // (&
-            auto endAdjust = 1 + shortName.size() + 1; // :foo)
-            auto blockPassLoc = receiverLoc.adjust(gs, beginAdjust, endAdjust);
-            if (blockPassLoc.exists()) {
-                auto blockPassSource = blockPassLoc.source(gs).value();
-                if (blockPassSource == fmt::format("(&:{})", shortName)) {
-                    e.replaceWith(fmt::format("Expand to block with `{}`", wrapInFn), blockPassLoc,
-                                  " {{ |x| {}(x).{} }}", wrapInFn, shortName);
+void autocorrectReceiver(const core::GlobalState &gs, core::ErrorBuilder &e, const DispatchArgs &args,
+                         string_view wrapInFn) {
+                if (args.receiverLoc().empty()) {
+                    auto shortName = args.name.shortName(gs);
+                    auto beginAdjust = -2;                     // (&
+                    auto endAdjust = 1 + shortName.size() + 1; // :foo)
+                    auto blockPassLoc = args.receiverLoc().adjust(gs, beginAdjust, endAdjust);
+                    if (blockPassLoc.exists()) {
+                        auto blockPassSource = blockPassLoc.source(gs).value();
+                        if (blockPassSource == fmt::format("(&:{})", shortName)) {
+                            e.replaceWith(fmt::format("Expand to block with `{}`", wrapInFn), blockPassLoc,
+                                          " {{ |x| {}(x).{} }}", wrapInFn, shortName);
+                        }
+                    }
+                } else if (args.errLoc() == args.funLoc() &&
+                           args.funLoc().source(gs) == absl::StrCat(args.name.shortName(gs), "=")) {
+                    e.replaceWith(fmt::format("Wrap in `{}`", wrapInFn), args.funLoc(), "= {}({}) {}", wrapInFn,
+                                  args.receiverLoc().source(gs).value(), args.name.shortName(gs));
+                } else {
+                    e.replaceWith(fmt::format("Wrap in `{}`", wrapInFn), args.receiverLoc(), "{}({})", wrapInFn,
+                                  args.receiverLoc().source(gs).value());
                 }
-            }
-        } else {
-            e.replaceWith(fmt::format("Wrap in `{}`", wrapInFn), receiverLoc, "{}({})", wrapInFn,
-                          receiverLoc.source(gs).value());
-        }
-    }
 }
 
 void addUnconstrainedIsaGenericNote(const GlobalState &gs, ErrorBuilder &e, SymbolRef definition, NameRef methodName,
@@ -230,7 +231,10 @@ DispatchResult SelfTypeParam::dispatchCall(const GlobalState &gs, const Dispatch
                 e.setHeader("Call to method `{}` on unconstrained generic type `{}`", args.name.show(gs), thisStr);
             }
             e.addErrorSection(args.fullType.explainGot(gs, args.originForUninitialized));
-            autocorrectReceiver(gs, e, args.receiverLoc(), args.name);
+            if (args.receiverLoc().exists() && gs.suggestUnsafe.has_value()) {
+                auto wrapInFn = gs.suggestUnsafe.value();
+                autocorrectReceiver(gs, e, args, wrapInFn);
+            }
             addUnconstrainedIsaGenericNote(gs, e, this->definition, args.name, "parameter");
         }
         emptyResult.main.errors.emplace_back(e.build());
@@ -258,7 +262,10 @@ DispatchResult SelfTypeParam::dispatchCall(const GlobalState &gs, const Dispatch
                     e.setHeader("Call to method `{}` on unbounded type {} `{}`", args.name.show(gs), member, thisStr);
                 }
                 e.addErrorSection(args.fullType.explainGot(gs, args.originForUninitialized));
-                autocorrectReceiver(gs, e, args.receiverLoc(), args.name);
+                if (args.receiverLoc().exists() && gs.suggestUnsafe.has_value()) {
+                    auto wrapInFn = gs.suggestUnsafe.value();
+                    autocorrectReceiver(gs, e, args, wrapInFn);
+                }
                 addUnconstrainedIsaGenericNote(gs, e, this->definition, args.name, member);
             }
             emptyResult.main.errors.emplace_back(e.build());
@@ -768,26 +775,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                          // Don't suggest T.must if the suggestion will produce bottom
                          !Types::dropNil(gs, args.fullType.type).isBottom()))) {
                 auto wrapInFn = gs.suggestUnsafe.value_or("T.must");
-                if (args.receiverLoc().empty()) {
-                    auto shortName = args.name.shortName(gs);
-                    auto beginAdjust = -2;                     // (&
-                    auto endAdjust = 1 + shortName.size() + 1; // :foo)
-                    auto blockPassLoc = args.receiverLoc().adjust(gs, beginAdjust, endAdjust);
-                    if (blockPassLoc.exists()) {
-                        auto blockPassSource = blockPassLoc.source(gs).value();
-                        if (blockPassSource == fmt::format("(&:{})", shortName)) {
-                            e.replaceWith(fmt::format("Expand to block with `{}`", wrapInFn), blockPassLoc,
-                                          " {{ |x| {}(x).{} }}", wrapInFn, shortName);
-                        }
-                    }
-                } else if (args.errLoc() == args.funLoc() &&
-                           args.funLoc().source(gs) == absl::StrCat(args.name.shortName(gs), "=")) {
-                    e.replaceWith(fmt::format("Wrap in `{}`", wrapInFn), args.funLoc(), "= {}({}) {}", wrapInFn,
-                                  args.receiverLoc().source(gs).value(), args.name.shortName(gs));
-                } else {
-                    e.replaceWith(fmt::format("Wrap in `{}`", wrapInFn), args.receiverLoc(), "{}({})", wrapInFn,
-                                  args.receiverLoc().source(gs).value());
-                }
+                autocorrectReceiver(gs, e, args, wrapInFn);
             } else {
                 auto canSkipFuzzyMatch = false;
                 if (symbol.data(gs)->isModule()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Main motivation is that I wanted to call this logic in another PR, and I
happened to notice that it was already duplicated, so rather than duplicate it a
third time I figured it's time to factor it out.

As a side benefit, this also means that the calls to `autocorrectReceiver` in
the `SelfTypeParam` case will also get the autocorrect which turns this:

```ruby
x += 1
```

into this:

```ruby
x = T.unsafe(x) + 1
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests to make sure that the `dispatchCallSymbol` case isn't broken. I
don't think it's newly beneficial to also show that the `SelfTypeParam` is
getting the ` = T.unsafe` case, because as long as the helper is working on
other cases, the `SelfTypeParam` case should not be special.