### PR TITLE
Don't rename dispatch-related methods

### DIFF
--- a/main/lsp/AbstractRewriter.cc
+++ b/main/lsp/AbstractRewriter.cc
@@ -124,20 +124,6 @@ void AbstractRewriter::addSubclassRelatedMethods(const core::GlobalState &gs, co
     }
 }
 
-// Add methods that are related because of dispatching via secondary components in sends (union types).
-void AbstractRewriter::addDispatchRelatedMethods(const core::GlobalState &gs,
-                                                 const core::DispatchResult *dispatchResult,
-                                                 shared_ptr<UniqueSymbolQueue> methods) {
-    for (const core::DispatchResult *dr = dispatchResult; dr != nullptr; dr = dr->secondary.get()) {
-        auto method = dr->main.method;
-        ENFORCE(method.exists());
-        auto isNew = methods->tryEnqueue(method);
-        if (isNew) {
-            addSubclassRelatedMethods(gs, method, methods);
-        }
-    }
-}
-
 void AbstractRewriter::getEdits(LSPTypecheckerDelegate &typechecker) {
     const core::GlobalState &gs = typechecker.state();
 

--- a/main/lsp/AbstractRewriter.h
+++ b/main/lsp/AbstractRewriter.h
@@ -45,9 +45,6 @@ protected:
 
     static void addSubclassRelatedMethods(const core::GlobalState &gs, core::MethodRef symbol,
                                           std::shared_ptr<UniqueSymbolQueue> methods);
-
-    static void addDispatchRelatedMethods(const core::GlobalState &gs, const core::DispatchResult *dispatchResult,
-                                          std::shared_ptr<UniqueSymbolQueue> methods);
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -129,12 +129,6 @@ public:
 
 private:
     string replaceMethodNameInSend(string source, const core::lsp::SendResponse *sendResp) {
-        // For sends with multiple components, traverse the list of dispatch components and add them to the
-        // queue of symbols to be renamed
-        if (sendResp->dispatchResult->secondary) {
-            addDispatchRelatedMethods(gs, sendResp->dispatchResult.get(), getQueue());
-        }
-
         // find the method in the send expression
         auto methodNameLoc = sendResp->getMethodNameLoc(gs);
         if (!methodNameLoc) {

--- a/test/testdata/lsp/rename/method_union_types.A.rbedited
+++ b/test/testdata/lsp/rename/method_union_types.A.rbedited
@@ -8,7 +8,7 @@ class C1
 end
 
 class C2
-  def m2
+  def m1
 #      ^ apply-rename: [B] newName: m2 placeholderText: m1
   end
 end
@@ -20,7 +20,7 @@ class C11 < C1
 end
 
 class C3
-  def m2
+  def m1
 #      ^ apply-rename: [E] newName: m2 placeholderText: m1
   end
 end

--- a/test/testdata/lsp/rename/method_union_types.B.rbedited
+++ b/test/testdata/lsp/rename/method_union_types.B.rbedited
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 class C1
-  def m2
+  def m1
 #      ^ apply-rename: [A] newName: m2 placeholderText: m1
   end
 end
@@ -14,13 +14,13 @@ class C2
 end
 
 class C11 < C1
-  def m2
+  def m1
 #      ^ apply-rename: [D] newName: m2 placeholderText: m1
   end
 end
 
 class C3
-  def m2
+  def m1
 #      ^ apply-rename: [E] newName: m2 placeholderText: m1
   end
 end
@@ -36,6 +36,6 @@ class CallerClass
 
   sig { params(c: T.any(C11, C3)).void }
   def caller2(c)
-    c.m2
+    c.m1
   end
 end

--- a/test/testdata/lsp/rename/method_union_types.C.rbedited
+++ b/test/testdata/lsp/rename/method_union_types.C.rbedited
@@ -20,7 +20,7 @@ class C11 < C1
 end
 
 class C3
-  def m2
+  def m1
 #      ^ apply-rename: [E] newName: m2 placeholderText: m1
   end
 end

--- a/test/testdata/lsp/rename/method_union_types.D.rbedited
+++ b/test/testdata/lsp/rename/method_union_types.D.rbedited
@@ -8,7 +8,7 @@ class C1
 end
 
 class C2
-  def m2
+  def m1
 #      ^ apply-rename: [B] newName: m2 placeholderText: m1
   end
 end
@@ -20,7 +20,7 @@ class C11 < C1
 end
 
 class C3
-  def m2
+  def m1
 #      ^ apply-rename: [E] newName: m2 placeholderText: m1
   end
 end

--- a/test/testdata/lsp/rename/method_union_types.E.rbedited
+++ b/test/testdata/lsp/rename/method_union_types.E.rbedited
@@ -2,19 +2,19 @@
 # frozen_string_literal: true
 
 class C1
-  def m2
+  def m1
 #      ^ apply-rename: [A] newName: m2 placeholderText: m1
   end
 end
 
 class C2
-  def m2
+  def m1
 #      ^ apply-rename: [B] newName: m2 placeholderText: m1
   end
 end
 
 class C11 < C1
-  def m2
+  def m1
 #      ^ apply-rename: [D] newName: m2 placeholderText: m1
   end
 end
@@ -30,7 +30,7 @@ class CallerClass
 
   sig { params(c: T.any(C1, C2)).void }
   def caller(c)
-    c.m2
+    c.m1
 #      ^ apply-rename: [C] newName: m2 placeholderText: m1
   end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Given this snippet:

```ruby
class A
  def foo; end
  #   ^ rename: bar
end

class B
  def foo; end
end

sig { params(x: T.any(A, B)).void }
def example(x)
  x.foo
end
```

Right now, Sorbet not only renames `A#foo`, but it also renames `B#foo`
just because there happened to be a successful call to `foo` on
`T.any(A, B)`.

When I polled Stripe engineers about this, I universally heard that the
behavior they preferred was that Sorbet should only rename calls to
`A#foo`, and let Sorbet report an error that now `foo_renamed` method
does not exist on `B` component of `T.any(A, B)`.

This is also the behavior that TypeScript has for renames.

The only other option in consideration was to **skip** all callsites on
unions, e.g., report that `foo` doesn't exist on `A` component of
`T.any(A, B)` after the rename. The argument against that one ended with
noticing that if you **do** want to rename all the call sites (both `A`
and `B`), you want to issue one rename on `A#foo`, one on `B#foo`, and
expect that all the call sites have been migrated. If we exclude the
union call sites, then you won't be able to programmatically rename
those: you'll just be stuck with a list of errors.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.