### PR TITLE
Directly desugar `PM_MULTI_WRITE_NODE`

### DIFF
--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -154,6 +154,9 @@ private:
     // String interpolation desugaring
     sorbet::ast::ExpressionPtr desugarDString(core::LocOffsets loc, pm_node_list prismNodeList);
 
+    // Multi-assignment desugaring
+    ast::ExpressionPtr desugarMlhs(core::LocOffsets loc, parser::Mlhs *lhs, ast::ExpressionPtr rhs);
+
     // Extracts the desugared expressions out of a "scope" (class/sclass/module) body.
     std::optional<ast::ClassDef::RHS_store> desugarScopeBodyToRHSStore(pm_node *prismBodyNode,
                                                                        std::unique_ptr<parser::Node> &scopeBody);


### PR DESCRIPTION
Part of #9065 

Directly desugars the `PM_MULTI_WRITE_NODE` as part of integrating Prism in Sorbet. 


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by existing test