### PR TITLE
Fix Kernel#p return type using type parameters

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -1926,18 +1926,6 @@ module Kernel
   end
   def puts(*arg0); end
 
-  ### TODO: this type is not correct. Observe this irb session:
-  ###
-  ### >> p
-  ### => nil
-  ### >> p 1
-  ### 1
-  ### => 1
-  ### >> p 1, 2
-  ### 1
-  ### 2
-  ### => [1, 2]
-
   # For each object, directly writes *obj*.`inspect` followed by a newline to
   # the program's standard output.
   #
@@ -1952,13 +1940,26 @@ module Kernel
   # ```ruby
   # #<S name="dave", state="TX">
   # ```
+  #
+  # Returns:
+  # - nil if no arguments
+  # - the single argument if one argument
+  # - an array of arguments if multiple arguments
+  sig { returns(NilClass) }
   sig do
-    params(
-        arg0: Object,
-    )
-    .returns(NilClass)
+    type_parameters(:T)
+      .params(arg0: T.all(T.type_parameter(:T), Object))
+      .returns(T.type_parameter(:T))
   end
-  def p(*arg0); end
+  sig do
+    type_parameters(:T)
+      .params(
+        arg0: T.all(T.type_parameter(:T), Object),
+        arg1: T.all(T.type_parameter(:T), Object)
+      )
+      .returns(T::Array[T.type_parameter(:T)])
+  end
+  def p(arg0=nil, *arg1); end
 
   # prints arguments in pretty form.
   #

--- a/test/testdata/cfg/textoutput.rb.cfg-text.exp
+++ b/test/testdata/cfg/textoutput.rb.cfg-text.exp
@@ -43,7 +43,7 @@ bb6[firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <
     <cfgAlias>$15: T.class_of(T) = alias <C T>
     e: T.untyped = <cfgAlias>$15: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
     <statTemp>$26: String("done") = "done"
-    <throwAwayTemp>$24: NilClass = <self>: T.class_of(<root>).p(<statTemp>$26: String("done"))
+    <throwAwayTemp>$24: String = <self>: T.class_of(<root>).p(<statTemp>$26: String("done"))
     <gotoDeadTemp>$23 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
@@ -52,7 +52,7 @@ bb7[firstDead=-1](<self>: T.class_of(<root>), <exceptionValue>$3: StandardError)
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$17: T.untyped = <keep-alive> <exceptionValue>$3
     <statTemp>$22: String("whoops") = "whoops"
-    <returnMethodTemp>$2: NilClass = <self>: T.class_of(<root>).p(<statTemp>$22: String("whoops"))
+    <returnMethodTemp>$2: String = <self>: T.class_of(<root>).p(<statTemp>$22: String("whoops"))
     <unconditional> -> bb6
 
 # backedges

--- a/test/testdata/rbi/kernel.rb
+++ b/test/testdata/rbi/kernel.rb
@@ -76,20 +76,25 @@ T.assert_type!(obj.object_id, Integer)
 obj = T.let("foo", String)
 T.assert_type!(obj.itself, String)
 
-
-# These types are deliberately wrong, because `Kernel#p` is difficult to type
-# in an RBI.  See the comments in kernel.rbi.
-p_result = Kernel.p 1
-# This should be `Integer`.
+p_result = p
+# Returns nil when called with no arguments
 T.reveal_type(p_result) # error: Revealed type: `NilClass`
+
+p_result = Kernel.p 1
+# Returns the argument when called with one argument
+T.reveal_type(p_result) # error: Revealed type: `Integer`
 
 p_result = p "string"
-# This should be `String`.
-T.reveal_type(p_result) # error: Revealed type: `NilClass`
+# Returns the argument when called with one argument
+T.reveal_type(p_result) # error: Revealed type: `String`
 
 p_result = p 1, 2
-# This should be `[1, 2]` or `T::Array[T.untyped]`
-T.reveal_type(p_result) # error: Revealed type: `NilClass`
+# Returns an array when called with multiple arguments
+T.reveal_type(p_result) # error: Revealed type: `T::Array[Integer]`
+
+p_result = Kernel.p 1, "string"
+# Returns a union type array when called with multiple arguments
+T.reveal_type(p_result) # error: Revealed type: `T::Array[T.any(Integer, String)]`
 
 class CustomError < StandardError
   def initialize(cause, team)


### PR DESCRIPTION
- Updated Kernel#p signature to use type_parameters(:T) with Object upper bound
- Changed method definition from 'def p(*arg0)' to 'def p(arg0=nil, *arg1)' to support overloaded signatures
- Added overloaded signatures:
  1. sig { returns(NilClass) } for p() with no arguments
  1. sig with single arg returning T.type_parameter(:T) for p(x)
  1. sig with multiple args returning T::Array[T.type_parameter(:T)] for p(x,y,...)
- Updated test expectations in test/testdata/rbi/kernel.rb
- Updated CFG test expectations in test/testdata/cfg/textoutput.rb.cfg-text.exp

The new signature correctly preserves argument types:
- p() returns NilClass
- p(42) returns Integer
- p('hello') returns String
- p(1, 2) returns T::Array[Integer]
- p(1, 'string') returns T::Array[T.any(Integer, String)]
