### PR TITLE
Store the UUID in a separate kvstore key

### DIFF
--- a/core/serialize/serialize.h
+++ b/core/serialize/serialize.h
@@ -9,6 +9,10 @@ public:
     static const uint32_t VERSION = 6;
 
     static constexpr std::string_view NAME_TABLE_KEY = "NameTable";
+    static constexpr std::string_view UUID_KEY = "UUID";
+
+    // Serialize only the UUID from a global state.
+    static std::vector<uint8_t> storeUUID(const GlobalState &gs);
 
     // Serialize only the name table from a global state. This is suffient for deserializing trees that have only been
     // through the indexing, as they won't have any non-well-known symbols present.
@@ -29,7 +33,7 @@ public:
     static std::vector<uint8_t> storeTree(const core::File &file, const ast::ParsedFile &tree);
 
     // Augment a global state with the name table stored in the cache.
-    static void loadAndOverwriteNameTable(GlobalState &gs, const uint8_t *const data);
+    static void loadAndOverwriteNameTable(GlobalState &gs, const uint8_t *const uuidData, const uint8_t *const data);
 
     // Load the global state out of buffers that contain the symbol table, name table, and file table. This is only
     // intended to be used for loading the payload out of buffers that are compiled in to the binary.

--- a/core/serialize/serialize.h
+++ b/core/serialize/serialize.h
@@ -9,7 +9,7 @@ public:
     static const uint32_t VERSION = 6;
 
     static constexpr std::string_view NAME_TABLE_KEY = "NameTable";
-    static constexpr std::string_view UUID_KEY = "UUID";
+    static constexpr std::string_view NAME_TABLE_UUID_KEY = "NameTableUUID";
 
     // Serialize only the UUID from a global state.
     static std::vector<uint8_t> storeUUID(const GlobalState &gs);

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -46,15 +46,15 @@ namespace {
  * kvstore (e.g., kvstore has not since been modified).
  */
 bool kvstoreChangedSinceGsCreation(const core::GlobalState &gs, const unique_ptr<OwnedKeyValueStore> &kvstore) {
-    const uint8_t *maybeUUIDBytes = kvstore->read(core::serialize::Serializer::UUID_KEY).data;
+    const uint8_t *maybeUUIDBytes = kvstore->read(core::serialize::Serializer::NAME_TABLE_UUID_KEY).data;
     if (maybeUUIDBytes) {
-        // If `UUID_KEY` is in kvstore but it's not what `gs.kvstoreUuid` contains, this implies that some other process
-        // wrote a different GlobalState to the cache.
+        // If `NAME_TABLE_UUID_KEY` is in kvstore but it's not what `gs.kvstoreUuid` contains, this implies that some
+        // other process wrote a different GlobalState to the cache.
         return gs.kvstoreUuid != core::serialize::Serializer::loadGlobalStateUUID(gs, maybeUUIDBytes);
     } else {
-        // `UUID_KEY` is not in kvstore, which implies the cache is empty. If kvstoreUuid != 0, that implies we tried to
-        // write GlobalState to the cache once before, and since we don't see `UUID_KEY` in there now, someone else
-        // overwrote/dropped the cache.
+        // `NAME_TABLE_UUID_KEY` is not in kvstore, which implies the cache is empty. If kvstoreUuid != 0, that implies
+        // we tried to write GlobalState to the cache once before, and since we don't see `NAME_TABLE_UUID_KEY` in there
+        // now, someone else overwrote/dropped the cache.
         return gs.kvstoreUuid != 0;
     }
 }
@@ -79,9 +79,9 @@ bool retainGlobalState(core::GlobalState &gs, const unique_ptr<OwnedKeyValueStor
     // into the database.
     if (kvstoreChangedSinceGsCreation(gs, kvstore)) {
         // Either
-        //   - `NAME_TABLE_KEY` is not in kvstore && `gs.kvstoreUuid != 0` (kvstore overwritten
+        //   - `NAME_TABLE_UUID_KEY` is not in kvstore && `gs.kvstoreUuid != 0` (kvstore overwritten
         //      with empty cache after we'd already written GlobalState to the cache once), or
-        //   - `NAME_TABLE_KEY` is in kvstore, BUT it's not what `gs.kvstoreUuid` contains
+        //   - `NAME_TABLE_UUID_KEY` is in kvstore, BUT it's not what `gs.kvstoreUuid` contains
         //      (some other process wrote a different GlobalState to the cache)
         return false;
     }
@@ -93,7 +93,7 @@ bool retainGlobalState(core::GlobalState &gs, const unique_ptr<OwnedKeyValueStor
     if (gs.wasNameTableModified()) {
         Timer timeit(gs.tracer(), "retainGlobalState.writeNameTable");
         gs.kvstoreUuid = Random::uniformU4();
-        kvstore->write(core::serialize::Serializer::UUID_KEY, core::serialize::Serializer::storeUUID(gs));
+        kvstore->write(core::serialize::Serializer::NAME_TABLE_UUID_KEY, core::serialize::Serializer::storeUUID(gs));
         kvstore->write(core::serialize::Serializer::NAME_TABLE_KEY, core::serialize::Serializer::storeNameTable(gs));
     }
 

--- a/payload/payload.cc
+++ b/payload/payload.cc
@@ -60,7 +60,7 @@ void createInitialGlobalState(core::GlobalState &gs, const realmain::options::Op
     // We can use the kvstore to read in the cached name table. We read this in after the payload has been initialized,
     // as the cached name table will extend the payload's existing table when the sorbet versions match.
     if (kvstore) {
-        auto maybeUUIDBytes = kvstore->read(core::serialize::Serializer::UUID_KEY);
+        auto maybeUUIDBytes = kvstore->read(core::serialize::Serializer::NAME_TABLE_UUID_KEY);
         auto maybeGsBytes = kvstore->read(core::serialize::Serializer::NAME_TABLE_KEY);
         if (maybeUUIDBytes.data != nullptr && maybeGsBytes.data != nullptr) {
             Timer timeit(gs.tracer(), "read_name_table.kvstore");

--- a/payload/payload.cc
+++ b/payload/payload.cc
@@ -60,10 +60,11 @@ void createInitialGlobalState(core::GlobalState &gs, const realmain::options::Op
     // We can use the kvstore to read in the cached name table. We read this in after the payload has been initialized,
     // as the cached name table will extend the payload's existing table when the sorbet versions match.
     if (kvstore) {
+        auto maybeUUIDBytes = kvstore->read(core::serialize::Serializer::UUID_KEY);
         auto maybeGsBytes = kvstore->read(core::serialize::Serializer::NAME_TABLE_KEY);
-        if (maybeGsBytes.data != nullptr) {
+        if (maybeUUIDBytes.data != nullptr && maybeGsBytes.data != nullptr) {
             Timer timeit(gs.tracer(), "read_name_table.kvstore");
-            core::serialize::Serializer::loadAndOverwriteNameTable(gs, maybeGsBytes.data);
+            core::serialize::Serializer::loadAndOverwriteNameTable(gs, maybeUUIDBytes.data, maybeGsBytes.data);
             if constexpr (debug_mode) {
                 for (unsigned int i = 1; i < gs.filesUsed(); i++) {
                     core::FileRef fref(i);


### PR DESCRIPTION
Checking the UUID of the kvstore requires decompressing the whole name table, even if we don't plan on using any of it. This PR removes that requirement by moving the UUID to its own key in the kvstore, which allows us to check it without needing to touch the name table.

### Motivation
Performance.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests should be sufficient.
