### PR TITLE
Inline name hash serialization

### DIFF
--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1014,7 +1014,7 @@ void SerializerImpl::unpickleNameTable(UnPickler &p, GlobalState &result) {
         for (int i = 0; i < namesSize; i++) {
             auto hash = p.getU4();
             result.utf8Names.emplace_back(unpickleUTF8Name(p, result));
-            auto &bucket = result.namesByHash.lookupBucket(hash, [](auto name) { return false; });
+            auto &bucket = result.namesByHash.lookupBucket(hash, NameHash::Bucket::isEmpty());
             bucket.hash = hash;
             bucket.rawId = core::NameRef(result, core::NameKind::UTF8, i).rawId();
         }
@@ -1024,7 +1024,7 @@ void SerializerImpl::unpickleNameTable(UnPickler &p, GlobalState &result) {
         for (int i = 0; i < namesSize; i++) {
             auto hash = p.getU4();
             result.constantNames.emplace_back(unpickleConstantName(p, result));
-            auto &bucket = result.namesByHash.lookupBucket(hash, [](auto name) { return false; });
+            auto &bucket = result.namesByHash.lookupBucket(hash, NameHash::Bucket::isEmpty());
             bucket.hash = hash;
             bucket.rawId = core::NameRef(result, core::NameKind::CONSTANT, i).rawId();
         }
@@ -1034,7 +1034,7 @@ void SerializerImpl::unpickleNameTable(UnPickler &p, GlobalState &result) {
         for (int i = 0; i < namesSize; i++) {
             auto hash = p.getU4();
             result.uniqueNames.emplace_back(unpickleUniqueName(p, result));
-            auto &bucket = result.namesByHash.lookupBucket(hash, [](auto name) { return false; });
+            auto &bucket = result.namesByHash.lookupBucket(hash, NameHash::Bucket::isEmpty());
             bucket.hash = hash;
             bucket.rawId = core::NameRef(result, core::NameKind::UNIQUE, i).rawId();
         }


### PR DESCRIPTION
Instead of writing out the whole `namesByHash` table, write out hashes along side each name table entry so that we can reconstruct the hash table as we deserialize.

### Motivation
Making the serialized form of the name table friendly to appending, and avoiding writing out a lot of zeros for tables that are right over a power of two in size.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
