### PR TITLE
Make Symbol queries search for multiple symbols

### DIFF
--- a/core/lsp/Query.cc
+++ b/core/lsp/Query.cc
@@ -21,7 +21,7 @@ Query Query::createSymbolQuery(core::SymbolRef symbol) {
     return Query(Query::Kind::SYMBOL, core::Loc::none(), symbol, core::LocalVariable());
 }
 
-Query Query::createVarQuery(core::SymbolRef owner, core::Loc enclosingLoc, core::LocalVariable variable) {
+Query Query::createVarQuery(core::MethodRef owner, core::Loc enclosingLoc, core::LocalVariable variable) {
     ENFORCE(owner.exists());
     ENFORCE(variable.exists());
     return Query(Query::Kind::VAR, enclosingLoc, owner, variable);
@@ -32,7 +32,7 @@ Query Query::createSuggestSigQuery(core::MethodRef method) {
     return Query(Query::Kind::SUGGEST_SIG, core::Loc::none(), method, core::LocalVariable());
 }
 
-bool Query::matchesSymbol(const core::SymbolRef &symbol) const {
+bool Query::matchesSymbol(core::SymbolRef symbol) const {
     return kind == Query::Kind::SYMBOL && this->symbol == symbol;
 }
 
@@ -43,11 +43,11 @@ bool Query::matchesLoc(const core::Loc &loc) const {
     return this->kind == Query::Kind::LOC && loc.exists() && !loc.empty() && loc.contains(this->loc);
 }
 
-bool Query::matchesVar(const core::SymbolRef &owner, const core::LocalVariable &var) const {
+bool Query::matchesVar(core::MethodRef owner, const core::LocalVariable &var) const {
     return kind == Query::Kind::VAR && var.exists() && this->symbol == owner && this->variable == var;
 }
 
-bool Query::matchesSuggestSig(const core::SymbolRef &method) const {
+bool Query::matchesSuggestSig(core::MethodRef method) const {
     return kind == Query::Kind::SUGGEST_SIG && this->symbol == method;
 }
 

--- a/core/lsp/Query.h
+++ b/core/lsp/Query.h
@@ -39,13 +39,13 @@ public:
     static Query noQuery();
     static Query createLocQuery(core::Loc loc);
     static Query createSymbolQuery(core::SymbolRef symbol);
-    static Query createVarQuery(core::SymbolRef owner, core::Loc enclosingLoc, core::LocalVariable variable);
+    static Query createVarQuery(core::MethodRef owner, core::Loc enclosingLoc, core::LocalVariable variable);
     static Query createSuggestSigQuery(core::MethodRef method);
 
-    bool matchesSymbol(const core::SymbolRef &symbol) const;
+    bool matchesSymbol(core::SymbolRef symbol) const;
     bool matchesLoc(const core::Loc &loc) const;
-    bool matchesVar(const core::SymbolRef &owner, const core::LocalVariable &var) const;
-    bool matchesSuggestSig(const core::SymbolRef &method) const;
+    bool matchesVar(core::MethodRef owner, const core::LocalVariable &var) const;
+    bool matchesSuggestSig(core::MethodRef method) const;
     bool isEmpty() const;
 
 private:

--- a/core/lsp/Query.h
+++ b/core/lsp/Query.h
@@ -18,8 +18,16 @@ public:
     };
 
     // Looking for all references to the given symbol.
+    //
+    // Allows searching for multiple symbols (as a performance optimization, instead of having to
+    // run multiple typecheck operations).
     struct Symbol {
-        core::SymbolRef symbol;
+        // 1 will be the most common length by far.
+        //
+        // 4 chosen as the largest number that does not increase the storage above how many bytes an
+        // `InlinedVector<SymbolRef, 1>` would require.
+        using STORAGE = InlinedVector<core::SymbolRef, 4>;
+        STORAGE symbols;
     };
 
     // Looking for all references to the given variable.
@@ -42,6 +50,8 @@ public:
     static Query noQuery();
     static Query createLocQuery(core::Loc loc);
     static Query createSymbolQuery(core::SymbolRef symbol);
+    static Query createSymbolQuery(Symbol::STORAGE &&symbols);
+    static Query createSymbolQuery(absl::Span<const core::SymbolRef> symbols);
     static Query createVarQuery(core::MethodRef owner, core::Loc enclosingLoc, core::LocalVariable variable);
     static Query createSuggestSigQuery(core::MethodRef method);
 
@@ -51,7 +61,7 @@ public:
     bool matchesSuggestSig(core::MethodRef method) const;
     bool isEmpty() const;
 };
-CheckSize(Query, 28, 4);
+CheckSize(Query, 32, 8);
 } // namespace sorbet::core::lsp
 
 #endif // SORBET_CORE_LSP_QUERYRESPONSE

--- a/core/lsp/Query.h
+++ b/core/lsp/Query.h
@@ -3,6 +3,7 @@
 
 #include "core/Loc.h"
 #include "core/LocalVariable.h"
+#include "core/SymbolRef.h"
 
 namespace sorbet::core::lsp {
 /**

--- a/core/lsp/Query.h
+++ b/core/lsp/Query.h
@@ -51,6 +51,7 @@ public:
 private:
     Query(Kind kind, core::Loc loc, core::SymbolRef symbol, core::LocalVariable variable);
 };
+CheckSize(Query, 28, 4);
 } // namespace sorbet::core::lsp
 
 #endif // SORBET_CORE_LSP_QUERYRESPONSE

--- a/main/lsp/AbstractRewriter.cc
+++ b/main/lsp/AbstractRewriter.cc
@@ -142,7 +142,9 @@ void AbstractRewriter::getEdits(LSPTypecheckerDelegate &typechecker, core::Symbo
 
     auto symbolQueue = getQueue();
     for (auto sym = symbolQueue->pop(); sym.exists(); sym = symbolQueue->pop()) {
-        auto queryResult = LSPQuery::bySymbol(config, typechecker, sym);
+        // TODO(jez) This is another prime candidate for passing multiple symbols all at once
+        auto symbols = core::lsp::Query::Symbol::STORAGE{1, sym};
+        auto queryResult = LSPQuery::bySymbol(config, typechecker, move(symbols));
         if (queryResult.error) {
             return;
         }

--- a/main/lsp/LSPQuery.h
+++ b/main/lsp/LSPQuery.h
@@ -17,7 +17,7 @@ public:
     static LSPQueryResult bySymbolInFiles(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker,
                                           core::SymbolRef symbol, std::vector<core::FileRef> frefs);
     static LSPQueryResult bySymbol(const LSPConfiguration &config, LSPTypecheckerDelegate &typechecker,
-                                   core::SymbolRef symbol,
+                                   absl::Span<const core::SymbolRef> symbols,
                                    core::packages::MangledName pkgName = core::packages::MangledName());
 };
 

--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -38,9 +38,9 @@ protected:
                           std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&priorRefs = {}) const;
 
     std::vector<std::unique_ptr<core::lsp::QueryResponse>>
-    getReferencesToSymbolInPackage(LSPTypecheckerDelegate &typechecker, core::packages::MangledName packageName,
-                                   core::SymbolRef symbol,
-                                   std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&priorRefs = {}) const;
+    getReferencesToSymbolsInPackage(LSPTypecheckerDelegate &typechecker, core::packages::MangledName packageName,
+                                    core::lsp::Query::Symbol::STORAGE &&symbols,
+                                    std::vector<std::unique_ptr<core::lsp::QueryResponse>> &&priorRefs = {}) const;
 
     std::vector<std::unique_ptr<core::lsp::QueryResponse>>
     getReferencesToSymbolInFile(LSPTypecheckerDelegate &typechecker, core::FileRef file, core::SymbolRef symbol,

--- a/main/lsp/LocalVarSaver.cc
+++ b/main/lsp/LocalVarSaver.cc
@@ -71,9 +71,8 @@ void LocalVarSaver::postTransformMethodDef(core::Context ctx, const ast::MethodD
                                                   methodDef.symbol, methodDefLoc));
 
                 if (this->signature.has_value()) {
-                    auto it = absl::c_find_if(this->signature->argTypes, [&](const auto &argSpec) {
-                        return argSpec.name == ctx.state.lspQuery.variable._name;
-                    });
+                    auto it = absl::c_find_if(this->signature->argTypes,
+                                              [&](const auto &argSpec) { return argSpec.name == variable._name; });
                     if (it != this->signature->argTypes.end()) {
                         core::lsp::QueryResponse::pushQueryResponse(
                             ctx, core::lsp::IdentResponse(ctx.locAt(it->nameLoc), localExp->localVariable, tp,

--- a/main/lsp/LocalVarSaver.h
+++ b/main/lsp/LocalVarSaver.h
@@ -11,10 +11,15 @@ namespace sorbet::realmain::lsp {
 class LocalVarSaver {
     std::vector<core::Loc> enclosingMethodDefLoc;
     std::optional<resolver::ParsedSig> signature;
+    // Technically this is redundant with what's in `ctx.state.lspQuery`, but we only ever run
+    // `LocalVarSaver` if the lspQuery is currently holding a Query::Var. Rather than assert that at
+    // runtime, we accept a `LocalVariable` when we construct this class so that the caller has to
+    // prove they've already done that check.
+    core::LocalVariable variable;
 
 public:
-    LocalVarSaver(core::Loc rootLoc, std::optional<resolver::ParsedSig> &&signature)
-        : enclosingMethodDefLoc({rootLoc}), signature(move(signature)) {}
+    LocalVarSaver(core::Loc rootLoc, std::optional<resolver::ParsedSig> &&signature, core::LocalVariable variable)
+        : enclosingMethodDefLoc({rootLoc}), signature(move(signature)), variable(variable) {}
 
     void postTransformBlock(core::Context ctx, const ast::Block &local);
     void postTransformLocal(core::Context ctx, const ast::Local &local);

--- a/main/lsp/requests/references.h
+++ b/main/lsp/requests/references.h
@@ -7,10 +7,6 @@ namespace sorbet::realmain::lsp {
 class ReferenceParams;
 class ReferencesTask final : public LSPRequestTask {
     std::unique_ptr<ReferenceParams> params;
-    std::vector<core::SymbolRef> getSymsToCheckWithinPackage(const core::GlobalState &gs, core::SymbolRef symInPackage,
-                                                             core::packages::MangledName packageName);
-    core::SymbolRef findSym(const core::GlobalState &gs, const std::vector<core::NameRef> &fullName,
-                            core::SymbolRef underNamespace);
 
 public:
     ReferencesTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<ReferenceParams> params);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There are a bunch of places where we're doing multiple typechecker
operations to search for multiple SymbolRefs.

Instead of doing that, let's do one typechecker operation, but with a query
that allows matching against multiple symbols.

So far, I've only modified the usage that powers some packager-specific behavior
in `textDocument/references`. I might add more to this PR, or I might open more
in future PRs.

The core motivation I have is that I want to build towards #9094.

- **fixup: Add `#include "core/SymbolRef.h"`** (699ef97741)

  It looks like this only compiled because this file was included in two 
  places, and those places already had an `#include` which defined
  `SymbolRef` earlier in the list of `#include`'s.

  I noticed this when I opened the file in my IDE and got a bunch of 
  errors for it.

- **prework: Tidy up the Query interface** (9dcf8689b3)

  Don't use references when the types are trivially copyable `Ref` 
  classes.

  Use `MethodRef` in place of `SymbolRef` wherever relevant.

- **prework: Add a CheckSize assertion** (8922d7b3ff)


- **prework: Use std::variant for `lsp::Query`** (dafd663c4d)

  We were kind of already doing this by way of a `Kind` tag and the 
  overloaded meanings of each field.

  Note that this doesn't increase the size of the `lsp::Query` class, 
  though this is not particularl memory sensitive.

- **no-op: Convert private methods to helper funcitons** (0e29cc7bc2)

  I wanted to modify this, and was surprised to see that I had to edit the 
  header. This function doesn't use any of the task state.

- **Make Symbol queries search for multiple symbols** (4485e00ba3)

  There are a bunch of places where we're doing multiple typechecker 
  operations to search for mutiple SymbolRefs.

  Instead of doing that, let's do one typechecker operation, but with a 
  query that allows matching against multiple symbols.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests