### PR TITLE
Add IRB::Color.colorize

### DIFF
--- a/rbi/stdlib/irb.rbi
+++ b/rbi/stdlib/irb.rbi
@@ -460,6 +460,14 @@ end
 # [`IRB.irb_abort`](https://docs.ruby-lang.org/en/2.7.0/IRB.html#method-c-irb_abort)
 class IRB::Abort < ::Exception; end
 
+module IRB::Color
+  class << self
+    # https://github.com/ruby/irb/blob/d43c3d76/lib/irb/color.rb#L120-L124
+    sig { params(text: String, seq: T::Enumerable[T.any(String, Symbol)], colorable: T::Boolean).returns(String) }
+    def colorize(text, seq, colorable: false); end
+  end
+end
+
 # A class that wraps the current state of the irb session, including the
 # configuration of
 # [`IRB.conf`](https://docs.ruby-lang.org/en/2.7.0/IRB.html#method-c-conf).


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
https://github.com/ruby/irb/blob/d43c3d76/lib/irb/color.rb#L120-L124

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The sig is exported from a working codebase. I also checked the [type](https://github.com/sorbet/sorbet/blob/57cd2cf499ba6bfff57d41c81be3ff481e1939a5/rbi/core/module.rbi#L636) of const_get for compatibility with the `seq` type.