### PR TITLE
Reserve packageForFile_ capacity up front

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1775,6 +1775,9 @@ FileRef GlobalState::enterFile(shared_ptr<File> file) {
     files.emplace_back(std::move(file));
     auto ret = FileRef(filesUsed() - 1);
     fileRefByPath[path] = ret;
+    if (this->packageDB_.enabled()) {
+        this->packageDB_.reservePackageNameForFiles(filesUsed() - 1);
+    }
     return ret;
 }
 

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -45,19 +45,19 @@ MangledName PackageDB::enterPackage(unique_ptr<PackageInfo> pkg) {
     return nr;
 }
 
-const MangledName PackageDB::getPackageNameForFile(FileRef file) const {
-    if (this->packageForFile_.size() <= file.id()) {
-        return MangledName();
-    }
+void PackageDB::reservePackageNameForFiles(size_t numFiles) {
+    // Add one, because `idx == 0` will be the package for the File that doesn't exist.
+    // (We could alternatively have chosen to use `file.id() - 1` in `{get,set}PackageNameForFile`.)
+    this->packageForFile_.resize(max(this->packageForFile_.size(), numFiles + 1), MangledName());
+}
 
+const MangledName PackageDB::getPackageNameForFile(FileRef file) const {
+    ENFORCE(file.id() < this->packageForFile_.size(), "Missing a call to reservePackageNameForFiles!");
     return this->packageForFile_[file.id()];
 }
 
 void PackageDB::setPackageNameForFile(FileRef file, MangledName mangledName) {
-    if (this->packageForFile_.size() <= file.id()) {
-        this->packageForFile_.resize(file.id() + 1, MangledName());
-    }
-
+    ENFORCE(file.id() < this->packageForFile_.size(), "Missing a call to reservePackageNameForFiles!");
     this->packageForFile_[file.id()] = mangledName;
 }
 

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -29,6 +29,21 @@ public:
 
     MangledName enterPackage(std::unique_ptr<PackageInfo> pkg);
 
+    // Reserve enough space in the `packageForFile_` vector for `numFiles` files.
+    //
+    // We also do this on GlobalState::enterFile, but this API is better because it avoids
+    // multiple reallocations if we can know ahead of time that we're going to use a certain number
+    // of files.
+    //
+    // You might wonder: why not have a field on a core::File that stores the package for that file?
+    //
+    // 1.  Files are agnostic of semantic information (e.g., they are valid to be moved from one
+    //     GlobalState to another). They do not store NameRef or SymbolRef, because those IDs change
+    //     from one GlobalState to the next.
+    //
+    // 2.  Users do not have to pay the additional memory for packages unless they have opted in.
+    void reservePackageNameForFiles(size_t numFiles);
+
     // Fetch the mangled package name for a file, returning a MangledName that doesn't exist if there is no
     // associated package for the file.
     const MangledName getPackageNameForFile(FileRef file) const;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -141,6 +141,9 @@ unique_ptr<core::GlobalState> copyForSlowPath(const core::GlobalState &from, con
 
 vector<core::FileRef> reserveFiles(core::GlobalState &gs, const vector<string> &files) {
     Timer timeit(gs.tracer(), "reserveFiles");
+    if (gs.packageDB().enabled()) {
+        gs.packageDB().reservePackageNameForFiles(files.size());
+    }
     vector<core::FileRef> ret;
     ret.reserve(files.size());
     core::UnfreezeFileTable unfreezeFiles(gs);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Makes it so that getting or setting the package for a specific file does not
imply a vector reallocation.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests