### PR TITLE
Replace check+cast pairs with just casts

### DIFF
--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -17,7 +17,7 @@ namespace sorbet::ast::Desugar::Prism {
 using namespace std::literals::string_view_literals;
 using sorbet::ast::MK;
 using sorbet::parser::Prism::cast_prism_string;
-using sorbet::parser::Prism::down_cast;
+using sorbet::parser::Prism::down_cast_nonnull;
 using sorbet::parser::Prism::Parser;
 using sorbet::parser::Prism::ParseResult;
 using sorbet::parser::Prism::up_cast;
@@ -380,28 +380,28 @@ void Desugarer::collectPatternMatchingVarsPrism(ast::InsSeq::STATS_store &vars, 
     }
 
     if (PM_NODE_TYPE_P(node, PM_LOCAL_VARIABLE_TARGET_NODE)) {
-        auto localVarTargetNode = down_cast<pm_local_variable_target_node>(node);
+        auto localVarTargetNode = down_cast_nonnull<pm_local_variable_target_node>(node);
         auto loc = translateLoc(localVarTargetNode->base.location);
         auto val = MK::RaiseUnimplemented(loc);
         auto name = translateConstantName(localVarTargetNode->name);
         vars.emplace_back(MK::Assign(loc, name, move(val)));
     } else if (PM_NODE_TYPE_P(node, PM_SPLAT_NODE)) {
         // MatchRest in array patterns - recurse on the expression (variable being splatted into)
-        auto splatNode = down_cast<pm_splat_node>(node);
+        auto splatNode = down_cast_nonnull<pm_splat_node>(node);
         collectPatternMatchingVarsPrism(vars, splatNode->expression);
     } else if (PM_NODE_TYPE_P(node, PM_ASSOC_SPLAT_NODE)) {
         // MatchRest in hash patterns - recurse on the value
-        auto assocSplatNode = down_cast<pm_assoc_splat_node>(node);
+        auto assocSplatNode = down_cast_nonnull<pm_assoc_splat_node>(node);
         collectPatternMatchingVarsPrism(vars, assocSplatNode->value);
     } else if (PM_NODE_TYPE_P(node, PM_ASSOC_NODE)) {
         // Pair in hash pattern - only recurse on the value (key is a symbol, not a variable)
-        auto assocNode = down_cast<pm_assoc_node>(node);
+        auto assocNode = down_cast_nonnull<pm_assoc_node>(node);
         // Special handling for implicit hash pattern keys like `n1:` which means `n1: n1`
         // Legacy parser uses the assoc node's location (including colon) for the variable
         if (PM_NODE_TYPE_P(assocNode->value, PM_IMPLICIT_NODE)) {
-            auto implicitNode = down_cast<pm_implicit_node>(assocNode->value);
+            auto implicitNode = down_cast_nonnull<pm_implicit_node>(assocNode->value);
             if (PM_NODE_TYPE_P(implicitNode->value, PM_LOCAL_VARIABLE_TARGET_NODE)) {
-                auto localVarTargetNode = down_cast<pm_local_variable_target_node>(implicitNode->value);
+                auto localVarTargetNode = down_cast_nonnull<pm_local_variable_target_node>(implicitNode->value);
                 auto loc = translateLoc(assocNode->base.location); // Use assoc node's location
                 auto name = translateConstantName(localVarTargetNode->name);
                 auto val = MK::RaiseUnimplemented(loc);
@@ -412,14 +412,14 @@ void Desugarer::collectPatternMatchingVarsPrism(ast::InsSeq::STATS_store &vars, 
         collectPatternMatchingVarsPrism(vars, assocNode->value);
     } else if (PM_NODE_TYPE_P(node, PM_CAPTURE_PATTERN_NODE)) {
         // MatchAs - use the target's location, not the whole pattern's location
-        auto matchAsNode = down_cast<pm_capture_pattern_node>(node);
+        auto matchAsNode = down_cast_nonnull<pm_capture_pattern_node>(node);
         auto loc = translateLoc(matchAsNode->target->base.location);
         auto name = translateConstantName(matchAsNode->target->name);
         auto val = MK::RaiseUnimplemented(loc);
         vars.emplace_back(MK::Assign(loc, name, move(val)));
         collectPatternMatchingVarsPrism(vars, matchAsNode->value);
     } else if (PM_NODE_TYPE_P(node, PM_ARRAY_PATTERN_NODE)) {
-        auto arrayPatternNode = down_cast<pm_array_pattern_node>(node);
+        auto arrayPatternNode = down_cast_nonnull<pm_array_pattern_node>(node);
         // Skip ConstPattern - legacy parser doesn't collect variables from ConstPattern
         if (arrayPatternNode->constant != nullptr) {
             return;
@@ -437,7 +437,7 @@ void Desugarer::collectPatternMatchingVarsPrism(ast::InsSeq::STATS_store &vars, 
             collectPatternMatchingVarsPrism(vars, elt);
         }
     } else if (PM_NODE_TYPE_P(node, PM_HASH_PATTERN_NODE)) {
-        auto hashPatternNode = down_cast<pm_hash_pattern_node>(node);
+        auto hashPatternNode = down_cast_nonnull<pm_hash_pattern_node>(node);
         // Skip ConstPattern - legacy parser doesn't collect variables from ConstPattern
         if (hashPatternNode->constant != nullptr) {
             return;
@@ -449,18 +449,18 @@ void Desugarer::collectPatternMatchingVarsPrism(ast::InsSeq::STATS_store &vars, 
         // Process rest element
         collectPatternMatchingVarsPrism(vars, hashPatternNode->rest);
     } else if (PM_NODE_TYPE_P(node, PM_ALTERNATION_PATTERN_NODE)) {
-        auto alternationPatternNode = down_cast<pm_alternation_pattern_node>(node);
+        auto alternationPatternNode = down_cast_nonnull<pm_alternation_pattern_node>(node);
         collectPatternMatchingVarsPrism(vars, alternationPatternNode->left);
         collectPatternMatchingVarsPrism(vars, alternationPatternNode->right);
     } else if (PM_NODE_TYPE_P(node, PM_IF_NODE)) {
         // Pattern with if guard - the actual pattern is inside statements
-        auto ifNode = down_cast<pm_if_node>(node);
+        auto ifNode = down_cast_nonnull<pm_if_node>(node);
         if (ifNode->statements != nullptr && ifNode->statements->body.size > 0) {
             collectPatternMatchingVarsPrism(vars, ifNode->statements->body.nodes[0]);
         }
     } else if (PM_NODE_TYPE_P(node, PM_UNLESS_NODE)) {
         // Pattern with unless guard - the actual pattern is inside statements
-        auto unlessNode = down_cast<pm_unless_node>(node);
+        auto unlessNode = down_cast_nonnull<pm_unless_node>(node);
         if (unlessNode->statements != nullptr && unlessNode->statements->body.size > 0) {
             collectPatternMatchingVarsPrism(vars, unlessNode->statements->body.nodes[0]);
         }
@@ -551,11 +551,11 @@ void Desugarer::flattenKwargs(pm_keyword_hash_node *kwargsHashNode, Container &d
 
     // Flatten each key/value pair directly
     for (auto *element : elements) {
-        auto *assoc = down_cast<pm_assoc_node>(element);
+        auto *assoc = down_cast_nonnull<pm_assoc_node>(element);
 
         // Special handling for symbol keys with trailing colon (like `a: 1` instead of `:a => 1`)
         if (PM_NODE_TYPE_P(assoc->key, PM_SYMBOL_NODE)) {
-            auto *symbolNode = down_cast<pm_symbol_node>(assoc->key);
+            auto *symbolNode = down_cast_nonnull<pm_symbol_node>(assoc->key);
 
             // If opening_loc is null, the symbol has a trailing colon syntax (e.g., `k5:` not `:k5 =>`)
             if (symbolNode->opening_loc.start == nullptr) {
@@ -769,12 +769,12 @@ ast::ExpressionPtr Desugarer::desugarMlhs(core::LocOffsets loc, PrismNode *lhs, 
             MK::Send1(zcloc, MK::Local(zcloc, tempExpanded), core::Names::squareBrackets(), zloc, MK::Int(zloc, i));
 
         if (PM_NODE_TYPE_P(c, PM_MULTI_TARGET_NODE)) {
-            auto *mlhs = down_cast<pm_multi_target_node>(c);
+            auto *mlhs = down_cast_nonnull<pm_multi_target_node>(c);
             stats.emplace_back(desugarMlhs(cloc, mlhs, move(val)));
         } else if (PM_NODE_TYPE_P(c, PM_CALL_TARGET_NODE)) {
             // Target of an indirect write to the result of a method call
             // ... like `self.target1, self.target2 = 1, 2`, `rescue => self.target`, etc.
-            auto callTargetNode = down_cast<pm_call_target_node>(c);
+            auto callTargetNode = down_cast_nonnull<pm_call_target_node>(c);
             auto receiverNode = callTargetNode->receiver;
 
             auto methodName = translateConstantName(callTargetNode->name);
@@ -824,7 +824,7 @@ ast::ExpressionPtr Desugarer::desugarMlhs(core::LocOffsets loc, PrismNode *lhs, 
     }
     if (hasSplat) {
         // Handle splat separately - use to_ary to capture remaining elements
-        auto *splat = down_cast<pm_splat_node>(lhs->rest);
+        auto *splat = down_cast_nonnull<pm_splat_node>(lhs->rest);
         size_t totalSize = lefts.size() + 1 + rights.size();
         int right = totalSize - i - 1;
         if (right == 0) {
@@ -900,7 +900,7 @@ ast::ExpressionPtr Desugarer::translateAnyOpAssignment(PrismAssignmentNode *node
 // The location is the location of the whole Prism assignment node.
 template <typename PrismAssignmentNode, typename SorbetAssignmentNode>
 ast::ExpressionPtr Desugarer::translateIndexAssignment(pm_node_t *untypedNode, core::LocOffsets location) {
-    auto node = down_cast<PrismAssignmentNode>(untypedNode);
+    auto node = down_cast_nonnull<PrismAssignmentNode>(untypedNode);
 
     // The LHS location includes the receiver and the `[]`, but not the `=` or rhs.
     // self.example[k] = v
@@ -1375,7 +1375,7 @@ constexpr bool isIvarOrCvarKind(ast::UnresolvedIdent::Kind kind) {
 //   - IdentKind: The kind of identifier (Local, Instance, Class, Global)
 template <typename PrismVariableNode, OpAssignKind Kind, ast::UnresolvedIdent::Kind IdentKind>
 ast::ExpressionPtr Desugarer::desugarVariableOpAssign(pm_node_t *untypedNode) {
-    auto node = down_cast<PrismVariableNode>(untypedNode);
+    auto node = down_cast_nonnull<PrismVariableNode>(untypedNode);
     auto location = translateLoc(untypedNode->location);
     auto nameLoc = translateLoc(node->name_loc);
     auto name = translateConstantName(node->name);
@@ -1404,7 +1404,7 @@ ast::ExpressionPtr Desugarer::desugarConstantOpAssign(pm_node_t *untypedNode) {
         e.setHeader("Constant reassignment is not supported");
     }
 
-    auto node = down_cast<PrismConstantNode>(untypedNode);
+    auto node = down_cast_nonnull<PrismConstantNode>(untypedNode);
     auto nameLoc = translateLoc(node->name_loc);
     auto name = translateConstantName(node->name);
 
@@ -1444,7 +1444,7 @@ ast::ExpressionPtr Desugarer::desugarConstantPathOpAssign(pm_node_t *untypedNode
         e.setHeader("Constant reassignment is not supported");
     }
 
-    auto node = down_cast<PrismConstantPathNode>(untypedNode);
+    auto node = down_cast_nonnull<PrismConstantPathNode>(untypedNode);
     auto target = node->target;
 
     auto nameLoc = translateLoc(target->name_loc);
@@ -1479,7 +1479,7 @@ ast::ExpressionPtr Desugarer::desugarConstantPathOpAssign(pm_node_t *untypedNode
 // Desugar index compound assignment nodes (e.g., `arr[i] &&= val`).
 template <typename PrismIndexNode, OpAssignKind Kind>
 ast::ExpressionPtr Desugarer::desugarIndexOpAssign(pm_node_t *untypedNode) {
-    auto node = down_cast<PrismIndexNode>(untypedNode);
+    auto node = down_cast_nonnull<PrismIndexNode>(untypedNode);
     auto location = translateLoc(untypedNode->location);
 
     // Handle operator assignment to an indexed expression, like `a[0] += 1`
@@ -1515,7 +1515,7 @@ ast::ExpressionPtr Desugarer::desugarIndexOpAssign(pm_node_t *untypedNode) {
 // Handles both regular sends and safe navigation sends (CSend).
 template <typename PrismSendNode, OpAssignKind Kind>
 ast::ExpressionPtr Desugarer::desugarSendOpAssign(pm_node_t *untypedNode) {
-    auto node = down_cast<PrismSendNode>(untypedNode);
+    auto node = down_cast_nonnull<PrismSendNode>(untypedNode);
     auto location = translateLoc(untypedNode->location);
     auto name = translateConstantName(node->read_name);
     auto messageLoc = translateLoc(node->message_loc);
@@ -1591,7 +1591,7 @@ const uint8_t *endLoc(pm_node_t *anyNode);
 //   - IdentKind: The kind of identifier (Local, Instance, Class, Global), or void for constants
 template <typename PrismAssignmentNode, ast::UnresolvedIdent::Kind IdentKind>
 ast::ExpressionPtr Desugarer::desugarAssignment(pm_node_t *untypedNode) {
-    auto node = down_cast<PrismAssignmentNode>(untypedNode);
+    auto node = down_cast_nonnull<PrismAssignmentNode>(untypedNode);
     // For heredocs, Prism's location only includes the opening tag (e.g., "x = <<~EOF").
     // Extend to include the full heredoc body by using endLoc() on the value.
     auto location = translateLoc(startLoc(untypedNode), endLoc(node->value));
@@ -1704,7 +1704,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
 
     switch (PM_NODE_TYPE(node)) {
         case PM_ALIAS_GLOBAL_VARIABLE_NODE: { // The `alias` keyword used for global vars, like `alias $new $old`
-            auto aliasGlobalVariableNode = down_cast<pm_alias_global_variable_node>(node);
+            auto aliasGlobalVariableNode = down_cast_nonnull<pm_alias_global_variable_node>(node);
 
             auto toExpr = desugar(aliasGlobalVariableNode->new_name);
             auto fromExpr = desugar(aliasGlobalVariableNode->old_name);
@@ -1714,7 +1714,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                              std::move(toExpr), std::move(fromExpr));
         }
         case PM_ALIAS_METHOD_NODE: { // The `alias` keyword, like `alias new_method old_method`
-            auto aliasMethodNode = down_cast<pm_alias_method_node>(node);
+            auto aliasMethodNode = down_cast_nonnull<pm_alias_method_node>(node);
 
             auto toExpr = desugar(aliasMethodNode->new_name);
             auto fromExpr = desugar(aliasMethodNode->old_name);
@@ -1724,7 +1724,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                              std::move(toExpr), std::move(fromExpr));
         }
         case PM_AND_NODE: { // operator `&&` and `and`
-            auto andNode = down_cast<pm_and_node>(node);
+            auto andNode = down_cast_nonnull<pm_and_node>(node);
 
             auto lhs = desugarNullable(andNode->left);
             auto rhs = desugarNullable(andNode->right);
@@ -1787,7 +1787,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             unreachable("PM_ARGUMENTS_NODE is handled separately in `Desugarer::translateArguments()`.");
         }
         case PM_ARRAY_NODE: { // An array literal, e.g. `[1, 2, 3]`
-            auto arrayNode = down_cast<pm_array_node>(node);
+            auto arrayNode = down_cast_nonnull<pm_array_node>(node);
 
             auto prismElements = absl::MakeSpan(arrayNode->elements.nodes, arrayNode->elements.size);
             auto elements = nodeListToStore<ast::Array::ENTRY_store>(arrayNode->elements);
@@ -1804,7 +1804,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
         }
         case PM_BACK_REFERENCE_READ_NODE: { // One of the special global variables for accessing info about the previous
                                             // Regexp match, such as `$&`, `$`, `$'`, and `$+`.
-            auto backReferenceReadNode = down_cast<pm_back_reference_read_node>(node);
+            auto backReferenceReadNode = down_cast_nonnull<pm_back_reference_read_node>(node);
             auto name = translateConstantName(backReferenceReadNode->name);
 
             // Desugar `$&` to `<Magic>.<regex-backref>(:&)`
@@ -1814,7 +1814,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return MK::Send1(location, move(recv), core::Names::regexBackref(), locZeroLen, move(arg));
         }
         case PM_BEGIN_NODE: { // A `begin ... end` block
-            auto beginNode = down_cast<pm_begin_node>(node);
+            auto beginNode = down_cast_nonnull<pm_begin_node>(node);
             return desugarBegin(beginNode);
         }
         case PM_BLOCK_ARGUMENT_NODE: { // A block arg passed into a method call, e.g. the `&b` in `a.map(&b)`
@@ -1824,7 +1824,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             unreachable("PM_BLOCK_NODE has special handling in PM_CALL_NODE, see it for details.");
         }
         case PM_BLOCK_LOCAL_VARIABLE_NODE: { // A named block local variable, like `baz` in `|bar; baz|`
-            auto blockLocalNode = down_cast<pm_block_local_variable_node>(node);
+            auto blockLocalNode = down_cast_nonnull<pm_block_local_variable_node>(node);
             auto sorbetName = translateConstantName(blockLocalNode->name);
             return MK::ShadowArg(location, MK::Local(location, sorbetName));
         }
@@ -1835,7 +1835,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             unreachable("PM_BLOCK_PARAMETERS_NODE is handled separately in `PM_CALL_NODE`.");
         }
         case PM_BREAK_NODE: { // A `break` statement, e.g. `break`, `break 1, 2, 3`
-            auto breakNode = down_cast<pm_break_node>(node);
+            auto breakNode = down_cast_nonnull<pm_break_node>(node);
             auto arguments = desugarBreakNextReturn(breakNode->arguments);
             return MK::Break(location, move(arguments));
         }
@@ -1843,7 +1843,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return desugarSendOpAssign<pm_call_and_write_node, OpAssignKind::And>(node);
         }
         case PM_CALL_NODE: { // A method call like `a.b()` or `a&.b()`
-            auto callNode = down_cast<pm_call_node>(node);
+            auto callNode = down_cast_nonnull<pm_call_node>(node);
 
             auto constantNameString = parser.resolveConstant(callNode->name);
             auto methodName = ctx.state.enterNameUTF8(constantNameString);
@@ -1965,7 +1965,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             unreachable("PM_CALL_TARGET_NODE is handled specially in `desugarMlhs()`.");
         }
         case PM_CASE_MATCH_NODE: { // A pattern-matching `case` statement that only uses `in` (and not `when`)
-            auto caseMatchNode = down_cast<pm_case_match_node>(node);
+            auto caseMatchNode = down_cast_nonnull<pm_case_match_node>(node);
 
             auto inNodes = absl::MakeSpan(caseMatchNode->conditions.nodes, caseMatchNode->conditions.size);
             auto elseClause = desugarNullable(up_cast(caseMatchNode->else_clause));
@@ -1977,19 +1977,19 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
 
             // Build the if ladder backwards from the last "in" to the first
             for (auto it = inNodes.rbegin(); it != inNodes.rend(); ++it) {
-                auto inPattern = down_cast<pm_in_node>(*it);
+                auto inPattern = down_cast_nonnull<pm_in_node>(*it);
 
                 // Get the actual pattern location (unwrapping if/unless guards)
                 pm_location_t patternLoc = inPattern->base.location;
                 pm_node_t *actualPattern = inPattern->pattern;
                 if (actualPattern != nullptr) {
                     if (PM_NODE_TYPE_P(actualPattern, PM_IF_NODE)) {
-                        auto ifNode = down_cast<pm_if_node>(actualPattern);
+                        auto ifNode = down_cast_nonnull<pm_if_node>(actualPattern);
                         if (ifNode->statements != nullptr && ifNode->statements->body.size > 0) {
                             patternLoc = ifNode->statements->body.nodes[0]->location;
                         }
                     } else if (PM_NODE_TYPE_P(actualPattern, PM_UNLESS_NODE)) {
-                        auto unlessNode = down_cast<pm_unless_node>(actualPattern);
+                        auto unlessNode = down_cast_nonnull<pm_unless_node>(actualPattern);
                         if (unlessNode->statements != nullptr && unlessNode->statements->body.size > 0) {
                             patternLoc = unlessNode->statements->body.nodes[0]->location;
                         }
@@ -2028,7 +2028,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return MK::InsSeq1(location, move(assignExpr), move(resultExpr));
         }
         case PM_CASE_NODE: { // A classic `case` statement that only uses `when` (and not pattern matching with `in`)
-            auto caseNode = down_cast<pm_case_node>(node);
+            auto caseNode = down_cast_nonnull<pm_case_node>(node);
 
             auto predicate = desugarNullable(caseNode->predicate);
 
@@ -2037,7 +2037,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             // Count the total number of patterns across all when clauses
             size_t totalPatterns = 0;
             for (auto *whenNodePtr : prismWhenNodes) {
-                auto *whenNode = down_cast<pm_when_node>(whenNodePtr);
+                auto *whenNode = down_cast_nonnull<pm_when_node>(whenNodePtr);
                 totalPatterns += whenNode->conditions.size;
             }
 
@@ -2068,7 +2068,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
 
                 // Extract pattern expressions directly from Prism nodes
                 for (auto *prismWhenPtr : prismWhenNodes) {
-                    auto *prismWhen = down_cast<pm_when_node>(prismWhenPtr);
+                    auto *prismWhen = down_cast_nonnull<pm_when_node>(prismWhenPtr);
                     auto prismPatterns = absl::MakeSpan(prismWhen->conditions.nodes, prismWhen->conditions.size);
 
                     for (auto *prismPattern : prismPatterns) {
@@ -2079,7 +2079,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
 
                 // Extract body expressions directly from Prism nodes
                 for (auto *prismWhenPtr : prismWhenNodes) {
-                    auto *prismWhen = down_cast<pm_when_node>(prismWhenPtr);
+                    auto *prismWhen = down_cast_nonnull<pm_when_node>(prismWhenPtr);
                     auto body = desugarStatements(prismWhen->statements);
                     args.emplace_back(move(body));
                 }
@@ -2113,7 +2113,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
 
             // Iterate over Prism when nodes in reverse to build the if/else ladder backwards
             for (auto it = prismWhenNodes.rbegin(); it != prismWhenNodes.rend(); ++it) {
-                auto *prismWhen = down_cast<pm_when_node>(*it);
+                auto *prismWhen = down_cast_nonnull<pm_when_node>(*it);
                 auto whenLoc = translateLoc(prismWhen->base.location);
                 auto prismPatterns = absl::MakeSpan(prismWhen->conditions.nodes, prismWhen->conditions.size);
 
@@ -2181,7 +2181,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return resultExpr;
         }
         case PM_CLASS_NODE: { // Class declarations, not including singleton class declarations (`class <<`)
-            auto classNode = down_cast<pm_class_node>(node);
+            auto classNode = down_cast_nonnull<pm_class_node>(node);
 
             auto name = desugarClassOrModuleName(classNode->constant_path, classNode->class_keyword_loc);
             auto declLoc = translateLoc(classNode->class_keyword_loc).join(name.loc());
@@ -2213,13 +2213,13 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                                            ast::UnresolvedIdent::Kind::Class>(node);
         }
         case PM_CLASS_VARIABLE_READ_NODE: { // A class variable, like `@@a`
-            auto classVarNode = down_cast<pm_class_variable_read_node>(node);
+            auto classVarNode = down_cast_nonnull<pm_class_variable_read_node>(node);
             auto name = translateConstantName(classVarNode->name);
             return ast::make_expression<ast::UnresolvedIdent>(location, ast::UnresolvedIdent::Kind::Class, name);
         }
         case PM_CLASS_VARIABLE_TARGET_NODE: { // Target of an indirect write to a class variable
             // ... like `@@target1, @@target2 = 1, 2`, `rescue => @@target`, etc.
-            auto classVariableTargetNode = down_cast<pm_class_variable_target_node>(node);
+            auto classVariableTargetNode = down_cast_nonnull<pm_class_variable_target_node>(node);
             auto name = translateConstantName(classVariableTargetNode->name);
             return ast::make_expression<ast::UnresolvedIdent>(location, ast::UnresolvedIdent::Kind::Class, name);
         }
@@ -2268,7 +2268,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return desugarAssignment<pm_constant_write_node>(node);
         }
         case PM_DEF_NODE: { // Method definitions, like `def m; ...; end` and `def m = 123`
-            auto defNode = down_cast<pm_def_node>(node);
+            auto defNode = down_cast_nonnull<pm_def_node>(node);
             auto declLoc = translateLoc(defNode->def_keyword_loc);
             declLoc = declLoc.join(translateLoc(defNode->name_loc));
 
@@ -2334,7 +2334,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                     //     end
                     //
                     // desugarBegin handles this directly, returning the desugared expression.
-                    auto beginNode = down_cast<pm_begin_node>(defNode->body);
+                    auto beginNode = down_cast_nonnull<pm_begin_node>(defNode->body);
                     body = methodContext.desugarBegin(beginNode);
                 } else {
                     // Side effect: If method has no explicit block parameter and contains a `yield`, translating it
@@ -2370,14 +2370,14 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return methodExpr;
         }
         case PM_DEFINED_NODE: {
-            auto definedNode = down_cast<pm_defined_node>(node);
+            auto definedNode = down_cast_nonnull<pm_defined_node>(node);
 
             auto argument = definedNode->value;
 
             switch (PM_NODE_TYPE(argument)) {
                 // Desugar `defined?(@ivar)` to `::Magic.defined_instance_var(:@ivar)`
                 case PM_INSTANCE_VARIABLE_READ_NODE: {
-                    auto ivarNode = down_cast<pm_instance_variable_read_node>(argument);
+                    auto ivarNode = down_cast_nonnull<pm_instance_variable_read_node>(argument);
                     auto loc = translateLoc(argument->location);
                     auto name = translateConstantName(ivarNode->name);
                     auto sym = MK::Symbol(loc, name);
@@ -2388,7 +2388,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
 
                 // Desugar `defined?(@@cvar)` to `::Magic.defined_instance_var(:@@cvar)`
                 case PM_CLASS_VARIABLE_READ_NODE: {
-                    auto cvarNode = down_cast<pm_class_variable_read_node>(argument);
+                    auto cvarNode = down_cast_nonnull<pm_class_variable_read_node>(argument);
                     auto loc = translateLoc(argument->location);
                     auto name = translateConstantName(cvarNode->name);
                     auto sym = MK::Symbol(loc, name);
@@ -2406,7 +2406,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
 
                     while (true) {
                         if (PM_NODE_TYPE_P(current, PM_CONSTANT_PATH_NODE)) {
-                            auto pathNode = down_cast<pm_constant_path_node>(current);
+                            auto pathNode = down_cast_nonnull<pm_constant_path_node>(current);
 
                             args.emplace_back(MK::String(translateLoc(pathNode->base.location),
                                                          translateConstantName(pathNode->name)));
@@ -2418,7 +2418,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
 
                             current = pathNode->parent;
                         } else if (PM_NODE_TYPE_P(current, PM_CONSTANT_READ_NODE)) {
-                            auto constNode = down_cast<pm_constant_read_node>(current);
+                            auto constNode = down_cast_nonnull<pm_constant_read_node>(current);
                             args.emplace_back(MK::String(translateLoc(constNode->base.location),
                                                          translateConstantName(constNode->name)));
                             break;
@@ -2443,13 +2443,13 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             }
         }
         case PM_ELSE_NODE: { // An `else` clauses, which can pertain to an `if`, `begin`, `case`, etc.
-            auto elseNode = down_cast<pm_else_node>(node);
+            auto elseNode = down_cast_nonnull<pm_else_node>(node);
             return desugarStatements(elseNode->statements);
         }
         case PM_EMBEDDED_STATEMENTS_NODE: { // Statements interpolated into a string.
             // e.g. the `#{bar}` in `"foo #{bar} baz"`
             // Can be multiple statements separated by `;`.
-            auto embeddedStmtsNode = down_cast<pm_embedded_statements_node>(node);
+            auto embeddedStmtsNode = down_cast_nonnull<pm_embedded_statements_node>(node);
 
             auto stmtsNode = embeddedStmtsNode->statements;
             if (stmtsNode == nullptr) {
@@ -2460,7 +2460,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return desugarStatements(stmtsNode, inlineIfSingle, location);
         }
         case PM_EMBEDDED_VARIABLE_NODE: {
-            auto embeddedVariableNode = down_cast<pm_embedded_variable_node>(node);
+            auto embeddedVariableNode = down_cast_nonnull<pm_embedded_variable_node>(node);
             return desugar(embeddedVariableNode->variable);
         }
         case PM_ENSURE_NODE: { // An `ensure` clause, which can pertain to a `begin`
@@ -2470,7 +2470,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return MK::False(location);
         }
         case PM_FLOAT_NODE: { // A floating point number literal, e.g. `1.23`
-            auto floatNode = down_cast<pm_float_node>(node);
+            auto floatNode = down_cast_nonnull<pm_float_node>(node);
             string valueString(sliceLocation(floatNode->base.location));
             auto withoutUnderscores = absl::StrReplaceAll(valueString, {{"_", ""}});
 
@@ -2494,7 +2494,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             }
         }
         case PM_FOR_NODE: { // `for x in a; ...; end`
-            auto forNode = down_cast<pm_for_node>(node);
+            auto forNode = down_cast_nonnull<pm_for_node>(node);
 
             // Index might be invalid in error recovery cases, match original parser behavior.
             if (!parser::Prism::isAssignmentTarget(forNode->index)) {
@@ -2502,7 +2502,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             }
 
             auto *mlhs = PM_NODE_TYPE_P(forNode->index, PM_MULTI_TARGET_NODE)
-                             ? down_cast<pm_multi_target_node>(forNode->index)
+                             ? down_cast_nonnull<pm_multi_target_node>(forNode->index)
                              : nullptr;
 
             auto collection = desugar(forNode->collection);
@@ -2564,7 +2564,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
         }
         case PM_FORWARDING_SUPER_NODE: { // A `super` with no explicit arguments
             // Surprisingly, a forwarding `super` call can still have a literal block argument, like `super { }`.
-            auto forwardingSuperNode = down_cast<pm_forwarding_super_node>(node);
+            auto forwardingSuperNode = down_cast_nonnull<pm_forwarding_super_node>(node);
 
             if (auto *blockNode = forwardingSuperNode->block) { // always a PM_BLOCK_NODE
                 // Desugar `super { ... }` to `self.<super>(<ZSuperArgs>) { ... }`
@@ -2609,13 +2609,13 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                                            ast::UnresolvedIdent::Kind::Global>(node);
         }
         case PM_GLOBAL_VARIABLE_READ_NODE: { // A global variable, like `$g`
-            auto globalVarReadNode = down_cast<pm_global_variable_read_node>(node);
+            auto globalVarReadNode = down_cast_nonnull<pm_global_variable_read_node>(node);
             auto name = translateConstantName(globalVarReadNode->name);
             return ast::make_expression<ast::UnresolvedIdent>(location, ast::UnresolvedIdent::Kind::Global, name);
         }
         case PM_GLOBAL_VARIABLE_TARGET_NODE: { // Target of an indirect write to a global variable
             // ... like `$target1, $target2 = 1, 2`, `rescue => $target`, etc.
-            auto globalVariableTargetNode = down_cast<pm_global_variable_target_node>(node);
+            auto globalVariableTargetNode = down_cast_nonnull<pm_global_variable_target_node>(node);
             auto name = translateConstantName(globalVariableTargetNode->name);
             return ast::make_expression<ast::UnresolvedIdent>(location, ast::UnresolvedIdent::Kind::Global, name);
         }
@@ -2623,12 +2623,12 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return desugarAssignment<pm_global_variable_write_node, ast::UnresolvedIdent::Kind::Global>(node);
         }
         case PM_HASH_NODE: { // A hash literal, like `{ a: 1, b: 2 }`
-            auto hashNode = down_cast<pm_hash_node>(node);
+            auto hashNode = down_cast_nonnull<pm_hash_node>(node);
 
             return desugarKeyValuePairs(location, hashNode->elements);
         }
         case PM_IF_NODE: { // An `if` statement or modifier, like `if cond; ...; end` or `a.b if cond`
-            auto ifNode = down_cast<pm_if_node>(node);
+            auto ifNode = down_cast_nonnull<pm_if_node>(node);
 
             auto predicateExpr = desugar(ifNode->predicate);
             auto thenExpr = desugarStatements(ifNode->statements);
@@ -2637,7 +2637,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return MK::If(location, move(predicateExpr), move(thenExpr), move(elseExpr));
         }
         case PM_IMAGINARY_NODE: { // An imaginary number literal, like `1.0i`, `+1.0i`, or `-1.0i`
-            auto imaginaryNode = down_cast<pm_imaginary_node>(node);
+            auto imaginaryNode = down_cast_nonnull<pm_imaginary_node>(node);
             // Create a string_view of the value without the trailing 'i'
             auto value = sliceLocation(imaginaryNode->base.location);
             value = value.substr(0, value.size() - "i"sv.size());
@@ -2692,7 +2692,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return complexCall;
         }
         case PM_IMPLICIT_NODE: { // A hash key without explicit value, like the `k4` in `{ k4: }`
-            auto implicitNode = down_cast<pm_implicit_node>(node);
+            auto implicitNode = down_cast_nonnull<pm_implicit_node>(node);
             return desugar(implicitNode->value);
         }
         case PM_IMPLICIT_REST_NODE: { // An implicit splat, like the `,` in `a, = 1, 2, 3`
@@ -2711,7 +2711,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
         }
         case PM_INDEX_TARGET_NODE: { // Target of an indirect write to an indexed expression
             // ... like `target[0], target[1] = 1, 2`, `rescue => target[0]`, etc.
-            auto indexedTargetNode = down_cast<pm_index_target_node>(node);
+            auto indexedTargetNode = down_cast_nonnull<pm_index_target_node>(node);
 
             auto openingLoc = translateLoc(indexedTargetNode->opening_loc);                  // The location of `[]=`
             auto lBracketLoc = core::LocOffsets{openingLoc.beginLoc, openingLoc.endLoc - 1}; // Drop the `=`
@@ -2735,13 +2735,13 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                                            ast::UnresolvedIdent::Kind::Instance>(node);
         }
         case PM_INSTANCE_VARIABLE_READ_NODE: { // An instance variable, like `@iv`
-            auto instanceVarNode = down_cast<pm_instance_variable_read_node>(node);
+            auto instanceVarNode = down_cast_nonnull<pm_instance_variable_read_node>(node);
             auto name = translateConstantName(instanceVarNode->name);
             return ast::make_expression<ast::UnresolvedIdent>(location, ast::UnresolvedIdent::Kind::Instance, name);
         }
         case PM_INSTANCE_VARIABLE_TARGET_NODE: { // Target of an indirect write to an instance variable
             // ... like `@target1, @target2 = 1, 2`, `rescue => @target`, etc.
-            auto instanceVariableTargetNode = down_cast<pm_instance_variable_target_node>(node);
+            auto instanceVariableTargetNode = down_cast_nonnull<pm_instance_variable_target_node>(node);
             auto name = translateConstantName(instanceVariableTargetNode->name);
             return ast::make_expression<ast::UnresolvedIdent>(location, ast::UnresolvedIdent::Kind::Instance, name);
         }
@@ -2749,7 +2749,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return desugarAssignment<pm_instance_variable_write_node, ast::UnresolvedIdent::Kind::Instance>(node);
         }
         case PM_INTEGER_NODE: { // An integer literal, e.g., `123`, `0xcafe`, `0b1010`, etc.
-            auto intNode = down_cast<pm_integer_node>(node);
+            auto intNode = down_cast_nonnull<pm_integer_node>(node);
             // For normal integers, retain the original valueString including any sign
             string valueString(sliceLocation(intNode->base.location));
             ENFORCE(!valueString.empty());
@@ -2808,7 +2808,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return make_unsupported_node(location, "MatchCurLine");
         }
         case PM_INTERPOLATED_REGULAR_EXPRESSION_NODE: { // A regular expression with interpolation, like `/a #{b} c/`
-            auto interpolatedRegexNode = down_cast<pm_interpolated_regular_expression_node>(node);
+            auto interpolatedRegexNode = down_cast_nonnull<pm_interpolated_regular_expression_node>(node);
 
             auto options = desugarRegexpOptions(interpolatedRegexNode->closing_loc);
 
@@ -2820,7 +2820,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                              move(options));
         }
         case PM_INTERPOLATED_STRING_NODE: { // An interpolated string like `"foo #{bar} baz"`
-            auto interpolatedStringNode = down_cast<pm_interpolated_string_node>(node);
+            auto interpolatedStringNode = down_cast_nonnull<pm_interpolated_string_node>(node);
 
             // For heredocs, endLoc() extends to the closing delimiter.
             auto strLoc = translateLoc(startLoc(node), endLoc(node));
@@ -2829,14 +2829,14 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return desugarDString(strLoc, interpolatedStringNode->parts);
         }
         case PM_INTERPOLATED_SYMBOL_NODE: { // A symbol like `:"a #{b} c"`
-            auto interpolatedSymbolNode = down_cast<pm_interpolated_symbol_node>(node);
+            auto interpolatedSymbolNode = down_cast_nonnull<pm_interpolated_symbol_node>(node);
 
             // Desugar `:"a #{b} c"` to `::Magic.<string-interpolate>("a ", b, " c").intern()`
             auto desugared = desugarDString(location, interpolatedSymbolNode->parts);
             return MK::Send0(location, move(desugared), core::Names::intern(), location.copyWithZeroLength());
         }
         case PM_INTERPOLATED_X_STRING_NODE: { // An executable string with backticks, like `echo "Hello, world!"`
-            auto interpolatedXStringNode = down_cast<pm_interpolated_x_string_node>(node);
+            auto interpolatedXStringNode = down_cast_nonnull<pm_interpolated_x_string_node>(node);
             // For heredocs, endLoc() extends to the closing delimiter (excluding trailing newline).
             auto xstringLoc = translateLoc(startLoc(node), endLoc(node));
             auto desugared = desugarDString(xstringLoc, interpolatedXStringNode->parts);
@@ -2858,7 +2858,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return MK::Local(itParamLoc, core::Names::it());
         }
         case PM_KEYWORD_HASH_NODE: { // A hash of keyword arguments, like `foo(a: 1, b: 2)`
-            auto keywordHashNode = down_cast<pm_keyword_hash_node>(node);
+            auto keywordHashNode = down_cast_nonnull<pm_keyword_hash_node>(node);
             return desugarKeyValuePairs(location, keywordHashNode->elements);
         }
         case PM_KEYWORD_REST_PARAMETER_NODE: { // A keyword rest parameter, like `def foo(**kwargs)`
@@ -2866,7 +2866,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             unreachable("PM_KEYWORD_REST_PARAMETER_NODE should be handled in translateParametersNode()");
         }
         case PM_LAMBDA_NODE: { // lambda literals, like `-> { 123 }`
-            auto lambdaNode = down_cast<pm_lambda_node>(node);
+            auto lambdaNode = down_cast_nonnull<pm_lambda_node>(node);
 
             auto operatorLoc = translateLoc(lambdaNode->operator_loc); // the `->` arrow
 
@@ -2895,13 +2895,13 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                                            ast::UnresolvedIdent::Kind::Local>(node);
         }
         case PM_LOCAL_VARIABLE_READ_NODE: { // A local variable, like `lv`
-            auto localVarReadNode = down_cast<pm_local_variable_read_node>(node);
+            auto localVarReadNode = down_cast_nonnull<pm_local_variable_read_node>(node);
             auto name = translateConstantName(localVarReadNode->name);
             return MK::Local(location, name);
         }
         case PM_LOCAL_VARIABLE_TARGET_NODE: { // Target of an indirect write to a local variable
             // ... like `target1, target2 = 1, 2`, `rescue => target`, etc.
-            auto localVarTargetNode = down_cast<pm_local_variable_target_node>(node);
+            auto localVarTargetNode = down_cast_nonnull<pm_local_variable_target_node>(node);
             auto name = translateConstantName(localVarTargetNode->name);
             return MK::Local(location, name);
         }
@@ -2913,7 +2913,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return make_unsupported_node(location, "MatchCurLine");
         }
         case PM_MATCH_REQUIRED_NODE: {
-            auto matchRequiredNode = down_cast<pm_match_required_node>(node);
+            auto matchRequiredNode = down_cast_nonnull<pm_match_required_node>(node);
 
             auto value = desugarPattern(matchRequiredNode->value);
             auto pattern = desugarPattern(matchRequiredNode->pattern);
@@ -2921,7 +2921,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return desugarOnelinePattern(location, matchRequiredNode->pattern);
         }
         case PM_MATCH_PREDICATE_NODE: {
-            auto matchPredicateNode = down_cast<pm_match_predicate_node>(node);
+            auto matchPredicateNode = down_cast_nonnull<pm_match_predicate_node>(node);
 
             auto value = desugarPattern(matchPredicateNode->value);
             auto pattern = desugarPattern(matchPredicateNode->pattern);
@@ -2929,7 +2929,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return desugarOnelinePattern(location, matchPredicateNode->pattern);
         }
         case PM_MATCH_WRITE_NODE: { // A regex match that assigns to a local variable, like `a =~ /wat/`
-            auto matchWriteNode = down_cast<pm_match_write_node>(node);
+            auto matchWriteNode = down_cast_nonnull<pm_match_write_node>(node);
 
             // "Match writes" let you bind regex capture groups directly into new variables.
             // Sorbet doesn't treat this syntax in a special way, so it doesn't know that it introduces new local var.
@@ -2940,7 +2940,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return desugar(up_cast(matchWriteNode->call));
         }
         case PM_MODULE_NODE: { // Modules declarations, like `module A::B::C; ...; end`
-            auto moduleNode = down_cast<pm_module_node>(node);
+            auto moduleNode = down_cast_nonnull<pm_module_node>(node);
 
             auto name = desugarClassOrModuleName(moduleNode->constant_path, moduleNode->module_keyword_loc);
             auto declLoc = translateLoc(moduleNode->module_keyword_loc).join(name.loc());
@@ -2951,19 +2951,19 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return MK::Module(location, declLoc, move(name), move(body));
         }
         case PM_MULTI_TARGET_NODE: { // A multi-target like the `(x2, y2)` in `p1, (x2, y2) = a`
-            auto multiTargetNode = down_cast<pm_multi_target_node>(node);
+            auto multiTargetNode = down_cast_nonnull<pm_multi_target_node>(node);
 
             return desugarMlhs(location, multiTargetNode, MK::EmptyTree());
         }
         case PM_MULTI_WRITE_NODE: { // Multi-assignment, like `a, b = 1, 2`
-            auto multiWriteNode = down_cast<pm_multi_write_node>(node);
+            auto multiWriteNode = down_cast_nonnull<pm_multi_write_node>(node);
 
             auto rhsExpr = desugar(multiWriteNode->value);
 
             return desugarMlhs(location, multiWriteNode, move(rhsExpr));
         }
         case PM_NEXT_NODE: { // A `next` statement, e.g. `next`, `next 1, 2, 3`
-            auto nextNode = down_cast<pm_next_node>(node);
+            auto nextNode = down_cast_nonnull<pm_next_node>(node);
             auto arguments = desugarBreakNextReturn(nextNode->arguments);
             return MK::Next(location, move(arguments));
         }
@@ -2979,14 +2979,14 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             unreachable("PM_NUMBERED_PARAMETERS_NODE is handled separately in `translateNumberedParametersNode()`.");
         }
         case PM_NUMBERED_REFERENCE_READ_NODE: {
-            auto numberedReferenceReadNode = down_cast<pm_numbered_reference_read_node>(node);
+            auto numberedReferenceReadNode = down_cast_nonnull<pm_numbered_reference_read_node>(node);
             auto number = numberedReferenceReadNode->number;
 
             auto name = ctx.state.enterNameUTF8(to_string(number));
             return ast::make_expression<ast::UnresolvedIdent>(location, ast::UnresolvedIdent::Kind::Global, name);
         }
         case PM_OPTIONAL_KEYWORD_PARAMETER_NODE: { // An optional keyword parameter, like `def foo(a: 1)`
-            auto optionalKeywordParamNode = down_cast<pm_optional_keyword_parameter_node>(node);
+            auto optionalKeywordParamNode = down_cast_nonnull<pm_optional_keyword_parameter_node>(node);
             auto nameLoc = translateLoc(optionalKeywordParamNode->name_loc);
 
             auto name = translateConstantName(optionalKeywordParamNode->name);
@@ -2995,7 +2995,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return MK::OptionalParam(location, MK::KeywordArg(nameLoc, name), move(value));
         }
         case PM_OPTIONAL_PARAMETER_NODE: { // An optional positional parameter, like `def foo(a = 1)`
-            auto optionalParamNode = down_cast<pm_optional_parameter_node>(node);
+            auto optionalParamNode = down_cast_nonnull<pm_optional_parameter_node>(node);
             auto nameLoc = translateLoc(optionalParamNode->name_loc);
 
             auto name = translateConstantName(optionalParamNode->name);
@@ -3004,7 +3004,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return MK::OptionalParam(location, MK::Local(nameLoc, name), move(value));
         }
         case PM_OR_NODE: { // operator `||` and `or`
-            auto orNode = down_cast<pm_or_node>(node);
+            auto orNode = down_cast_nonnull<pm_or_node>(node);
 
             auto lhs = desugarNullable(orNode->left);
             auto rhs = desugarNullable(orNode->right);
@@ -3037,7 +3037,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             unreachable("PM_PARAMETERS_NODE is handled separately in desugarParametersNode.");
         }
         case PM_PARENTHESES_NODE: { // A parethesized expression, e.g. `(a)`
-            auto parensNode = down_cast<pm_parentheses_node>(node);
+            auto parensNode = down_cast_nonnull<pm_parentheses_node>(node);
 
             auto body = parensNode->body;
 
@@ -3047,7 +3047,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
 
             if (PM_NODE_TYPE_P(body, PM_STATEMENTS_NODE)) {
                 auto inlineIfSingle = false;
-                return desugarStatements(down_cast<pm_statements_node>(body), inlineIfSingle);
+                return desugarStatements(down_cast_nonnull<pm_statements_node>(body), inlineIfSingle);
             } else {
                 return desugar(body);
             }
@@ -3056,7 +3056,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return make_unsupported_node(location, "Preexe");
         }
         case PM_PROGRAM_NODE: { // The root node of the parse tree, representing the entire program
-            pm_program_node *programNode = down_cast<pm_program_node>(node);
+            pm_program_node *programNode = down_cast_nonnull<pm_program_node>(node);
 
             ENFORCE(programNode->statements != nullptr,
                     "A `PM_STATEMENTS_NODE` should always have non-null statements, even for totally empty programs.");
@@ -3101,7 +3101,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return make_unsupported_node(location, "Postexe");
         }
         case PM_RANGE_NODE: { // A Range literal, e.g. `a..b`, `a..`, `..b`, `a...b`, `a...`, `...b`
-            auto rangeNode = down_cast<pm_range_node>(node);
+            auto rangeNode = down_cast_nonnull<pm_range_node>(node);
 
             bool isExclusive = PM_NODE_FLAG_P(rangeNode, PM_RANGE_FLAGS_EXCLUDE_END);
 
@@ -3120,7 +3120,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
         case PM_RATIONAL_NODE: { // A rational number literal, e.g. `1r`
             // Note: in `1/2r`, only the `2r` is part of the `PM_RATIONAL_NODE`.
             // The `1/` is just divison of an integer.
-            auto *rationalNode = down_cast<pm_rational_node>(node);
+            auto *rationalNode = down_cast_nonnull<pm_rational_node>(node);
 
             auto value = sliceLocation(rationalNode->base.location);
             value = value.substr(0, value.size() - "r"sv.size()); // drop the `r` suffix
@@ -3137,24 +3137,24 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return make_unsupported_node(location, "Redo");
         }
         case PM_REGULAR_EXPRESSION_NODE: { // A regular expression literal, e.g. `/foo/`
-            auto regexNode = down_cast<pm_regular_expression_node>(node);
+            auto regexNode = down_cast_nonnull<pm_regular_expression_node>(node);
 
             auto contentLoc = translateLoc(regexNode->content_loc);
 
             return desugarRegexp(location, contentLoc, regexNode->unescaped, regexNode->closing_loc);
         }
         case PM_REQUIRED_KEYWORD_PARAMETER_NODE: { // A required keyword parameter, like `def foo(a:)`
-            auto requiredKeywordParamNode = down_cast<pm_required_keyword_parameter_node>(node);
+            auto requiredKeywordParamNode = down_cast_nonnull<pm_required_keyword_parameter_node>(node);
             auto name = translateConstantName(requiredKeywordParamNode->name);
             return MK::KeywordArg(location, name);
         }
         case PM_REQUIRED_PARAMETER_NODE: { // A required positional parameter, like `def foo(a)`
-            auto requiredParamNode = down_cast<pm_required_parameter_node>(node);
+            auto requiredParamNode = down_cast_nonnull<pm_required_parameter_node>(node);
             auto name = translateConstantName(requiredParamNode->name);
             return MK::Local(location, name);
         }
         case PM_RESCUE_MODIFIER_NODE: {
-            auto rescueModifierNode = down_cast<pm_rescue_modifier_node>(node);
+            auto rescueModifierNode = down_cast_nonnull<pm_rescue_modifier_node>(node);
             auto keywordLoc = translateLoc(rescueModifierNode->keyword_loc);
 
             // Create a RescueCase with empty exceptions and a <rescueTemp> variable
@@ -3180,7 +3180,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             unreachable("PM_RESCUE_NODE is handled separately in PM_BEGIN_NODE, see its docs for details.");
         }
         case PM_REST_PARAMETER_NODE: { // A rest parameter, like `def foo(*rest)`
-            auto restParamNode = down_cast<pm_rest_parameter_node>(node);
+            auto restParamNode = down_cast_nonnull<pm_rest_parameter_node>(node);
             core::LocOffsets nameLoc;
 
             core::NameRef sorbetName;
@@ -3196,7 +3196,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return MK::RestParam(location, MK::Local(nameLoc, sorbetName));
         }
         case PM_RETURN_NODE: { // A `return` statement, like `return 1, 2, 3`
-            auto returnNode = down_cast<pm_return_node>(node);
+            auto returnNode = down_cast_nonnull<pm_return_node>(node);
             auto arguments = desugarBreakNextReturn(returnNode->arguments);
             return MK::Return(location, move(arguments));
         }
@@ -3209,11 +3209,11 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
         case PM_SHAREABLE_CONSTANT_NODE: {
             // Sorbet doesn't handle `shareable_constant_value` yet (https://bugs.ruby-lang.org/issues/17273).
             // We'll just handle the inner constant assignment as normal.
-            auto shareableConstantNode = down_cast<pm_shareable_constant_node>(node);
+            auto shareableConstantNode = down_cast_nonnull<pm_shareable_constant_node>(node);
             return desugar(shareableConstantNode->write);
         }
         case PM_SINGLETON_CLASS_NODE: { // A singleton class, like `class << self ... end`
-            auto classNode = down_cast<pm_singleton_class_node>(node);
+            auto classNode = down_cast_nonnull<pm_singleton_class_node>(node);
 
             auto declLoc = translateLoc(classNode->class_keyword_loc);
             auto receiverLoc = translateLoc(classNode->expression->location);
@@ -3247,7 +3247,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return MK::Int(location, details.first.line);
         }
         case PM_SPLAT_NODE: { // A splat, like `*a` in an array literal or method call
-            auto splatNode = down_cast<pm_splat_node>(node);
+            auto splatNode = down_cast_nonnull<pm_splat_node>(node);
 
             auto expr = desugarNullable(splatNode->expression);
 
@@ -3259,11 +3259,11 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             }
         }
         case PM_STATEMENTS_NODE: { // A sequence of statements, such a in a `begin` block, `()`, etc.
-            auto statementsNode = down_cast<pm_statements_node>(node);
+            auto statementsNode = down_cast_nonnull<pm_statements_node>(node);
             return desugarStatements(statementsNode);
         }
         case PM_STRING_NODE: { // A string literal, e.g. `"foo"`
-            auto strNode = down_cast<pm_string_node>(node);
+            auto strNode = down_cast_nonnull<pm_string_node>(node);
 
             // For heredocs, endLoc() extends to the closing delimiter.
             auto strLoc = translateLoc(startLoc(node), endLoc(node));
@@ -3275,7 +3275,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
         }
         case PM_SUPER_NODE: { // A `super` call with explicit args, like `super()`, `super(a, b)`
             // If there's no arguments (except a literal block argument), then it's a `PM_FORWARDING_SUPER_NODE`.
-            auto superNode = down_cast<pm_super_node>(node);
+            auto superNode = down_cast_nonnull<pm_super_node>(node);
 
             auto receiver = MK::Self(location.copyWithZeroLength());
             auto methodName = maybeTypedSuper();
@@ -3288,7 +3288,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                                      superNode->rparen_loc, move(block), location, isPrivateOk);
         }
         case PM_SYMBOL_NODE: { // A symbol literal, e.g. `:foo`, or `a:` in `{a: 1}`
-            auto symNode = down_cast<pm_symbol_node>(node);
+            auto symNode = down_cast_nonnull<pm_symbol_node>(node);
 
             auto [content, location] = translateSymbol(symNode);
 
@@ -3298,7 +3298,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return MK::True(location);
         }
         case PM_UNDEF_NODE: { // The `undef` keyword, like `undef :method_to_undef
-            auto undefNode = down_cast<pm_undef_node>(node);
+            auto undefNode = down_cast_nonnull<pm_undef_node>(node);
 
             ENFORCE(undefNode->names.size > 0, "PM_UNDEF_NODE without names is expected to be a parse error");
 
@@ -3309,7 +3309,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                             args.size(), move(args));
         }
         case PM_UNLESS_NODE: { // An `unless` branch, either in a statement or modifier form.
-            auto unlessNode = down_cast<pm_unless_node>(node);
+            auto unlessNode = down_cast_nonnull<pm_unless_node>(node);
 
             auto predicateExpr = desugar(unlessNode->predicate);
             // For `unless`, then/else are swapped: `statements` is the else branch, `else_clause` is the then branch
@@ -3319,7 +3319,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             return MK::If(location, move(predicateExpr), move(thenExpr), move(elseExpr));
         }
         case PM_UNTIL_NODE: { // A `until` loop, like `until stop_condition; ...; end`
-            auto untilNode = down_cast<pm_until_node>(node);
+            auto untilNode = down_cast_nonnull<pm_until_node>(node);
 
             // When the until loop is placed after a `begin` block, like `begin; end until false`,
             bool beginModifier = PM_NODE_FLAG_P(untilNode, PM_LOOP_FLAGS_BEGIN_MODIFIER);
@@ -3342,7 +3342,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             unreachable("`PM_WHEN_NODE` is handled separately in `PM_CASE_NODE`.");
         }
         case PM_WHILE_NODE: { // A `while` loop, like `while condition; ...; end`
-            auto whileNode = down_cast<pm_while_node>(node);
+            auto whileNode = down_cast_nonnull<pm_while_node>(node);
 
             // When the while loop is placed after a `begin` block, like `begin; end while false`,
             bool beginModifier = PM_NODE_FLAG_P(whileNode, PM_LOOP_FLAGS_BEGIN_MODIFIER);
@@ -3363,7 +3363,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             }
         }
         case PM_X_STRING_NODE: { // A non-interpolated x-string, like `/usr/bin/env ls`
-            auto strNode = down_cast<pm_x_string_node>(node);
+            auto strNode = down_cast_nonnull<pm_x_string_node>(node);
 
             // For heredocs, endLoc() extends to the closing delimiter (excluding trailing newline).
             auto xstringLoc = translateLoc(startLoc(node), endLoc(node));
@@ -3378,7 +3378,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                              MK::String(contentLoc, content));
         }
         case PM_YIELD_NODE: { // The `yield` keyword, like `yield`, `yield 1, 2, 3`
-            auto yieldNode = down_cast<pm_yield_node>(node);
+            auto yieldNode = down_cast_nonnull<pm_yield_node>(node);
 
             auto yieldArgs = desugarArguments<ast::Send::ARGS_store>(yieldNode->arguments);
 
@@ -3443,14 +3443,14 @@ const uint8_t *closingLocEnd(pm_location_t closingLoc) {
 const uint8_t *endLoc(pm_node_t *anyNode) {
     switch (PM_NODE_TYPE(anyNode)) {
         case PM_MULTI_WRITE_NODE: {
-            auto *node = down_cast<pm_multi_write_node>(anyNode);
+            auto *node = down_cast_nonnull<pm_multi_write_node>(anyNode);
             return endLoc(node->value);
         }
         case PM_CALL_NODE: {
             // For call nodes with heredoc xstring arguments, Prism's location only includes the opening.
             // Extend to include the full heredoc by checking the last argument.
             // NOTE: Only xstrings extend the call location; regular string heredocs do not.
-            auto *node = down_cast<pm_call_node>(anyNode);
+            auto *node = down_cast_nonnull<pm_call_node>(anyNode);
             if (node->arguments && node->arguments->arguments.size > 0) {
                 auto *lastArg = node->arguments->arguments.nodes[node->arguments->arguments.size - 1];
                 if (PM_NODE_TYPE_P(lastArg, PM_X_STRING_NODE) ||
@@ -3463,7 +3463,7 @@ const uint8_t *endLoc(pm_node_t *anyNode) {
         case PM_STRING_NODE: {
             // For heredoc strings, Prism's base.location only includes the opening delimiter.
             // Use closing_loc to get the full heredoc span, excluding the trailing newline.
-            auto *node = down_cast<pm_string_node>(anyNode);
+            auto *node = down_cast_nonnull<pm_string_node>(anyNode);
             if (auto end = closingLocEnd(node->closing_loc)) {
                 return end;
             }
@@ -3471,7 +3471,7 @@ const uint8_t *endLoc(pm_node_t *anyNode) {
         }
         case PM_INTERPOLATED_STRING_NODE: {
             // Same as PM_STRING_NODE - extend to closing delimiter for heredocs.
-            auto *node = down_cast<pm_interpolated_string_node>(anyNode);
+            auto *node = down_cast_nonnull<pm_interpolated_string_node>(anyNode);
             if (auto end = closingLocEnd(node->closing_loc)) {
                 return end;
             }
@@ -3480,7 +3480,7 @@ const uint8_t *endLoc(pm_node_t *anyNode) {
         case PM_X_STRING_NODE: {
             // For heredoc xstrings, Prism's base.location only includes the opening delimiter.
             // Use closing_loc to get the full heredoc span, excluding the trailing newline.
-            auto *node = down_cast<pm_x_string_node>(anyNode);
+            auto *node = down_cast_nonnull<pm_x_string_node>(anyNode);
             if (auto end = closingLocEnd(node->closing_loc)) {
                 return end;
             }
@@ -3488,7 +3488,7 @@ const uint8_t *endLoc(pm_node_t *anyNode) {
         }
         case PM_INTERPOLATED_X_STRING_NODE: {
             // Same as PM_X_STRING_NODE - extend to closing delimiter for heredocs.
-            auto *node = down_cast<pm_interpolated_x_string_node>(anyNode);
+            auto *node = down_cast_nonnull<pm_interpolated_x_string_node>(anyNode);
             if (auto end = closingLocEnd(node->closing_loc)) {
                 return end;
             }
@@ -3496,27 +3496,27 @@ const uint8_t *endLoc(pm_node_t *anyNode) {
         }
         case PM_LOCAL_VARIABLE_WRITE_NODE: {
             // For assignments with heredoc values, extend to the heredoc closing delimiter.
-            auto *node = down_cast<pm_local_variable_write_node>(anyNode);
+            auto *node = down_cast_nonnull<pm_local_variable_write_node>(anyNode);
             return endLoc(node->value);
         }
         case PM_INSTANCE_VARIABLE_WRITE_NODE: {
-            auto *node = down_cast<pm_instance_variable_write_node>(anyNode);
+            auto *node = down_cast_nonnull<pm_instance_variable_write_node>(anyNode);
             return endLoc(node->value);
         }
         case PM_CLASS_VARIABLE_WRITE_NODE: {
-            auto *node = down_cast<pm_class_variable_write_node>(anyNode);
+            auto *node = down_cast_nonnull<pm_class_variable_write_node>(anyNode);
             return endLoc(node->value);
         }
         case PM_GLOBAL_VARIABLE_WRITE_NODE: {
-            auto *node = down_cast<pm_global_variable_write_node>(anyNode);
+            auto *node = down_cast_nonnull<pm_global_variable_write_node>(anyNode);
             return endLoc(node->value);
         }
         case PM_CONSTANT_WRITE_NODE: {
-            auto *node = down_cast<pm_constant_write_node>(anyNode);
+            auto *node = down_cast_nonnull<pm_constant_write_node>(anyNode);
             return endLoc(node->value);
         }
         case PM_CONSTANT_PATH_WRITE_NODE: {
-            auto *node = down_cast<pm_constant_path_write_node>(anyNode);
+            auto *node = down_cast_nonnull<pm_constant_path_write_node>(anyNode);
             return endLoc(node->value);
         }
         default: {
@@ -3545,7 +3545,7 @@ ast::ExpressionPtr Desugarer::desugarPattern(pm_node_t *node) {
 
     switch (PM_NODE_TYPE(node)) {
         case PM_ALTERNATION_PATTERN_NODE: { // A pattern like `1 | 2`
-            auto alternationPatternNode = down_cast<pm_alternation_pattern_node>(node);
+            auto alternationPatternNode = down_cast_nonnull<pm_alternation_pattern_node>(node);
 
             auto left = desugarPattern(alternationPatternNode->left);
             auto right = desugarPattern(alternationPatternNode->right);
@@ -3555,7 +3555,7 @@ ast::ExpressionPtr Desugarer::desugarPattern(pm_node_t *node) {
             return MK::Nil(location);
         }
         case PM_ASSOC_NODE: { // A key-value pair in a Hash pattern, e.g. the `k: v` in `h in { k: v }
-            auto assocNode = down_cast<pm_assoc_node>(node);
+            auto assocNode = down_cast_nonnull<pm_assoc_node>(node);
 
             // If the value is an implicit node, skip creating the pair, and return that value directly.
             if (PM_NODE_TYPE_P(assocNode->value, PM_IMPLICIT_NODE)) {
@@ -3569,7 +3569,7 @@ ast::ExpressionPtr Desugarer::desugarPattern(pm_node_t *node) {
             return MK::Nil(location);
         }
         case PM_ARRAY_PATTERN_NODE: { // An array pattern such as the `[head, *tail]` in the `a in [head, *tail]`
-            auto arrayPatternNode = down_cast<pm_array_pattern_node>(node);
+            auto arrayPatternNode = down_cast_nonnull<pm_array_pattern_node>(node);
 
             auto prismPrefixNodes = absl::MakeSpan(arrayPatternNode->requireds.nodes, arrayPatternNode->requireds.size);
             auto prismRestNode = arrayPatternNode->rest;
@@ -3615,7 +3615,7 @@ ast::ExpressionPtr Desugarer::desugarPattern(pm_node_t *node) {
             return MK::Nil(patternLoc);
         }
         case PM_CAPTURE_PATTERN_NODE: { // A variable capture such as the `Integer => i` in `in Integer => i`
-            auto capturePatternNode = down_cast<pm_capture_pattern_node>(node);
+            auto capturePatternNode = down_cast_nonnull<pm_capture_pattern_node>(node);
 
             auto pattern = desugarPattern(capturePatternNode->value);
             auto target = desugarPattern(up_cast(capturePatternNode->target));
@@ -3623,7 +3623,7 @@ ast::ExpressionPtr Desugarer::desugarPattern(pm_node_t *node) {
             return MK::Nil(location);
         }
         case PM_FIND_PATTERN_NODE: { // A find pattern such as the `[*, middle, *]` in the `a in [*, middle, *]`
-            auto findPatternNode = down_cast<pm_find_pattern_node>(node);
+            auto findPatternNode = down_cast_nonnull<pm_find_pattern_node>(node);
 
             auto prismLeadingSplat = findPatternNode->left;
             auto prismMiddleNodes = absl::MakeSpan(findPatternNode->requireds.nodes, findPatternNode->requireds.size);
@@ -3645,7 +3645,7 @@ ast::ExpressionPtr Desugarer::desugarPattern(pm_node_t *node) {
             return MK::Nil(location);
         }
         case PM_HASH_PATTERN_NODE: { // An hash pattern such as the `{ k: Integer }` in the `h in { k: Integer }`
-            auto hashPatternNode = down_cast<pm_hash_pattern_node>(node);
+            auto hashPatternNode = down_cast_nonnull<pm_hash_pattern_node>(node);
 
             auto prismElements = absl::MakeSpan(hashPatternNode->elements.nodes, hashPatternNode->elements.size);
             auto prismRestNode = hashPatternNode->rest;
@@ -3694,11 +3694,11 @@ ast::ExpressionPtr Desugarer::desugarPattern(pm_node_t *node) {
             return MK::Nil(patternLoc);
         }
         case PM_IMPLICIT_NODE: {
-            auto implicitNode = down_cast<pm_implicit_node>(node);
+            auto implicitNode = down_cast_nonnull<pm_implicit_node>(node);
             return desugarPattern(implicitNode->value);
         }
         case PM_IN_NODE: { // An `in` pattern such as in a `case` statement, or as a standalone expression.
-            auto inNode = down_cast<pm_in_node>(node);
+            auto inNode = down_cast_nonnull<pm_in_node>(node);
 
             auto prismPattern = inNode->pattern;
             ast::ExpressionPtr sorbetGuard;
@@ -3709,12 +3709,12 @@ ast::ExpressionPtr Desugarer::desugarPattern(pm_node_t *node) {
                 pm_statements_node *conditionalStatements = nullptr;
 
                 if (PM_NODE_TYPE_P(prismPattern, PM_IF_NODE)) {
-                    auto ifNode = down_cast<pm_if_node>(prismPattern);
+                    auto ifNode = down_cast_nonnull<pm_if_node>(prismPattern);
                     conditionalStatements = ifNode->statements;
                     sorbetGuard = desugar(ifNode->predicate);
                 } else { // PM_UNLESS_NODE
                     ENFORCE(PM_NODE_TYPE_P(prismPattern, PM_UNLESS_NODE));
-                    auto unlessNode = down_cast<pm_unless_node>(prismPattern);
+                    auto unlessNode = down_cast_nonnull<pm_unless_node>(prismPattern);
                     conditionalStatements = unlessNode->statements;
                     sorbetGuard = desugar(unlessNode->predicate);
                 }
@@ -3731,7 +3731,7 @@ ast::ExpressionPtr Desugarer::desugarPattern(pm_node_t *node) {
             return MK::EmptyTree();
         }
         case PM_LOCAL_VARIABLE_TARGET_NODE: { // A variable binding in a pattern, like the `head` in `[head, *tail]`
-            auto localVarTargetNode = down_cast<pm_local_variable_target_node>(node);
+            auto localVarTargetNode = down_cast_nonnull<pm_local_variable_target_node>(node);
             auto name = translateConstantName(localVarTargetNode->name);
 
             // For a match variable, the desugared expression is a local variable reference
@@ -3739,28 +3739,28 @@ ast::ExpressionPtr Desugarer::desugarPattern(pm_node_t *node) {
             return MK::Local(location, name);
         }
         case PM_PINNED_EXPRESSION_NODE: { // A "pinned" expression, like `^(1 + 2)` in `in ^(1 + 2)`
-            auto pinnedExprNode = down_cast<pm_pinned_expression_node>(node);
+            auto pinnedExprNode = down_cast_nonnull<pm_pinned_expression_node>(node);
 
             auto expr = desugar(pinnedExprNode->expression);
 
             return MK::Nil(location);
         }
         case PM_PINNED_VARIABLE_NODE: { // A "pinned" variable, like `^x` in `in ^x`
-            auto pinnedVarNode = down_cast<pm_pinned_variable_node>(node);
+            auto pinnedVarNode = down_cast_nonnull<pm_pinned_variable_node>(node);
 
             auto variable = desugar(pinnedVarNode->variable);
 
             return MK::Nil(location);
         }
         case PM_SPLAT_NODE: { // A splat, like `*a` in an array pattern
-            auto prismSplatNode = down_cast<pm_splat_node>(node);
+            auto prismSplatNode = down_cast_nonnull<pm_splat_node>(node);
             auto expr = desugar(prismSplatNode->expression);
 
             // MatchRest is a structural pattern component with no simple desugared expression
             return MK::Nil(location);
         }
         case PM_SYMBOL_NODE: { // A symbol literal, e.g. `:foo`, or `a:` in `{a: 1}`
-            auto symNode = down_cast<pm_symbol_node>(node);
+            auto symNode = down_cast_nonnull<pm_symbol_node>(node);
 
             auto [content, _] = translateSymbol(symNode);
 
@@ -3820,7 +3820,7 @@ Desugarer::desugarParametersNode(pm_parameters_node *paramsNode, core::LocOffset
 
     auto desugarPositionalParam = [this, &paramsStore, &statsStore](auto *n) {
         if (PM_NODE_TYPE_P(n, PM_MULTI_TARGET_NODE)) {
-            auto multiTargetNode = down_cast<pm_multi_target_node>(n);
+            auto multiTargetNode = down_cast_nonnull<pm_multi_target_node>(n);
 
             ENFORCE(multiTargetNode->lparen_loc.start);
             ENFORCE(multiTargetNode->lparen_loc.end);
@@ -3873,7 +3873,7 @@ Desugarer::desugarParametersNode(pm_parameters_node *paramsNode, core::LocOffset
         switch (PM_NODE_TYPE(prismKwRestNode)) {
             case PM_KEYWORD_REST_PARAMETER_NODE: { // `def foo(**kwargs)`
                 // This doesn't include `**nil`, which is a `PM_NO_KEYWORDS_PARAMETER_NODE`.
-                auto keywordRestParamNode = down_cast<pm_keyword_rest_parameter_node>(prismKwRestNode);
+                auto keywordRestParamNode = down_cast_nonnull<pm_keyword_rest_parameter_node>(prismKwRestNode);
 
                 core::NameRef sorbetName;
                 core::LocOffsets kwrestLoc;
@@ -3981,14 +3981,14 @@ core::LocOffsets Desugarer::findItParamUsageLoc(pm_statements_node *statements) 
         }
         // Don't descend into nested blocks/lambdas that have their own 'it' parameter
         if (PM_NODE_TYPE_P(node, PM_BLOCK_NODE)) {
-            auto blockNode = down_cast<pm_block_node>(const_cast<pm_node_t *>(node));
+            auto blockNode = down_cast_nonnull<pm_block_node>(const_cast<pm_node_t *>(node));
             if (blockNode->parameters != nullptr && PM_NODE_TYPE_P(blockNode->parameters, PM_IT_PARAMETERS_NODE)) {
                 // This nested block has its own 'it', don't descend into it
                 return false;
             }
         }
         if (PM_NODE_TYPE_P(node, PM_LAMBDA_NODE)) {
-            auto lambdaNode = down_cast<pm_lambda_node>(const_cast<pm_node_t *>(node));
+            auto lambdaNode = down_cast_nonnull<pm_lambda_node>(const_cast<pm_node_t *>(node));
             if (lambdaNode->parameters != nullptr && PM_NODE_TYPE_P(lambdaNode->parameters, PM_IT_PARAMETERS_NODE)) {
                 // This nested lambda has its own 'it', don't descend into it
                 return false;
@@ -4012,7 +4012,7 @@ Desugarer::findNumberedParamsUsageLocs(core::LocOffsets loc, pm_statements_node 
 
     walkPrismAST(up_cast(statements), [this, &activeRegion](const pm_node_t *node) -> bool {
         if (PM_NODE_TYPE_P(node, PM_LOCAL_VARIABLE_READ_NODE)) {
-            auto var = down_cast<pm_local_variable_read_node>(const_cast<pm_node_t *>(node));
+            auto var = down_cast_nonnull<pm_local_variable_read_node>(const_cast<pm_node_t *>(node));
             auto varName = this->parser.resolveConstant(var->name);
 
             if (varName.length() == 2 && varName[0] == '_' && '1' <= varName[1] && varName[1] <= '9') {
@@ -4076,7 +4076,7 @@ Desugarer::DesugaredBlockArgument Desugarer::desugarBlock(pm_node_t *block, pm_a
         auto args = absl::MakeSpan(otherArgs->arguments.nodes, otherArgs->arguments.size);
         for (auto *arg : args) {
             if (PM_NODE_TYPE_P(arg, PM_BLOCK_ARGUMENT_NODE)) {
-                blockArgInArgs = down_cast<pm_block_argument_node>(arg);
+                blockArgInArgs = down_cast_nonnull<pm_block_argument_node>(arg);
                 break;
             }
         }
@@ -4094,7 +4094,7 @@ Desugarer::DesugaredBlockArgument Desugarer::desugarBlock(pm_node_t *block, pm_a
     }
 
     if (PM_NODE_TYPE_P(block, PM_BLOCK_NODE)) { // a literal block with `{ ... }` or `do ... end`
-        auto blockNode = down_cast<pm_block_node>(block);
+        auto blockNode = down_cast_nonnull<pm_block_node>(block);
 
         auto literalBlock = desugarLiteralBlock(blockNode->body, blockNode->parameters, blockNode->base.location,
                                                 blockNode->opening_loc);
@@ -4132,7 +4132,7 @@ Desugarer::DesugaredBlockArgument Desugarer::desugarBlock(pm_node_t *block, pm_a
 
     } else {
         ENFORCE(PM_NODE_TYPE_P(block, PM_BLOCK_ARGUMENT_NODE)); // the `&b` in `a.map(&b)`
-        auto *bp = down_cast<pm_block_argument_node>(block);
+        auto *bp = down_cast_nonnull<pm_block_argument_node>(block);
 
         return desugarBlockPassArgument(bp);
     }
@@ -4148,7 +4148,7 @@ ast::ExpressionPtr Desugarer::desugarLiteralBlock(pm_node *blockBodyNode, pm_nod
         switch (PM_NODE_TYPE(blockParameters)) {
             case PM_BLOCK_PARAMETERS_NODE: { // The params declared at the top of a PM_BLOCK_NODE
                 // Like the `|x|` in `foo { |x| ... }`
-                auto paramsNode = down_cast<pm_block_parameters_node>(blockParameters);
+                auto paramsNode = down_cast_nonnull<pm_block_parameters_node>(blockParameters);
 
                 auto paramsLoc = translateLoc(paramsNode->base.location);
 
@@ -4170,7 +4170,7 @@ ast::ExpressionPtr Desugarer::desugarLiteralBlock(pm_node *blockBodyNode, pm_nod
 
             case PM_NUMBERED_PARAMETERS_NODE: { // The params in a PM_BLOCK_NODE with numbered params
                 // Like the implicit `|_1, _2, _3|` in `foo { _3 }`
-                auto numberedParamsNode = down_cast<pm_numbered_parameters_node>(blockParameters);
+                auto numberedParamsNode = down_cast_nonnull<pm_numbered_parameters_node>(blockParameters);
 
                 // Use a 0-length loc just after the `do` or `{` token, as if you had written:
                 //     do|_1, _2| ... end`
@@ -4179,7 +4179,7 @@ ast::ExpressionPtr Desugarer::desugarLiteralBlock(pm_node *blockBodyNode, pm_nod
                 //      ^
 
                 blockParamsStore =
-                    translateNumberedParametersNode(numberedParamsNode, down_cast<pm_statements_node>(blockBodyNode));
+                    translateNumberedParametersNode(numberedParamsNode, down_cast_nonnull<pm_statements_node>(blockBodyNode));
 
                 break;
             }
@@ -4191,7 +4191,7 @@ ast::ExpressionPtr Desugarer::desugarLiteralBlock(pm_node *blockBodyNode, pm_nod
                 // Find the actual usage location of 'it' in the block body by walking the AST
                 auto itUsageLoc = itParamLoc;
                 if (blockBodyNode != nullptr) {
-                    auto statements = down_cast<pm_statements_node>(blockBodyNode);
+                    auto statements = down_cast_nonnull<pm_statements_node>(blockBodyNode);
                     auto foundLoc = findItParamUsageLoc(statements);
                     if (foundLoc.exists()) {
                         itUsageLoc = foundLoc;
@@ -4221,7 +4221,7 @@ Desugarer::DesugaredBlockArgument Desugarer::desugarBlockPassArgument(pm_block_a
     if (bp->expression) { // Block pass with an explicit expression, like `f(&block)`
         if (PM_NODE_TYPE_P(bp->expression, PM_SYMBOL_NODE)) {
             // Symbol proc, e.g. `&:foo` - desugar to a literal block
-            auto symbol = down_cast<pm_symbol_node>(bp->expression);
+            auto symbol = down_cast_nonnull<pm_symbol_node>(bp->expression);
             return DesugaredBlockArgument::literalBlock(desugarSymbolProc(symbol));
         } else {
             return DesugaredBlockArgument::blockPass(desugar(bp->expression), blockPassLoc);
@@ -4331,13 +4331,13 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
     if (!prismArgs.empty()) {
         // Pop the Kwargs Hash off the end of the arguments, if there is one.
         if (PM_NODE_TYPE_P(prismArgs.back(), PM_KEYWORD_HASH_NODE)) {
-            auto keywordHashNode = down_cast<pm_keyword_hash_node>(prismArgs.back());
+            auto keywordHashNode = down_cast_nonnull<pm_keyword_hash_node>(prismArgs.back());
             auto elements = absl::MakeSpan(keywordHashNode->elements.nodes, keywordHashNode->elements.size);
 
             auto isKwargs = PM_NODE_FLAG_P(keywordHashNode, PM_KEYWORD_HASH_NODE_FLAGS_SYMBOL_KEYS) ||
                             absl::c_all_of(elements, [](auto *node) {
                                 if (PM_NODE_TYPE_P(node, PM_ASSOC_NODE)) {
-                                    auto pair = down_cast<pm_assoc_node>(node);
+                                    auto pair = down_cast_nonnull<pm_assoc_node>(node);
                                     return pair->key && PM_NODE_TYPE_P(pair->key, PM_SYMBOL_NODE);
                                 }
                                 if (PM_NODE_TYPE_P(node, PM_ASSOC_SPLAT_NODE)) {
@@ -4358,7 +4358,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
         if (PM_NODE_FLAG_P(argumentsNode, PM_ARGUMENTS_NODE_FLAGS_CONTAINS_SPLAT)) {
             for (auto &arg : prismArgs) {
                 if (PM_NODE_TYPE_P(arg, PM_SPLAT_NODE)) {
-                    auto splatNode = down_cast<pm_splat_node>(arg);
+                    auto splatNode = down_cast_nonnull<pm_splat_node>(arg);
                     if (splatNode->expression == nullptr) { // An anonymous splat like `f(*)`
                         hasFwdRestArg = true;
                     } else { // Splatting an expression like `f(*a)`
@@ -4382,7 +4382,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
         ast::Array::ENTRY_store argExprs;
         argExprs.reserve(prismArgs.size());
         for (auto *arg : prismArgs) {
-            if (PM_NODE_TYPE_P(arg, PM_SPLAT_NODE) && down_cast<pm_splat_node>(arg)->expression == nullptr) {
+            if (PM_NODE_TYPE_P(arg, PM_SPLAT_NODE) && down_cast_nonnull<pm_splat_node>(arg)->expression == nullptr) {
                 continue; // Skip anonymous splats (like `f(*)`), which are handled separately in `PM_CALL_NODE`
             } else if (PM_NODE_TYPE_P(arg, PM_FORWARDING_ARGUMENTS_NODE)) {
                 continue; // Skip forwarded args (like `f(...)`), which are handled separately in `PM_CALL_NODE`
@@ -4633,7 +4633,7 @@ ast::ExpressionPtr Desugarer::desugarArray(core::LocOffsets location, absl::Span
         auto &stat = elements[sorbetIndex];
 
         if (PM_NODE_TYPE_P(node, PM_SPLAT_NODE)) {
-            auto isAnonymousSplat = down_cast<pm_splat_node>(node)->expression == nullptr;
+            auto isAnonymousSplat = down_cast_nonnull<pm_splat_node>(node)->expression == nullptr;
             if (calledFromCallNode && isAnonymousSplat) {
                 prismIndex++;
                 continue; // Skip anonymous splats (like `f(*)`), which are handled separately in `PM_CALL_NODE`
@@ -4751,11 +4751,11 @@ ast::ExpressionPtr Desugarer::desugarKeyValuePairs(core::LocOffsets loc, pm_node
         ENFORCE(pairAsExpression != nullptr);
 
         if (PM_NODE_TYPE_P(pairAsExpression, PM_ASSOC_NODE)) {
-            auto *pair = down_cast<pm_assoc_node>(pairAsExpression);
+            auto *pair = down_cast_nonnull<pm_assoc_node>(pairAsExpression);
 
             ast::ExpressionPtr key;
             if (PM_NODE_TYPE_P(pair->key, PM_SYMBOL_NODE)) { // Special case to modify Symbol locations
-                auto symbolNode = down_cast<pm_symbol_node>(pair->key);
+                auto symbolNode = down_cast_nonnull<pm_symbol_node>(pair->key);
 
                 auto [symbolContent, _] = translateSymbol(symbolNode);
 
@@ -4782,10 +4782,10 @@ ast::ExpressionPtr Desugarer::desugarKeyValuePairs(core::LocOffsets loc, pm_node
                 if (symbolNode->opening_loc.start == nullptr) {
                     core::LocOffsets symbolLoc;
                     if (PM_NODE_TYPE_P(pair->value, PM_IMPLICIT_NODE)) {
-                        auto implicitNode = down_cast<pm_implicit_node>(pair->value);
+                        auto implicitNode = down_cast_nonnull<pm_implicit_node>(pair->value);
 
                         if (PM_NODE_TYPE_P(implicitNode->value, PM_CALL_NODE)) {
-                            auto callNode = down_cast<pm_call_node>(implicitNode->value);
+                            auto callNode = down_cast_nonnull<pm_call_node>(implicitNode->value);
 
                             // Prism's method_loc excludes the ':' here, but Sorbet's legacy parser includes it.
                             // Not a fan of modifying the Prism tree in-place, but the alternative is much trickier.
@@ -4820,7 +4820,7 @@ ast::ExpressionPtr Desugarer::desugarKeyValuePairs(core::LocOffsets loc, pm_node
         }
 
         ENFORCE(PM_NODE_TYPE_P(pairAsExpression, PM_ASSOC_SPLAT_NODE));
-        auto splatNode = down_cast<pm_assoc_splat_node>(pairAsExpression);
+        auto splatNode = down_cast_nonnull<pm_assoc_splat_node>(pairAsExpression);
 
         ast::ExpressionPtr expr;
         if (splatNode->value) { // Splatting an expression like `f(**h)`
@@ -5110,7 +5110,7 @@ ast::ExpressionPtr Desugarer::desugarStatements(pm_statements_node *stmtsNode, b
 // it can can return an `LVarLhs` as a workaround in the case of a dynamic constant assignment.
 template <typename PrismLhsNode, bool checkForDynamicConstAssign>
 ast::ExpressionPtr Desugarer::translateConst(pm_node_t *anyNode) {
-    auto node = down_cast<PrismLhsNode>(anyNode);
+    auto node = down_cast_nonnull<PrismLhsNode>(anyNode);
 
     // Constant name might be unset, e.g. `::`.
     if (node->name == PM_CONSTANT_ID_UNSET) {
@@ -5173,7 +5173,7 @@ ast::ExpressionPtr Desugarer::translateConst(pm_node_t *anyNode) {
             while (current != nullptr && segments.size() < 4) {
                 switch (PM_NODE_TYPE(current)) {
                     case PM_CONSTANT_PATH_NODE: {
-                        auto *p = down_cast<pm_constant_path_node>(current);
+                        auto *p = down_cast_nonnull<pm_constant_path_node>(current);
                         segments.push_back(parser.resolveConstant(p->name));
                         current = p->parent;
                         if (current == nullptr) {
@@ -5182,7 +5182,7 @@ ast::ExpressionPtr Desugarer::translateConst(pm_node_t *anyNode) {
                         break;
                     }
                     case PM_CONSTANT_READ_NODE: {
-                        auto *r = down_cast<pm_constant_read_node>(current);
+                        auto *r = down_cast_nonnull<pm_constant_read_node>(current);
                         segments.push_back(parser.resolveConstant(r->name));
                         current = nullptr;
                         break;
@@ -5345,7 +5345,7 @@ ast::ClassDef::RHS_store Desugarer::desugarClassOrModule(pm_node *prismBodyNode)
     }
 
     if (PM_NODE_TYPE_P(prismBodyNode, PM_BEGIN_NODE)) {
-        auto beginNode = down_cast<pm_begin_node>(prismBodyNode);
+        auto beginNode = down_cast_nonnull<pm_begin_node>(prismBodyNode);
         ast::ClassDef::RHS_store result;
         result.emplace_back(desugarBegin(beginNode));
         return result;
@@ -5355,7 +5355,7 @@ ast::ClassDef::RHS_store Desugarer::desugarClassOrModule(pm_node *prismBodyNode)
 
     auto body = desugar(prismBodyNode);
 
-    if (1 < down_cast<pm_statements_node>(prismBodyNode)->body.size) { // Handle multi-statement body
+    if (1 < down_cast_nonnull<pm_statements_node>(prismBodyNode)->body.size) { // Handle multi-statement body
         auto insSeqExpr = ast::cast_tree<ast::InsSeq>(body);
         ENFORCE(insSeqExpr != nullptr, "The cached expr on every multi-statement Begin should be an InsSeq.")
 

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -17,6 +17,7 @@ namespace sorbet::ast::Desugar::Prism {
 using namespace std::literals::string_view_literals;
 using sorbet::ast::MK;
 using sorbet::parser::Prism::cast_prism_string;
+using sorbet::parser::Prism::down_cast;
 using sorbet::parser::Prism::down_cast_nonnull;
 using sorbet::parser::Prism::Parser;
 using sorbet::parser::Prism::ParseResult;
@@ -379,29 +380,24 @@ void Desugarer::collectPatternMatchingVarsPrism(ast::InsSeq::STATS_store &vars, 
         return;
     }
 
-    if (PM_NODE_TYPE_P(node, PM_LOCAL_VARIABLE_TARGET_NODE)) {
-        auto localVarTargetNode = down_cast_nonnull<pm_local_variable_target_node>(node);
+    if (auto *localVarTargetNode = down_cast<pm_local_variable_target_node>(node)) {
         auto loc = translateLoc(localVarTargetNode->base.location);
         auto val = MK::RaiseUnimplemented(loc);
         auto name = translateConstantName(localVarTargetNode->name);
         vars.emplace_back(MK::Assign(loc, name, move(val)));
-    } else if (PM_NODE_TYPE_P(node, PM_SPLAT_NODE)) {
+    } else if (auto *splatNode = down_cast<pm_splat_node>(node)) {
         // MatchRest in array patterns - recurse on the expression (variable being splatted into)
-        auto splatNode = down_cast_nonnull<pm_splat_node>(node);
         collectPatternMatchingVarsPrism(vars, splatNode->expression);
-    } else if (PM_NODE_TYPE_P(node, PM_ASSOC_SPLAT_NODE)) {
+    } else if (auto *assocSplatNode = down_cast<pm_assoc_splat_node>(node)) {
         // MatchRest in hash patterns - recurse on the value
-        auto assocSplatNode = down_cast_nonnull<pm_assoc_splat_node>(node);
         collectPatternMatchingVarsPrism(vars, assocSplatNode->value);
-    } else if (PM_NODE_TYPE_P(node, PM_ASSOC_NODE)) {
+    } else if (auto *assocNode = down_cast<pm_assoc_node>(node)) {
         // Pair in hash pattern - only recurse on the value (key is a symbol, not a variable)
-        auto assocNode = down_cast_nonnull<pm_assoc_node>(node);
+
         // Special handling for implicit hash pattern keys like `n1:` which means `n1: n1`
         // Legacy parser uses the assoc node's location (including colon) for the variable
-        if (PM_NODE_TYPE_P(assocNode->value, PM_IMPLICIT_NODE)) {
-            auto implicitNode = down_cast_nonnull<pm_implicit_node>(assocNode->value);
-            if (PM_NODE_TYPE_P(implicitNode->value, PM_LOCAL_VARIABLE_TARGET_NODE)) {
-                auto localVarTargetNode = down_cast_nonnull<pm_local_variable_target_node>(implicitNode->value);
+        if (auto *implicitNode = down_cast<pm_implicit_node>(assocNode->value)) {
+            if (auto *localVarTargetNode = down_cast<pm_local_variable_target_node>(implicitNode->value)) {
                 auto loc = translateLoc(assocNode->base.location); // Use assoc node's location
                 auto name = translateConstantName(localVarTargetNode->name);
                 auto val = MK::RaiseUnimplemented(loc);
@@ -409,17 +405,16 @@ void Desugarer::collectPatternMatchingVarsPrism(ast::InsSeq::STATS_store &vars, 
                 return;
             }
         }
+
         collectPatternMatchingVarsPrism(vars, assocNode->value);
-    } else if (PM_NODE_TYPE_P(node, PM_CAPTURE_PATTERN_NODE)) {
+    } else if (auto *matchAsNode = down_cast<pm_capture_pattern_node>(node)) {
         // MatchAs - use the target's location, not the whole pattern's location
-        auto matchAsNode = down_cast_nonnull<pm_capture_pattern_node>(node);
         auto loc = translateLoc(matchAsNode->target->base.location);
         auto name = translateConstantName(matchAsNode->target->name);
         auto val = MK::RaiseUnimplemented(loc);
         vars.emplace_back(MK::Assign(loc, name, move(val)));
         collectPatternMatchingVarsPrism(vars, matchAsNode->value);
-    } else if (PM_NODE_TYPE_P(node, PM_ARRAY_PATTERN_NODE)) {
-        auto arrayPatternNode = down_cast_nonnull<pm_array_pattern_node>(node);
+    } else if (auto *arrayPatternNode = down_cast<pm_array_pattern_node>(node)) {
         // Skip ConstPattern - legacy parser doesn't collect variables from ConstPattern
         if (arrayPatternNode->constant != nullptr) {
             return;
@@ -436,31 +431,29 @@ void Desugarer::collectPatternMatchingVarsPrism(ast::InsSeq::STATS_store &vars, 
         for (auto &elt : posts) {
             collectPatternMatchingVarsPrism(vars, elt);
         }
-    } else if (PM_NODE_TYPE_P(node, PM_HASH_PATTERN_NODE)) {
-        auto hashPatternNode = down_cast_nonnull<pm_hash_pattern_node>(node);
+    } else if (auto *hashPatternNode = down_cast<pm_hash_pattern_node>(node)) {
         // Skip ConstPattern - legacy parser doesn't collect variables from ConstPattern
         if (hashPatternNode->constant != nullptr) {
             return;
         }
+
         auto elements = absl::MakeSpan(hashPatternNode->elements.nodes, hashPatternNode->elements.size);
         for (auto &elt : elements) {
             collectPatternMatchingVarsPrism(vars, elt);
         }
+
         // Process rest element
         collectPatternMatchingVarsPrism(vars, hashPatternNode->rest);
-    } else if (PM_NODE_TYPE_P(node, PM_ALTERNATION_PATTERN_NODE)) {
-        auto alternationPatternNode = down_cast_nonnull<pm_alternation_pattern_node>(node);
+    } else if (auto *alternationPatternNode = down_cast<pm_alternation_pattern_node>(node)) {
         collectPatternMatchingVarsPrism(vars, alternationPatternNode->left);
         collectPatternMatchingVarsPrism(vars, alternationPatternNode->right);
-    } else if (PM_NODE_TYPE_P(node, PM_IF_NODE)) {
+    } else if (auto *ifNode = down_cast<pm_if_node>(node)) {
         // Pattern with if guard - the actual pattern is inside statements
-        auto ifNode = down_cast_nonnull<pm_if_node>(node);
         if (ifNode->statements != nullptr && ifNode->statements->body.size > 0) {
             collectPatternMatchingVarsPrism(vars, ifNode->statements->body.nodes[0]);
         }
-    } else if (PM_NODE_TYPE_P(node, PM_UNLESS_NODE)) {
+    } else if (auto *unlessNode = down_cast<pm_unless_node>(node)) {
         // Pattern with unless guard - the actual pattern is inside statements
-        auto unlessNode = down_cast_nonnull<pm_unless_node>(node);
         if (unlessNode->statements != nullptr && unlessNode->statements->body.size > 0) {
             collectPatternMatchingVarsPrism(vars, unlessNode->statements->body.nodes[0]);
         }
@@ -554,9 +547,7 @@ void Desugarer::flattenKwargs(pm_keyword_hash_node *kwargsHashNode, Container &d
         auto *assoc = down_cast_nonnull<pm_assoc_node>(element);
 
         // Special handling for symbol keys with trailing colon (like `a: 1` instead of `:a => 1`)
-        if (PM_NODE_TYPE_P(assoc->key, PM_SYMBOL_NODE)) {
-            auto *symbolNode = down_cast_nonnull<pm_symbol_node>(assoc->key);
-
+        if (auto *symbolNode = down_cast<pm_symbol_node>(assoc->key)) {
             // If opening_loc is null, the symbol has a trailing colon syntax (e.g., `k5:` not `:k5 =>`)
             if (symbolNode->opening_loc.start == nullptr) {
                 auto [symbolContent, _] = translateSymbol(symbolNode);
@@ -768,13 +759,11 @@ ast::ExpressionPtr Desugarer::desugarMlhs(core::LocOffsets loc, PrismNode *lhs, 
         auto val =
             MK::Send1(zcloc, MK::Local(zcloc, tempExpanded), core::Names::squareBrackets(), zloc, MK::Int(zloc, i));
 
-        if (PM_NODE_TYPE_P(c, PM_MULTI_TARGET_NODE)) {
-            auto *mlhs = down_cast_nonnull<pm_multi_target_node>(c);
+        if (auto *mlhs = down_cast<pm_multi_target_node>(c)) {
             stats.emplace_back(desugarMlhs(cloc, mlhs, move(val)));
-        } else if (PM_NODE_TYPE_P(c, PM_CALL_TARGET_NODE)) {
+        } else if (auto *callTargetNode = down_cast<pm_call_target_node>(c)) {
             // Target of an indirect write to the result of a method call
             // ... like `self.target1, self.target2 = 1, 2`, `rescue => self.target`, etc.
-            auto callTargetNode = down_cast_nonnull<pm_call_target_node>(c);
             auto receiverNode = callTargetNode->receiver;
 
             auto methodName = translateConstantName(callTargetNode->name);
@@ -1983,13 +1972,11 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                 pm_location_t patternLoc = inPattern->base.location;
                 pm_node_t *actualPattern = inPattern->pattern;
                 if (actualPattern != nullptr) {
-                    if (PM_NODE_TYPE_P(actualPattern, PM_IF_NODE)) {
-                        auto ifNode = down_cast_nonnull<pm_if_node>(actualPattern);
+                    if (auto *ifNode = down_cast<pm_if_node>(actualPattern)) {
                         if (ifNode->statements != nullptr && ifNode->statements->body.size > 0) {
                             patternLoc = ifNode->statements->body.nodes[0]->location;
                         }
-                    } else if (PM_NODE_TYPE_P(actualPattern, PM_UNLESS_NODE)) {
-                        auto unlessNode = down_cast_nonnull<pm_unless_node>(actualPattern);
+                    } else if (auto *unlessNode = down_cast<pm_unless_node>(actualPattern)) {
                         if (unlessNode->statements != nullptr && unlessNode->statements->body.size > 0) {
                             patternLoc = unlessNode->statements->body.nodes[0]->location;
                         }
@@ -2324,7 +2311,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
 
             ast::ExpressionPtr body;
             if (defNode->body != nullptr) {
-                if (PM_NODE_TYPE_P(defNode->body, PM_BEGIN_NODE)) {
+                if (auto *beginNode = down_cast<pm_begin_node>(defNode->body)) {
                     // Prism uses a PM_BEGIN_NODE to model the body of a method that has a top level rescue/ensure, e.g.
                     //
                     //     def method_with_top_level_rescue
@@ -2334,7 +2321,6 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                     //     end
                     //
                     // desugarBegin handles this directly, returning the desugared expression.
-                    auto beginNode = down_cast_nonnull<pm_begin_node>(defNode->body);
                     body = methodContext.desugarBegin(beginNode);
                 } else {
                     // Side effect: If method has no explicit block parameter and contains a `yield`, translating it
@@ -2405,9 +2391,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                     auto current = argument;
 
                     while (true) {
-                        if (PM_NODE_TYPE_P(current, PM_CONSTANT_PATH_NODE)) {
-                            auto pathNode = down_cast_nonnull<pm_constant_path_node>(current);
-
+                        if (auto *pathNode = down_cast<pm_constant_path_node>(current)) {
                             args.emplace_back(MK::String(translateLoc(pathNode->base.location),
                                                          translateConstantName(pathNode->name)));
 
@@ -2417,8 +2401,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                             }
 
                             current = pathNode->parent;
-                        } else if (PM_NODE_TYPE_P(current, PM_CONSTANT_READ_NODE)) {
-                            auto constNode = down_cast_nonnull<pm_constant_read_node>(current);
+                        } else if (auto *constNode = down_cast<pm_constant_read_node>(current)) {
                             args.emplace_back(MK::String(translateLoc(constNode->base.location),
                                                          translateConstantName(constNode->name)));
                             break;
@@ -2501,9 +2484,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                 return MK::Nil(location.copyWithZeroLength());
             }
 
-            auto *mlhs = PM_NODE_TYPE_P(forNode->index, PM_MULTI_TARGET_NODE)
-                             ? down_cast_nonnull<pm_multi_target_node>(forNode->index)
-                             : nullptr;
+            auto *mlhs = down_cast<pm_multi_target_node>(forNode->index);
 
             auto collection = desugar(forNode->collection);
             auto body = desugarStatements(forNode->statements);
@@ -3045,9 +3026,9 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                 return MK::Nil(location);
             }
 
-            if (PM_NODE_TYPE_P(body, PM_STATEMENTS_NODE)) {
+            if (auto *stmtsNode = down_cast<pm_statements_node>(body)) {
                 auto inlineIfSingle = false;
-                return desugarStatements(down_cast_nonnull<pm_statements_node>(body), inlineIfSingle);
+                return desugarStatements(stmtsNode, inlineIfSingle);
             } else {
                 return desugar(body);
             }
@@ -3704,21 +3685,17 @@ ast::ExpressionPtr Desugarer::desugarPattern(pm_node_t *node) {
             ast::ExpressionPtr sorbetGuard;
             auto statements = desugarStatements(inNode->statements);
 
-            if (prismPattern != nullptr &&
-                (PM_NODE_TYPE_P(prismPattern, PM_IF_NODE) || PM_NODE_TYPE_P(prismPattern, PM_UNLESS_NODE))) {
-                pm_statements_node *conditionalStatements = nullptr;
+            pm_statements_node *conditionalStatements = nullptr;
 
-                if (PM_NODE_TYPE_P(prismPattern, PM_IF_NODE)) {
-                    auto ifNode = down_cast_nonnull<pm_if_node>(prismPattern);
-                    conditionalStatements = ifNode->statements;
-                    sorbetGuard = desugar(ifNode->predicate);
-                } else { // PM_UNLESS_NODE
-                    ENFORCE(PM_NODE_TYPE_P(prismPattern, PM_UNLESS_NODE));
-                    auto unlessNode = down_cast_nonnull<pm_unless_node>(prismPattern);
-                    conditionalStatements = unlessNode->statements;
-                    sorbetGuard = desugar(unlessNode->predicate);
-                }
+            if (auto *ifNode = down_cast<pm_if_node>(prismPattern)) {
+                conditionalStatements = ifNode->statements;
+                sorbetGuard = desugar(ifNode->predicate);
+            } else if (auto *unlessNode = down_cast<pm_unless_node>(prismPattern)) {
+                conditionalStatements = unlessNode->statements;
+                sorbetGuard = desugar(unlessNode->predicate);
+            }
 
+            if (conditionalStatements != nullptr) {
                 ENFORCE(
                     conditionalStatements->body.size == 1,
                     "In pattern-matching's `in` clause, a conditional (if/unless) guard must have a single statement.");
@@ -3819,9 +3796,7 @@ Desugarer::desugarParametersNode(pm_parameters_node *paramsNode, core::LocOffset
                         blockSize + blockLocalVariables.size());
 
     auto desugarPositionalParam = [this, &paramsStore, &statsStore](auto *n) {
-        if (PM_NODE_TYPE_P(n, PM_MULTI_TARGET_NODE)) {
-            auto multiTargetNode = down_cast_nonnull<pm_multi_target_node>(n);
-
+        if (auto *multiTargetNode = down_cast<pm_multi_target_node>(n)) {
             ENFORCE(multiTargetNode->lparen_loc.start);
             ENFORCE(multiTargetNode->lparen_loc.end);
             ENFORCE(multiTargetNode->rparen_loc.start);
@@ -3980,15 +3955,13 @@ core::LocOffsets Desugarer::findItParamUsageLoc(pm_statements_node *statements) 
             return false;
         }
         // Don't descend into nested blocks/lambdas that have their own 'it' parameter
-        if (PM_NODE_TYPE_P(node, PM_BLOCK_NODE)) {
-            auto blockNode = down_cast_nonnull<pm_block_node>(const_cast<pm_node_t *>(node));
+        if (auto *blockNode = down_cast<pm_block_node>(const_cast<pm_node_t *>(node))) {
             if (blockNode->parameters != nullptr && PM_NODE_TYPE_P(blockNode->parameters, PM_IT_PARAMETERS_NODE)) {
                 // This nested block has its own 'it', don't descend into it
                 return false;
             }
         }
-        if (PM_NODE_TYPE_P(node, PM_LAMBDA_NODE)) {
-            auto lambdaNode = down_cast_nonnull<pm_lambda_node>(const_cast<pm_node_t *>(node));
+        if (auto *lambdaNode = down_cast<pm_lambda_node>(const_cast<pm_node_t *>(node))) {
             if (lambdaNode->parameters != nullptr && PM_NODE_TYPE_P(lambdaNode->parameters, PM_IT_PARAMETERS_NODE)) {
                 // This nested lambda has its own 'it', don't descend into it
                 return false;
@@ -4011,8 +3984,7 @@ Desugarer::findNumberedParamsUsageLocs(core::LocOffsets loc, pm_statements_node 
     auto activeRegion = absl::MakeSpan(result).first(maxParamNumber);
 
     walkPrismAST(up_cast(statements), [this, &activeRegion](const pm_node_t *node) -> bool {
-        if (PM_NODE_TYPE_P(node, PM_LOCAL_VARIABLE_READ_NODE)) {
-            auto var = down_cast_nonnull<pm_local_variable_read_node>(const_cast<pm_node_t *>(node));
+        if (auto *var = down_cast<pm_local_variable_read_node>(const_cast<pm_node_t *>(node))) {
             auto varName = this->parser.resolveConstant(var->name);
 
             if (varName.length() == 2 && varName[0] == '_' && '1' <= varName[1] && varName[1] <= '9') {
@@ -4093,9 +4065,7 @@ Desugarer::DesugaredBlockArgument Desugarer::desugarBlock(pm_node_t *block, pm_a
         return DesugaredBlockArgument::none();
     }
 
-    if (PM_NODE_TYPE_P(block, PM_BLOCK_NODE)) { // a literal block with `{ ... }` or `do ... end`
-        auto blockNode = down_cast_nonnull<pm_block_node>(block);
-
+    if (auto *blockNode = down_cast<pm_block_node>(block)) { // a literal block with `{ ... }` or `do ... end`
         auto literalBlock = desugarLiteralBlock(blockNode->body, blockNode->parameters, blockNode->base.location,
                                                 blockNode->opening_loc);
 
@@ -4130,11 +4100,10 @@ Desugarer::DesugaredBlockArgument Desugarer::desugarBlock(pm_node_t *block, pm_a
 
         return DesugaredBlockArgument::literalBlock(move(literalBlock));
 
-    } else {
-        ENFORCE(PM_NODE_TYPE_P(block, PM_BLOCK_ARGUMENT_NODE)); // the `&b` in `a.map(&b)`
-        auto *bp = down_cast_nonnull<pm_block_argument_node>(block);
-
+    } else if (auto *bp = down_cast<pm_block_argument_node>(block)) { // the `&b` in `a.map(&b)`
         return desugarBlockPassArgument(bp);
+    } else {
+        unreachable("Expected blocks to always be either PM_BLOCK_NODE or PM_BLOCK_ARGUMENT_NODE");
     }
 }
 
@@ -4178,8 +4147,8 @@ ast::ExpressionPtr Desugarer::desugarLiteralBlock(pm_node *blockBodyNode, pm_nod
                 //     {|_1, _2| ... }`
                 //      ^
 
-                blockParamsStore =
-                    translateNumberedParametersNode(numberedParamsNode, down_cast_nonnull<pm_statements_node>(blockBodyNode));
+                blockParamsStore = translateNumberedParametersNode(
+                    numberedParamsNode, down_cast_nonnull<pm_statements_node>(blockBodyNode));
 
                 break;
             }
@@ -4219,9 +4188,8 @@ Desugarer::DesugaredBlockArgument Desugarer::desugarBlockPassArgument(pm_block_a
     auto blockPassLoc = translateLoc(bp->base.location); // The location of the entire block pass, including the `&`.
 
     if (bp->expression) { // Block pass with an explicit expression, like `f(&block)`
-        if (PM_NODE_TYPE_P(bp->expression, PM_SYMBOL_NODE)) {
+        if (auto *symbol = down_cast<pm_symbol_node>(bp->expression)) {
             // Symbol proc, e.g. `&:foo` - desugar to a literal block
-            auto symbol = down_cast_nonnull<pm_symbol_node>(bp->expression);
             return DesugaredBlockArgument::literalBlock(desugarSymbolProc(symbol));
         } else {
             return DesugaredBlockArgument::blockPass(desugar(bp->expression), blockPassLoc);
@@ -4330,14 +4298,12 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
     pm_keyword_hash_node *kwargsHashNode = nullptr;
     if (!prismArgs.empty()) {
         // Pop the Kwargs Hash off the end of the arguments, if there is one.
-        if (PM_NODE_TYPE_P(prismArgs.back(), PM_KEYWORD_HASH_NODE)) {
-            auto keywordHashNode = down_cast_nonnull<pm_keyword_hash_node>(prismArgs.back());
+        if (auto *keywordHashNode = down_cast<pm_keyword_hash_node>(prismArgs.back())) {
             auto elements = absl::MakeSpan(keywordHashNode->elements.nodes, keywordHashNode->elements.size);
 
             auto isKwargs = PM_NODE_FLAG_P(keywordHashNode, PM_KEYWORD_HASH_NODE_FLAGS_SYMBOL_KEYS) ||
                             absl::c_all_of(elements, [](auto *node) {
-                                if (PM_NODE_TYPE_P(node, PM_ASSOC_NODE)) {
-                                    auto pair = down_cast_nonnull<pm_assoc_node>(node);
+                                if (auto *pair = down_cast<pm_assoc_node>(node)) {
                                     return pair->key && PM_NODE_TYPE_P(pair->key, PM_SYMBOL_NODE);
                                 }
                                 if (PM_NODE_TYPE_P(node, PM_ASSOC_SPLAT_NODE)) {
@@ -4357,8 +4323,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
         // Detect splats in the argument list
         if (PM_NODE_FLAG_P(argumentsNode, PM_ARGUMENTS_NODE_FLAGS_CONTAINS_SPLAT)) {
             for (auto &arg : prismArgs) {
-                if (PM_NODE_TYPE_P(arg, PM_SPLAT_NODE)) {
-                    auto splatNode = down_cast_nonnull<pm_splat_node>(arg);
+                if (auto *splatNode = down_cast<pm_splat_node>(arg)) {
                     if (splatNode->expression == nullptr) { // An anonymous splat like `f(*)`
                         hasFwdRestArg = true;
                     } else { // Splatting an expression like `f(*a)`
@@ -4382,7 +4347,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
         ast::Array::ENTRY_store argExprs;
         argExprs.reserve(prismArgs.size());
         for (auto *arg : prismArgs) {
-            if (PM_NODE_TYPE_P(arg, PM_SPLAT_NODE) && down_cast_nonnull<pm_splat_node>(arg)->expression == nullptr) {
+            if (auto *splatNode = down_cast<pm_splat_node>(arg); splatNode && splatNode->expression == nullptr) {
                 continue; // Skip anonymous splats (like `f(*)`), which are handled separately in `PM_CALL_NODE`
             } else if (PM_NODE_TYPE_P(arg, PM_FORWARDING_ARGUMENTS_NODE)) {
                 continue; // Skip forwarded args (like `f(...)`), which are handled separately in `PM_CALL_NODE`
@@ -4632,8 +4597,8 @@ ast::ExpressionPtr Desugarer::desugarArray(core::LocOffsets location, absl::Span
         auto *node = prismElements[prismIndex];
         auto &stat = elements[sorbetIndex];
 
-        if (PM_NODE_TYPE_P(node, PM_SPLAT_NODE)) {
-            auto isAnonymousSplat = down_cast_nonnull<pm_splat_node>(node)->expression == nullptr;
+        if (auto *splatNode = down_cast<pm_splat_node>(node)) {
+            auto isAnonymousSplat = splatNode->expression == nullptr;
             if (calledFromCallNode && isAnonymousSplat) {
                 prismIndex++;
                 continue; // Skip anonymous splats (like `f(*)`), which are handled separately in `PM_CALL_NODE`
@@ -4750,13 +4715,9 @@ ast::ExpressionPtr Desugarer::desugarKeyValuePairs(core::LocOffsets loc, pm_node
     for (auto &pairAsExpression : kvPairs) {
         ENFORCE(pairAsExpression != nullptr);
 
-        if (PM_NODE_TYPE_P(pairAsExpression, PM_ASSOC_NODE)) {
-            auto *pair = down_cast_nonnull<pm_assoc_node>(pairAsExpression);
-
+        if (auto *pair = down_cast<pm_assoc_node>(pairAsExpression)) {
             ast::ExpressionPtr key;
-            if (PM_NODE_TYPE_P(pair->key, PM_SYMBOL_NODE)) { // Special case to modify Symbol locations
-                auto symbolNode = down_cast_nonnull<pm_symbol_node>(pair->key);
-
+            if (auto *symbolNode = down_cast<pm_symbol_node>(pair->key)) { // Special case to modify Symbol locations
                 auto [symbolContent, _] = translateSymbol(symbolNode);
 
                 // If the opening location is null, the symbol is used as a key with a colon postfix, like `{ a: 1 }`
@@ -4781,12 +4742,8 @@ ast::ExpressionPtr Desugarer::desugarKeyValuePairs(core::LocOffsets loc, pm_node
                 //              ^^
                 if (symbolNode->opening_loc.start == nullptr) {
                     core::LocOffsets symbolLoc;
-                    if (PM_NODE_TYPE_P(pair->value, PM_IMPLICIT_NODE)) {
-                        auto implicitNode = down_cast_nonnull<pm_implicit_node>(pair->value);
-
-                        if (PM_NODE_TYPE_P(implicitNode->value, PM_CALL_NODE)) {
-                            auto callNode = down_cast_nonnull<pm_call_node>(implicitNode->value);
-
+                    if (auto *implicitNode = down_cast<pm_implicit_node>(pair->value)) {
+                        if (auto *callNode = down_cast<pm_call_node>(implicitNode->value)) {
                             // Prism's method_loc excludes the ':' here, but Sorbet's legacy parser includes it.
                             // Not a fan of modifying the Prism tree in-place, but the alternative is much trickier.
                             // TODO: revisit this when we extract a helper function for translating call nodes.
@@ -4819,8 +4776,8 @@ ast::ExpressionPtr Desugarer::desugarKeyValuePairs(core::LocOffsets loc, pm_node
             continue;
         }
 
-        ENFORCE(PM_NODE_TYPE_P(pairAsExpression, PM_ASSOC_SPLAT_NODE));
-        auto splatNode = down_cast_nonnull<pm_assoc_splat_node>(pairAsExpression);
+        auto *splatNode = down_cast<pm_assoc_splat_node>(pairAsExpression);
+        ENFORCE(splatNode != nullptr, "Expected PM_ASSOC_NODE or PM_ASSOC_SPLAT_NODE");
 
         ast::ExpressionPtr expr;
         if (splatNode->value) { // Splatting an expression like `f(**h)`
@@ -5344,8 +5301,7 @@ ast::ClassDef::RHS_store Desugarer::desugarClassOrModule(pm_node *prismBodyNode)
         return result;
     }
 
-    if (PM_NODE_TYPE_P(prismBodyNode, PM_BEGIN_NODE)) {
-        auto beginNode = down_cast_nonnull<pm_begin_node>(prismBodyNode);
+    if (auto *beginNode = down_cast<pm_begin_node>(prismBodyNode)) {
         ast::ClassDef::RHS_store result;
         result.emplace_back(desugarBegin(beginNode));
         return result;

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -551,7 +551,6 @@ void Desugarer::flattenKwargs(pm_keyword_hash_node *kwargsHashNode, Container &d
 
     // Flatten each key/value pair directly
     for (auto *element : elements) {
-        ENFORCE(PM_NODE_TYPE_P(element, PM_ASSOC_NODE));
         auto *assoc = down_cast<pm_assoc_node>(element);
 
         // Special handling for symbol keys with trailing colon (like `a: 1` instead of `:a => 1`)
@@ -1978,7 +1977,6 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
 
             // Build the if ladder backwards from the last "in" to the first
             for (auto it = inNodes.rbegin(); it != inNodes.rend(); ++it) {
-                ENFORCE(PM_NODE_TYPE_P(*it, PM_IN_NODE));
                 auto inPattern = down_cast<pm_in_node>(*it);
 
                 // Get the actual pattern location (unwrapping if/unless guards)

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -3039,17 +3039,17 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
         case PM_PARENTHESES_NODE: { // A parethesized expression, e.g. `(a)`
             auto parensNode = down_cast<pm_parentheses_node>(node);
 
-            auto stmtsNode = parensNode->body;
+            auto body = parensNode->body;
 
-            if (stmtsNode == nullptr) {
+            if (body == nullptr) {
                 return MK::Nil(location);
             }
 
-            if (PM_NODE_TYPE_P(stmtsNode, PM_STATEMENTS_NODE)) {
+            if (PM_NODE_TYPE_P(body, PM_STATEMENTS_NODE)) {
                 auto inlineIfSingle = false;
-                return desugarStatements(down_cast<pm_statements_node>(stmtsNode), inlineIfSingle);
+                return desugarStatements(down_cast<pm_statements_node>(body), inlineIfSingle);
             } else {
-                return desugar(stmtsNode);
+                return desugar(body);
             }
         }
         case PM_PRE_EXECUTION_NODE: { // The BEGIN keyword and body, like `BEGIN { ... }`

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -19,6 +19,7 @@ using sorbet::ast::MK;
 using sorbet::parser::Prism::cast_prism_string;
 using sorbet::parser::Prism::down_cast;
 using sorbet::parser::Prism::down_cast_nonnull;
+using sorbet::parser::Prism::isa_node;
 using sorbet::parser::Prism::Parser;
 using sorbet::parser::Prism::ParseResult;
 using sorbet::parser::Prism::up_cast;
@@ -424,7 +425,7 @@ void Desugarer::collectPatternMatchingVarsPrism(ast::InsSeq::STATS_store &vars, 
             collectPatternMatchingVarsPrism(vars, elt);
         }
         // Process rest element (skip implicit rest nodes as they don't bind variables)
-        if (arrayPatternNode->rest != nullptr && !PM_NODE_TYPE_P(arrayPatternNode->rest, PM_IMPLICIT_REST_NODE)) {
+        if (arrayPatternNode->rest != nullptr && !isa_node<pm_implicit_rest_node>(arrayPatternNode->rest)) {
             collectPatternMatchingVarsPrism(vars, arrayPatternNode->rest);
         }
         auto posts = absl::MakeSpan(arrayPatternNode->posts.nodes, arrayPatternNode->posts.size);
@@ -520,7 +521,7 @@ bool isCallToBlockGivenP(pm_call_node *callNode, core::NameRef methodName, ast::
         return false;
     }
 
-    return callNode->receiver == nullptr || PM_NODE_TYPE_P(callNode->receiver, PM_SELF_NODE) ||
+    return callNode->receiver == nullptr || isa_node<pm_self_node>(callNode->receiver) ||
            MK::isKernelApproximate(receiverExpr);
 };
 
@@ -533,7 +534,7 @@ void Desugarer::flattenKwargs(pm_keyword_hash_node *kwargsHashNode, Container &d
     auto elements = absl::MakeSpan(kwargsHashNode->elements.nodes, kwargsHashNode->elements.size);
 
     // Check if there are any splats - if so, can't flatten
-    bool hasKwsplat = absl::c_any_of(elements, [](auto *node) { return PM_NODE_TYPE_P(node, PM_ASSOC_SPLAT_NODE); });
+    bool hasKwsplat = absl::c_any_of(elements, [](auto *node) { return isa_node<pm_assoc_splat_node>(node); });
 
     if (hasKwsplat) {
         // Desugar the whole hash using desugarKeyValuePairs which handles kwsplats properly
@@ -554,7 +555,7 @@ void Desugarer::flattenKwargs(pm_keyword_hash_node *kwargsHashNode, Container &d
 
                 // For shorthand kwargs like `foo(k5:)` where the value is implicit, keep the colon in the location
                 // to match Whitequark behavior. For regular kwargs like `foo(k5: v)`, drop the colon.
-                bool isImplicitValue = PM_NODE_TYPE_P(assoc->value, PM_IMPLICIT_NODE);
+                bool isImplicitValue = isa_node<pm_implicit_node>(assoc->value);
                 auto symbolLoc = isImplicitValue
                                      ? translateLoc(symbolNode->base.location)
                                      : translateLoc(symbolNode->base.location.start, symbolNode->base.location.end - 1);
@@ -724,7 +725,7 @@ ast::ExpressionPtr Desugarer::desugarMlhs(core::LocOffsets loc, PrismNode *lhs, 
     static_assert(is_same_v<PrismNode, pm_multi_target_node> || is_same_v<PrismNode, pm_multi_write_node>);
 
     auto isValidAssignmentTarget = [](pm_node_t *node) -> bool {
-        return parser::Prism::isAssignmentTarget(node) || PM_NODE_TYPE_P(node, PM_REQUIRED_PARAMETER_NODE);
+        return parser::Prism::isAssignmentTarget(node) || isa_node<pm_required_parameter_node>(node);
     };
 
     auto lefts = absl::MakeSpan(lhs->lefts.nodes, lhs->lefts.size);
@@ -749,10 +750,10 @@ ast::ExpressionPtr Desugarer::desugarMlhs(core::LocOffsets loc, PrismNode *lhs, 
     int before = 0, after = 0;
     auto zloc = loc.copyWithZeroLength();
 
-    bool hasSplat = lhs->rest && PM_NODE_TYPE_P(lhs->rest, PM_SPLAT_NODE);
+    bool hasSplat = lhs->rest && isa_node<pm_splat_node>(lhs->rest);
 
     auto processTarget = [this, &stats, &i, zloc, tempExpanded](pm_node_t *c) {
-        ENFORCE(!PM_NODE_TYPE_P(c, PM_SPLAT_NODE), "splat already handled");
+        ENFORCE(!isa_node<pm_splat_node>(c), "splat already handled");
 
         auto cloc = translateLoc(c->location);
         auto zcloc = cloc.copyWithZeroLength();
@@ -1907,7 +1908,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             if (isCallToBlockGivenP(callNode, methodName, receiver) && isInMethodDef()) {
                 // Workaround to match legacy desugarer behaviour in `Dugar.cc`'s version of `desugarBlock().
                 // https://github.com/sorbet/sorbet/issues/9860
-                if (callNode->block != nullptr && PM_NODE_TYPE_P(callNode->block, PM_BLOCK_NODE)) {
+                if (callNode->block != nullptr && isa_node<pm_block_node>(callNode->block)) {
                     auto blockLoc = translateLoc(callNode->block->location);
                     if (auto e = ctx.beginIndexerError(blockLoc, core::errors::Desugar::UnsupportedNode)) {
                         e.setHeader("No body in block");
@@ -2110,7 +2111,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                     auto patternLoc = pattern.loc();
 
                     ExpressionPtr testExpr;
-                    if (PM_NODE_TYPE_P(prismPattern, PM_SPLAT_NODE)) {
+                    if (isa_node<pm_splat_node>(prismPattern)) {
                         // splat pattern in when clause, predicate is required, `case a when *others`
                         ENFORCE(hasPredicate, "splats need something to test against");
                         auto local = MK::Local(predicateLoc, tempName);
@@ -2497,10 +2498,10 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                 // Multi-target: check if all are local variables (no nested multi-targets or other complex targets)
                 auto targets = absl::MakeSpan(mlhs->lefts.nodes, mlhs->lefts.size);
                 canProvideNiceDesugar = absl::c_all_of(
-                    targets, [](pm_node_t *target) { return PM_NODE_TYPE_P(target, PM_LOCAL_VARIABLE_TARGET_NODE); });
+                    targets, [](pm_node_t *target) { return isa_node<pm_local_variable_target_node>(target); });
             } else {
                 // Single variable: check if it's a local variable
-                canProvideNiceDesugar = PM_NODE_TYPE_P(forNode->index, PM_LOCAL_VARIABLE_TARGET_NODE);
+                canProvideNiceDesugar = isa_node<pm_local_variable_target_node>(forNode->index);
             }
 
             auto locZeroLen = location.copyWithZeroLength();
@@ -2641,7 +2642,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             // The value itself might be a rational (e.g. `1ri`), which would desugar to:
             //     ::Kernel.Complex(0, Kernel.Rational("1"))
             ast::ExpressionPtr imaginaryPart;
-            if (PM_NODE_TYPE_P(imaginaryNode->numeric, PM_RATIONAL_NODE)) {
+            if (isa_node<pm_rational_node>(imaginaryNode->numeric)) {
                 // The `i` is already stripped out of `value`, but there is still an `r`, so strip that off too.
                 auto rationalValue = value.substr(0, value.size() - "r"sv.size());
                 auto kernel = MK::Constant(numberLoc, core::Symbols::Kernel());
@@ -3199,7 +3200,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             auto declLoc = translateLoc(classNode->class_keyword_loc);
             auto receiverLoc = translateLoc(classNode->expression->location);
 
-            if (!PM_NODE_TYPE_P(classNode->expression, PM_SELF_NODE)) { // Only `class << self` is supported
+            if (!isa_node<pm_self_node>(classNode->expression)) { // Only `class << self` is supported
                 if (auto e = ctx.beginIndexerError(receiverLoc, core::errors::Desugar::InvalidSingletonDef)) {
                     e.setHeader("`{}` is only supported for `{}`", "class << EXPRESSION", "class << self");
                 }
@@ -3434,8 +3435,7 @@ const uint8_t *endLoc(pm_node_t *anyNode) {
             auto *node = down_cast_nonnull<pm_call_node>(anyNode);
             if (node->arguments && node->arguments->arguments.size > 0) {
                 auto *lastArg = node->arguments->arguments.nodes[node->arguments->arguments.size - 1];
-                if (PM_NODE_TYPE_P(lastArg, PM_X_STRING_NODE) ||
-                    PM_NODE_TYPE_P(lastArg, PM_INTERPOLATED_X_STRING_NODE)) {
+                if (isa_node<pm_x_string_node>(lastArg) || isa_node<pm_interpolated_x_string_node>(lastArg)) {
                     return endLoc(lastArg);
                 }
             }
@@ -3539,7 +3539,7 @@ ast::ExpressionPtr Desugarer::desugarPattern(pm_node_t *node) {
             auto assocNode = down_cast_nonnull<pm_assoc_node>(node);
 
             // If the value is an implicit node, skip creating the pair, and return that value directly.
-            if (PM_NODE_TYPE_P(assocNode->value, PM_IMPLICIT_NODE)) {
+            if (isa_node<pm_implicit_node>(assocNode->value)) {
                 return desugarPattern(assocNode->value);
             }
 
@@ -3561,7 +3561,7 @@ ast::ExpressionPtr Desugarer::desugarPattern(pm_node_t *node) {
             }
 
             // Implicit rest nodes in array patterns don't need to be translated
-            if (prismRestNode != nullptr && !PM_NODE_TYPE_P(prismRestNode, PM_IMPLICIT_REST_NODE)) {
+            if (prismRestNode != nullptr && !isa_node<pm_implicit_rest_node>(prismRestNode)) {
                 desugarPattern(prismRestNode);
             }
 
@@ -3618,7 +3618,7 @@ ast::ExpressionPtr Desugarer::desugarPattern(pm_node_t *node) {
                 desugarPattern(prismNode);
             }
 
-            if (prismTrailingSplat != nullptr && PM_NODE_TYPE_P(prismTrailingSplat, PM_SPLAT_NODE)) {
+            if (prismTrailingSplat != nullptr && isa_node<pm_splat_node>(prismTrailingSplat)) {
                 desugarPattern(prismTrailingSplat);
             }
 
@@ -3772,7 +3772,7 @@ Desugarer::desugarParametersNode(pm_parameters_node *paramsNode, core::LocOffset
         // Add in the block-local variables, if any.
         paramsStore.reserve(blockLocalVariables.size());
         for (auto *node : blockLocalVariables) {
-            ENFORCE(PM_NODE_TYPE_P(node, PM_BLOCK_LOCAL_VARIABLE_NODE));
+            ENFORCE(isa_node<pm_block_local_variable_node>(node));
             // TODO: move `PM_BLOCK_LOCAL_VARIABLE_NODE` case logic to here
             paramsStore.emplace_back(desugar(node));
         }
@@ -3832,7 +3832,7 @@ Desugarer::desugarParametersNode(pm_parameters_node *paramsNode, core::LocOffset
         // If invalid code tries to use more than one `**nil` (like `def foo(**nil, **nil)`),
         // Prism will report an error, but still place the excess `**nil` nodes in `posts` list (never the others like
         // `requireds` or `optionals`), which we need to skip here.
-        if (!PM_NODE_TYPE_P(prismNode, PM_NO_KEYWORDS_PARAMETER_NODE)) {
+        if (!isa_node<pm_no_keywords_parameter_node>(prismNode)) {
             paramsStore.emplace_back(desugar(prismNode));
         }
     }
@@ -3926,7 +3926,7 @@ Desugarer::desugarParametersNode(pm_parameters_node *paramsNode, core::LocOffset
 
     // Add in the block-local variables, if any.
     for (auto *node : blockLocalVariables) {
-        ENFORCE(PM_NODE_TYPE_P(node, PM_BLOCK_LOCAL_VARIABLE_NODE));
+        ENFORCE(isa_node<pm_block_local_variable_node>(node));
         paramsStore.emplace_back(desugar(node));
     }
 
@@ -4250,7 +4250,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
     // Extend the location to include the full heredoc using endLoc(), which handles heredocs.
     if (!prismArgs.empty()) {
         auto lastArg = prismArgs.back();
-        if (PM_NODE_TYPE_P(lastArg, PM_X_STRING_NODE) || PM_NODE_TYPE_P(lastArg, PM_INTERPOLATED_X_STRING_NODE)) {
+        if (isa_node<pm_x_string_node>(lastArg) || isa_node<pm_interpolated_x_string_node>(lastArg)) {
             auto heredocEnd = translateLoc(lastArg->location.start, endLoc(lastArg));
             location = core::LocOffsets{location.beginPos(), heredocEnd.endPos()};
         }
@@ -4306,7 +4306,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
                                 if (auto *pair = down_cast<pm_assoc_node>(node)) {
                                     return pair->key && PM_NODE_TYPE_P(pair->key, PM_SYMBOL_NODE);
                                 }
-                                if (PM_NODE_TYPE_P(node, PM_ASSOC_SPLAT_NODE)) {
+                                if (isa_node<pm_assoc_splat_node>(node)) {
                                     return true;
                                 }
                                 return false;
@@ -4349,9 +4349,9 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
         for (auto *arg : prismArgs) {
             if (auto *splatNode = down_cast<pm_splat_node>(arg); splatNode && splatNode->expression == nullptr) {
                 continue; // Skip anonymous splats (like `f(*)`), which are handled separately in `PM_CALL_NODE`
-            } else if (PM_NODE_TYPE_P(arg, PM_FORWARDING_ARGUMENTS_NODE)) {
+            } else if (isa_node<pm_forwarding_arguments_node>(arg)) {
                 continue; // Skip forwarded args (like `f(...)`), which are handled separately in `PM_CALL_NODE`
-            } else if (PM_NODE_TYPE_P(arg, PM_BLOCK_ARGUMENT_NODE)) {
+            } else if (isa_node<pm_block_argument_node>(arg)) {
                 continue; // Skip block args (like `f(&block)`), which are handled by `desugarBlock`
             }
 
@@ -4469,8 +4469,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
     }
 
     // Count args, excluding block arguments which are handled separately
-    int numPosArgs =
-        absl::c_count_if(prismArgs, [](auto *arg) { return !PM_NODE_TYPE_P(arg, PM_BLOCK_ARGUMENT_NODE); });
+    int numPosArgs = absl::c_count_if(prismArgs, [](auto *arg) { return !isa_node<pm_block_argument_node>(arg); });
 
     if (block.hasBlockPass()) {
         // Desugar a call (without splat) with a block pass argument.
@@ -4495,7 +4494,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
         }
 
         for (auto *arg : prismArgs) {
-            if (PM_NODE_TYPE_P(arg, PM_BLOCK_ARGUMENT_NODE)) {
+            if (isa_node<pm_block_argument_node>(arg)) {
                 continue; // Skip block args, handled above
             }
             magicSendArgs.emplace_back(desugar(arg));
@@ -4515,7 +4514,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
     // TODO: reserve size for the block, if needed.
     sendArgs.reserve(prismArgs.size());
     for (auto *arg : prismArgs) {
-        if (PM_NODE_TYPE_P(arg, PM_BLOCK_ARGUMENT_NODE)) {
+        if (isa_node<pm_block_argument_node>(arg)) {
             continue; // Skip block args, handled by `desugarBlock`
         }
         sendArgs.emplace_back(desugar(arg));
@@ -5283,8 +5282,8 @@ string_view Desugarer::sliceLocation(pm_location_t loc) const {
 
 // Handle invalid or missing constant paths in class/module declarations.
 ast::ExpressionPtr Desugarer::desugarClassOrModuleName(pm_node_t *constantPath, pm_location_t keywordLoc) {
-    if (constantPath == nullptr || (!PM_NODE_TYPE_P(constantPath, PM_CONSTANT_PATH_NODE) &&
-                                    !PM_NODE_TYPE_P(constantPath, PM_CONSTANT_READ_NODE))) {
+    if (constantPath == nullptr ||
+        (!isa_node<pm_constant_path_node>(constantPath) && !isa_node<pm_constant_read_node>(constantPath))) {
         auto nameLoc = translateLoc(keywordLoc);
         return MK::UnresolvedConstant(nameLoc, MK::EmptyTree(), core::Names::Constants::ConstantNameMissing());
     }
@@ -5307,7 +5306,7 @@ ast::ClassDef::RHS_store Desugarer::desugarClassOrModule(pm_node *prismBodyNode)
         return result;
     }
 
-    ENFORCE(PM_NODE_TYPE_P(prismBodyNode, PM_STATEMENTS_NODE));
+    ENFORCE(isa_node<pm_statements_node>(prismBodyNode));
 
     auto body = desugar(prismBodyNode);
 

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -20,6 +20,7 @@ using sorbet::parser::Prism::cast_prism_string;
 using sorbet::parser::Prism::down_cast;
 using sorbet::parser::Prism::down_cast_nonnull;
 using sorbet::parser::Prism::isa_node;
+using sorbet::parser::Prism::isa_node_nullable;
 using sorbet::parser::Prism::Parser;
 using sorbet::parser::Prism::ParseResult;
 using sorbet::parser::Prism::up_cast;
@@ -750,7 +751,7 @@ ast::ExpressionPtr Desugarer::desugarMlhs(core::LocOffsets loc, PrismNode *lhs, 
     int before = 0, after = 0;
     auto zloc = loc.copyWithZeroLength();
 
-    bool hasSplat = lhs->rest && isa_node<pm_splat_node>(lhs->rest);
+    bool hasSplat = isa_node_nullable<pm_splat_node>(lhs->rest);
 
     auto processTarget = [this, &stats, &i, zloc, tempExpanded](pm_node_t *c) {
         ENFORCE(!isa_node<pm_splat_node>(c), "splat already handled");
@@ -1908,7 +1909,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             if (isCallToBlockGivenP(callNode, methodName, receiver) && isInMethodDef()) {
                 // Workaround to match legacy desugarer behaviour in `Dugar.cc`'s version of `desugarBlock().
                 // https://github.com/sorbet/sorbet/issues/9860
-                if (callNode->block != nullptr && isa_node<pm_block_node>(callNode->block)) {
+                if (isa_node_nullable<pm_block_node>(callNode->block)) {
                     auto blockLoc = translateLoc(callNode->block->location);
                     if (auto e = ctx.beginIndexerError(blockLoc, core::errors::Desugar::UnsupportedNode)) {
                         e.setHeader("No body in block");
@@ -3618,7 +3619,7 @@ ast::ExpressionPtr Desugarer::desugarPattern(pm_node_t *node) {
                 desugarPattern(prismNode);
             }
 
-            if (prismTrailingSplat != nullptr && isa_node<pm_splat_node>(prismTrailingSplat)) {
+            if (isa_node_nullable<pm_splat_node>(prismTrailingSplat)) {
                 desugarPattern(prismTrailingSplat);
             }
 
@@ -3956,13 +3957,13 @@ core::LocOffsets Desugarer::findItParamUsageLoc(pm_statements_node *statements) 
         }
         // Don't descend into nested blocks/lambdas that have their own 'it' parameter
         if (auto *blockNode = down_cast<pm_block_node>(const_cast<pm_node_t *>(node))) {
-            if (blockNode->parameters != nullptr && PM_NODE_TYPE_P(blockNode->parameters, PM_IT_PARAMETERS_NODE)) {
+            if (isa_node_nullable<pm_it_parameters_node>(blockNode->parameters)) {
                 // This nested block has its own 'it', don't descend into it
                 return false;
             }
         }
         if (auto *lambdaNode = down_cast<pm_lambda_node>(const_cast<pm_node_t *>(node))) {
-            if (lambdaNode->parameters != nullptr && PM_NODE_TYPE_P(lambdaNode->parameters, PM_IT_PARAMETERS_NODE)) {
+            if (isa_node_nullable<pm_it_parameters_node>(lambdaNode->parameters)) {
                 // This nested lambda has its own 'it', don't descend into it
                 return false;
             }
@@ -4304,7 +4305,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
             auto isKwargs = PM_NODE_FLAG_P(keywordHashNode, PM_KEYWORD_HASH_NODE_FLAGS_SYMBOL_KEYS) ||
                             absl::c_all_of(elements, [](auto *node) {
                                 if (auto *pair = down_cast<pm_assoc_node>(node)) {
-                                    return pair->key && PM_NODE_TYPE_P(pair->key, PM_SYMBOL_NODE);
+                                    return isa_node_nullable<pm_symbol_node>(pair->key);
                                 }
                                 if (isa_node<pm_assoc_splat_node>(node)) {
                                     return true;

--- a/parser/prism/Factory.cc
+++ b/parser/prism/Factory.cc
@@ -174,7 +174,7 @@ pm_call_node_t *Factory::createCallNode(pm_node_t *receiver, pm_constant_id_t me
                              .name = methodId,
                              .message_loc = messageLoc,
                              .opening_loc = tinyLoc,
-                             .arguments = down_cast<pm_arguments_node_t>(arguments),
+                             .arguments = down_cast_nonnull<pm_arguments_node_t>(arguments),
                              .closing_loc = tinyLoc,
                              .block = block};
 
@@ -463,7 +463,7 @@ pm_node_t *Factory::TTypeAlias(core::LocOffsets loc, pm_node_t *type) const {
 
     pm_node_t *block = Block(loc, StatementsNode(loc, absl::Span<pm_node_t *>{&type, 1}));
 
-    auto *call = down_cast<pm_call_node_t>(typeAliasCall);
+    auto *call = down_cast_nonnull<pm_call_node_t>(typeAliasCall);
     call->block = block;
 
     return typeAliasCall;

--- a/parser/prism/Helpers.h
+++ b/parser/prism/Helpers.h
@@ -194,6 +194,23 @@ template <typename PrismNode> pm_node_t *up_cast(PrismNode *node) {
     return reinterpret_cast<pm_node_t *>(node);
 }
 
+// Take a pointer to a type-erased `pm_node_t` and down-cast it to a pointer of a specific Prism node "subclass",
+// or return `nullptr` if the node is null or not of the expected type. Matches the convention of other Sorbet
+// downcasting helpers like `cast_tree`, `cast_node`, `cast_type`, and C++'s `dynamic_cast`.
+template <typename PrismNode> PrismNode *down_cast(pm_node_t *anyNode) {
+    static_assert(std::is_same_v<decltype(PrismNode::base), pm_node_t>,
+                  "The `down_cast` function should only be called on Prism node pointers.");
+
+    if (anyNode == nullptr) {
+        return nullptr;
+    }
+
+    if (!PM_NODE_TYPE_P(anyNode, PrismNodeTypeHelper<PrismNode>::TypeID)) {
+        return nullptr;
+    }
+    return reinterpret_cast<PrismNode *>(anyNode);
+}
+
 // Take a pointer to a type-erased `pm_node_t` and down-cast it to a pointer of a specific Prism node "subclass".
 // In debug builds, this helper checks the node's type before casting, to ensure it's casted correctly.
 template <typename PrismNode> PrismNode *down_cast_nonnull(pm_node_t *anyNode) {

--- a/parser/prism/Helpers.h
+++ b/parser/prism/Helpers.h
@@ -196,9 +196,9 @@ template <typename PrismNode> pm_node_t *up_cast(PrismNode *node) {
 
 // Take a pointer to a type-erased `pm_node_t` and down-cast it to a pointer of a specific Prism node "subclass".
 // In debug builds, this helper checks the node's type before casting, to ensure it's casted correctly.
-template <typename PrismNode> PrismNode *down_cast(pm_node_t *anyNode) {
+template <typename PrismNode> PrismNode *down_cast_nonnull(pm_node_t *anyNode) {
     static_assert(std::is_same_v<decltype(PrismNode::base), pm_node_t>,
-                  "The `down_cast` function should only be called on Prism node pointers.");
+                  "The `down_cast_nonnull` function should only be called on Prism node pointers.");
     ENFORCE(anyNode == nullptr || PM_NODE_TYPE_P(anyNode, PrismNodeTypeHelper<PrismNode>::TypeID),
             "Failed to cast a Prism AST Node. Expected {} (#{}), but got {} (#{}).",
             pm_node_type_to_str(PrismNodeTypeHelper<PrismNode>::TypeID), PrismNodeTypeHelper<PrismNode>::TypeID,

--- a/parser/prism/Helpers.h
+++ b/parser/prism/Helpers.h
@@ -194,18 +194,24 @@ template <typename PrismNode> pm_node_t *up_cast(PrismNode *node) {
     return reinterpret_cast<pm_node_t *>(node);
 }
 
+// Check if a type-erased non-null `pm_node_t` pointer is of a specific Prism node "subclass".
+template <typename PrismNode> inline bool isa_node(pm_node_t *anyNode) {
+    static_assert(isPrismNode<PrismNode>, "The `isa_node` function should only be called on Prism node pointers.");
+
+    ENFORCE(anyNode != nullptr, "Cannot check the type of a null Prism AST Node pointer.");
+
+    return PM_NODE_TYPE_P(anyNode, PrismNodeTypeHelper<PrismNode>::TypeID);
+}
+
 // Take a pointer to a type-erased `pm_node_t` and down-cast it to a pointer of a specific Prism node "subclass",
 // or return `nullptr` if the node is null or not of the expected type. Matches the convention of other Sorbet
 // downcasting helpers like `cast_tree`, `cast_node`, `cast_type`, and C++'s `dynamic_cast`.
 template <typename PrismNode> PrismNode *down_cast(pm_node_t *anyNode) {
-    static_assert(std::is_same_v<decltype(PrismNode::base), pm_node_t>,
-                  "The `down_cast` function should only be called on Prism node pointers.");
-
     if (anyNode == nullptr) {
         return nullptr;
     }
 
-    if (!PM_NODE_TYPE_P(anyNode, PrismNodeTypeHelper<PrismNode>::TypeID)) {
+    if (!isa_node<PrismNode>(anyNode)) {
         return nullptr;
     }
     return reinterpret_cast<PrismNode *>(anyNode);
@@ -214,9 +220,7 @@ template <typename PrismNode> PrismNode *down_cast(pm_node_t *anyNode) {
 // Take a pointer to a type-erased `pm_node_t` and down-cast it to a pointer of a specific Prism node "subclass".
 // In debug builds, this helper checks the node's type before casting, to ensure it's casted correctly.
 template <typename PrismNode> PrismNode *down_cast_nonnull(pm_node_t *anyNode) {
-    static_assert(std::is_same_v<decltype(PrismNode::base), pm_node_t>,
-                  "The `down_cast_nonnull` function should only be called on Prism node pointers.");
-    ENFORCE(anyNode == nullptr || PM_NODE_TYPE_P(anyNode, PrismNodeTypeHelper<PrismNode>::TypeID),
+    ENFORCE(anyNode == nullptr || isa_node<PrismNode>(anyNode),
             "Failed to cast a Prism AST Node. Expected {} (#{}), but got {} (#{}).",
             pm_node_type_to_str(PrismNodeTypeHelper<PrismNode>::TypeID), PrismNodeTypeHelper<PrismNode>::TypeID,
             pm_node_type_to_str(PM_NODE_TYPE(anyNode)), PM_NODE_TYPE(anyNode));

--- a/parser/prism/Helpers.h
+++ b/parser/prism/Helpers.h
@@ -203,18 +203,20 @@ template <typename PrismNode> inline bool isa_node(pm_node_t *anyNode) {
     return PM_NODE_TYPE_P(anyNode, PrismNodeTypeHelper<PrismNode>::TypeID);
 }
 
+// Like `isa_node`, but also returns `false` if the node is null.
+template <typename PrismNode> inline bool isa_node_nullable(pm_node_t *anyNode) {
+    return anyNode != nullptr && isa_node<PrismNode>(anyNode);
+}
+
 // Take a pointer to a type-erased `pm_node_t` and down-cast it to a pointer of a specific Prism node "subclass",
 // or return `nullptr` if the node is null or not of the expected type. Matches the convention of other Sorbet
 // downcasting helpers like `cast_tree`, `cast_node`, `cast_type`, and C++'s `dynamic_cast`.
 template <typename PrismNode> PrismNode *down_cast(pm_node_t *anyNode) {
-    if (anyNode == nullptr) {
-        return nullptr;
+    if (isa_node_nullable<PrismNode>(anyNode)) {
+        return reinterpret_cast<PrismNode *>(anyNode);
     }
 
-    if (!isa_node<PrismNode>(anyNode)) {
-        return nullptr;
-    }
-    return reinterpret_cast<PrismNode *>(anyNode);
+    return nullptr;
 }
 
 // Take a pointer to a type-erased `pm_node_t` and down-cast it to a pointer of a specific Prism node "subclass".

--- a/parser/prism/Parser.cc
+++ b/parser/prism/Parser.cc
@@ -106,7 +106,7 @@ bool Parser::isTUntyped(pm_node_t *node) const {
         return false;
     }
 
-    pm_call_node_t *call = down_cast<pm_call_node_t>(node);
+    pm_call_node_t *call = down_cast_nonnull<pm_call_node_t>(node);
     auto methodName = resolveConstant(call->name);
 
     return methodName == "untyped"sv && isT(call->receiver);
@@ -118,11 +118,11 @@ bool Parser::isT(pm_node_t *node) const {
     }
 
     if (PM_NODE_TYPE_P(node, PM_CONSTANT_READ_NODE)) { // T
-        auto *constNode = down_cast<pm_constant_read_node_t>(node);
+        auto *constNode = down_cast_nonnull<pm_constant_read_node_t>(node);
         auto name = resolveConstant(constNode->name);
         return name == "T";
     } else if (PM_NODE_TYPE_P(node, PM_CONSTANT_PATH_NODE)) { // ::T
-        auto *pathNode = down_cast<pm_constant_path_node_t>(node);
+        auto *pathNode = down_cast_nonnull<pm_constant_path_node_t>(node);
         auto name = resolveConstant(pathNode->name);
         return name == "T" && pathNode->parent == nullptr;
     }
@@ -135,7 +135,7 @@ bool Parser::isSetterCall(pm_node_t *node) const {
         return false;
     }
 
-    auto *call = down_cast<pm_call_node_t>(node);
+    auto *call = down_cast_nonnull<pm_call_node_t>(node);
     auto methodName = resolveConstant(call->name);
     return !methodName.empty() && methodName.back() == '=';
 }
@@ -149,7 +149,7 @@ bool Parser::isMethodDefModifierCall(pm_node_t *node, const core::GlobalState &g
         return false;
     }
 
-    auto *call = down_cast<pm_call_node_t>(node);
+    auto *call = down_cast_nonnull<pm_call_node_t>(node);
 
     // Must have no receiver (implicit self)
     if (call->receiver != nullptr) {
@@ -176,7 +176,7 @@ bool Parser::isAttrAccessorCall(pm_node_t *node) const {
         return false;
     }
 
-    auto *call = down_cast<pm_call_node_t>(node);
+    auto *call = down_cast_nonnull<pm_call_node_t>(node);
 
     // Must have no receiver or self receiver
     if (call->receiver != nullptr && !PM_NODE_TYPE_P(call->receiver, PM_SELF_NODE)) {

--- a/rbs/prism/AssertionsRewriterPrism.cc
+++ b/rbs/prism/AssertionsRewriterPrism.cc
@@ -67,7 +67,7 @@ extractTypeParamsPrism(core::MutableContext ctx, const parser::Prism::Parser &pa
         return typeParams;
     }
 
-    auto *blockNode = down_cast<pm_block_node_t>(block);
+    auto *blockNode = down_cast_nonnull<pm_block_node_t>(block);
     if (!blockNode->body) {
         return typeParams;
     }
@@ -77,7 +77,7 @@ extractTypeParamsPrism(core::MutableContext ctx, const parser::Prism::Parser &pa
 
     // If it's a statements node, get the first statement
     if (PM_NODE_TYPE_P(node, PM_STATEMENTS_NODE)) {
-        auto *statements = down_cast<pm_statements_node_t>(node);
+        auto *statements = down_cast_nonnull<pm_statements_node_t>(node);
         ENFORCE(statements->body.size > 0);
         node = statements->body.nodes[0];
     }
@@ -86,7 +86,7 @@ extractTypeParamsPrism(core::MutableContext ctx, const parser::Prism::Parser &pa
 
     // Walk through the call chain to find type_parameters()
     while (node && PM_NODE_TYPE_P(node, PM_CALL_NODE)) {
-        auto *callNode = down_cast<pm_call_node_t>(node);
+        auto *callNode = down_cast_nonnull<pm_call_node_t>(node);
         auto methodName = parser.resolveConstant(callNode->name);
 
         if (methodName == "type_parameters") {
@@ -109,7 +109,7 @@ extractTypeParamsPrism(core::MutableContext ctx, const parser::Prism::Parser &pa
                 continue;
             }
 
-            auto *sym = down_cast<pm_symbol_node_t>(arg);
+            auto *sym = down_cast_nonnull<pm_symbol_node_t>(arg);
             auto symbolName = parser.extractString(&sym->unescaped);
             auto nameRef = ctx.state.enterNameUTF8(symbolName);
             auto loc = parser.translateLocation(arg->location);
@@ -132,14 +132,14 @@ bool sameConstant(parser::Prism::Parser &parser, pm_node_t *a, pm_node_t *b) {
         pm_node_type bType = PM_NODE_TYPE(b);
 
         if (aType == PM_CONSTANT_READ_NODE && bType == PM_CONSTANT_READ_NODE) {
-            auto *aConst = down_cast<pm_constant_read_node_t>(a);
-            auto *bConst = down_cast<pm_constant_read_node_t>(b);
+            auto *aConst = down_cast_nonnull<pm_constant_read_node_t>(a);
+            auto *bConst = down_cast_nonnull<pm_constant_read_node_t>(b);
             return aConst->name == bConst->name;
         }
 
         if (aType == PM_CONSTANT_PATH_NODE && bType == PM_CONSTANT_PATH_NODE) {
-            auto *aPath = down_cast<pm_constant_path_node_t>(a);
-            auto *bPath = down_cast<pm_constant_path_node_t>(b);
+            auto *aPath = down_cast_nonnull<pm_constant_path_node_t>(a);
+            auto *bPath = down_cast_nonnull<pm_constant_path_node_t>(b);
 
             if (aPath->name != bPath->name) {
                 return false;
@@ -184,7 +184,7 @@ pm_node_t *deepCopyGenericTypeNode(parser::Prism::Parser &parser, pm_node_t *nod
         //   - G2[T.any(Integer, String)] -> T.any() call
         //   - G3[T.type_parameter(:X)] -> T.type_parameter() call
         case PM_CALL_NODE: {
-            auto *original = down_cast<pm_call_node_t>(node);
+            auto *original = down_cast_nonnull<pm_call_node_t>(node);
             auto *copy = prism.allocateNode<pm_call_node_t>();
 
             *copy = (pm_call_node_t){.base = original->base,
@@ -193,7 +193,7 @@ pm_node_t *deepCopyGenericTypeNode(parser::Prism::Parser &parser, pm_node_t *nod
                                      .name = original->name,
                                      .message_loc = original->message_loc,
                                      .opening_loc = original->opening_loc,
-                                     .arguments = down_cast<pm_arguments_node_t>(
+                                     .arguments = down_cast_nonnull<pm_arguments_node_t>(
                                          deepCopyGenericTypeNode(parser, up_cast(original->arguments))),
                                      .closing_loc = original->closing_loc,
                                      .block = deepCopyGenericTypeNode(parser, original->block)};
@@ -202,7 +202,7 @@ pm_node_t *deepCopyGenericTypeNode(parser::Prism::Parser &parser, pm_node_t *nod
         }
 
         case PM_ARGUMENTS_NODE: {
-            auto *original = down_cast<pm_arguments_node_t>(node);
+            auto *original = down_cast_nonnull<pm_arguments_node_t>(node);
             vector<pm_node_t *> copiedArgs;
             copiedArgs.reserve(original->arguments.size);
             for (size_t i = 0; i < original->arguments.size; i++) {
@@ -213,7 +213,7 @@ pm_node_t *deepCopyGenericTypeNode(parser::Prism::Parser &parser, pm_node_t *nod
 
         // Example: G1[Integer] -> Integer
         case PM_CONSTANT_READ_NODE: {
-            auto *original = down_cast<pm_constant_read_node_t>(node);
+            auto *original = down_cast_nonnull<pm_constant_read_node_t>(node);
             return prism.ConstantReadNode(original->name, original->base.location);
         }
 
@@ -221,7 +221,7 @@ pm_node_t *deepCopyGenericTypeNode(parser::Prism::Parser &parser, pm_node_t *nod
         //   - Array[String] -> T::Array
         //   - G1[Foo::Bar] -> Foo::Bar
         case PM_CONSTANT_PATH_NODE: {
-            auto *original = down_cast<pm_constant_path_node_t>(node);
+            auto *original = down_cast_nonnull<pm_constant_path_node_t>(node);
             return prism.ConstantPathNode(original->base.location, deepCopyGenericTypeNode(parser, original->parent),
                                           original->name);
         }
@@ -230,7 +230,7 @@ pm_node_t *deepCopyGenericTypeNode(parser::Prism::Parser &parser, pm_node_t *nod
         //   - G1[X] where X is a type parameter -> T.type_parameter(:X)
         //   - The :X symbol needs to be copied with proper string allocation
         case PM_SYMBOL_NODE: {
-            auto *original = down_cast<pm_symbol_node_t>(node);
+            auto *original = down_cast_nonnull<pm_symbol_node_t>(node);
             auto symbolStr = parser.extractString(&original->unescaped);
             auto loc = parser.translateLocation(original->base.location);
             return prism.Symbol(loc, symbolStr);
@@ -267,7 +267,7 @@ void maybeSupplyGenericTypeArguments(core::MutableContext ctx, parser::Prism::Pa
         return;
     }
 
-    auto *newCall = down_cast<pm_call_node_t>(*node);
+    auto *newCall = down_cast_nonnull<pm_call_node_t>(*node);
     auto methodName = parser.resolveConstant(newCall->name);
 
     if (methodName != "new"sv) {
@@ -279,7 +279,7 @@ void maybeSupplyGenericTypeArguments(core::MutableContext ctx, parser::Prism::Pa
         return;
     }
 
-    auto *bracketCall = down_cast<pm_call_node_t>(*type);
+    auto *bracketCall = down_cast_nonnull<pm_call_node_t>(*type);
     auto bracketMethodName = parser.resolveConstant(bracketCall->name);
 
     if (bracketMethodName != "<syntheticSquareBrackets>"sv) {
@@ -312,7 +312,7 @@ bool AssertionsRewriterPrism::saveMethodTypeParams(pm_node_t *call) {
         return false;
     }
 
-    auto *callNode = down_cast<pm_call_node_t>(call);
+    auto *callNode = down_cast_nonnull<pm_call_node_t>(call);
 
     // Check if this is a sig() call
     auto methodName = parser.resolveConstant(callNode->name);
@@ -574,25 +574,25 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
     switch (PM_NODE_TYPE(node)) {
         // Scopes
         case PM_MODULE_NODE: {
-            auto *module = down_cast<pm_module_node_t>(node);
+            auto *module = down_cast_nonnull<pm_module_node_t>(node);
             module->body = rewriteNullableNode(module->body);
             typeParams.clear();
             return node;
         }
         case PM_CLASS_NODE: {
-            auto *klass = down_cast<pm_class_node_t>(node);
+            auto *klass = down_cast_nonnull<pm_class_node_t>(node);
             klass->body = rewriteNullableNode(klass->body);
             typeParams.clear();
             return node;
         }
         case PM_SINGLETON_CLASS_NODE: {
-            auto *sclass = down_cast<pm_singleton_class_node_t>(node);
+            auto *sclass = down_cast_nonnull<pm_singleton_class_node_t>(node);
             sclass->body = rewriteNullableNode(sclass->body);
             typeParams.clear();
             return node;
         }
         case PM_DEF_NODE: {
-            auto *def = down_cast<pm_def_node_t>(node);
+            auto *def = down_cast_nonnull<pm_def_node_t>(node);
             def->body = rewriteNullableNode(def->body);
             typeParams.clear();
             return node;
@@ -600,7 +600,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
 
         // Begin statements
         case PM_BEGIN_NODE: {
-            auto *begin = down_cast<pm_begin_node_t>(node);
+            auto *begin = down_cast_nonnull<pm_begin_node_t>(node);
             node = maybeInsertCast(node);
             rewriteNullableNode(up_cast(begin->statements));
             rewriteNullableNode(up_cast(begin->rescue_clause));
@@ -611,81 +611,81 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
 
         // Simple write assignments
         case PM_LOCAL_VARIABLE_WRITE_NODE: {
-            auto *write = down_cast<pm_local_variable_write_node_t>(node);
+            auto *write = down_cast_nonnull<pm_local_variable_write_node_t>(node);
             write->value = rewriteNode(write->value);
             return node;
         }
         case PM_INSTANCE_VARIABLE_WRITE_NODE: {
-            auto *write = down_cast<pm_instance_variable_write_node_t>(node);
+            auto *write = down_cast_nonnull<pm_instance_variable_write_node_t>(node);
             write->value = rewriteNode(write->value);
             return node;
         }
         case PM_CLASS_VARIABLE_WRITE_NODE: {
-            auto *write = down_cast<pm_class_variable_write_node_t>(node);
+            auto *write = down_cast_nonnull<pm_class_variable_write_node_t>(node);
             write->value = rewriteNode(write->value);
             return node;
         }
         case PM_GLOBAL_VARIABLE_WRITE_NODE: {
-            auto *write = down_cast<pm_global_variable_write_node_t>(node);
+            auto *write = down_cast_nonnull<pm_global_variable_write_node_t>(node);
             write->value = rewriteNode(write->value);
             return node;
         }
         case PM_CONSTANT_WRITE_NODE: {
-            auto *write = down_cast<pm_constant_write_node_t>(node);
+            auto *write = down_cast_nonnull<pm_constant_write_node_t>(node);
             write->value = rewriteNode(write->value);
             return node;
         }
         case PM_CONSTANT_PATH_WRITE_NODE: {
-            auto *write = down_cast<pm_constant_path_write_node_t>(node);
-            write->target = down_cast<pm_constant_path_node_t>(rewriteNode(up_cast(write->target)));
+            auto *write = down_cast_nonnull<pm_constant_path_write_node_t>(node);
+            write->target = down_cast_nonnull<pm_constant_path_node_t>(rewriteNode(up_cast(write->target)));
             write->value = rewriteNode(write->value);
             return node;
         }
 
         // And assignments
         case PM_LOCAL_VARIABLE_AND_WRITE_NODE: {
-            auto *andWrite = down_cast<pm_local_variable_and_write_node_t>(node);
+            auto *andWrite = down_cast_nonnull<pm_local_variable_and_write_node_t>(node);
             andWrite->value = rewriteNode(maybeInsertCast(andWrite->value));
             return node;
         }
         case PM_INSTANCE_VARIABLE_AND_WRITE_NODE: {
-            auto *andWrite = down_cast<pm_instance_variable_and_write_node_t>(node);
+            auto *andWrite = down_cast_nonnull<pm_instance_variable_and_write_node_t>(node);
             andWrite->value = rewriteNode(maybeInsertCast(andWrite->value));
             return node;
         }
         case PM_CLASS_VARIABLE_AND_WRITE_NODE: {
-            auto *andWrite = down_cast<pm_class_variable_and_write_node_t>(node);
+            auto *andWrite = down_cast_nonnull<pm_class_variable_and_write_node_t>(node);
             andWrite->value = rewriteNode(maybeInsertCast(andWrite->value));
             return node;
         }
         case PM_GLOBAL_VARIABLE_AND_WRITE_NODE: {
-            auto *andWrite = down_cast<pm_global_variable_and_write_node_t>(node);
+            auto *andWrite = down_cast_nonnull<pm_global_variable_and_write_node_t>(node);
             andWrite->value = rewriteNode(maybeInsertCast(andWrite->value));
             return node;
         }
         case PM_CONSTANT_AND_WRITE_NODE: {
-            auto *andWrite = down_cast<pm_constant_and_write_node_t>(node);
+            auto *andWrite = down_cast_nonnull<pm_constant_and_write_node_t>(node);
             andWrite->value = rewriteNode(maybeInsertCast(andWrite->value));
             return node;
         }
         case PM_CONSTANT_PATH_AND_WRITE_NODE: {
-            auto *andWrite = down_cast<pm_constant_path_and_write_node_t>(node);
-            andWrite->target = down_cast<pm_constant_path_node_t>(rewriteNode(up_cast(andWrite->target)));
+            auto *andWrite = down_cast_nonnull<pm_constant_path_and_write_node_t>(node);
+            andWrite->target = down_cast_nonnull<pm_constant_path_node_t>(rewriteNode(up_cast(andWrite->target)));
             andWrite->value = rewriteNode(maybeInsertCast(andWrite->value));
             return node;
         }
         case PM_CALL_AND_WRITE_NODE: {
-            auto *andWrite = down_cast<pm_call_and_write_node_t>(node);
+            auto *andWrite = down_cast_nonnull<pm_call_and_write_node_t>(node);
             andWrite->receiver = rewriteNode(andWrite->receiver);
             andWrite->value = rewriteNode(maybeInsertCast(andWrite->value));
             return node;
         }
         case PM_INDEX_AND_WRITE_NODE: {
-            auto *andWrite = down_cast<pm_index_and_write_node_t>(node);
+            auto *andWrite = down_cast_nonnull<pm_index_and_write_node_t>(node);
             andWrite->receiver = rewriteNode(andWrite->receiver);
             rewriteArgumentsNode(andWrite->arguments);
             if (andWrite->block != nullptr) {
-                andWrite->block = down_cast<pm_block_argument_node_t>(rewriteNode(up_cast(andWrite->block)));
+                andWrite->block = down_cast_nonnull<pm_block_argument_node_t>(rewriteNode(up_cast(andWrite->block)));
             }
             andWrite->value = maybeInsertCast(andWrite->value);
             andWrite->value = rewriteNode(andWrite->value);
@@ -694,48 +694,48 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
 
         // Operator assignments
         case PM_LOCAL_VARIABLE_OPERATOR_WRITE_NODE: {
-            auto *opWrite = down_cast<pm_local_variable_operator_write_node_t>(node);
+            auto *opWrite = down_cast_nonnull<pm_local_variable_operator_write_node_t>(node);
             opWrite->value = rewriteNode(maybeInsertCast(opWrite->value));
             return node;
         }
         case PM_INSTANCE_VARIABLE_OPERATOR_WRITE_NODE: {
-            auto *opWrite = down_cast<pm_instance_variable_operator_write_node_t>(node);
+            auto *opWrite = down_cast_nonnull<pm_instance_variable_operator_write_node_t>(node);
             opWrite->value = rewriteNode(maybeInsertCast(opWrite->value));
             return node;
         }
         case PM_CLASS_VARIABLE_OPERATOR_WRITE_NODE: {
-            auto *opWrite = down_cast<pm_class_variable_operator_write_node_t>(node);
+            auto *opWrite = down_cast_nonnull<pm_class_variable_operator_write_node_t>(node);
             opWrite->value = rewriteNode(maybeInsertCast(opWrite->value));
             return node;
         }
         case PM_GLOBAL_VARIABLE_OPERATOR_WRITE_NODE: {
-            auto *opWrite = down_cast<pm_global_variable_operator_write_node_t>(node);
+            auto *opWrite = down_cast_nonnull<pm_global_variable_operator_write_node_t>(node);
             opWrite->value = rewriteNode(maybeInsertCast(opWrite->value));
             return node;
         }
         case PM_CONSTANT_OPERATOR_WRITE_NODE: {
-            auto *opWrite = down_cast<pm_constant_operator_write_node_t>(node);
+            auto *opWrite = down_cast_nonnull<pm_constant_operator_write_node_t>(node);
             opWrite->value = rewriteNode(maybeInsertCast(opWrite->value));
             return node;
         }
         case PM_CONSTANT_PATH_OPERATOR_WRITE_NODE: {
-            auto *opWrite = down_cast<pm_constant_path_operator_write_node_t>(node);
-            opWrite->target = down_cast<pm_constant_path_node_t>(rewriteNode(up_cast(opWrite->target)));
+            auto *opWrite = down_cast_nonnull<pm_constant_path_operator_write_node_t>(node);
+            opWrite->target = down_cast_nonnull<pm_constant_path_node_t>(rewriteNode(up_cast(opWrite->target)));
             opWrite->value = rewriteNode(maybeInsertCast(opWrite->value));
             return node;
         }
         case PM_CALL_OPERATOR_WRITE_NODE: {
-            auto *opWrite = down_cast<pm_call_operator_write_node_t>(node);
+            auto *opWrite = down_cast_nonnull<pm_call_operator_write_node_t>(node);
             opWrite->receiver = rewriteNode(opWrite->receiver);
             opWrite->value = rewriteNode(maybeInsertCast(opWrite->value));
             return node;
         }
         case PM_INDEX_OPERATOR_WRITE_NODE: {
-            auto *opWrite = down_cast<pm_index_operator_write_node_t>(node);
+            auto *opWrite = down_cast_nonnull<pm_index_operator_write_node_t>(node);
             opWrite->receiver = rewriteNode(opWrite->receiver);
             rewriteArgumentsNode(opWrite->arguments);
             if (opWrite->block != nullptr) {
-                opWrite->block = down_cast<pm_block_argument_node_t>(rewriteNode(up_cast(opWrite->block)));
+                opWrite->block = down_cast_nonnull<pm_block_argument_node_t>(rewriteNode(up_cast(opWrite->block)));
             }
             opWrite->value = maybeInsertCast(opWrite->value);
             opWrite->value = rewriteNode(opWrite->value);
@@ -744,48 +744,48 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
 
         // Or assignments
         case PM_LOCAL_VARIABLE_OR_WRITE_NODE: {
-            auto *orWrite = down_cast<pm_local_variable_or_write_node_t>(node);
+            auto *orWrite = down_cast_nonnull<pm_local_variable_or_write_node_t>(node);
             orWrite->value = rewriteNode(maybeInsertCast(orWrite->value));
             return node;
         }
         case PM_INSTANCE_VARIABLE_OR_WRITE_NODE: {
-            auto *orWrite = down_cast<pm_instance_variable_or_write_node_t>(node);
+            auto *orWrite = down_cast_nonnull<pm_instance_variable_or_write_node_t>(node);
             orWrite->value = rewriteNode(maybeInsertCast(orWrite->value));
             return node;
         }
         case PM_CLASS_VARIABLE_OR_WRITE_NODE: {
-            auto *orWrite = down_cast<pm_class_variable_or_write_node_t>(node);
+            auto *orWrite = down_cast_nonnull<pm_class_variable_or_write_node_t>(node);
             orWrite->value = rewriteNode(maybeInsertCast(orWrite->value));
             return node;
         }
         case PM_GLOBAL_VARIABLE_OR_WRITE_NODE: {
-            auto *orWrite = down_cast<pm_global_variable_or_write_node_t>(node);
+            auto *orWrite = down_cast_nonnull<pm_global_variable_or_write_node_t>(node);
             orWrite->value = rewriteNode(maybeInsertCast(orWrite->value));
             return node;
         }
         case PM_CONSTANT_OR_WRITE_NODE: {
-            auto *orWrite = down_cast<pm_constant_or_write_node_t>(node);
+            auto *orWrite = down_cast_nonnull<pm_constant_or_write_node_t>(node);
             orWrite->value = rewriteNode(maybeInsertCast(orWrite->value));
             return node;
         }
         case PM_CONSTANT_PATH_OR_WRITE_NODE: {
-            auto *orWrite = down_cast<pm_constant_path_or_write_node_t>(node);
-            orWrite->target = down_cast<pm_constant_path_node_t>(rewriteNode(up_cast(orWrite->target)));
+            auto *orWrite = down_cast_nonnull<pm_constant_path_or_write_node_t>(node);
+            orWrite->target = down_cast_nonnull<pm_constant_path_node_t>(rewriteNode(up_cast(orWrite->target)));
             orWrite->value = rewriteNode(maybeInsertCast(orWrite->value));
             return node;
         }
         case PM_CALL_OR_WRITE_NODE: {
-            auto *orWrite = down_cast<pm_call_or_write_node_t>(node);
+            auto *orWrite = down_cast_nonnull<pm_call_or_write_node_t>(node);
             orWrite->receiver = rewriteNode(orWrite->receiver);
             orWrite->value = rewriteNode(maybeInsertCast(orWrite->value));
             return node;
         }
         case PM_INDEX_OR_WRITE_NODE: {
-            auto *orWrite = down_cast<pm_index_or_write_node_t>(node);
+            auto *orWrite = down_cast_nonnull<pm_index_or_write_node_t>(node);
             orWrite->receiver = rewriteNode(orWrite->receiver);
             rewriteArgumentsNode(orWrite->arguments);
             if (orWrite->block != nullptr) {
-                orWrite->block = down_cast<pm_block_argument_node_t>(rewriteNode(up_cast(orWrite->block)));
+                orWrite->block = down_cast_nonnull<pm_block_argument_node_t>(rewriteNode(up_cast(orWrite->block)));
             }
             orWrite->value = maybeInsertCast(orWrite->value);
             orWrite->value = rewriteNode(orWrite->value);
@@ -794,14 +794,14 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
 
         // Multi-assignment
         case PM_MULTI_WRITE_NODE: {
-            auto *masgn = down_cast<pm_multi_write_node_t>(node);
+            auto *masgn = down_cast_nonnull<pm_multi_write_node_t>(node);
             masgn->value = rewriteNode(maybeInsertCast(masgn->value));
             return node;
         }
 
         // Calls
         case PM_CALL_NODE: {
-            auto *call = down_cast<pm_call_node_t>(node);
+            auto *call = down_cast_nonnull<pm_call_node_t>(node);
             if (saveMethodTypeParams(node)) {
                 // If this is a `sig` call, we need to save the type parameters so we can use them to resolve the type
                 // parameters from the method signature.
@@ -816,13 +816,13 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
 
         // Blocks
         case PM_BLOCK_NODE: {
-            auto *block = down_cast<pm_block_node_t>(node);
+            auto *block = down_cast_nonnull<pm_block_node_t>(node);
             node = maybeInsertCast(node);
             block->body = rewriteNullableNode(block->body);
             return node;
         }
         case PM_LAMBDA_NODE: {
-            auto *lambda = down_cast<pm_lambda_node_t>(node);
+            auto *lambda = down_cast_nonnull<pm_lambda_node_t>(node);
             node = maybeInsertCast(node);
             lambda->body = rewriteNullableNode(lambda->body);
             return node;
@@ -830,7 +830,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
 
         // Loops
         case PM_WHILE_NODE: {
-            auto *wl = down_cast<pm_while_node_t>(node);
+            auto *wl = down_cast_nonnull<pm_while_node_t>(node);
             // Check if this is a post-while (BEGIN_MODIFIER flag)
             bool isPost = PM_NODE_FLAG_P(wl, PM_LOOP_FLAGS_BEGIN_MODIFIER);
             if (!isPost) {
@@ -843,7 +843,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             return node;
         }
         case PM_UNTIL_NODE: {
-            auto *until = down_cast<pm_until_node_t>(node);
+            auto *until = down_cast_nonnull<pm_until_node_t>(node);
             // Check if this is a post-until (BEGIN_MODIFIER flag)
             bool isPost = PM_NODE_FLAG_P(until, PM_LOOP_FLAGS_BEGIN_MODIFIER);
             if (!isPost) {
@@ -856,7 +856,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             return node;
         }
         case PM_FOR_NODE: {
-            auto *for_ = down_cast<pm_for_node_t>(node);
+            auto *for_ = down_cast_nonnull<pm_for_node_t>(node);
             node = maybeInsertCast(node);
             for_->index = rewriteNode(for_->index);
             for_->collection = rewriteNode(for_->collection);
@@ -868,7 +868,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
 
         // Control flow
         case PM_BREAK_NODE: {
-            auto *break_ = down_cast<pm_break_node_t>(node);
+            auto *break_ = down_cast_nonnull<pm_break_node_t>(node);
             if (auto *args = break_->arguments; !args || args->arguments.size == 0) {
                 return node;
             }
@@ -876,7 +876,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             return node;
         }
         case PM_NEXT_NODE: {
-            auto *next = down_cast<pm_next_node_t>(node);
+            auto *next = down_cast_nonnull<pm_next_node_t>(node);
             if (auto *args = next->arguments; !args || args->arguments.size == 0) {
                 return node;
             }
@@ -884,7 +884,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             return node;
         }
         case PM_RETURN_NODE: {
-            auto *ret = down_cast<pm_return_node_t>(node);
+            auto *ret = down_cast_nonnull<pm_return_node_t>(node);
             if (auto *args = ret->arguments; !args || args->arguments.size == 0) {
                 return node;
             }
@@ -894,7 +894,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
 
         // Conditionals
         case PM_IF_NODE: {
-            auto *if_ = down_cast<pm_if_node_t>(node);
+            auto *if_ = down_cast_nonnull<pm_if_node_t>(node);
             node = maybeInsertCast(node);
             if_->predicate = rewriteNode(if_->predicate);
             if (if_->statements) {
@@ -904,7 +904,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             return node;
         }
         case PM_UNLESS_NODE: {
-            auto *unless_ = down_cast<pm_unless_node_t>(node);
+            auto *unless_ = down_cast_nonnull<pm_unless_node_t>(node);
             node = maybeInsertCast(node);
             unless_->predicate = rewriteNode(unless_->predicate);
             if (unless_->statements) {
@@ -914,7 +914,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             return node;
         }
         case PM_CASE_NODE: {
-            auto *case_ = down_cast<pm_case_node_t>(node);
+            auto *case_ = down_cast_nonnull<pm_case_node_t>(node);
             node = maybeInsertCast(node);
             case_->predicate = rewriteNullableNode(case_->predicate);
             rewriteNodes(case_->conditions);
@@ -922,14 +922,14 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             return node;
         }
         case PM_WHEN_NODE: {
-            auto *when = down_cast<pm_when_node_t>(node);
+            auto *when = down_cast_nonnull<pm_when_node_t>(node);
             if (when->statements) {
                 rewriteStatements(when->statements);
             }
             return node;
         }
         case PM_CASE_MATCH_NODE: {
-            auto *caseMatch = down_cast<pm_case_match_node_t>(node);
+            auto *caseMatch = down_cast_nonnull<pm_case_match_node_t>(node);
             node = maybeInsertCast(node);
             caseMatch->predicate = rewriteNode(caseMatch->predicate);
             rewriteNodes(caseMatch->conditions);
@@ -937,7 +937,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             return node;
         }
         case PM_IN_NODE: {
-            auto *inPattern = down_cast<pm_in_node_t>(node);
+            auto *inPattern = down_cast_nonnull<pm_in_node_t>(node);
             inPattern->pattern = rewriteNode(inPattern->pattern);
             if (inPattern->statements) {
                 rewriteStatements(inPattern->statements);
@@ -947,14 +947,14 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
 
         // Rescue/Ensure
         case PM_RESCUE_MODIFIER_NODE: {
-            auto *rescueMod = down_cast<pm_rescue_modifier_node_t>(node);
+            auto *rescueMod = down_cast_nonnull<pm_rescue_modifier_node_t>(node);
             node = maybeInsertCast(node);
             rescueMod->rescue_expression = rewriteNode(rescueMod->rescue_expression);
             rescueMod->expression = rewriteNode(rescueMod->expression);
             return node;
         }
         case PM_RESCUE_NODE: {
-            auto *rescue = down_cast<pm_rescue_node_t>(node);
+            auto *rescue = down_cast_nonnull<pm_rescue_node_t>(node);
             if (rescue->statements) {
                 rewriteStatements(rescue->statements);
             }
@@ -962,14 +962,14 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             return node;
         }
         case PM_ELSE_NODE: {
-            auto *else_ = down_cast<pm_else_node_t>(node);
+            auto *else_ = down_cast_nonnull<pm_else_node_t>(node);
             if (else_->statements) {
                 rewriteStatements(else_->statements);
             }
             return node;
         }
         case PM_ENSURE_NODE: {
-            auto *ensure = down_cast<pm_ensure_node_t>(node);
+            auto *ensure = down_cast_nonnull<pm_ensure_node_t>(node);
             if (ensure->statements) {
                 rewriteStatements(ensure->statements);
             }
@@ -978,14 +978,14 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
 
         // Boolean operators
         case PM_AND_NODE: {
-            auto *and_ = down_cast<pm_and_node_t>(node);
+            auto *and_ = down_cast_nonnull<pm_and_node_t>(node);
             node = maybeInsertCast(node);
             and_->left = rewriteNode(and_->left);
             and_->right = rewriteNode(and_->right);
             return node;
         }
         case PM_OR_NODE: {
-            auto *or_ = down_cast<pm_or_node_t>(node);
+            auto *or_ = down_cast_nonnull<pm_or_node_t>(node);
             node = maybeInsertCast(node);
             or_->left = rewriteNode(or_->left);
             or_->right = rewriteNode(or_->right);
@@ -994,24 +994,24 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
 
         // Collections
         case PM_HASH_NODE: {
-            auto *hash = down_cast<pm_hash_node_t>(node);
+            auto *hash = down_cast_nonnull<pm_hash_node_t>(node);
             node = maybeInsertCast(node);
             rewriteNodes(hash->elements);
             return node;
         }
         case PM_KEYWORD_HASH_NODE: {
-            auto *kwh = down_cast<pm_keyword_hash_node_t>(node);
+            auto *kwh = down_cast_nonnull<pm_keyword_hash_node_t>(node);
             rewriteNodes(kwh->elements);
             return node;
         }
         case PM_ASSOC_NODE: {
-            auto *pair = down_cast<pm_assoc_node_t>(node);
+            auto *pair = down_cast_nonnull<pm_assoc_node_t>(node);
             pair->key = rewriteNode(pair->key);
             pair->value = rewriteNode(pair->value);
             return node;
         }
         case PM_ARRAY_NODE: {
-            auto *arr = down_cast<pm_array_node_t>(node);
+            auto *arr = down_cast_nonnull<pm_array_node_t>(node);
             node = maybeInsertCast(node);
             rewriteNodes(arr->elements);
             return node;
@@ -1019,19 +1019,19 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
 
         // Splat
         case PM_SPLAT_NODE: {
-            auto *splat = down_cast<pm_splat_node_t>(node);
+            auto *splat = down_cast_nonnull<pm_splat_node_t>(node);
             splat->expression = rewriteNullableNode(splat->expression);
             return node;
         }
         case PM_ASSOC_SPLAT_NODE: {
-            auto *splat = down_cast<pm_assoc_splat_node_t>(node);
+            auto *splat = down_cast_nonnull<pm_assoc_splat_node_t>(node);
             splat->value = rewriteNode(maybeInsertCast(splat->value));
             return node;
         }
 
         // Super
         case PM_SUPER_NODE: {
-            auto *super_ = down_cast<pm_super_node_t>(node);
+            auto *super_ = down_cast_nonnull<pm_super_node_t>(node);
             rewriteArgumentsNode(super_->arguments);
             node = maybeInsertCast(node);
             return node;
@@ -1039,21 +1039,21 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
 
         // Program (top-level AST root)
         case PM_PROGRAM_NODE: {
-            auto *program = down_cast<pm_program_node_t>(node);
+            auto *program = down_cast_nonnull<pm_program_node_t>(node);
             // Rewrite the top-level statements
             rewriteStatements(program->statements);
             return node;
         }
 
         case PM_PARENTHESES_NODE: {
-            auto *paren = down_cast<pm_parentheses_node_t>(node);
+            auto *paren = down_cast_nonnull<pm_parentheses_node_t>(node);
             node = maybeInsertCast(node);
             paren->body = rewriteNullableNode(paren->body);
             return node;
         }
 
         case PM_STATEMENTS_NODE: {
-            auto *statements = down_cast<pm_statements_node_t>(node);
+            auto *statements = down_cast_nonnull<pm_statements_node_t>(node);
             rewriteNodes(statements->body);
             return node;
         }
@@ -1061,7 +1061,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
         // Synthetic bind node for bind comments
         // We use PM_CONSTANT_READ_NODE with PM_CONSTANT_ID_UNSET to distinguish it from regular constant reads
         case PM_CONSTANT_READ_NODE: {
-            auto *constantRead = down_cast<pm_constant_read_node_t>(node);
+            auto *constantRead = down_cast_nonnull<pm_constant_read_node_t>(node);
 
             // Check if this is a synthetic bind node
             if (constantRead->name == RBS_SYNTHETIC_BIND_MARKER) {

--- a/rbs/prism/AssertionsRewriterPrism.cc
+++ b/rbs/prism/AssertionsRewriterPrism.cc
@@ -63,11 +63,11 @@ vector<pair<core::LocOffsets, core::NameRef>>
 extractTypeParamsPrism(core::MutableContext ctx, const parser::Prism::Parser &parser, pm_node_t *block) {
     vector<pair<core::LocOffsets, core::NameRef>> typeParams;
 
-    if (!block || !PM_NODE_TYPE_P(block, PM_BLOCK_NODE)) {
+    auto *blockNode = down_cast<pm_block_node_t>(block);
+    if (!blockNode) {
         return typeParams;
     }
 
-    auto *blockNode = down_cast_nonnull<pm_block_node_t>(block);
     if (!blockNode->body) {
         return typeParams;
     }
@@ -76,8 +76,7 @@ extractTypeParamsPrism(core::MutableContext ctx, const parser::Prism::Parser &pa
     pm_node_t *node = blockNode->body;
 
     // If it's a statements node, get the first statement
-    if (PM_NODE_TYPE_P(node, PM_STATEMENTS_NODE)) {
-        auto *statements = down_cast_nonnull<pm_statements_node_t>(node);
+    if (auto *statements = down_cast<pm_statements_node_t>(node)) {
         ENFORCE(statements->body.size > 0);
         node = statements->body.nodes[0];
     }
@@ -85,8 +84,7 @@ extractTypeParamsPrism(core::MutableContext ctx, const parser::Prism::Parser &pa
     pm_call_node_t *call = nullptr;
 
     // Walk through the call chain to find type_parameters()
-    while (node && PM_NODE_TYPE_P(node, PM_CALL_NODE)) {
-        auto *callNode = down_cast_nonnull<pm_call_node_t>(node);
+    while (auto *callNode = down_cast<pm_call_node_t>(node)) {
         auto methodName = parser.resolveConstant(callNode->name);
 
         if (methodName == "type_parameters") {
@@ -105,11 +103,11 @@ extractTypeParamsPrism(core::MutableContext ctx, const parser::Prism::Parser &pa
     if (auto *args = call->arguments) {
         for (size_t i = 0; i < args->arguments.size; i++) {
             pm_node_t *arg = args->arguments.nodes[i];
-            if (!PM_NODE_TYPE_P(arg, PM_SYMBOL_NODE)) {
+            auto *sym = down_cast<pm_symbol_node_t>(arg);
+            if (!sym) {
                 continue;
             }
 
-            auto *sym = down_cast_nonnull<pm_symbol_node_t>(arg);
             auto symbolName = parser.extractString(&sym->unescaped);
             auto nameRef = ctx.state.enterNameUTF8(symbolName);
             auto loc = parser.translateLocation(arg->location);
@@ -128,29 +126,24 @@ extractTypeParamsPrism(core::MutableContext ctx, const parser::Prism::Parser &pa
  */
 bool sameConstant(parser::Prism::Parser &parser, pm_node_t *a, pm_node_t *b) {
     while (a != nullptr && b != nullptr) {
-        pm_node_type aType = PM_NODE_TYPE(a);
-        pm_node_type bType = PM_NODE_TYPE(b);
-
-        if (aType == PM_CONSTANT_READ_NODE && bType == PM_CONSTANT_READ_NODE) {
-            auto *aConst = down_cast_nonnull<pm_constant_read_node_t>(a);
-            auto *bConst = down_cast_nonnull<pm_constant_read_node_t>(b);
-            return aConst->name == bConst->name;
+        if (auto *constA = down_cast<pm_constant_read_node_t>(a), *constB = down_cast<pm_constant_read_node_t>(b);
+            constA && constB) {
+            return constA->name == constB->name;
         }
 
-        if (aType == PM_CONSTANT_PATH_NODE && bType == PM_CONSTANT_PATH_NODE) {
-            auto *aPath = down_cast_nonnull<pm_constant_path_node_t>(a);
-            auto *bPath = down_cast_nonnull<pm_constant_path_node_t>(b);
-
-            if (aPath->name != bPath->name) {
+        if (auto *pathA = down_cast<pm_constant_path_node_t>(a), *pathB = down_cast<pm_constant_path_node_t>(b);
+            pathA && pathB) {
+            if (pathA->name != pathB->name) {
                 return false;
             }
 
-            if (aPath->parent == nullptr && bPath->parent == nullptr) {
+            if (pathA->parent == nullptr && pathB->parent == nullptr) {
                 return true;
             }
 
-            a = aPath->parent;
-            b = bPath->parent;
+            a = pathA->parent;
+            b = pathB->parent;
+
             continue;
         }
 
@@ -262,27 +255,23 @@ pm_node_t *deepCopyGenericTypeNode(parser::Prism::Parser &parser, pm_node_t *nod
  */
 void maybeSupplyGenericTypeArguments(core::MutableContext ctx, parser::Prism::Parser &parser, pm_node_t **node,
                                      pm_node_t **type) {
-    // We only rewrite `.new` calls
-    if (!PM_NODE_TYPE_P(*node, PM_CALL_NODE)) {
+    auto *newCall = down_cast<pm_call_node_t>(*node);
+    if (!newCall) {
         return;
     }
 
-    auto *newCall = down_cast_nonnull<pm_call_node_t>(*node);
-    auto methodName = parser.resolveConstant(newCall->name);
+    // We only rewrite `.new` calls
+    if (parser.resolveConstant(newCall->name) != "new"sv) {
+        return;
+    }
 
-    if (methodName != "new"sv) {
+    auto *bracketCall = down_cast<pm_call_node_t>(*type);
+    if (!bracketCall) {
         return;
     }
 
     // We only rewrite when casted to a generic type (syntheticSquareBrackets)
-    if (!PM_NODE_TYPE_P(*type, PM_CALL_NODE)) {
-        return;
-    }
-
-    auto *bracketCall = down_cast_nonnull<pm_call_node_t>(*type);
-    auto bracketMethodName = parser.resolveConstant(bracketCall->name);
-
-    if (bracketMethodName != "<syntheticSquareBrackets>"sv) {
+    if (parser.resolveConstant(bracketCall->name) != "<syntheticSquareBrackets>"sv) {
         return;
     }
 
@@ -308,11 +297,10 @@ void maybeSupplyGenericTypeArguments(core::MutableContext ctx, parser::Prism::Pa
  * Returns `true` if the node is a `sig` call (so caller can skip further processing), `false` otherwise.
  */
 bool AssertionsRewriterPrism::saveMethodTypeParams(pm_node_t *call) {
-    if (!call || !PM_NODE_TYPE_P(call, PM_CALL_NODE)) {
+    auto *callNode = down_cast<pm_call_node_t>(call);
+    if (!callNode) {
         return false;
     }
-
-    auto *callNode = down_cast_nonnull<pm_call_node_t>(call);
 
     // Check if this is a sig() call
     auto methodName = parser.resolveConstant(callNode->name);

--- a/rbs/prism/CommentsAssociatorPrism.cc
+++ b/rbs/prism/CommentsAssociatorPrism.cc
@@ -436,9 +436,8 @@ pm_node_t *CommentsAssociatorPrism::walkBody(pm_node_t *node, pm_node_t *body) {
         return nullptr;
     }
 
-    if (PM_NODE_TYPE_P(body, PM_BEGIN_NODE)) {
+    if (auto *begin = down_cast<pm_begin_node_t>(body)) {
         // The body is already a Begin node, so we don't need any wrapping
-        auto *begin = down_cast_nonnull<pm_begin_node_t>(body);
         walkNode(body);
 
         if (begin->statements) {
@@ -448,8 +447,7 @@ pm_node_t *CommentsAssociatorPrism::walkBody(pm_node_t *node, pm_node_t *body) {
         return body;
     }
 
-    if (PM_NODE_TYPE_P(body, PM_STATEMENTS_NODE)) {
-        auto *statements = down_cast_nonnull<pm_statements_node_t>(body);
+    if (auto *statements = down_cast<pm_statements_node_t>(body)) {
         walkNode(body);
         processTrailingComments(node, statements->body);
 

--- a/rbs/prism/CommentsAssociatorPrism.cc
+++ b/rbs/prism/CommentsAssociatorPrism.cc
@@ -543,7 +543,7 @@ void CommentsAssociatorPrism::walkStatements(pm_node_list_t &nodes) {
     for (size_t i = 0; i < nodes.size; i++) {
         auto *stmt = nodes.nodes[i];
 
-        if (PM_NODE_TYPE_P(stmt, PM_ENSURE_NODE)) {
+        if (isa_node<pm_ensure_node_t>(stmt)) {
             // Ensure need to be visited handled differently because of how we desugar their structure.
             // The bind needs to be added _inside_ them and not before if we want the type to be applied
             // properly.

--- a/rbs/prism/CommentsAssociatorPrism.cc
+++ b/rbs/prism/CommentsAssociatorPrism.cc
@@ -82,7 +82,7 @@ optional<uint32_t> CommentsAssociatorPrism::locateTargetLine(pm_node_t *node) {
             break;
         }
         case PM_ARRAY_NODE: {
-            auto *arr = down_cast<pm_array_node_t>(node);
+            auto *arr = down_cast_nonnull<pm_array_node_t>(node);
             for (size_t i = 0; i < arr->elements.size; i++) {
                 if (auto line = locateTargetLine(arr->elements.nodes[i])) {
                     return *line;
@@ -91,7 +91,7 @@ optional<uint32_t> CommentsAssociatorPrism::locateTargetLine(pm_node_t *node) {
             break;
         }
         case PM_CALL_NODE: {
-            auto *call = down_cast<pm_call_node_t>(node);
+            auto *call = down_cast_nonnull<pm_call_node_t>(node);
             return locateTargetLine(call->receiver);
         }
         default: {
@@ -381,7 +381,7 @@ void CommentsAssociatorPrism::walkConditionalNode(pm_node_t *node, pm_node_t *pr
     // Bound to thenBody so processTrailingComments doesn't scan into the else branch.
     pm_node_t *thenBound = thenBody ? thenBody : node;
     pm_node_t *thenResult = walkBody(thenBound, thenBody);
-    statements = down_cast<pm_statements_node_t>(thenResult);
+    statements = down_cast_nonnull<pm_statements_node_t>(thenResult);
 
     if (thenResult) {
         auto thenLoc = translateLocation(thenResult->location);
@@ -438,7 +438,7 @@ pm_node_t *CommentsAssociatorPrism::walkBody(pm_node_t *node, pm_node_t *body) {
 
     if (PM_NODE_TYPE_P(body, PM_BEGIN_NODE)) {
         // The body is already a Begin node, so we don't need any wrapping
-        auto *begin = down_cast<pm_begin_node_t>(body);
+        auto *begin = down_cast_nonnull<pm_begin_node_t>(body);
         walkNode(body);
 
         if (begin->statements) {
@@ -449,7 +449,7 @@ pm_node_t *CommentsAssociatorPrism::walkBody(pm_node_t *node, pm_node_t *body) {
     }
 
     if (PM_NODE_TYPE_P(body, PM_STATEMENTS_NODE)) {
-        auto *statements = down_cast<pm_statements_node_t>(body);
+        auto *statements = down_cast_nonnull<pm_statements_node_t>(body);
         walkNode(body);
         processTrailingComments(node, statements->body);
 
@@ -500,7 +500,7 @@ pm_node_t *CommentsAssociatorPrism::walkBody(pm_node_t *node, pm_node_t *body) {
 }
 
 template <typename PrismNode> void CommentsAssociatorPrism::walkAssignmentNode(pm_node_t *untypedNode) {
-    auto *assign = down_cast<PrismNode>(untypedNode);
+    auto *assign = down_cast_nonnull<PrismNode>(untypedNode);
     associateAssertionCommentsToNode(assign->value, true);
     walkNode(assign->value);
     consumeCommentsInsideNode(untypedNode, "assign");
@@ -508,7 +508,7 @@ template <typename PrismNode> void CommentsAssociatorPrism::walkAssignmentNode(p
 
 template <typename PrismNode>
 void CommentsAssociatorPrism::walkCallAssignmentNode(pm_node_t *untypedNode, std::string_view label) {
-    auto *assign = down_cast<PrismNode>(untypedNode);
+    auto *assign = down_cast_nonnull<PrismNode>(untypedNode);
     associateAssertionCommentsToNode(assign->value, true);
     walkNode(assign->value);
     walkNode(assign->receiver);
@@ -517,7 +517,7 @@ void CommentsAssociatorPrism::walkCallAssignmentNode(pm_node_t *untypedNode, std
 
 template <typename PrismNode>
 void CommentsAssociatorPrism::walkIndexAssignmentNode(pm_node_t *untypedNode, std::string_view label) {
-    auto *assign = down_cast<PrismNode>(untypedNode);
+    auto *assign = down_cast_nonnull<PrismNode>(untypedNode);
     associateAssertionCommentsToNode(assign->value, true);
     walkNode(assign->receiver);
     if (assign->arguments != nullptr) {
@@ -579,7 +579,7 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
 
     switch (PM_NODE_TYPE(node)) {
         case PM_AND_NODE: {
-            auto *and_ = down_cast<pm_and_node_t>(node);
+            auto *and_ = down_cast_nonnull<pm_and_node_t>(node);
             associateAssertionCommentsToNode(node);
             walkNode(and_->right);
             walkNode(and_->left);
@@ -587,14 +587,14 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_ARRAY_NODE: {
-            auto *array = down_cast<pm_array_node_t>(node);
+            auto *array = down_cast_nonnull<pm_array_node_t>(node);
             associateAssertionCommentsToNode(node);
             walkNodes(array->elements);
             consumeCommentsInsideNode(node, "array");
             break;
         }
         case PM_BEGIN_NODE: {
-            auto *begin = down_cast<pm_begin_node_t>(node);
+            auto *begin = down_cast_nonnull<pm_begin_node_t>(node);
 
             // PM_BEGIN_NODE represents both implicit begins (parenthesized expressions) and explicit begins
             // (begin...end blocks)
@@ -630,7 +630,7 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_BLOCK_NODE: {
-            auto *block = down_cast<pm_block_node_t>(node);
+            auto *block = down_cast_nonnull<pm_block_node_t>(node);
 
             auto blockLoc = translateLocation(node->location);
             auto beginLine = posToLine(blockLoc.beginPos());
@@ -644,7 +644,7 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_LAMBDA_NODE: {
-            auto *lambda = down_cast<pm_lambda_node_t>(node);
+            auto *lambda = down_cast_nonnull<pm_lambda_node_t>(node);
             auto lambdaLoc = translateLocation(node->location);
             auto beginLine = posToLine(lambdaLoc.beginPos());
             associateAssertionCommentsToNode(node);
@@ -655,7 +655,7 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_BREAK_NODE: {
-            auto *break_ = down_cast<pm_break_node_t>(node);
+            auto *break_ = down_cast_nonnull<pm_break_node_t>(node);
 
             // Only associate comments if the last expression is on the same line as the break
             if (auto *args = break_->arguments; args && args->arguments.size > 0) {
@@ -675,27 +675,27 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_CASE_NODE: {
-            auto *case_ = down_cast<pm_case_node_t>(node);
+            auto *case_ = down_cast_nonnull<pm_case_node_t>(node);
 
             associateAssertionCommentsToNode(node);
             walkNode(case_->predicate);
             walkNodes(case_->conditions);
-            case_->else_clause = down_cast<pm_else_node_t>(walkBody(node, up_cast(case_->else_clause)));
+            case_->else_clause = down_cast_nonnull<pm_else_node_t>(walkBody(node, up_cast(case_->else_clause)));
             consumeCommentsInsideNode(node, "case");
             break;
         }
         case PM_CASE_MATCH_NODE: {
-            auto *case_ = down_cast<pm_case_match_node_t>(node);
+            auto *case_ = down_cast_nonnull<pm_case_match_node_t>(node);
 
             associateAssertionCommentsToNode(node);
             walkNode(case_->predicate);
             walkNodes(case_->conditions);
-            case_->else_clause = down_cast<pm_else_node_t>(walkBody(node, up_cast(case_->else_clause)));
+            case_->else_clause = down_cast_nonnull<pm_else_node_t>(walkBody(node, up_cast(case_->else_clause)));
             consumeCommentsInsideNode(node, "case");
             break;
         }
         case PM_CLASS_NODE: {
-            auto *cls = down_cast<pm_class_node_t>(node);
+            auto *cls = down_cast_nonnull<pm_class_node_t>(node);
 
             auto classKeywordLoc = translateLocation(cls->class_keyword_loc);
             contextAllowingTypeAlias.push_back(make_pair(true, classKeywordLoc));
@@ -713,7 +713,7 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_CALL_NODE: {
-            auto *call = down_cast<pm_call_node_t>(node);
+            auto *call = down_cast_nonnull<pm_call_node_t>(node);
 
             if (parser.isMethodDefModifierCall(node, ctx.state)) {
                 // This is a modifier wrapping a method definition, like `private def foo; end`
@@ -782,7 +782,7 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_DEF_NODE: {
-            auto *def = down_cast<pm_def_node_t>(node);
+            auto *def = down_cast_nonnull<pm_def_node_t>(node);
 
             auto defKeywordLoc = translateLocation(def->def_keyword_loc);
             contextAllowingTypeAlias.push_back(make_pair(false, defKeywordLoc));
@@ -797,7 +797,7 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_ELSE_NODE: {
-            auto *else_ = down_cast<pm_else_node_t>(node);
+            auto *else_ = down_cast_nonnull<pm_else_node_t>(node);
             walkNode(up_cast(else_->statements));
             // Leave comments on the `end` line for the parent node to associate.
             auto beginLine = posToLine(translateLocation(node->location).beginPos());
@@ -811,13 +811,13 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_ENSURE_NODE: {
-            auto *ensure = down_cast<pm_ensure_node_t>(node);
+            auto *ensure = down_cast_nonnull<pm_ensure_node_t>(node);
             walkNode(up_cast(ensure->statements));
             consumeCommentsInsideNode(node, "ensure");
             break;
         }
         case PM_FOR_NODE: {
-            auto *for_ = down_cast<pm_for_node_t>(node);
+            auto *for_ = down_cast_nonnull<pm_for_node_t>(node);
 
             associateAssertionCommentsToNode(node);
             walkNode(for_->collection);
@@ -827,27 +827,27 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_HASH_NODE: {
-            auto *hash = down_cast<pm_hash_node_t>(node);
+            auto *hash = down_cast_nonnull<pm_hash_node_t>(node);
             associateAssertionCommentsToNode(node);
             walkNodes(hash->elements);
             consumeCommentsInsideNode(node, "hash");
             break;
         }
         case PM_IF_NODE: {
-            auto *if_ = down_cast<pm_if_node_t>(node);
+            auto *if_ = down_cast_nonnull<pm_if_node_t>(node);
             walkConditionalNode(node, if_->predicate, if_->statements, if_->subsequent, "if");
             break;
         }
         case PM_UNLESS_NODE: {
-            auto *unless_ = down_cast<pm_unless_node_t>(node);
+            auto *unless_ = down_cast_nonnull<pm_unless_node_t>(node);
 
             pm_node_t *elseClause = up_cast(unless_->else_clause);
             walkConditionalNode(node, unless_->predicate, unless_->statements, elseClause, "unless");
-            unless_->else_clause = down_cast<pm_else_node_t>(elseClause);
+            unless_->else_clause = down_cast_nonnull<pm_else_node_t>(elseClause);
             break;
         }
         case PM_IN_NODE: {
-            auto *inPattern = down_cast<pm_in_node_t>(node);
+            auto *inPattern = down_cast_nonnull<pm_in_node_t>(node);
             walkNode(inPattern->pattern);
             // Note: InNode doesn't have a guard field in Prism
             walkNode(up_cast(inPattern->statements));
@@ -855,20 +855,20 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_KEYWORD_HASH_NODE: {
-            auto *kwh = down_cast<pm_keyword_hash_node_t>(node);
+            auto *kwh = down_cast_nonnull<pm_keyword_hash_node_t>(node);
             walkNodes(kwh->elements);
             consumeCommentsInsideNode(node, "keyword arguments");
             break;
         }
         case PM_MULTI_WRITE_NODE: {
-            auto *masgn = down_cast<pm_multi_write_node_t>(node);
+            auto *masgn = down_cast_nonnull<pm_multi_write_node_t>(node);
             associateAssertionCommentsToNode(masgn->value, true);
             walkNode(masgn->value);
             consumeCommentsInsideNode(node, "masgn");
             break;
         }
         case PM_MODULE_NODE: {
-            auto *mod = down_cast<pm_module_node_t>(node);
+            auto *mod = down_cast_nonnull<pm_module_node_t>(node);
 
             auto moduleKeywordLoc = translateLocation(mod->module_keyword_loc);
             contextAllowingTypeAlias.push_back(make_pair(true, moduleKeywordLoc));
@@ -886,7 +886,7 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_NEXT_NODE: {
-            auto *next = down_cast<pm_next_node_t>(node);
+            auto *next = down_cast_nonnull<pm_next_node_t>(node);
 
             // Only associate comments if the last expression is on the same line as the next
             if (auto *args = next->arguments; args && args->arguments.size > 0) {
@@ -904,7 +904,7 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_OR_NODE: {
-            auto *or_ = down_cast<pm_or_node_t>(node);
+            auto *or_ = down_cast_nonnull<pm_or_node_t>(node);
             associateAssertionCommentsToNode(node);
             walkNode(or_->right);
             walkNode(or_->left);
@@ -912,14 +912,14 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_ASSOC_NODE: {
-            auto *pair = down_cast<pm_assoc_node_t>(node);
+            auto *pair = down_cast_nonnull<pm_assoc_node_t>(node);
             walkNode(pair->value);
             walkNode(pair->key);
             consumeCommentsInsideNode(node, "pair");
             break;
         }
         case PM_RESCUE_NODE: {
-            auto *rescue = down_cast<pm_rescue_node_t>(node);
+            auto *rescue = down_cast_nonnull<pm_rescue_node_t>(node);
 
             auto rescueLoc = translateLocation(node->location);
             auto beginLine = posToLine(rescueLoc.beginPos());
@@ -951,14 +951,14 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_RESCUE_MODIFIER_NODE: {
-            auto *rescueMod = down_cast<pm_rescue_modifier_node_t>(node);
+            auto *rescueMod = down_cast_nonnull<pm_rescue_modifier_node_t>(node);
             walkNode(rescueMod->rescue_expression);
             walkNode(rescueMod->expression);
             consumeCommentsInsideNode(node, "rescue");
             break;
         }
         case PM_RETURN_NODE: {
-            auto *ret = down_cast<pm_return_node_t>(node);
+            auto *ret = down_cast_nonnull<pm_return_node_t>(node);
 
             // Only associate comments if the last expression is on the same line as the return
             if (auto *args = ret->arguments; args && args->arguments.size > 0) {
@@ -976,7 +976,7 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_SINGLETON_CLASS_NODE: {
-            auto *sclass = down_cast<pm_singleton_class_node_t>(node);
+            auto *sclass = down_cast_nonnull<pm_singleton_class_node_t>(node);
 
             auto classKeywordLoc = translateLocation(sclass->class_keyword_loc);
             contextAllowingTypeAlias.push_back(make_pair(true, classKeywordLoc));
@@ -994,13 +994,13 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_SPLAT_NODE: {
-            auto *splat = down_cast<pm_splat_node_t>(node);
+            auto *splat = down_cast_nonnull<pm_splat_node_t>(node);
             walkNode(splat->expression);
             consumeCommentsInsideNode(node, "splat");
             break;
         }
         case PM_ASSOC_SPLAT_NODE: {
-            auto *splatAssoc = down_cast<pm_assoc_splat_node_t>(node);
+            auto *splatAssoc = down_cast_nonnull<pm_assoc_splat_node_t>(node);
             if (auto *value = splatAssoc->value) {
                 associateAssertionCommentsToNode(value);
                 walkNode(value);
@@ -1008,7 +1008,7 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_SUPER_NODE: {
-            auto *super_ = down_cast<pm_super_node_t>(node);
+            auto *super_ = down_cast_nonnull<pm_super_node_t>(node);
             associateAssertionCommentsToNode(node);
             walkArgumentsNode(super_->arguments);
             walkNode(super_->block);
@@ -1016,7 +1016,7 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_UNTIL_NODE: {
-            auto *until = down_cast<pm_until_node_t>(node);
+            auto *until = down_cast_nonnull<pm_until_node_t>(node);
 
             // Check if this is post-condition until (modifier form: "body until condition")
             bool isModifier = PM_NODE_FLAG_P(until, PM_LOOP_FLAGS_BEGIN_MODIFIER);
@@ -1035,7 +1035,7 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_WHEN_NODE: {
-            auto *when = down_cast<pm_when_node_t>(node);
+            auto *when = down_cast_nonnull<pm_when_node_t>(node);
             walkNode(up_cast(when->statements));
             if (when->statements) {
                 consumeCommentsInsideNode(up_cast(when->statements), "when");
@@ -1043,7 +1043,7 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_WHILE_NODE: {
-            auto *while_ = down_cast<pm_while_node_t>(node);
+            auto *while_ = down_cast_nonnull<pm_while_node_t>(node);
 
             // Check if this is post-condition while (modifier form: "body while condition")
             bool isModifier = PM_NODE_FLAG_P(while_, PM_LOOP_FLAGS_BEGIN_MODIFIER);
@@ -1062,19 +1062,19 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
             break;
         }
         case PM_PROGRAM_NODE: {
-            auto *program = down_cast<pm_program_node_t>(node);
+            auto *program = down_cast_nonnull<pm_program_node_t>(node);
             if (program->statements) {
                 walkStatements(program->statements->body);
             }
             break;
         }
         case PM_STATEMENTS_NODE: {
-            auto *statements = down_cast<pm_statements_node_t>(node);
+            auto *statements = down_cast_nonnull<pm_statements_node_t>(node);
             walkStatements(statements->body);
             break;
         }
         case PM_PARENTHESES_NODE: {
-            auto *paren = down_cast<pm_parentheses_node_t>(node);
+            auto *paren = down_cast_nonnull<pm_parentheses_node_t>(node);
             associateAssertionCommentsToNode(node);
             walkNode(paren->body);
             consumeCommentsInsideNode(node, "begin");

--- a/rbs/prism/MethodTypeToParserNodePrism.cc
+++ b/rbs/prism/MethodTypeToParserNodePrism.cc
@@ -22,15 +22,13 @@ bool isSelfOrKernel(pm_node_t *node, const parser::Prism::Parser *prismParser) {
         return true;
     }
 
-    if (PM_NODE_TYPE_P(node, PM_CONSTANT_READ_NODE)) {
-        auto *constant = down_cast_nonnull<pm_constant_read_node_t>(node);
+    if (auto *constant = down_cast<pm_constant_read_node_t>(node)) {
         auto name = prismParser->resolveConstant(constant->name);
         // Check if it's Kernel constant with no scope (::Kernel or bare Kernel)
         return name == "Kernel";
     }
 
-    if (PM_NODE_TYPE_P(node, PM_CONSTANT_PATH_NODE)) {
-        auto *constantPath = down_cast_nonnull<pm_constant_path_node_t>(node);
+    if (auto *constantPath = down_cast<pm_constant_path_node_t>(node)) {
         // Check if it's ::Kernel (parent is nullptr, representing root ::)
         // We reject Foo::Kernel or any other scoped constant
         if (constantPath->parent == nullptr) {
@@ -74,11 +72,10 @@ core::AutocorrectSuggestion autocorrectAbstractBody(core::MutableContext ctx, pm
 // Returns true if the node is a valid abstract method (def node with a body that only raises)
 // e.g. def abstract_method = raise
 bool isValidAbstractMethod(pm_node_t *node, const parser::Prism::Parser *prismParser) {
-    if (!PM_NODE_TYPE_P(node, PM_DEF_NODE)) {
+    auto *def = down_cast<pm_def_node_t>(node);
+    if (def == nullptr) {
         return false;
     }
-
-    auto *def = down_cast_nonnull<pm_def_node_t>(node);
 
     if (def->body == nullptr) {
         return false;
@@ -87,19 +84,18 @@ bool isValidAbstractMethod(pm_node_t *node, const parser::Prism::Parser *prismPa
     pm_node_t *bodyNode = def->body;
 
     // Unwrap statements node if it contains exactly one statement
-    if (PM_NODE_TYPE_P(bodyNode, PM_STATEMENTS_NODE)) {
-        auto *stmts = down_cast_nonnull<pm_statements_node_t>(bodyNode);
+    if (auto *stmts = down_cast<pm_statements_node_t>(bodyNode)) {
         if (stmts->body.size != 1) {
             return false; // Multiple statements, not just a raise
         }
         bodyNode = stmts->body.nodes[0];
     }
 
-    if (!PM_NODE_TYPE_P(bodyNode, PM_CALL_NODE)) {
+    auto *call = down_cast<pm_call_node_t>(bodyNode);
+    if (call == nullptr) {
         return false;
     }
 
-    auto *call = down_cast_nonnull<pm_call_node_t>(bodyNode);
     auto methodName = prismParser->resolveConstant(call->name);
 
     // Check if it's a raise call with no receiver or self/Kernel receiver
@@ -492,10 +488,10 @@ pm_node_t *MethodTypeToParserNodePrism::attrSignature(pm_call_node_t *call, cons
 
         // For attr_writer, we need to add the param to the sig
         pm_node_t *arg = call->arguments->arguments.nodes[0];
-        if (!PM_NODE_TYPE_P(arg, PM_SYMBOL_NODE)) {
+        auto *symbolNode = down_cast<pm_symbol_node_t>(arg);
+        if (symbolNode == nullptr) {
             return nullptr;
         }
-        auto *symbolNode = down_cast_nonnull<pm_symbol_node_t>(arg);
         auto argName = prismParser.extractString(&symbolNode->unescaped);
 
         // The location points to the `:name` symbol, adjust to point to actual name
@@ -602,8 +598,7 @@ pm_node_t *MethodTypeToParserNodePrism::methodSignature(pm_node_t *methodDef, co
     pm_node_t *receiver = prism.TSigWithoutRuntime(firstLineTypeLoc);
 
     vector<pm_node_t *> methodParams;
-    if (PM_NODE_TYPE_P(methodDef, PM_DEF_NODE)) {
-        auto def = down_cast_nonnull<pm_def_node_t>(methodDef);
+    if (auto *def = down_cast<pm_def_node_t>(methodDef)) {
         methodParams = getMethodParams(def);
     }
 

--- a/rbs/prism/MethodTypeToParserNodePrism.cc
+++ b/rbs/prism/MethodTypeToParserNodePrism.cc
@@ -23,14 +23,14 @@ bool isSelfOrKernel(pm_node_t *node, const parser::Prism::Parser *prismParser) {
     }
 
     if (PM_NODE_TYPE_P(node, PM_CONSTANT_READ_NODE)) {
-        auto *constant = down_cast<pm_constant_read_node_t>(node);
+        auto *constant = down_cast_nonnull<pm_constant_read_node_t>(node);
         auto name = prismParser->resolveConstant(constant->name);
         // Check if it's Kernel constant with no scope (::Kernel or bare Kernel)
         return name == "Kernel";
     }
 
     if (PM_NODE_TYPE_P(node, PM_CONSTANT_PATH_NODE)) {
-        auto *constantPath = down_cast<pm_constant_path_node_t>(node);
+        auto *constantPath = down_cast_nonnull<pm_constant_path_node_t>(node);
         // Check if it's ::Kernel (parent is nullptr, representing root ::)
         // We reject Foo::Kernel or any other scoped constant
         if (constantPath->parent == nullptr) {
@@ -47,7 +47,7 @@ core::AutocorrectSuggestion autocorrectAbstractBody(core::MutableContext ctx, pm
     core::LocOffsets editLoc;
     string corrected;
 
-    auto *def = down_cast<pm_def_node_t>(method);
+    auto *def = down_cast_nonnull<pm_def_node_t>(method);
     auto methodLoc = prismParser->translateLocation(method->location);
     auto nameLoc = prismParser->translateLocation(def->name_loc);
 
@@ -78,7 +78,7 @@ bool isValidAbstractMethod(pm_node_t *node, const parser::Prism::Parser *prismPa
         return false;
     }
 
-    auto *def = down_cast<pm_def_node_t>(node);
+    auto *def = down_cast_nonnull<pm_def_node_t>(node);
 
     if (def->body == nullptr) {
         return false;
@@ -88,7 +88,7 @@ bool isValidAbstractMethod(pm_node_t *node, const parser::Prism::Parser *prismPa
 
     // Unwrap statements node if it contains exactly one statement
     if (PM_NODE_TYPE_P(bodyNode, PM_STATEMENTS_NODE)) {
-        auto *stmts = down_cast<pm_statements_node_t>(bodyNode);
+        auto *stmts = down_cast_nonnull<pm_statements_node_t>(bodyNode);
         if (stmts->body.size != 1) {
             return false; // Multiple statements, not just a raise
         }
@@ -99,7 +99,7 @@ bool isValidAbstractMethod(pm_node_t *node, const parser::Prism::Parser *prismPa
         return false;
     }
 
-    auto *call = down_cast<pm_call_node_t>(bodyNode);
+    auto *call = down_cast_nonnull<pm_call_node_t>(bodyNode);
     auto methodName = prismParser->resolveConstant(call->name);
 
     // Check if it's a raise call with no receiver or self/Kernel receiver
@@ -109,13 +109,13 @@ bool isValidAbstractMethod(pm_node_t *node, const parser::Prism::Parser *prismPa
 void ensureAbstractMethodRaises(core::MutableContext ctx, pm_node_t *node, parser::Prism::Parser *prismParser) {
     if (isValidAbstractMethod(node, prismParser)) {
         // Method properly raises, remove body to avoid error 5019 later in the pipeline
-        auto *def = down_cast<pm_def_node_t>(node);
+        auto *def = down_cast_nonnull<pm_def_node_t>(node);
         prismParser->destroyNode(def->body);
         def->body = nullptr;
         return;
     }
 
-    auto *def = down_cast<pm_def_node_t>(node);
+    auto *def = down_cast_nonnull<pm_def_node_t>(node);
     auto nodeLoc = prismParser->translateLocation(node->location);
 
     if (auto e = ctx.beginIndexerError(nodeLoc, core::errors::Rewriter::RBSAbstractMethodNoRaises)) {
@@ -224,7 +224,7 @@ optional<core::AutocorrectSuggestion> autocorrectArg(core::MutableContext ctx, p
     switch (PM_NODE_TYPE(methodArg)) {
         // Should be: `Type name`
         case PM_REQUIRED_PARAMETER_NODE: {
-            auto *param = down_cast<pm_required_parameter_node_t>(methodArg);
+            auto *param = down_cast_nonnull<pm_required_parameter_node_t>(methodArg);
             if (arg.name) {
                 auto nameStr = prismParser.resolveConstant(param->name);
                 corrected = fmt::format("{} {}", typeString, nameStr);
@@ -235,7 +235,7 @@ optional<core::AutocorrectSuggestion> autocorrectArg(core::MutableContext ctx, p
         }
         // Should be: `?Type name`
         case PM_OPTIONAL_PARAMETER_NODE: {
-            auto *param = down_cast<pm_optional_parameter_node_t>(methodArg);
+            auto *param = down_cast_nonnull<pm_optional_parameter_node_t>(methodArg);
             if (arg.name) {
                 auto nameStr = prismParser.resolveConstant(param->name);
                 corrected = fmt::format("?{} {}", typeString, nameStr);
@@ -246,7 +246,7 @@ optional<core::AutocorrectSuggestion> autocorrectArg(core::MutableContext ctx, p
         }
         // Should be: `*Type name`
         case PM_REST_PARAMETER_NODE: {
-            auto *param = down_cast<pm_rest_parameter_node_t>(methodArg);
+            auto *param = down_cast_nonnull<pm_rest_parameter_node_t>(methodArg);
             if (arg.name) {
                 auto nameStr = prismParser.resolveConstant(param->name);
                 corrected = fmt::format("*{} {}", typeString, nameStr);
@@ -257,21 +257,21 @@ optional<core::AutocorrectSuggestion> autocorrectArg(core::MutableContext ctx, p
         }
         // Should be: `name: Type`
         case PM_REQUIRED_KEYWORD_PARAMETER_NODE: {
-            auto *param = down_cast<pm_required_keyword_parameter_node_t>(methodArg);
+            auto *param = down_cast_nonnull<pm_required_keyword_parameter_node_t>(methodArg);
             auto nameStr = prismParser.resolveConstant(param->name);
             corrected = fmt::format("{}: {}", nameStr, typeString);
             break;
         }
         // Should be: `?name: Type`
         case PM_OPTIONAL_KEYWORD_PARAMETER_NODE: {
-            auto *param = down_cast<pm_optional_keyword_parameter_node_t>(methodArg);
+            auto *param = down_cast_nonnull<pm_optional_keyword_parameter_node_t>(methodArg);
             auto nameStr = prismParser.resolveConstant(param->name);
             corrected = fmt::format("?{}: {}", nameStr, typeString);
             break;
         }
         // Should be: `**Type name`
         case PM_KEYWORD_REST_PARAMETER_NODE: {
-            auto *param = down_cast<pm_keyword_rest_parameter_node_t>(methodArg);
+            auto *param = down_cast_nonnull<pm_keyword_rest_parameter_node_t>(methodArg);
             if (arg.name) {
                 auto nameStr = prismParser.resolveConstant(param->name);
                 corrected = fmt::format("**{} {}", typeString, nameStr);
@@ -393,19 +393,19 @@ pm_constant_id_t getParamName(pm_node_t *paramNode) {
 
     switch (PM_NODE_TYPE(paramNode)) {
         case PM_REQUIRED_PARAMETER_NODE:
-            return down_cast<pm_required_parameter_node_t>(paramNode)->name;
+            return down_cast_nonnull<pm_required_parameter_node_t>(paramNode)->name;
         case PM_OPTIONAL_PARAMETER_NODE:
-            return down_cast<pm_optional_parameter_node_t>(paramNode)->name;
+            return down_cast_nonnull<pm_optional_parameter_node_t>(paramNode)->name;
         case PM_REST_PARAMETER_NODE:
-            return down_cast<pm_rest_parameter_node_t>(paramNode)->name;
+            return down_cast_nonnull<pm_rest_parameter_node_t>(paramNode)->name;
         case PM_REQUIRED_KEYWORD_PARAMETER_NODE:
-            return down_cast<pm_required_keyword_parameter_node_t>(paramNode)->name;
+            return down_cast_nonnull<pm_required_keyword_parameter_node_t>(paramNode)->name;
         case PM_OPTIONAL_KEYWORD_PARAMETER_NODE:
-            return down_cast<pm_optional_keyword_parameter_node_t>(paramNode)->name;
+            return down_cast_nonnull<pm_optional_keyword_parameter_node_t>(paramNode)->name;
         case PM_KEYWORD_REST_PARAMETER_NODE:
-            return down_cast<pm_keyword_rest_parameter_node_t>(paramNode)->name;
+            return down_cast_nonnull<pm_keyword_rest_parameter_node_t>(paramNode)->name;
         case PM_BLOCK_PARAMETER_NODE:
-            return down_cast<pm_block_parameter_node_t>(paramNode)->name;
+            return down_cast_nonnull<pm_block_parameter_node_t>(paramNode)->name;
         default:
             return PM_CONSTANT_ID_UNSET;
     }
@@ -495,7 +495,7 @@ pm_node_t *MethodTypeToParserNodePrism::attrSignature(pm_call_node_t *call, cons
         if (!PM_NODE_TYPE_P(arg, PM_SYMBOL_NODE)) {
             return nullptr;
         }
-        auto *symbolNode = down_cast<pm_symbol_node_t>(arg);
+        auto *symbolNode = down_cast_nonnull<pm_symbol_node_t>(arg);
         auto argName = prismParser.extractString(&symbolNode->unescaped);
 
         // The location points to the `:name` symbol, adjust to point to actual name
@@ -603,7 +603,7 @@ pm_node_t *MethodTypeToParserNodePrism::methodSignature(pm_node_t *methodDef, co
 
     vector<pm_node_t *> methodParams;
     if (PM_NODE_TYPE_P(methodDef, PM_DEF_NODE)) {
-        auto def = down_cast<pm_def_node_t>(methodDef);
+        auto def = down_cast_nonnull<pm_def_node_t>(methodDef);
         methodParams = getMethodParams(def);
     }
 

--- a/rbs/prism/MethodTypeToParserNodePrism.cc
+++ b/rbs/prism/MethodTypeToParserNodePrism.cc
@@ -18,7 +18,7 @@ namespace sorbet::rbs {
 namespace {
 
 bool isSelfOrKernel(pm_node_t *node, const parser::Prism::Parser *prismParser) {
-    if (PM_NODE_TYPE_P(node, PM_SELF_NODE)) {
+    if (isa_node<pm_self_node>(node)) {
         return true;
     }
 
@@ -202,7 +202,7 @@ core::NameRef anonymousParamName(core::MutableContext ctx, const pm_node_t *node
 optional<core::AutocorrectSuggestion> autocorrectArg(core::MutableContext ctx, pm_node_t *methodArg, RBSArg arg,
                                                      const parser::Prism::Parser &prismParser,
                                                      const RBSDeclaration &declaration) {
-    if (arg.kind == RBSArg::Kind::Block || PM_NODE_TYPE_P(methodArg, PM_BLOCK_PARAMETER_NODE)) {
+    if (arg.kind == RBSArg::Kind::Block || isa_node<pm_block_parameter_node_t>(methodArg)) {
         // Block arguments are not autocorrected
         return nullopt;
     }

--- a/rbs/prism/SigsRewriterPrism.cc
+++ b/rbs/prism/SigsRewriterPrism.cc
@@ -147,13 +147,12 @@ bool containsExtendTHelper(pm_statements_node_t *body, const parser::Prism::Pars
 
     auto statements = absl::MakeSpan(body->body.nodes, body->body.size);
     return absl::c_any_of(statements, [&](pm_node_t *stmt) {
-        if (!PM_NODE_TYPE_P(stmt, PM_CALL_NODE)) {
+        auto *call = down_cast<pm_call_node_t>(stmt);
+        if (call == nullptr) {
             return false;
         }
 
-        auto *call = down_cast_nonnull<pm_call_node_t>(stmt);
         auto methodName = prismParser.resolveConstant(call->name);
-
         if (methodName != "extend") {
             return false;
         }
@@ -167,13 +166,12 @@ bool containsExtendTHelper(pm_statements_node_t *body, const parser::Prism::Pars
         }
 
         pm_node_t *arg = call->arguments->arguments.nodes[0];
-        if (!PM_NODE_TYPE_P(arg, PM_CONSTANT_PATH_NODE)) {
+        auto *constantPath = down_cast<pm_constant_path_node_t>(arg);
+        if (constantPath == nullptr) {
             return false;
         }
 
-        auto *constantPath = down_cast_nonnull<pm_constant_path_node_t>(arg);
         auto argName = prismParser.resolveConstant(constantPath->name);
-
         if (argName != "Helpers") {
             return false;
         }
@@ -343,8 +341,7 @@ unique_ptr<vector<pm_node_t *>> SigsRewriterPrism::signaturesForNode(pm_node_t *
             if (sig) {
                 signatures->emplace_back(sig);
             }
-        } else if (PM_NODE_TYPE_P(node, PM_CALL_NODE)) {
-            auto *call = down_cast_nonnull<pm_call_node_t>(node);
+        } else if (auto *call = down_cast<pm_call_node_t>(node)) {
             if (parser.isMethodDefModifierCall(node, ctx.state)) {
                 // For method definition modifiers, translate the signature for the inner method definition
                 auto sig = signatureTranslator.translateMethodSignature(call->arguments->arguments.nodes[0],
@@ -424,9 +421,7 @@ pm_node_t *SigsRewriterPrism::rewriteBody(pm_node_t *node) {
     }
 
     // Handle statements nodes (class/module bodies with multiple statements)
-    if (PM_NODE_TYPE_P(node, PM_STATEMENTS_NODE)) {
-        auto *statements = down_cast_nonnull<pm_statements_node_t>(node);
-
+    if (auto *statements = down_cast<pm_statements_node_t>(node)) {
         // Save old statements before modifying (pm_node_list_append can realloc, invalidating pointers)
         pm_node_list_t oldStmts = statements->body;
         statements->body = (pm_node_list_t){.size = 0, .capacity = 0, .nodes = nullptr};
@@ -710,9 +705,7 @@ void SigsRewriterPrism::rewriteNode(pm_node_t *node) {
         case PM_CONSTANT_WRITE_NODE: {
             auto *write = down_cast_nonnull<pm_constant_write_node_t>(node);
             // Check if this is a type alias assignment with synthetic marker
-            if (auto *constantRead = PM_NODE_TYPE_P(write->value, PM_CONSTANT_READ_NODE)
-                                         ? down_cast_nonnull<pm_constant_read_node_t>(write->value)
-                                         : nullptr) {
+            if (auto *constantRead = down_cast<pm_constant_read_node_t>(write->value)) {
                 if (constantRead->name == RBS_SYNTHETIC_TYPE_ALIAS_MARKER) {
                     // Replace the value with the T.type_alias call
                     write->value = replaceSyntheticTypeAlias(write->value);

--- a/rbs/prism/SigsRewriterPrism.cc
+++ b/rbs/prism/SigsRewriterPrism.cc
@@ -103,7 +103,7 @@ vector<pm_node_t *> extractHelpers(core::MutableContext ctx, absl::Span<const Co
 
                 pm_node_t *callNode =
                     prism.Call0(annotation.typeLoc, prism.Self(annotation.typeLoc), "requires_ancestor"sv);
-                auto *call = down_cast<pm_call_node_t>(callNode);
+                auto *call = down_cast_nonnull<pm_call_node_t>(callNode);
                 call->block = prism.Block(annotation.typeLoc, stmts);
 
                 helperNode = callNode;
@@ -151,7 +151,7 @@ bool containsExtendTHelper(pm_statements_node_t *body, const parser::Prism::Pars
             return false;
         }
 
-        auto *call = down_cast<pm_call_node_t>(stmt);
+        auto *call = down_cast_nonnull<pm_call_node_t>(stmt);
         auto methodName = prismParser.resolveConstant(call->name);
 
         if (methodName != "extend") {
@@ -171,7 +171,7 @@ bool containsExtendTHelper(pm_statements_node_t *body, const parser::Prism::Pars
             return false;
         }
 
-        auto *constantPath = down_cast<pm_constant_path_node_t>(arg);
+        auto *constantPath = down_cast_nonnull<pm_constant_path_node_t>(arg);
         auto argName = prismParser.resolveConstant(constantPath->name);
 
         if (argName != "Helpers") {
@@ -187,7 +187,7 @@ bool containsExtendTHelper(pm_statements_node_t *body, const parser::Prism::Pars
  */
 void maybeInsertExtendTHelpers(pm_node_t *body, core::LocOffsets loc, const parser::Prism::Parser &prismParser,
                                core::MutableContext ctx, const parser::Prism::Factory &prism) {
-    auto *statements = down_cast<pm_statements_node_t>(body);
+    auto *statements = down_cast_nonnull<pm_statements_node_t>(body);
     ENFORCE(statements != nullptr);
 
     if (containsExtendTHelper(statements, prismParser, ctx)) {
@@ -205,7 +205,7 @@ void maybeInsertExtendTHelpers(pm_node_t *body, core::LocOffsets loc, const pars
  * Inserts the helpers into the body.
  */
 void insertHelpers(pm_node_t *body, absl::Span<pm_node_t *const> helpers) {
-    auto *statements = down_cast<pm_statements_node_t>(body);
+    auto *statements = down_cast_nonnull<pm_statements_node_t>(body);
     ENFORCE(statements != nullptr);
 
     for (auto *helper : helpers) {
@@ -241,7 +241,7 @@ void SigsRewriterPrism::insertTypeParams(pm_node_t *node, pm_node_t *body) {
         return;
     }
 
-    auto *statements = down_cast<pm_statements_node_t>(body);
+    auto *statements = down_cast_nonnull<pm_statements_node_t>(body);
 
     for (auto *typeParam : typeParams) {
         pm_node_list_append(&statements->body, typeParam);
@@ -344,7 +344,7 @@ unique_ptr<vector<pm_node_t *>> SigsRewriterPrism::signaturesForNode(pm_node_t *
                 signatures->emplace_back(sig);
             }
         } else if (PM_NODE_TYPE_P(node, PM_CALL_NODE)) {
-            auto *call = down_cast<pm_call_node_t>(node);
+            auto *call = down_cast_nonnull<pm_call_node_t>(node);
             if (parser.isMethodDefModifierCall(node, ctx.state)) {
                 // For method definition modifiers, translate the signature for the inner method definition
                 auto sig = signatureTranslator.translateMethodSignature(call->arguments->arguments.nodes[0],
@@ -425,7 +425,7 @@ pm_node_t *SigsRewriterPrism::rewriteBody(pm_node_t *node) {
 
     // Handle statements nodes (class/module bodies with multiple statements)
     if (PM_NODE_TYPE_P(node, PM_STATEMENTS_NODE)) {
-        auto *statements = down_cast<pm_statements_node_t>(node);
+        auto *statements = down_cast_nonnull<pm_statements_node_t>(node);
 
         // Save old statements before modifying (pm_node_list_append can realloc, invalidating pointers)
         pm_node_list_t oldStmts = statements->body;
@@ -501,13 +501,13 @@ void SigsRewriterPrism::rewriteClass(pm_node_t *node) {
 
     switch (PM_NODE_TYPE(node)) {
         case PM_CLASS_NODE:
-            processClassBody(node, down_cast<pm_class_node_t>(node)->body, helpers);
+            processClassBody(node, down_cast_nonnull<pm_class_node_t>(node)->body, helpers);
             break;
         case PM_MODULE_NODE:
-            processClassBody(node, down_cast<pm_module_node_t>(node)->body, helpers);
+            processClassBody(node, down_cast_nonnull<pm_module_node_t>(node)->body, helpers);
             break;
         case PM_SINGLETON_CLASS_NODE:
-            processClassBody(node, down_cast<pm_singleton_class_node_t>(node)->body, helpers);
+            processClassBody(node, down_cast_nonnull<pm_singleton_class_node_t>(node)->body, helpers);
             break;
         default:
             Exception::raise("Unimplemented node type for rewriteClass: {}", (int)PM_NODE_TYPE(node));
@@ -523,7 +523,7 @@ inline void SigsRewriterPrism::rewriteNullableNode(pm_node_t *node) {
 void SigsRewriterPrism::rewriteNode(pm_node_t *node) {
     switch (PM_NODE_TYPE(node)) {
         case PM_BEGIN_NODE: {
-            auto *begin = down_cast<pm_begin_node_t>(node);
+            auto *begin = down_cast_nonnull<pm_begin_node_t>(node);
             rewriteNullableNode(up_cast(begin->statements));
             rewriteNullableNode(up_cast(begin->rescue_clause));
             rewriteNullableNode(up_cast(begin->else_clause));
@@ -531,79 +531,79 @@ void SigsRewriterPrism::rewriteNode(pm_node_t *node) {
             break;
         }
         case PM_BLOCK_NODE: {
-            auto *block = down_cast<pm_block_node_t>(node);
+            auto *block = down_cast_nonnull<pm_block_node_t>(node);
             block->body = rewriteBody(block->body);
             break;
         }
         case PM_LOCAL_VARIABLE_WRITE_NODE: {
-            auto *n = down_cast<pm_local_variable_write_node_t>(node);
+            auto *n = down_cast_nonnull<pm_local_variable_write_node_t>(node);
             rewriteNode(n->value);
             break;
             break;
         }
         case PM_LOCAL_VARIABLE_AND_WRITE_NODE: {
-            auto *n = down_cast<pm_local_variable_and_write_node_t>(node);
+            auto *n = down_cast_nonnull<pm_local_variable_and_write_node_t>(node);
             rewriteNode(n->value);
             break;
         }
         case PM_LOCAL_VARIABLE_OR_WRITE_NODE: {
-            auto *n = down_cast<pm_local_variable_or_write_node_t>(node);
+            auto *n = down_cast_nonnull<pm_local_variable_or_write_node_t>(node);
             rewriteNode(n->value);
             break;
         }
         case PM_LOCAL_VARIABLE_OPERATOR_WRITE_NODE: {
-            auto *n = down_cast<pm_local_variable_operator_write_node_t>(node);
+            auto *n = down_cast_nonnull<pm_local_variable_operator_write_node_t>(node);
             rewriteNode(n->value);
             break;
         }
         case PM_MODULE_NODE: {
-            auto *mod = down_cast<pm_module_node_t>(node);
+            auto *mod = down_cast_nonnull<pm_module_node_t>(node);
             rewriteBody(mod->body);
             rewriteClass(node);
             break;
         }
         case PM_CLASS_NODE: {
-            auto *cls = down_cast<pm_class_node_t>(node);
+            auto *cls = down_cast_nonnull<pm_class_node_t>(node);
             rewriteBody(cls->body);
             rewriteClass(node);
             break;
         }
         case PM_DEF_NODE: {
-            auto *def = down_cast<pm_def_node_t>(node);
+            auto *def = down_cast_nonnull<pm_def_node_t>(node);
             rewriteBody(def->body);
             break;
         }
         case PM_SINGLETON_CLASS_NODE: {
-            auto *sclass = down_cast<pm_singleton_class_node_t>(node);
+            auto *sclass = down_cast_nonnull<pm_singleton_class_node_t>(node);
             rewriteBody(sclass->body);
             rewriteClass(node);
             break;
         }
         case PM_FOR_NODE: {
-            auto *for_ = down_cast<pm_for_node_t>(node);
+            auto *for_ = down_cast_nonnull<pm_for_node_t>(node);
             if (auto *stmts = for_->statements) {
                 rewriteBody(stmts);
             }
             break;
         }
         case PM_ARRAY_NODE: {
-            auto *array = down_cast<pm_array_node_t>(node);
+            auto *array = down_cast_nonnull<pm_array_node_t>(node);
             rewriteNodes(array->elements);
             break;
         }
         case PM_HASH_NODE: {
-            auto *hash = down_cast<pm_hash_node_t>(node);
+            auto *hash = down_cast_nonnull<pm_hash_node_t>(node);
             rewriteNodes(hash->elements);
             break;
         }
         case PM_ASSOC_NODE: {
-            auto *pair = down_cast<pm_assoc_node_t>(node);
+            auto *pair = down_cast_nonnull<pm_assoc_node_t>(node);
             rewriteNode(pair->key);
             rewriteNode(pair->value);
             break;
         }
         case PM_RESCUE_NODE: {
-            auto *rescue = down_cast<pm_rescue_node_t>(node);
+            auto *rescue = down_cast_nonnull<pm_rescue_node_t>(node);
             if (auto *stmts = rescue->statements) {
                 rewriteBody(stmts);
             }
@@ -613,21 +613,21 @@ void SigsRewriterPrism::rewriteNode(pm_node_t *node) {
             break;
         }
         case PM_ELSE_NODE: {
-            auto *else_ = down_cast<pm_else_node_t>(node);
+            auto *else_ = down_cast_nonnull<pm_else_node_t>(node);
             if (auto *stmts = else_->statements) {
                 rewriteBody(stmts);
             }
             break;
         }
         case PM_ENSURE_NODE: {
-            auto *ensure = down_cast<pm_ensure_node_t>(node);
+            auto *ensure = down_cast_nonnull<pm_ensure_node_t>(node);
             if (auto *stmts = ensure->statements) {
                 rewriteBody(stmts);
             }
             break;
         }
         case PM_IF_NODE: {
-            auto *if_ = down_cast<pm_if_node_t>(node);
+            auto *if_ = down_cast_nonnull<pm_if_node_t>(node);
             if (auto *stmts = if_->statements) {
                 rewriteBody(stmts);
             }
@@ -637,45 +637,45 @@ void SigsRewriterPrism::rewriteNode(pm_node_t *node) {
             break;
         }
         case PM_UNLESS_NODE: {
-            auto *unless_ = down_cast<pm_unless_node_t>(node);
+            auto *unless_ = down_cast_nonnull<pm_unless_node_t>(node);
             if (auto *stmts = unless_->statements) {
                 rewriteBody(stmts);
             }
             if (auto *elseClause = unless_->else_clause) {
-                unless_->else_clause = down_cast<pm_else_node_t>(rewriteBody(up_cast(elseClause)));
+                unless_->else_clause = down_cast_nonnull<pm_else_node_t>(rewriteBody(up_cast(elseClause)));
             }
             break;
         }
         case PM_MULTI_WRITE_NODE: {
-            auto *masgn = down_cast<pm_multi_write_node_t>(node);
+            auto *masgn = down_cast_nonnull<pm_multi_write_node_t>(node);
             rewriteNode(masgn->value);
             break;
         }
         case PM_CASE_NODE: {
-            auto *case_ = down_cast<pm_case_node_t>(node);
+            auto *case_ = down_cast_nonnull<pm_case_node_t>(node);
             rewriteNodes(case_->conditions);
             if (auto *elseClause = case_->else_clause) {
-                case_->else_clause = down_cast<pm_else_node_t>(rewriteBody(up_cast(elseClause)));
+                case_->else_clause = down_cast_nonnull<pm_else_node_t>(rewriteBody(up_cast(elseClause)));
             }
             break;
         }
         case PM_CASE_MATCH_NODE: {
-            auto *case_ = down_cast<pm_case_match_node_t>(node);
+            auto *case_ = down_cast_nonnull<pm_case_match_node_t>(node);
             rewriteNodes(case_->conditions);
             if (auto *elseClause = case_->else_clause) {
-                case_->else_clause = down_cast<pm_else_node_t>(rewriteBody(up_cast(elseClause)));
+                case_->else_clause = down_cast_nonnull<pm_else_node_t>(rewriteBody(up_cast(elseClause)));
             }
             break;
         }
         case PM_WHEN_NODE: {
-            auto *when = down_cast<pm_when_node_t>(node);
+            auto *when = down_cast_nonnull<pm_when_node_t>(node);
             if (auto *stmts = when->statements) {
                 rewriteBody(stmts);
             }
             break;
         }
         case PM_CALL_NODE: {
-            auto *call = down_cast<pm_call_node_t>(node);
+            auto *call = down_cast_nonnull<pm_call_node_t>(node);
             if (auto *block = call->block) {
                 rewriteNode(block);
             }
@@ -683,35 +683,35 @@ void SigsRewriterPrism::rewriteNode(pm_node_t *node) {
             break;
         }
         case PM_SUPER_NODE: {
-            auto *sup = down_cast<pm_super_node_t>(node);
+            auto *sup = down_cast_nonnull<pm_super_node_t>(node);
             rewriteArgumentsNode(sup->arguments);
             break;
         }
         case PM_RETURN_NODE: {
-            auto *ret = down_cast<pm_return_node_t>(node);
+            auto *ret = down_cast_nonnull<pm_return_node_t>(node);
             rewriteArgumentsNode(ret->arguments);
             break;
         }
         case PM_NEXT_NODE: {
-            auto *n = down_cast<pm_next_node_t>(node);
+            auto *n = down_cast_nonnull<pm_next_node_t>(node);
             rewriteArgumentsNode(n->arguments);
             break;
         }
         case PM_BREAK_NODE: {
-            auto *b = down_cast<pm_break_node_t>(node);
+            auto *b = down_cast_nonnull<pm_break_node_t>(node);
             rewriteArgumentsNode(b->arguments);
             break;
         }
         case PM_SPLAT_NODE: {
-            auto *s = down_cast<pm_splat_node_t>(node);
+            auto *s = down_cast_nonnull<pm_splat_node_t>(node);
             rewriteNullableNode(s->expression);
             break;
         }
         case PM_CONSTANT_WRITE_NODE: {
-            auto *write = down_cast<pm_constant_write_node_t>(node);
+            auto *write = down_cast_nonnull<pm_constant_write_node_t>(node);
             // Check if this is a type alias assignment with synthetic marker
             if (auto *constantRead = PM_NODE_TYPE_P(write->value, PM_CONSTANT_READ_NODE)
-                                         ? down_cast<pm_constant_read_node_t>(write->value)
+                                         ? down_cast_nonnull<pm_constant_read_node_t>(write->value)
                                          : nullptr) {
                 if (constantRead->name == RBS_SYNTHETIC_TYPE_ALIAS_MARKER) {
                     // Replace the value with the T.type_alias call
@@ -723,12 +723,12 @@ void SigsRewriterPrism::rewriteNode(pm_node_t *node) {
             break;
         }
         case PM_PROGRAM_NODE: {
-            auto *program = down_cast<pm_program_node_t>(node);
+            auto *program = down_cast_nonnull<pm_program_node_t>(node);
             rewriteBody(up_cast(program->statements));
             break;
         }
         case PM_STATEMENTS_NODE: {
-            auto *statements = down_cast<pm_statements_node_t>(node);
+            auto *statements = down_cast_nonnull<pm_statements_node_t>(node);
             rewriteNodes(statements->body);
             break;
         }

--- a/rbs/prism/SigsRewriterPrism.cc
+++ b/rbs/prism/SigsRewriterPrism.cc
@@ -241,7 +241,6 @@ void SigsRewriterPrism::insertTypeParams(pm_node_t *node, pm_node_t *body) {
         return;
     }
 
-    ENFORCE(body != nullptr && PM_NODE_TYPE_P(body, PM_STATEMENTS_NODE), "Body must be a statements node");
     auto *statements = down_cast<pm_statements_node_t>(body);
 
     for (auto *typeParam : typeParams) {

--- a/rbs/prism/SigsRewriterPrism.cc
+++ b/rbs/prism/SigsRewriterPrism.cc
@@ -130,7 +130,7 @@ pm_node_t *maybeWrapBody(pm_node_t *body, core::LocOffsets loc, parser::Prism::P
         return prism.StatementsNode(loc, absl::Span<pm_node_t *>{});
     }
 
-    if (PM_NODE_TYPE_P(body, PM_STATEMENTS_NODE)) {
+    if (isa_node<pm_statements_node_t>(body)) {
         return body; // Already wrapped
     }
 
@@ -157,7 +157,7 @@ bool containsExtendTHelper(pm_statements_node_t *body, const parser::Prism::Pars
             return false;
         }
 
-        if (call->receiver != nullptr && !PM_NODE_TYPE_P(call->receiver, PM_SELF_NODE)) {
+        if (call->receiver != nullptr && !isa_node<pm_self_node_t>(call->receiver)) {
             return false;
         }
 
@@ -214,8 +214,8 @@ void insertHelpers(pm_node_t *body, absl::Span<pm_node_t *const> helpers) {
 } // namespace
 
 void SigsRewriterPrism::insertTypeParams(pm_node_t *node, pm_node_t *body) {
-    ENFORCE(PM_NODE_TYPE_P(node, PM_CLASS_NODE) || PM_NODE_TYPE_P(node, PM_MODULE_NODE) ||
-                PM_NODE_TYPE_P(node, PM_SINGLETON_CLASS_NODE),
+    ENFORCE(isa_node<pm_class_node_t>(node) || isa_node<pm_module_node_t>(node) ||
+                isa_node<pm_singleton_class_node_t>(node),
             "Type parameters can only exist on classes, singleton classes, and modules");
 
     auto comments = commentsForNode(node);
@@ -336,7 +336,7 @@ unique_ptr<vector<pm_node_t *>> SigsRewriterPrism::signaturesForNode(pm_node_t *
     auto signatureTranslator = rbs::SignatureTranslatorPrism{ctx, parser};
 
     for (auto &declaration : comments.signatures) {
-        if (PM_NODE_TYPE_P(node, PM_DEF_NODE)) {
+        if (isa_node<pm_def_node_t>(node)) {
             auto sig = signatureTranslator.translateMethodSignature(node, declaration, comments.annotations);
             if (sig) {
                 signatures->emplace_back(sig);

--- a/rbs/prism/TypeToParserNodePrism.cc
+++ b/rbs/prism/TypeToParserNodePrism.cc
@@ -18,8 +18,8 @@ bool hasTypeParam(absl::Span<const pair<core::LocOffsets, core::NameRef>> typePa
 }
 
 bool isEnumerator(pm_node_t *node, parser::Prism::Parser &prismParser, core::GlobalState &gs) {
-    auto *constNode = PM_NODE_TYPE_P(node, PM_CONSTANT_READ_NODE) ? down_cast_nonnull<pm_constant_read_node_t>(node) : nullptr;
-    auto *pathNode = PM_NODE_TYPE_P(node, PM_CONSTANT_PATH_NODE) ? down_cast_nonnull<pm_constant_path_node_t>(node) : nullptr;
+    auto *constNode = down_cast<pm_constant_read_node_t>(node);
+    auto *pathNode = down_cast<pm_constant_path_node_t>(node);
 
     if (!constNode && !pathNode) {
         return false;

--- a/rbs/prism/TypeToParserNodePrism.cc
+++ b/rbs/prism/TypeToParserNodePrism.cc
@@ -18,8 +18,8 @@ bool hasTypeParam(absl::Span<const pair<core::LocOffsets, core::NameRef>> typePa
 }
 
 bool isEnumerator(pm_node_t *node, parser::Prism::Parser &prismParser, core::GlobalState &gs) {
-    auto *constNode = PM_NODE_TYPE_P(node, PM_CONSTANT_READ_NODE) ? down_cast<pm_constant_read_node_t>(node) : nullptr;
-    auto *pathNode = PM_NODE_TYPE_P(node, PM_CONSTANT_PATH_NODE) ? down_cast<pm_constant_path_node_t>(node) : nullptr;
+    auto *constNode = PM_NODE_TYPE_P(node, PM_CONSTANT_READ_NODE) ? down_cast_nonnull<pm_constant_read_node_t>(node) : nullptr;
+    auto *pathNode = PM_NODE_TYPE_P(node, PM_CONSTANT_PATH_NODE) ? down_cast_nonnull<pm_constant_path_node_t>(node) : nullptr;
 
     if (!constNode && !pathNode) {
         return false;


### PR DESCRIPTION
### Motivation

This pattern is clunky and error-prone:

```c++
if (PM_NODE_TYPE_P(node, PM_BLOCK_PARAMETERS_NODE)) {
    auto *blockParam = down_cast<pm_block_parameter_node>(node);
    ...
}
```

Did you catch the extra `S`?

This PR reworks the semantics of the `down_cast()` helper to do both of these in one operation, similar to `parser::cast_node()` and `ast::cast_tree()`. It does a bit of a renaming dance:

1. Rename `down_cast()` to `down_cast_nonnull()`, whose name better describes its existing semantics
   * Enforces non-null and correct type
2. Introduce a new function as `down_cast()`
   * Returns null on null, or incorrect type
3. Add a similar `isa_node()` helper for consistency (and to dedupe some explicit null checks)
   * In the vast majority of calls, the `null` check can be skipped. So there's `isa_node_nonnull()`, to only add the null checks where needed.

### Test plan

Pure refactor, covered by existing desugar tests.