### PR TITLE
First-class KeywordArgResponse handling

### DIFF
--- a/core/lsp/QueryResponse.cc
+++ b/core/lsp/QueryResponse.cc
@@ -11,6 +11,10 @@ void QueryResponse::pushQueryResponse(core::Context ctx, QueryResponseVariant re
     ctx.state.errorQueue->pushQueryResponse(ctx.file, make_unique<QueryResponse>(std::move(response)));
 }
 
+void QueryResponse::pushQueryResponse(const GlobalState &gs, FileRef file, QueryResponseVariant response) {
+    gs.errorQueue->pushQueryResponse(file, make_unique<QueryResponse>(std::move(response)));
+}
+
 QueryResponse::QueryResponse(QueryResponseVariant response) : response(std::move(response)) {}
 
 const SendResponse *QueryResponse::isSend() const {
@@ -28,6 +32,10 @@ const IdentResponse *QueryResponse::isIdent() const {
 
 const LiteralResponse *QueryResponse::isLiteral() const {
     return get_if<LiteralResponse>(&response);
+}
+
+const KeywordArgResponse *QueryResponse::isKeywordArg() const {
+    return get_if<KeywordArgResponse>(&response);
 }
 
 const ConstantResponse *QueryResponse::isConstant() const {
@@ -56,6 +64,8 @@ core::Loc QueryResponse::getLoc() const {
                 return res.termLoc();
             } else if constexpr (is_same_v<T, LiteralResponse>) {
                 return res.termLoc;
+            } else if constexpr (is_same_v<T, KeywordArgResponse>) {
+                return res.termLoc;
             } else if constexpr (is_same_v<T, ConstantResponse>) {
                 return res.termLoc;
             } else if constexpr (is_same_v<T, FieldResponse>) {
@@ -82,6 +92,8 @@ core::TypePtr QueryResponse::getRetType() const {
                 return res.dispatchResult->returnType;
             } else if constexpr (is_same_v<T, LiteralResponse>) {
                 return res.retType.type;
+            } else if constexpr (is_same_v<T, KeywordArgResponse>) {
+                return res.paramType;
             } else if constexpr (is_same_v<T, ConstantResponse>) {
                 return res.retType.type;
             } else if constexpr (is_same_v<T, FieldResponse>) {

--- a/core/lsp/QueryResponse.cc
+++ b/core/lsp/QueryResponse.cc
@@ -97,30 +97,4 @@ core::TypePtr QueryResponse::getRetType() const {
         this->response);
 }
 
-const core::TypeAndOrigins &QueryResponse::getTypeAndOrigins() const {
-    // TODO(jez) C++26: Convert this to variant::visit instance method
-    return visit(
-        [](auto &&res) -> const core::TypeAndOrigins & {
-            using T = decay_t<decltype(res)>;
-            if constexpr (is_same_v<T, IdentResponse>) {
-                return res.retType;
-            } else if constexpr (is_same_v<T, LiteralResponse>) {
-                return res.retType;
-            } else if constexpr (is_same_v<T, ConstantResponse>) {
-                return res.retType;
-            } else if constexpr (is_same_v<T, FieldResponse>) {
-                return res.retType;
-            } else if constexpr (is_same_v<T, MethodDefResponse>) {
-                return res.retType;
-            } else if constexpr (is_same_v<T, SendResponse>) {
-                Exception::raise("QueryResponse is of type that does not have retType.");
-            } else if constexpr (is_same_v<T, EditResponse>) {
-                Exception::raise("QueryResponse is of type that does not have retType.");
-            } else {
-                static_assert(always_false_v<T>, "Should never happen, as the above checks should be exhaustive.");
-            }
-        },
-        this->response);
-}
-
 } // namespace sorbet::core::lsp

--- a/core/lsp/QueryResponse.cc
+++ b/core/lsp/QueryResponse.cc
@@ -47,58 +47,80 @@ const EditResponse *QueryResponse::isEdit() const {
 }
 
 core::Loc QueryResponse::getLoc() const {
-    if (auto ident = isIdent()) {
-        return ident->termLoc;
-    } else if (auto send = isSend()) {
-        return send->termLoc();
-    } else if (auto literal = isLiteral()) {
-        return literal->termLoc;
-    } else if (auto constant = isConstant()) {
-        return constant->termLoc;
-    } else if (auto field = isField()) {
-        return field->termLoc;
-    } else if (auto def = isMethodDef()) {
-        return def->termLoc;
-    } else if (auto edit = isEdit()) {
-        return edit->loc;
-    } else {
-        return core::Loc::none();
-    }
+    return visit(
+        [](auto &&res) -> core::Loc {
+            using T = decay_t<decltype(res)>;
+            if constexpr (is_same_v<T, IdentResponse>) {
+                return res.termLoc;
+            } else if constexpr (is_same_v<T, SendResponse>) {
+                return res.termLoc();
+            } else if constexpr (is_same_v<T, LiteralResponse>) {
+                return res.termLoc;
+            } else if constexpr (is_same_v<T, ConstantResponse>) {
+                return res.termLoc;
+            } else if constexpr (is_same_v<T, FieldResponse>) {
+                return res.termLoc;
+            } else if constexpr (is_same_v<T, MethodDefResponse>) {
+                return res.termLoc;
+            } else if constexpr (is_same_v<T, EditResponse>) {
+                return res.loc;
+            } else {
+                static_assert(always_false_v<T>, "Should never happen, as the above checks should be exhaustive.");
+            }
+        },
+        this->response);
 }
 
 core::TypePtr QueryResponse::getRetType() const {
-    if (auto ident = isIdent()) {
-        return ident->retType.type;
-    } else if (auto send = isSend()) {
-        return send->dispatchResult->returnType;
-    } else if (auto literal = isLiteral()) {
-        return literal->retType.type;
-    } else if (auto constant = isConstant()) {
-        return constant->retType.type;
-    } else if (auto field = isField()) {
-        return field->retType.type;
-    } else if (auto def = isMethodDef()) {
-        return def->retType.type;
-    } else {
-        // Should never happen, as the above checks should be exhaustive.
-        Exception::raise("QueryResponse is of type that does not have retType.");
-    }
+    // TODO(jez) C++26: Convert this to variant::visit instance method
+    return visit(
+        [](auto &&res) -> core::TypePtr {
+            using T = decay_t<decltype(res)>;
+            if constexpr (is_same_v<T, IdentResponse>) {
+                return res.retType.type;
+            } else if constexpr (is_same_v<T, SendResponse>) {
+                return res.dispatchResult->returnType;
+            } else if constexpr (is_same_v<T, LiteralResponse>) {
+                return res.retType.type;
+            } else if constexpr (is_same_v<T, ConstantResponse>) {
+                return res.retType.type;
+            } else if constexpr (is_same_v<T, FieldResponse>) {
+                return res.retType.type;
+            } else if constexpr (is_same_v<T, MethodDefResponse>) {
+                return res.retType.type;
+            } else if constexpr (is_same_v<T, EditResponse>) {
+                Exception::raise("QueryResponse is of type that does not have retType.");
+            } else {
+                static_assert(always_false_v<T>, "Should never happen, as the above checks should be exhaustive.");
+            }
+        },
+        this->response);
 }
 
 const core::TypeAndOrigins &QueryResponse::getTypeAndOrigins() const {
-    if (auto ident = isIdent()) {
-        return ident->retType;
-    } else if (auto literal = isLiteral()) {
-        return literal->retType;
-    } else if (auto constant = isConstant()) {
-        return constant->retType;
-    } else if (auto field = isField()) {
-        return field->retType;
-    } else if (auto def = isMethodDef()) {
-        return def->retType;
-    } else {
-        Exception::raise("QueryResponse is of type that does not have TypeAndOrigins.");
-    }
+    // TODO(jez) C++26: Convert this to variant::visit instance method
+    return visit(
+        [](auto &&res) -> const core::TypeAndOrigins & {
+            using T = decay_t<decltype(res)>;
+            if constexpr (is_same_v<T, IdentResponse>) {
+                return res.retType;
+            } else if constexpr (is_same_v<T, LiteralResponse>) {
+                return res.retType;
+            } else if constexpr (is_same_v<T, ConstantResponse>) {
+                return res.retType;
+            } else if constexpr (is_same_v<T, FieldResponse>) {
+                return res.retType;
+            } else if constexpr (is_same_v<T, MethodDefResponse>) {
+                return res.retType;
+            } else if constexpr (is_same_v<T, SendResponse>) {
+                Exception::raise("QueryResponse is of type that does not have retType.");
+            } else if constexpr (is_same_v<T, EditResponse>) {
+                Exception::raise("QueryResponse is of type that does not have retType.");
+            } else {
+                static_assert(always_false_v<T>, "Should never happen, as the above checks should be exhaustive.");
+            }
+        },
+        this->response);
 }
 
 } // namespace sorbet::core::lsp

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -81,14 +81,14 @@ CheckSize(LiteralResponse, 48, 8);
 class KeywordArgResponse final {
 public:
     KeywordArgResponse(Loc termLoc, const MethodRef owner, const ParamInfo &param)
-        : termLoc(termLoc), owner(owner), paramName(param.name), paramLoc(param.loc), paramType(param.type) {}
+        : termLoc(termLoc), owner(owner), paramLoc(param.loc), paramName(param.name), paramType(param.type) {}
     const Loc termLoc;
     MethodRef owner;
-    NameRef paramName;
     Loc paramLoc;
+    NameRef paramName;
     TypePtr paramType;
 };
-CheckSize(KeywordArgResponse, 48, 8);
+CheckSize(KeywordArgResponse, 40, 8);
 
 class ConstantResponse final {
 public:

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -155,6 +155,10 @@ public:
 
     QueryResponse(QueryResponseVariant response);
 
+    const QueryResponseVariant &asResponse() const {
+        return this->response;
+    };
+
     /**
      * Returns nullptr unless this is a Send.
      */

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -78,6 +78,18 @@ public:
 };
 CheckSize(LiteralResponse, 48, 8);
 
+class KeywordArgResponse final {
+public:
+    KeywordArgResponse(Loc termLoc, const MethodRef owner, const ParamInfo &param)
+        : termLoc(termLoc), owner(owner), paramName(param.name), paramLoc(param.loc), paramType(param.type) {}
+    const Loc termLoc;
+    MethodRef owner;
+    NameRef paramName;
+    Loc paramLoc;
+    TypePtr paramType;
+};
+CheckSize(KeywordArgResponse, 48, 8);
+
 class ConstantResponse final {
 public:
     using Scopes = InlinedVector<core::SymbolRef, 1>;
@@ -125,7 +137,7 @@ public:
 CheckSize(EditResponse, 40, 8);
 
 using QueryResponseVariant = std::variant<SendResponse, IdentResponse, LiteralResponse, ConstantResponse, FieldResponse,
-                                          MethodDefResponse, EditResponse>;
+                                          MethodDefResponse, EditResponse, KeywordArgResponse>;
 
 /**
  * Represents a response to a LSP query. Wraps a variant that contains one of several response types.
@@ -139,6 +151,7 @@ public:
      * Pushes the given query response on to the error queue.
      */
     static void pushQueryResponse(core::Context ctx, QueryResponseVariant rawResponse);
+    static void pushQueryResponse(const GlobalState &gs, FileRef file, QueryResponseVariant rawResponse);
 
     QueryResponse(QueryResponseVariant response);
 
@@ -156,6 +169,11 @@ public:
      * Returns nullptr unless this is a Literal.
      */
     const LiteralResponse *isLiteral() const;
+
+    /**
+     * Returns nullptr unless this is a KeywordArg.
+     */
+    const KeywordArgResponse *isKeywordArg() const;
 
     /**
      * Returns nullptr unless this is a Constant.

--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -187,12 +187,6 @@ public:
      * Returns the type of this expression's rval.
      */
     core::TypePtr getRetType() const;
-
-    /**
-     * Returns a reference to this response's TypeAndOrigins, if it has any.
-     * If response is of a type without TypeAndOrigins, it throws an exception.
-     */
-    const core::TypeAndOrigins &getTypeAndOrigins() const;
 };
 
 } // namespace sorbet::core::lsp

--- a/main/lsp/QueryCollector.cc
+++ b/main/lsp/QueryCollector.cc
@@ -8,16 +8,18 @@ namespace {
 uint16_t getQueryResponseTypeSpecificity(const core::lsp::QueryResponse &q) {
     if (q.isEdit()) {
         // Only reported for autocomplete, and should take precedence over anything else reported
-        return 8;
+        return 9;
     } else if (q.isMethodDef()) {
-        return 7;
+        return 8;
     } else if (q.isSend()) {
-        return 6;
+        return 7;
     } else if (q.isField()) {
-        return 5;
+        return 6;
     } else if (q.isIdent()) {
-        return 4;
+        return 5;
     } else if (q.isConstant()) {
+        return 4;
+    } else if (q.isKeywordArg()) {
         return 3;
     } else if (q.isLiteral()) {
         return 2;

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -93,9 +93,13 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
             }
             std::transform(locMapping.begin(), locMapping.end(), std::back_inserter(locations),
                            [](auto &p) { return std::move(p.second); });
-        } else if (resp->isField() || (fileIsTyped && resp->isIdent())) {
-            const auto &retType = resp->getTypeAndOrigins();
-            for (auto &originLoc : retType.origins) {
+        } else if (auto f = resp->isField()) {
+            for (auto &originLoc : f->retType.origins) {
+                addLocIfExists(gs, locations, originLoc);
+            }
+        } else if (fileIsTyped && resp->isIdent()) {
+            auto identResp = resp->isIdent();
+            for (auto &originLoc : identResp->retType.origins) {
                 addLocIfExists(gs, locations, originLoc);
             }
         } else if (fileIsTyped && resp->isMethodDef()) {

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -202,8 +202,8 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
         }
 
         typeString = core::source_generator::prettyTypeForMethod(gs, d->symbol, nullptr, options);
-    } else if (resp->isField()) {
-        const auto &origins = resp->getTypeAndOrigins().origins;
+    } else if (auto f = resp->isField()) {
+        const auto &origins = f->retType.origins;
         for (auto loc : origins) {
             if (loc.exists()) {
                 documentationLocations.emplace_back(loc);

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -44,73 +44,13 @@ string methodInfoString(const core::GlobalState &gs, const core::DispatchResult 
     return contents;
 }
 
-// TODO(jez) There's an opportunity here to use this helper in places like definition.cc to go to the
-// definition of keyword arguments.
-pair<const core::lsp::SendResponse *, core::NameRef>
-enclosingSendForKwarg(const core::GlobalState &gs, const core::lsp::LiteralResponse &l,
-                      const vector<unique_ptr<core::lsp::QueryResponse>> &queryResponses) {
-    if (!core::isa_type<core::NamedLiteralType>(l.retType.type)) {
-        return {nullptr, core::NameRef::noName()};
+void handleHoverKeywordArg(const core::GlobalState &gs, const core::lsp::KeywordArgResponse *kw, string &typeString) {
+    if (!typeString.empty()) {
+        typeString += '\n';
     }
-
-    auto litType = core::cast_type_nonnull<core::NamedLiteralType>(l.retType.type);
-    if (litType.kind != core::NamedLiteralType::Kind::Symbol) {
-        return {nullptr, core::NameRef::noName()};
-    }
-
-    auto respIt = queryResponses.begin();
-    while (respIt != queryResponses.end() && (*respIt) != nullptr) {
-        respIt++;
-    }
-
-    if (respIt == queryResponses.end() || respIt + 1 == queryResponses.end() || *respIt != nullptr) {
-        // Didn't find the gap in the query responses where we stole the canonical response
-        return {nullptr, core::NameRef::noName()};
-    }
-
-    auto &nextResp = *(respIt + 1);
-    auto send = nextResp->isSend();
-    if (send == nullptr) {
-        return {nullptr, core::NameRef::noName()};
-    }
-
-    auto argLoc =
-        absl::c_find_if(send->argLocOffsets, [&](auto loc) { return l.termLoc == core::Loc(send->file, loc); });
-    if (argLoc == send->argLocOffsets.end()) {
-        return {nullptr, core::NameRef::noName()};
-    }
-
-    auto argIdx = distance(send->argLocOffsets.begin(), argLoc);
-    if (argIdx < send->numPosArgs) {
-        return {nullptr, core::NameRef::noName()};
-    }
-
-    return {send, litType.name};
-}
-
-string handleHoverKeywordArg(const core::GlobalState &gs, const core::lsp::SendResponse *send,
-                             core::NameRef kwargName) {
-    string typeString;
-    auto curr = send->dispatchResult.get();
-    while (curr != nullptr) {
-        if (curr->main.method.exists() && !curr->main.receiver.isUntyped()) {
-            auto &parameters = curr->main.method.data(gs)->parameters;
-            auto param = absl::c_find_if(
-                parameters, [&](auto &p) { return p.flags.isKeyword && !p.flags.isRepeated && p.name == kwargName; });
-            if (param != parameters.end()) {
-                if (!typeString.empty()) {
-                    typeString += '\n';
-                }
-                // nullptr implies no type provided in sig
-                auto paramType = param->type == nullptr ? "T.untyped" : param->type.showWithMoreInfo(gs);
-                typeString += fmt::format("# {}\n(kwparam) {}: {}", curr->main.method.show(gs),
-                                          param->parameterName(gs), paramType);
-            }
-        }
-        curr = curr->secondary.get();
-    }
-
-    return typeString;
+    // nullptr implies no type provided in sig
+    auto paramType = kw->paramType == nullptr ? "T.untyped" : kw->paramType.showWithMoreInfo(gs);
+    typeString += fmt::format("# {}\n(kwparam) {}: {}", kw->owner.show(gs), kw->paramName.show(gs), paramType);
 }
 
 HoverTask::HoverTask(const LSPConfiguration &config, MessageId id, unique_ptr<TextDocumentPositionParams> params)
@@ -216,15 +156,20 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
             retType = core::Types::untypedUntracked();
         }
         typeString = retType.showWithMoreInfo(gs);
-    } else if (auto l = resp->isLiteral()) {
-        auto [send, kwargName] = enclosingSendForKwarg(gs, *l, queryResponses);
-        if (send != nullptr) {
-            typeString = handleHoverKeywordArg(gs, send, kwargName);
-        }
+    } else if (auto *kw = resp->isKeywordArg()) {
+        // Have do do this one separate, because it was stolen out of the queryResponses vector
+        handleHoverKeywordArg(gs, kw, typeString);
+        // Want to find everything, for the case of methods with multiple dispatch components.
+        for (const auto &resp : queryResponses) {
+            if (resp == nullptr) {
+                continue;
+            }
+            auto *kw = resp->isKeywordArg();
+            if (kw == nullptr) {
+                continue;
+            }
 
-        if (typeString.empty()) {
-            // fallback, in case it wasn't a keyword arg
-            typeString = resp->getRetType().showWithMoreInfo(gs);
+            handleHoverKeywordArg(gs, kw, typeString);
         }
     } else {
         auto retType = resp->getRetType();

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -1412,12 +1412,10 @@ public:
             value = const_(key);
         }
 
-        auto keyLoc =
-            core::LocOffsets{clamp((uint32_t)key->start()), clamp((uint32_t)key->end() - 1)}; // drop the trailing :
-        auto accessible_value = accessible(std::move(value));
-        return make_unique<Pair>(tokLoc(key).join(maybe_loc(accessible_value)),
-                                 make_unique<Symbol>(keyLoc, gs_.enterNameUTF8(key->view())),
-                                 std::move(accessible_value));
+        auto keyLoc = tokLoc(key);
+        auto accessible_value = accessible(move(value));
+        return make_unique<Pair>(keyLoc, make_unique<Symbol>(keyLoc, gs_.enterNameUTF8(key->view())),
+                                 move(accessible_value));
     }
 
     unique_ptr<Node> pair_quoted(const token *begin, sorbet::parser::NodeVec parts, const token *end,

--- a/test/testdata/lsp/hover_kwarg.rb
+++ b/test/testdata/lsp/hover_kwarg.rb
@@ -20,7 +20,8 @@ class A::B::C::D
 
   account = ""
   example(account:)
-  #         ^ hover: String("")
+  #         ^ hover-line: 2 # A::B::C::D.example
+  #         ^ hover-line: 3 (kwparam) account: T.any(String, Account)
 
   # Imperfect, does not reimplement calls.cc's hash literal -> kwparam logic
   example({account: ""})

--- a/test/testdata/lsp/hover_kwarg.rb
+++ b/test/testdata/lsp/hover_kwarg.rb
@@ -20,8 +20,7 @@ class A::B::C::D
 
   account = ""
   example(account:)
-  #         ^ hover-line: 2 # A::B::C::D.example
-  #         ^ hover-line: 3 (kwparam) account: T.any(String, Account)
+  #         ^ hover: String("")
 
   # Imperfect, does not reimplement calls.cc's hash literal -> kwparam logic
   example({account: ""})


### PR DESCRIPTION
Handled by calls.cc, so that we don't have reimplement that ad hoc in
hover.cc. Will make it easier if we want to make use of this in other
requests.




<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It should be pretty easy to use this to implement support for go-to-def and
go-to-type-def. If we wanted to add support for references, we would need
to also build support for a `PARAM_INFO` kind of `lsp::Query`. Right now,
references only lets you find references of symbols, unclear whether that's
something worth doing right now.

I started work on that branch here: https://github.com/sorbet/sorbet/pull/9428 . You can see how little code there is involved.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests

One test changes

I thought about this for a while. What's happening is that the loc of the
keyword symbol and the synthetic variable of the value are different:

```ruby
example(account:)
#       ^^^^^^^ the `:account` symbol
#       ^^^^^^^^ the `account` variable
```

~~These locs are load bearing.~~ Not sure whether these locs are load
bearing at the moment, I had done some spelunking but now I think that it
might not matter if we wanted to change them to make them equal.

Since the `:account` symbol is a more narrow loc, it gets sorted to appear
lower in the `queryResponses`, and thus we hit the `isKeywordArg` case
instead of hitting the `isIdent` case.

I thought about ways to recover this (change the loc of the symbol as
mentioned above, or do some more "scan back over the `queryResponses`"
logic like we used to be doing before this PR).

But then I thought about it, and I'm not even sure what the user would want
to see here. It's possible that the answer is "both," it's possible that
the answer is just the keyword param info. And since it's ambiguous, I
think that asking people to manually un-pun the keyword arg to get the one
that they're after is not that bad.

Anyways, out of convenience, I've opted to just let the behavior change
here. We could change it back if that ends up being people's preference.

**Update**: that loc is **not load bearing** at all

https://github.com/sorbet/sorbet/compare/jez-patch-2

If we want to put the behavior back to showing the inferred type of the variable, instead of the declared type of the keyword param, we could do that trivially by applying the above patch to this branch. As is, no tests fail when that patch is applied in isolation.

If you have thoughts on this let me know, I could go either way.

**Update 2**: I'm taking the shot—if we don't preserve the existing behavior, it breaks find all references for punned keyword args, which I think is worse.