### PR TITLE
no-op: Reorganize some code in `_methods.rb`

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -104,19 +104,6 @@ module T::Private::Methods
     T::Types::Proc.new(decl.params, decl.returns)
   end
 
-  # Returns the signature for a method whose definition was preceded by `sig`.
-  #
-  # @param method [UnboundMethod]
-  # @return [T::Private::Methods::Signature]
-  def self.signature_for_method(method)
-    signature_for_key(method_to_key(method))
-  end
-
-  private_class_method def self.signature_for_key(key)
-    maybe_run_sig_block_for_key(key)
-    @signatures_by_method[key]
-  end
-
   # Fetch the directory name of the file that defines the `T::Private` constant and
   # add a trailing slash to allow us to match it as a directory prefix.
   SORBET_RUNTIME_LIB_PATH = File.dirname(T.const_source_location(:Private).first) + File::SEPARATOR
@@ -402,6 +389,19 @@ module T::Private::Methods
     end
   end
 
+  # Returns the signature for a method whose definition was preceded by `sig`.
+  #
+  # @param method [UnboundMethod]
+  # @return [T::Private::Methods::Signature]
+  def self.signature_for_method(method)
+    signature_for_key(method_to_key(method))
+  end
+
+  private_class_method def self.signature_for_key(key)
+    maybe_run_sig_block_for_key(key)
+    @signatures_by_method[key]
+  end
+
   def self.unwrap_method(mod, signature, original_method)
     maybe_wrapped_method = CallValidation.wrap_method_if_needed(mod, signature, original_method)
     @signatures_by_method[method_to_key(maybe_wrapped_method)] = signature
@@ -426,6 +426,25 @@ module T::Private::Methods
 
   def self.run_sig_block_for_method(method)
     run_sig_block_for_key(method_to_key(method))
+  end
+
+  # use this directly if you don't want/need to box up the method into an object to pass to method_to_key.
+  private_class_method def self.method_owner_and_name_to_key(owner, name)
+    "#{owner.object_id}##{name}"
+  end
+
+  private_class_method def self.method_to_key(method)
+    # If a subclass Sub inherits a method `foo` from Base, then
+    # Sub.instance_method(:foo) != Base.instance_method(:foo) even though they resolve to the
+    # same method. Similarly, Foo.method(:bar) != Foo.singleton_class.instance_method(:bar).
+    # So, we always do the look up by the method on the owner (Base in this example).
+    method_owner_and_name_to_key(method.owner, method.name)
+  end
+
+  private_class_method def self.key_to_method(key)
+    id, name = key.split("#")
+    obj = ObjectSpace._id2ref(id.to_i)
+    obj.instance_method(name)
   end
 
   private_class_method def self.run_sig_block_for_key(key, force_type_init: false)
@@ -598,25 +617,6 @@ module T::Private::Methods
       # cause tests to fail if they were dependent on hard coding errors).
       mod.method(name)
     end
-  end
-
-  # use this directly if you don't want/need to box up the method into an object to pass to method_to_key.
-  private_class_method def self.method_owner_and_name_to_key(owner, name)
-    "#{owner.object_id}##{name}"
-  end
-
-  private_class_method def self.method_to_key(method)
-    # If a subclass Sub inherits a method `foo` from Base, then
-    # Sub.instance_method(:foo) != Base.instance_method(:foo) even though they resolve to the
-    # same method. Similarly, Foo.method(:bar) != Foo.singleton_class.instance_method(:bar).
-    # So, we always do the look up by the method on the owner (Base in this example).
-    method_owner_and_name_to_key(method.owner, method.name)
-  end
-
-  private_class_method def self.key_to_method(key)
-    id, name = key.split("#")
-    obj = ObjectSpace._id2ref(id.to_i)
-    obj.instance_method(name)
   end
 end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->




- **Move a comment to where it seems more relevant** (2087f18358)

  The old comment location is talking about the method's owner but is not
  doing any logic that deals with the method owner. My guess is that at
  some point it was refactored such that the `method_to_key` method got
  separated from the comment documenting it, but if that's the case, it
  must have been before sorbet-runtime was vendored into the Sorbet repo,
  because the separation is there in the first commit adding
  sorbet-runtime.

- **Move all "method_to_key" methods to one spot** (a77a7fef5a)

  There were three groupings of methods that deal with signature
  reflection. Now, all of these methods are in one spot in the file, which
  makes it easier to have them all on screen at once.







### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests