### PR TITLE
Go to Definition for keyword argument

### DIFF
--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -132,6 +132,23 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
                     start = start->secondary.get();
                 }
             }
+        } else if (fileIsTyped && resp->isKeywordArg()) {
+            auto kw = resp->isKeywordArg();
+            // We only store one loc for a ParamInfo, which disguises the full set of locs if there are multiple.
+            addLocIfExists(gs, locations, kw->paramLoc);
+
+            // Loop over all (in case of multiple dispatch targets)
+            for (const auto &resp : queryResponses) {
+                if (resp == nullptr) {
+                    continue;
+                }
+                auto *kw = resp->isKeywordArg();
+                if (kw == nullptr) {
+                    continue;
+                }
+
+                addLocIfExists(gs, locations, kw->paramLoc);
+            }
         }
     }
     response->result = move(locations);

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -97,17 +97,19 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
             for (auto &originLoc : f->retType.origins) {
                 addLocIfExists(gs, locations, originLoc);
             }
-        } else if (fileIsTyped && resp->isIdent()) {
+        } else if (!fileIsTyped) {
+            // everything after this requires a typed: true or higher file
+        } else if (resp->isIdent()) {
             auto identResp = resp->isIdent();
             for (auto &originLoc : identResp->retType.origins) {
                 addLocIfExists(gs, locations, originLoc);
             }
-        } else if (fileIsTyped && resp->isMethodDef()) {
+        } else if (resp->isMethodDef()) {
             auto sym = resp->isMethodDef()->symbol;
             for (auto loc : sym.data(gs)->locs()) {
                 addLocIfExists(gs, locations, loc);
             }
-        } else if (fileIsTyped && resp->isSend()) {
+        } else if (resp->isSend()) {
             auto sendResp = resp->isSend();
             // Don't want to show hover results if we're hovering over, e.g., the arguments, and there's nothing there.
             if (sendResp->funLoc().exists() && sendResp->funLoc().contains(queryLoc)) {
@@ -132,8 +134,7 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
                     start = start->secondary.get();
                 }
             }
-        } else if (fileIsTyped && resp->isKeywordArg()) {
-            auto kw = resp->isKeywordArg();
+        } else if (auto kw = resp->isKeywordArg()) {
             // We only store one loc for a ParamInfo, which disguises the full set of locs if there are multiple.
             addLocIfExists(gs, locations, kw->paramLoc);
 

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -157,7 +157,7 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
         }
         typeString = retType.showWithMoreInfo(gs);
     } else if (auto *kw = resp->isKeywordArg()) {
-        // Have do do this one separate, because it was stolen out of the queryResponses vector
+        // Have to do this one separately, because it was stolen out of the queryResponses vector
         handleHoverKeywordArg(gs, kw, typeString);
         // Want to find everything, for the case of methods with multiple dispatch components.
         for (const auto &resp : queryResponses) {

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -117,6 +117,22 @@ unique_ptr<ResponseMessage> TypeDefinitionTask::runRequest(LSPTypecheckerDelegat
             for (auto loc : locsForType(gs, resp->getRetType())) {
                 addLocIfExists(gs, locations, loc);
             }
+        } else if (fileIsTyped && resp->isKeywordArg()) {
+            // We only store one loc for a ParamInfo, which disguises the full set of locs if there are multiple.
+            for (auto loc : locsForType(gs, resp->getRetType())) {
+                addLocIfExists(gs, locations, loc);
+            }
+
+            // Loop over all (in case of multiple dispatch targets)
+            for (const auto &resp : queryResponses) {
+                if (resp == nullptr || !resp->isKeywordArg()) {
+                    continue;
+                }
+
+                for (auto loc : locsForType(gs, resp->getRetType())) {
+                    addLocIfExists(gs, locations, loc);
+                }
+            }
         } else if (fileIsTyped && resp->isSend()) {
             auto sendResp = resp->isSend();
             // Don't want to show hover results if we're hovering over, e.g., the arguments, and there's nothing there.

--- a/test/testdata/lsp/hover_kwarg.rb
+++ b/test/testdata/lsp/hover_kwarg.rb
@@ -59,6 +59,16 @@ class A::B::C::D
   #               ^ hover: Symbol(:kwargs)
 end
 
+class A::B::C::E
+  extend T::Sig
+
+  sig { params(account: T.any(String, Account)).void }
+  #            ^ def: account-other 1 not-def-of-self
+  def self.example(account:)
+    account
+  end
+end
+
 class Other
   extend T::Sig
 
@@ -69,14 +79,14 @@ class Other
 end
 
 sig {
-  params(x: T.any(T.class_of(A::B::C::D), T.class_of(Other))).void
+  params(x: T.any(T.class_of(A::B::C::E), T.class_of(Other))).void
 }
 def takes_any(x)
   x.example(account: '')
-  #           ^ hover-line 1 ```
-  #           ^ hover-line 2 # A::B::C::D.example
-  #           ^ hover-line 3 (kwparam) account: T.any(String, Account
-  #           ^ hover-line 4 # Other.example
-  #           ^ hover-line 5 (kwparam) account: String
-  #           ^ hover-line 6 ```
+  #           ^ hover-line: 1 ```ruby
+  #           ^ hover-line: 2 # A::B::C::E.example
+  #           ^ hover-line: 3 (kwparam) account: T.any(String, Account)
+  #           ^ hover-line: 4 # Other.example
+  #           ^ hover-line: 5 (kwparam) account: String
+  #           ^ hover-line: 6 ```
 end

--- a/test/testdata/lsp/hover_kwarg.rb
+++ b/test/testdata/lsp/hover_kwarg.rb
@@ -9,6 +9,7 @@ class A::B::C::D
   extend T::Sig
 
   sig { params(account: T.any(String, Account)).void }
+  #            ^ def: account 1 not-def-of-self
   def self.example(account:)
     account
   end
@@ -17,6 +18,7 @@ class A::B::C::D
   #                ^ error: Expected `T.any(String, Account)`
   #         ^ hover-line: 2 # A::B::C::D.example
   #         ^ hover-line: 3 (kwparam) account: T.any(String, Account)
+  #         ^ go-to-def-special: account
 
   account = ""
   example(account:)
@@ -25,6 +27,7 @@ class A::B::C::D
   # Imperfect, does not reimplement calls.cc's hash literal -> kwparam logic
   example({account: ""})
   #         ^ hover: Symbol(:account)
+  #         ^ def: (nothing)
 
   example(:account)
   #       ^^^^^^^^ error: Too many positional arguments
@@ -44,6 +47,7 @@ class A::B::C::D
   #                        ^ error: Missing required keyword argument `account`
   #       ^^^^^^^^^^^^^^^^^ error: Unrecognized keyword argument `does_not_exist`
   #         ^ hover: Symbol(:does_not_exist)
+  #         ^ go-to-def-special: (nothing)
 
   def self.takes_untyped(arg0:)
   end
@@ -73,6 +77,7 @@ class Other
   extend T::Sig
 
   sig { params(account: String).void }
+  #            ^ def: account-other 1 not-def-of-self
   def self.example(account:)
     account
   end
@@ -89,4 +94,5 @@ def takes_any(x)
   #           ^ hover-line: 4 # Other.example
   #           ^ hover-line: 5 (kwparam) account: String
   #           ^ hover-line: 6 ```
+  #           ^ go-to-def-special: account-other
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

The implementation is stacked on #9427, which adds the KeywordArgResponse query response type.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Once we have hover for keyword args (#9391), we may as well have jump-to-def.

https://github.com/user-attachments/assets/784b6d33-e3ee-4c9b-a9cf-115099cb4103



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->



Automated tests for definition. Some things to note about the test:

- We have to use the `not-def-of-self` assertion so that we don't
  attempt to make a definition and references request on that `def`
  assertion. Rather, it's just the target of a `go-to-def-special`
  assertion.

- It can't be a def of self, because we've wired up find all references
  on a method parameter to mean "references of the local variable inside
  the current method," so it can't also mean "show me all references of
  this keyword argument at callsites"


Tested manually for type definition support, because I don't think it's wiring up a whole new assertion for this, and I don't think this code will be prone to breaking:

<img width="1007" height="711" alt="Screenshot 2025-10-03 at 2 38 20 PM" src="https://github.com/user-attachments/assets/71804ebb-ffc1-4080-8ec4-deff7a78e795" />

