### PR TITLE
Add RBS support for `override(allow_incompatible: visibility)`

### DIFF
--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -155,6 +155,18 @@ unique_ptr<parser::Node> handleAnnotations(core::MutableContext ctx, const parse
 
             sigBuilder = parser::MK::Send(annotation.typeLoc, move(sigBuilder), core::Names::override_(),
                                           annotation.typeLoc, move(args));
+        } else if (annotation.string == "override(allow_incompatible: :visibility)") {
+            auto pairs = parser::NodeVec();
+            auto key = parser::MK::Symbol(annotation.typeLoc, core::Names::allowIncompatible());
+            auto value = parser::MK::Symbol(annotation.typeLoc, core::Names::visibility());
+            pairs.emplace_back(make_unique<parser::Pair>(annotation.typeLoc, move(key), move(value)));
+            auto hash = parser::MK::Hash(annotation.typeLoc, true, move(pairs));
+
+            auto args = parser::NodeVec();
+            args.emplace_back(move(hash));
+
+            sigBuilder = parser::MK::Send(annotation.typeLoc, move(sigBuilder), core::Names::override_(),
+                                          annotation.typeLoc, move(args));
         }
     }
 

--- a/test/testdata/rbs/signatures_defs.rb
+++ b/test/testdata/rbs/signatures_defs.rb
@@ -313,6 +313,22 @@ module Annotations
     end
   end
 
+  class OverrideIncompatibleVisibility < Parent
+    # @override
+    #: (Integer) -> void
+    private def method(x) # error: Method `method` is private in `Annotations::OverrideIncompatibleVisibility` but not in `Annotations::Parent`
+      T.reveal_type(x) # error: Revealed type: `Integer`
+    end
+  end
+
+  class OverrideAllowIncompatibleVisibility < Parent
+    # @override(allow_incompatible: :visibility)
+    #: (Integer) -> void
+    private def method(x)
+      T.reveal_type(x) # error: Revealed type: `Integer`
+    end
+  end
+
   # @abstract
   class Abstract
     # @abstract

--- a/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
@@ -600,6 +600,30 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <runtime method definition of method>
     end
 
+    class <emptyTree>::<C OverrideIncompatibleVisibility><<C <todo sym>>> < (<emptyTree>::<C Parent>)
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.override().params(:x, <emptyTree>::<C Integer>).void()
+      end
+
+      def method<<todo method>>(x, &<blk>)
+        <emptyTree>::<C T>.reveal_type(x)
+      end
+
+      <self>.private(<runtime method definition of method>)
+    end
+
+    class <emptyTree>::<C OverrideAllowIncompatibleVisibility><<C <todo sym>>> < (<emptyTree>::<C Parent>)
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.override(:allow_incompatible, :visibility).params(:x, <emptyTree>::<C Integer>).void()
+      end
+
+      def method<<todo method>>(x, &<blk>)
+        <emptyTree>::<C T>.reveal_type(x)
+      end
+
+      <self>.private(<runtime method definition of method>)
+    end
+
     class <emptyTree>::<C Abstract><<C <todo sym>>> < (::<todo sym>)
       ::T::Sig::WithoutRuntime.sig() do ||
         <self>.abstract().returns(<emptyTree>::<C Integer>)


### PR DESCRIPTION
### Motivation

Follow up on #8959:

```rb

class Parent
  # @abstract
  #: -> Integer
  def foo; raise; end
end

class Child1 < Parent
  # @override
  #: -> Integer
  private def foo; 0; end # error: Method foo is private in Child1 but not in Parent
end

class Child3 < Parent
  # @override(allow_incompatible: :visibility)
  #: -> Integer
  private def foo; 0; end
end
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
