### PR TITLE
Avoid copying the file table while indexing

### DIFF
--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -297,6 +297,9 @@ public:
     NameRef lookupNameConstant(NameRef original) const;
     NameRef lookupNameConstant(std::string_view original) const;
 
+    FileRef enterSingleFileForIndex(std::shared_ptr<File> file);
+    std::shared_ptr<File> copyFileForIndexing(core::FileRef file);
+
     FileRef enterFile(std::string_view path, std::string_view source);
     FileRef enterFile(std::shared_ptr<File> file);
     FileRef enterNewFileAt(std::shared_ptr<File> file, FileRef id);


### PR DESCRIPTION
Copying the whole file table while indexing is quite expensive, and avoiding that would save us some time. We can minimally copy the `GlobalState` used by indexing threads, and populate their file table with a single entry for each file that they're processing.

### Motivation
Performance. Indexing happens a lot for package-directed type checking, and paying the cost of copying the file table every time is not acceptable.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.