### PR TITLE
completion: Put the `(|)` and `{|}` back into the snippet

### DIFF
--- a/test/testdata/lsp/completion/sig_non_self.B.rbedited
+++ b/test/testdata/lsp/completion/sig_non_self.B.rbedited
@@ -10,7 +10,7 @@ class A
   #                         ^ apply-completion: [A] item: 0
   def without_runtime; ''; end
 
-  Sorbet::Private::Static.sig${0}
+  Sorbet::Private::Static.sig(${0})
   #                          ^ error: Not enough arguments
   #                          ^ error: no block
   #                          ^ apply-completion: [B] item: 0

--- a/test/testdata/lsp/completion/sig_non_self.D.rbedited
+++ b/test/testdata/lsp/completion/sig_non_self.D.rbedited
@@ -27,7 +27,7 @@ class Outer
     T::Sig::WithoutRuntime.sig # error: no block
     #                         ^ apply-completion: [C] item: 0
 
-    Sorbet::Private::Static.sig${0}
+    Sorbet::Private::Static.sig(${0})
     #                          ^ error: Not enough arguments
     #                          ^ error: no block
     #                          ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_arity.B.rbedited
+++ b/test/testdata/lsp/completion/snippet_arity.B.rbedited
@@ -13,7 +13,7 @@ end
 Test.new.test_method_null # error: does not exist
 #                        ^ apply-completion: [A] item: 0
 
-Test.new.test_method_unary${0} # error: does not exist
+Test.new.test_method_unary(${0}) # error: does not exist
 #                        ^ apply-completion: [B] item: 0
 
 Test.new.test_method_bina # error: does not exist

--- a/test/testdata/lsp/completion/snippet_arity.C.rbedited
+++ b/test/testdata/lsp/completion/snippet_arity.C.rbedited
@@ -16,7 +16,7 @@ Test.new.test_method_null # error: does not exist
 Test.new.test_method_unar # error: does not exist
 #                        ^ apply-completion: [B] item: 0
 
-Test.new.test_method_binary${0} # error: does not exist
+Test.new.test_method_binary(${0}) # error: does not exist
 #                        ^ apply-completion: [C] item: 0
 
 Test.new.test_method_kwar # error: does not exist

--- a/test/testdata/lsp/completion/snippet_arity.D.rbedited
+++ b/test/testdata/lsp/completion/snippet_arity.D.rbedited
@@ -19,5 +19,5 @@ Test.new.test_method_unar # error: does not exist
 Test.new.test_method_bina # error: does not exist
 #                        ^ apply-completion: [C] item: 0
 
-Test.new.test_method_kwarg${0} # error: does not exist
+Test.new.test_method_kwarg(${0}) # error: does not exist
 #                        ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_before_variable.A.rbedited
+++ b/test/testdata/lsp/completion/snippet_before_variable.A.rbedited
@@ -15,7 +15,7 @@ begin
 
   x = nil # error: does not exist
 
-  A.example${0}
+  A.example(${0})
   # ^ completion: example, ...
   # ^ apply-completion: [A] item: 0
 

--- a/test/testdata/lsp/completion/snippet_before_variable.B.rbedited
+++ b/test/testdata/lsp/completion/snippet_before_variable.B.rbedited
@@ -9,7 +9,7 @@ class A
 end
 
 begin
-  A.example${0}
+  A.example(${0})
   # ^ completion: example, ...
   # ^ apply-completion: [B] item: 0
 

--- a/test/testdata/lsp/completion/snippet_block.A.rbedited
+++ b/test/testdata/lsp/completion/snippet_block.A.rbedited
@@ -25,7 +25,7 @@ class A
   end
 end
 
-A.required_block${0} # error: does not exist
+A.required_block {${0}} # error: does not exist
 #              ^ apply-completion: [A] item: 0
 A.nilable_bloc # error: does not exist
 #             ^ apply-completion: [B] item: 0

--- a/test/testdata/lsp/completion/snippet_block_arity.A.rbedited
+++ b/test/testdata/lsp/completion/snippet_block_arity.A.rbedited
@@ -28,7 +28,7 @@ class A
   end
 end
 
-A.unary_block${0} # error: does not exist
+A.unary_block {${0}} # error: does not exist
 #           ^ apply-completion: [A] item: 0
 A.binary_bloc # error: does not exist
 #            ^ apply-completion: [B] item: 0

--- a/test/testdata/lsp/completion/snippet_block_arity.B.rbedited
+++ b/test/testdata/lsp/completion/snippet_block_arity.B.rbedited
@@ -30,7 +30,7 @@ end
 
 A.unary_bloc # error: does not exist
 #           ^ apply-completion: [A] item: 0
-A.binary_block${0} # error: does not exist
+A.binary_block {${0}} # error: does not exist
 #            ^ apply-completion: [B] item: 0
 A.arg0_arg1_bl # error: does not exist
 #             ^ apply-completion: [C] item: 0

--- a/test/testdata/lsp/completion/snippet_block_arity.C.rbedited
+++ b/test/testdata/lsp/completion/snippet_block_arity.C.rbedited
@@ -32,5 +32,5 @@ A.unary_bloc # error: does not exist
 #           ^ apply-completion: [A] item: 0
 A.binary_bloc # error: does not exist
 #            ^ apply-completion: [B] item: 0
-A.arg0_arg1_blk${0} # error: does not exist
+A.arg0_arg1_blk(${0}) # error: does not exist
 #             ^ apply-completion: [C] item: 0

--- a/test/testdata/lsp/completion/snippet_default.A.rbedited
+++ b/test/testdata/lsp/completion/snippet_default.A.rbedited
@@ -7,5 +7,5 @@ class Test
   def method_with_defaults(x, y:, z: ''); end
 end
 
-Test.new.method_with_defaults${0} # error: does not exist
+Test.new.method_with_defaults(${0}) # error: does not exist
 #                           ^ apply-completion: [A] item: 0

--- a/test/testdata/lsp/completion/snippet_repeated.C.rbedited
+++ b/test/testdata/lsp/completion/snippet_repeated.C.rbedited
@@ -25,7 +25,7 @@ A.new.method_using_kwar # error: does not exist
 A.new.method_using_rest_ar # error: does not exist
 #                         ^ apply-completion: [B] item: 0
 
-A.new.positional_then_kwarg${0} # error: does not exist
+A.new.positional_then_kwarg(${0}) # error: does not exist
 #                         ^ apply-completion: [C] item: 0
 
 A.new.positional_then_rest_ar # error: does not exist

--- a/test/testdata/lsp/completion/snippet_repeated.D.rbedited
+++ b/test/testdata/lsp/completion/snippet_repeated.D.rbedited
@@ -28,5 +28,5 @@ A.new.method_using_rest_ar # error: does not exist
 A.new.positional_then_kwar # error: does not exist
 #                         ^ apply-completion: [C] item: 0
 
-A.new.positional_then_rest_arg${0} # error: does not exist
+A.new.positional_then_rest_arg(${0}) # error: does not exist
 #                            ^ apply-completion: [D] item: 0

--- a/test/testdata/lsp/completion/snippet_types.A.rbedited
+++ b/test/testdata/lsp/completion/snippet_types.A.rbedited
@@ -7,7 +7,7 @@ class Test
   def x_is_integer(x); end
 end
 
-Test.new.x_is_integer${0} # error: does not exist
+Test.new.x_is_integer(${0}) # error: does not exist
 #             ^ apply-completion: [A] item: 0
 
 # Snippet for applied generic should respect TypeConstraint


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Follow up to #9425. After typing out a bunch of snippets, I'm noticing
how much muscle memory I had for the `()` getting put into the snippet
for me.

I noticed that IntelliJ also had this behavior, so I think it's not too
wild for Sorbet to also do it. TypeScript doesn't do it, but JavaScript
allows passing around first-class objects, while if you want to do that
in Ruby you're going to have to do something else entirely
(`x.method(:foo)` vs `x.foo`).

I've chosen to only insert the `()` for methods that have required
parameters, because the overwhelming style in the Ruby community is to
omit trailing parens for nullary method calls (despite my petitions to
change that).

While I was here, I figured that if the method had no required
arguments, but did have a required block, then we should also go ahead
and put the user's cursor inside a `{|}`. I didn't want to combine those
(put both the `(|) {|}` in one snippet) because then we end up with the
same problem we had before, which is that the presence of a snippet that
has multiple tabstops prevents completion requests from firing.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Luckily we still had great coverage from the original completion snippet
change--I don't think there is any logic in this change that isn't covered by an
existing test.