### PR TITLE
Forward args for generic constructors

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/typed_array.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_array.rb
@@ -22,8 +22,8 @@ module T::Types
       obj.is_a?(Array)
     end
 
-    def new(*args)
-      Array.new(*T.unsafe(args))
+    def new(...)
+      Array.new(...)
     end
 
     module Private

--- a/gems/sorbet-runtime/lib/types/types/typed_enumerator.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerator.rb
@@ -22,8 +22,8 @@ module T::Types
       obj.is_a?(Enumerator)
     end
 
-    def new(*args, &blk)
-      T.unsafe(Enumerator).new(*args, &blk)
+    def new(...)
+      T.unsafe(Enumerator).new(...)
     end
 
     class Untyped < TypedEnumerator

--- a/gems/sorbet-runtime/lib/types/types/typed_enumerator_chain.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerator_chain.rb
@@ -22,8 +22,8 @@ module T::Types
       obj.is_a?(Enumerator::Chain)
     end
 
-    def new(*args, &blk)
-      T.unsafe(Enumerator::Chain).new(*args, &blk)
+    def new(...)
+      T.unsafe(Enumerator::Chain).new(...)
     end
 
     class Untyped < TypedEnumeratorChain

--- a/gems/sorbet-runtime/lib/types/types/typed_enumerator_lazy.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerator_lazy.rb
@@ -22,8 +22,8 @@ module T::Types
       obj.is_a?(Enumerator::Lazy)
     end
 
-    def new(*args, &blk)
-      T.unsafe(Enumerator::Lazy).new(*args, &blk)
+    def new(...)
+      T.unsafe(Enumerator::Lazy).new(...)
     end
 
     class Untyped < TypedEnumeratorLazy

--- a/gems/sorbet-runtime/lib/types/types/typed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_hash.rb
@@ -41,8 +41,8 @@ module T::Types
       obj.is_a?(Hash)
     end
 
-    def new(*args, &blk)
-      Hash.new(*T.unsafe(args), &blk)
+    def new(...)
+      Hash.new(...)
     end
 
     class Untyped < TypedHash

--- a/gems/sorbet-runtime/lib/types/types/typed_range.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_range.rb
@@ -22,8 +22,8 @@ module T::Types
       obj.is_a?(Range)
     end
 
-    def new(*args)
-      T.unsafe(Range).new(*args)
+    def new(...)
+      T.unsafe(Range).new(...)
     end
   end
 end

--- a/gems/sorbet-runtime/lib/types/types/typed_set.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_set.rb
@@ -28,11 +28,11 @@ module T::Types
       obj.is_a?(Set)
     end
 
-    def new(*args)
+    def new(...)
       # Fine for this to blow up, because hopefully if they're trying to make a
       # Set, they don't mind putting (or already have put) a `require 'set'` in
       # their program directly.
-      Set.new(*T.unsafe(args))
+      Set.new(...)
     end
 
     class Untyped < TypedSet


### PR DESCRIPTION
We aren't forwarding the block argument for the `A::Array[...].new` method, which means that the behavior of `T::Array[String].new(4) { "hi" }` does not currently match the behavior of `Array.new(4) { "hi" }`. This PR switches from manually forwarding arguments and blocks for the generic type wrappers to using the `...` style argument forwarding that was introduced in ruby 2.7. (We no longer suport ruby < 3.0, so we shouldn't need any backwards-compatibility here.)

### Motivation
Fixing runtime behavior.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
