### PR TITLE
Update OrdinaryParamDefined error message

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -198,7 +198,7 @@ public:
             auto name_str = id->name.shortName(gs_);
             if (isNumberedParameterName(name_str) && driver_->lex.context.allowNumparams) {
                 if (driver_->numparam_stack.seen_ordinary_params()) {
-                    error(ruby_parser::dclass::OrdinaryParamDefined, id->loc);
+                    error(ruby_parser::dclass::NumberedParamWithOrdinaryParam, id->loc);
                 }
 
                 auto raw_numparam_stack = driver_->numparam_stack.stackCopy();

--- a/parser/parser/codegen/generate_diagnostics.cc
+++ b/parser/parser/codegen/generate_diagnostics.cc
@@ -58,7 +58,7 @@ tuple<string, string> MESSAGES[] = {
     {"BlockGivenToYield", "block given to yield"},
     {"InvalidReturn", "invalid return in class/module body"},
     {"CSendInLHSOfMAsgn", "&. inside multiple assignment destination"},
-    {"OrdinaryParamDefined", "can't use anonymous parameters when ordinary parameters are defined"},
+    {"NumberedParamWithOrdinaryParam", "numbered parameters are not allowed when an ordinary parameter is defined"},
     {"NumparamUsedInOuterScope", "numbered parameter is already used in an outer scope"},
     {"CircularArgumentReference", "circular argument reference {}"},
     {"PatternInterpInVarName", "symbol literal with interpolation is not allowed"},

--- a/test/testdata/parser/error_recovery/forward_args.rb
+++ b/test/testdata/parser/error_recovery/forward_args.rb
@@ -3,5 +3,5 @@
 def foo(*, ...)
       # ^ error: ... after rest argument
   [1,2,3].each { |x| _1 }
-                   # ^^ error: can't use anonymous parameters when ordinary parameters are defined
+                   # ^^ error: numbered parameters are not allowed when an ordinary parameter is defined
 end

--- a/test/testdata/parser/error_recovery/numparams.rb
+++ b/test/testdata/parser/error_recovery/numparams.rb
@@ -1,7 +1,7 @@
 # typed: true
 
 [1,2,3].map { |x| _1 }
-                # ^^ error: can't use anonymous parameters when ordinary parameters are defined
+                # ^^ error: numbered parameters are not allowed when an ordinary parameter is defined
 
 # recover
 successful_parse = 10

--- a/test/testdata/parser/error_recovery/numparams_crash_1.rb
+++ b/test/testdata/parser/error_recovery/numparams_crash_1.rb
@@ -1,6 +1,6 @@
 # typed: false
 
 [1,2,3].map { |x| _1 }
-                # ^^ error: can't use anonymous parameters when ordinary parameters are defined
+                # ^^ error: numbered parameters are not allowed when an ordinary parameter is defined
 
 _1

--- a/test/testdata/parser/error_recovery/numparams_crash_2.rb
+++ b/test/testdata/parser/error_recovery/numparams_crash_2.rb
@@ -1,6 +1,6 @@
 # typed: false
 
 f (1) { |x| _1 }
-          # ^^ error: can't use anonymous parameters when ordinary parameters are defined
+          # ^^ error: numbered parameters are not allowed when an ordinary parameter is defined
 
 _1

--- a/test/testdata/parser/error_recovery/numparams_crash_5.rb
+++ b/test/testdata/parser/error_recovery/numparams_crash_5.rb
@@ -1,7 +1,7 @@
 # typed: false
 
 [1,2,3].map do |x|
-  _1 # error: can't use anonymous parameters when ordinary parameters are defined
+  _1 # error: numbered parameters are not allowed when an ordinary parameter is defined
 end
 
 _1

--- a/test/whitequark/test_numbered_and_ordinary_parameters_0.rb
+++ b/test/whitequark/test_numbered_and_ordinary_parameters_0.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-m { || _1 }  # error: can't use anonymous parameters when ordinary parameters are defined
+m { || _1 }  # error: numbered parameters are not allowed when an ordinary parameter is defined

--- a/test/whitequark/test_numbered_and_ordinary_parameters_1.rb
+++ b/test/whitequark/test_numbered_and_ordinary_parameters_1.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-m { |a| _1 }  # error: can't use anonymous parameters when ordinary parameters are defined
+m { |a| _1 }  # error: numbered parameters are not allowed when an ordinary parameter is defined

--- a/test/whitequark/test_numbered_and_ordinary_parameters_10.rb
+++ b/test/whitequark/test_numbered_and_ordinary_parameters_10.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-->(x=_1) {} # error: can't use anonymous parameters when ordinary parameters are defined
+->(x=_1) {} # error: numbered parameters are not allowed when an ordinary parameter is defined

--- a/test/whitequark/test_numbered_and_ordinary_parameters_11.rb
+++ b/test/whitequark/test_numbered_and_ordinary_parameters_11.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-->(x: _1) {} # error: can't use anonymous parameters when ordinary parameters are defined
+->(x: _1) {} # error: numbered parameters are not allowed when an ordinary parameter is defined

--- a/test/whitequark/test_numbered_and_ordinary_parameters_12.rb
+++ b/test/whitequark/test_numbered_and_ordinary_parameters_12.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-proc {|;a| _1} # error: can't use anonymous parameters when ordinary parameters are defined
+proc {|;a| _1} # error: numbered parameters are not allowed when an ordinary parameter is defined

--- a/test/whitequark/test_numbered_and_ordinary_parameters_2.rb
+++ b/test/whitequark/test_numbered_and_ordinary_parameters_2.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-m do || _1 end  # error: can't use anonymous parameters when ordinary parameters are defined
+m do || _1 end  # error: numbered parameters are not allowed when an ordinary parameter is defined

--- a/test/whitequark/test_numbered_and_ordinary_parameters_3.rb
+++ b/test/whitequark/test_numbered_and_ordinary_parameters_3.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-m do |a, b| _1 end  # error: can't use anonymous parameters when ordinary parameters are defined
+m do |a, b| _1 end  # error: numbered parameters are not allowed when an ordinary parameter is defined

--- a/test/whitequark/test_numbered_and_ordinary_parameters_4.rb
+++ b/test/whitequark/test_numbered_and_ordinary_parameters_4.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-m { |x = _1| } # error: can't use anonymous parameters when ordinary parameters are defined
+m { |x = _1| } # error: numbered parameters are not allowed when an ordinary parameter is defined

--- a/test/whitequark/test_numbered_and_ordinary_parameters_5.rb
+++ b/test/whitequark/test_numbered_and_ordinary_parameters_5.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-m { |x: _1| } # error: can't use anonymous parameters when ordinary parameters are defined
+m { |x: _1| } # error: numbered parameters are not allowed when an ordinary parameter is defined

--- a/test/whitequark/test_numbered_and_ordinary_parameters_6.rb
+++ b/test/whitequark/test_numbered_and_ordinary_parameters_6.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-->() { _1 }  # error: can't use anonymous parameters when ordinary parameters are defined
+->() { _1 }  # error: numbered parameters are not allowed when an ordinary parameter is defined

--- a/test/whitequark/test_numbered_and_ordinary_parameters_7.rb
+++ b/test/whitequark/test_numbered_and_ordinary_parameters_7.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-->(a) { _1 }  # error: can't use anonymous parameters when ordinary parameters are defined
+->(a) { _1 }  # error: numbered parameters are not allowed when an ordinary parameter is defined

--- a/test/whitequark/test_numbered_and_ordinary_parameters_8.rb
+++ b/test/whitequark/test_numbered_and_ordinary_parameters_8.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-->() do _1 end  # error: can't use anonymous parameters when ordinary parameters are defined
+->() do _1 end  # error: numbered parameters are not allowed when an ordinary parameter is defined

--- a/test/whitequark/test_numbered_and_ordinary_parameters_9.rb
+++ b/test/whitequark/test_numbered_and_ordinary_parameters_9.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-->(a, b) do _1 end # error: can't use anonymous parameters when ordinary parameters are defined
+->(a, b) do _1 end # error: numbered parameters are not allowed when an ordinary parameter is defined


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This proposes a new error message for `OrdinaryParamDefined`, so that it applies to errors using "it" as the anonymous param (which is not a numbered param).

Relates to https://github.com/sorbet/sorbet/pull/9443

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This breaks off an atomic piece of the draft PR implementing "it" support, to reduce the PR scope: https://github.com/sorbet/sorbet/pull/9443

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Updated existing tests
