### PR TITLE
Drop `root` parameter from `isSubclassOrMixin`

### DIFF
--- a/main/lsp/LSPLoop.h
+++ b/main/lsp/LSPLoop.h
@@ -97,19 +97,18 @@ std::unique_ptr<MarkupContent> formatRubyMarkup(MarkupKind markupKind, std::stri
 std::string prettyTypeForConstant(const core::GlobalState &gs, core::SymbolRef constant);
 SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef sym, bool isAttrBestEffortUIOnly);
 
-// Returns all subclasses of ClassOrModuleRef (including itself)
+// Returns all subclasses of ClassOrModuleRef (including itself if includeRoot is true)
 //
-// This method scans the entire list of classes or modules, which means scanning tens of thousands,
-// at least.
+// This method scans the entire list of classes or modules, which means scanning tens of thousands, at least.
 //
 // This method MUST NOT be used in Sorbet's core type checking pipeline, because it would be
 // prohibitively expensive. It is defined here in lsp_helpers for use implementing certain LSP
 // methods where performance is not a constraint (i.e., where the user is ok waiting for multiple
 // seconds for a response). This means it must not be used to respond to e.g. completion requests.
 //
-// @param includeSelf Whether to include `sym` in the list of subclasses or not.
-std::vector<core::ClassOrModuleRef> getSubclassesSlow(const core::GlobalState &gs, core::ClassOrModuleRef sym,
-                                                      bool includeSelf);
+// @param includeRoot Whether to include `root` in the list of subclasses or not.
+std::vector<core::ClassOrModuleRef> getSubclassesSlow(const core::GlobalState &gs, core::ClassOrModuleRef root,
+                                                      bool includeRoot);
 
 std::unique_ptr<core::lsp::QueryResponse>
 skipLiteralIfPunnedKeywordArg(const core::GlobalState &gs,

--- a/main/lsp/lsp_helpers.cc
+++ b/main/lsp/lsp_helpers.cc
@@ -134,8 +134,8 @@ SymbolKind symbolRef2SymbolKind(const core::GlobalState &gs, core::SymbolRef sym
 namespace {
 
 // Checks if s is a subclass of root or contains root as a mixin, and updates visited and memoized vectors.
-bool isSubclassOrMixin(const core::GlobalState &gs, core::ClassOrModuleRef root, core::ClassOrModuleRef s,
-                       vector<bool> &memoized, vector<bool> &visited) {
+bool isSubclassOrMixin(const core::GlobalState &gs, core::ClassOrModuleRef s, vector<bool> &memoized,
+                       vector<bool> &visited) {
     // don't visit the same class twice
     if (visited[s.id()] == true) {
         return memoized[s.id()];
@@ -143,13 +143,13 @@ bool isSubclassOrMixin(const core::GlobalState &gs, core::ClassOrModuleRef root,
     visited[s.id()] = true;
 
     for (auto a : s.data(gs)->mixins()) {
-        if (a == root) {
+        if (memoized[a.id()]) {
             memoized[s.id()] = true;
             return true;
         }
     }
     if (s.data(gs)->superClass().exists()) {
-        memoized[s.id()] = isSubclassOrMixin(gs, root, s.data(gs)->superClass(), memoized, visited);
+        memoized[s.id()] = isSubclassOrMixin(gs, s.data(gs)->superClass(), memoized, visited);
     }
 
     return memoized[s.id()];
@@ -158,20 +158,20 @@ bool isSubclassOrMixin(const core::GlobalState &gs, core::ClassOrModuleRef root,
 } // namespace
 
 // This is slow. See the comment in the header file.
-vector<core::ClassOrModuleRef> getSubclassesSlow(const core::GlobalState &gs, core::ClassOrModuleRef sym,
-                                                 bool includeSelf) {
+vector<core::ClassOrModuleRef> getSubclassesSlow(const core::GlobalState &gs, core::ClassOrModuleRef root,
+                                                 bool includeRoot) {
     vector<bool> memoized(gs.classAndModulesUsed());
     vector<bool> visited(gs.classAndModulesUsed());
-    memoized[sym.id()] = true;
-    visited[sym.id()] = true;
+    memoized[root.id()] = true;
+    visited[root.id()] = true;
 
     vector<core::ClassOrModuleRef> subclasses;
     for (uint32_t i = 1; i < gs.classAndModulesUsed(); ++i) {
         auto s = core::ClassOrModuleRef(gs, i);
-        if (!includeSelf && s == sym) {
+        if (!includeRoot && s == root) {
             continue;
         }
-        if (isSubclassOrMixin(gs, sym, s, memoized, visited)) {
+        if (isSubclassOrMixin(gs, s, memoized, visited)) {
             subclasses.emplace_back(s);
         }
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I want to make a version of `getSubclassesSlow` that takes multiple
roots and searches for subclasses of all of them. Rather than needing to
thread something like `UnorderedSet<ClassOrModuleRef>` to
`isSubclassOrMixin`, I think we can just use the existing `memoized`
vector, because the first thing that we do in `getSubclassesSlow` is
populate `memoized[root.id()] = true`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests