### PR TITLE
wip: Try to make builder_walk use const tree

### DIFF
--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -10,7 +10,7 @@ public:
     static std::unique_ptr<CFG> buildFor(core::Context ctx, ast::MethodDef &md);
 
 private:
-    static BasicBlock *walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlock *current);
+    static BasicBlock *walk(CFGContext cctx, const ast::ExpressionPtr &what, BasicBlock *current);
     static void fillInTopoSorts(core::Context ctx, CFG &cfg);
     static void dealias(core::Context ctx, CFG &cfg);
     static void simplify(core::Context ctx, CFG &cfg);
@@ -26,15 +26,16 @@ private:
     static void unconditionalJump(BasicBlock *from, BasicBlock *to, CFG &inWhat, core::LocOffsets loc);
     static void jumpToDead(BasicBlock *from, CFG &inWhat, core::LocOffsets loc);
     static void synthesizeExpr(BasicBlock *bb, LocalRef var, core::LocOffsets loc, InstructionPtr inst);
-    static BasicBlock *walkHash(CFGContext cctx, ast::Hash &h, BasicBlock *current, core::NameRef method);
+    static BasicBlock *walkHash(CFGContext cctx, const ast::Hash &h, BasicBlock *current, core::NameRef method);
     static BasicBlock *walkEmptyTreeInIf(CFGContext cctx, core::LocOffsets loc, BasicBlock *current);
-    static BasicBlock *walkBlockReturn(CFGContext cctx, core::LocOffsets loc, ast::ExpressionPtr &expr,
+    static BasicBlock *walkBlockReturn(CFGContext cctx, core::LocOffsets loc, const ast::ExpressionPtr &expr,
                                        BasicBlock *current);
     static std::tuple<LocalRef, BasicBlock *, BasicBlock *>
     walkDefault(CFGContext cctx, int paramIndex, const core::ParamInfo &paramInfo, LocalRef paramLocal,
-                core::LocOffsets paramLoc, ast::ExpressionPtr &def, BasicBlock *presentCont, BasicBlock *defaultCont);
+                core::LocOffsets paramLoc, const ast::ExpressionPtr &def, BasicBlock *presentCont,
+                BasicBlock *defaultCont);
     static BasicBlock *joinBlocks(CFGContext cctx, BasicBlock *a, BasicBlock *b);
-    static BasicBlock *buildExceptionHandler(CFGContext cctx, ast::ExpressionPtr &ex, BasicBlock *caseBody,
+    static BasicBlock *buildExceptionHandler(CFGContext cctx, const ast::ExpressionPtr &ex, BasicBlock *caseBody,
                                              cfg::LocalRef exceptionValue, BasicBlock *rescueHandlersBlock);
 };
 

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -106,7 +106,7 @@ pair<LocalRef, bool> unresolvedIdent2Local(CFGContext cctx, const ast::Unresolve
     }
 }
 
-bool sendRecvIsT(ast::Send &s) {
+bool sendRecvIsT(const ast::Send &s) {
     if (auto cnst = ast::cast_tree<ast::ConstantLit>(s.recv)) {
         return cnst->symbol() == core::Symbols::T();
     } else {
@@ -114,7 +114,7 @@ bool sendRecvIsT(ast::Send &s) {
     }
 }
 
-bool isKernelLambda(ast::Send &s) {
+bool isKernelLambda(const ast::Send &s) {
     if (s.fun != core::Names::lambda() && s.fun != core::Names::lambdaTLet()) {
         return false;
     }
@@ -128,7 +128,7 @@ bool isKernelLambda(ast::Send &s) {
     return cnst != nullptr && cnst->symbol() == core::Symbols::Kernel();
 }
 
-InstructionPtr maybeMakeTypeParameterAlias(CFGContext &cctx, ast::Send &s) {
+InstructionPtr maybeMakeTypeParameterAlias(CFGContext &cctx, const ast::Send &s) {
     const auto &ctx = cctx.ctx;
     auto method = cctx.inWhat.symbol;
     if (!method.data(ctx)->flags.isGenericMethod) {
@@ -183,7 +183,7 @@ InstructionPtr maybeMakeTypeParameterAlias(CFGContext &cctx, ast::Send &s) {
     return make_insn<Alias>(typeParam);
 }
 
-ast::Send *isKernelProcOrLambda(ast::ExpressionPtr &expr) {
+const ast::Send *isKernelProcOrLambda(const ast::ExpressionPtr &expr) {
     auto send = ast::cast_tree<ast::Send>(expr);
     if (send == nullptr || send->hasNonBlockArgs() ||
         (send->fun != core::Names::lambda() && send->fun != core::Names::proc())) {
@@ -219,7 +219,7 @@ void CFGBuilder::synthesizeExpr(BasicBlock *bb, LocalRef var, core::LocOffsets l
     inserted.value.setSynthetic();
 }
 
-BasicBlock *CFGBuilder::walkHash(CFGContext cctx, ast::Hash &h, BasicBlock *current, core::NameRef method) {
+BasicBlock *CFGBuilder::walkHash(CFGContext cctx, const ast::Hash &h, BasicBlock *current, core::NameRef method) {
     InlinedVector<cfg::LocalRef, 2> vars;
     InlinedVector<core::LocOffsets, 2> locs;
     for (int i = 0; i < h.keys.size(); i++) {
@@ -249,7 +249,7 @@ BasicBlock *CFGBuilder::walkEmptyTreeInIf(CFGContext cctx, core::LocOffsets nilL
     return current;
 }
 
-BasicBlock *CFGBuilder::walkBlockReturn(CFGContext cctx, core::LocOffsets loc, ast::ExpressionPtr &expr,
+BasicBlock *CFGBuilder::walkBlockReturn(CFGContext cctx, core::LocOffsets loc, const ast::ExpressionPtr &expr,
                                         BasicBlock *current) {
     LocalRef exprSym = cctx.newTemporary(core::Names::nextTemp());
     auto afterNext = walk(cctx.withTarget(exprSym), expr, current);
@@ -282,8 +282,8 @@ BasicBlock *CFGBuilder::joinBlocks(CFGContext cctx, BasicBlock *a, BasicBlock *b
 tuple<LocalRef, BasicBlock *, BasicBlock *> CFGBuilder::walkDefault(CFGContext cctx, int paramIndex,
                                                                     const core::ParamInfo &paramInfo,
                                                                     LocalRef paramLocal, core::LocOffsets paramLoc,
-                                                                    ast::ExpressionPtr &def, BasicBlock *presentCont,
-                                                                    BasicBlock *defaultCont) {
+                                                                    const ast::ExpressionPtr &def,
+                                                                    BasicBlock *presentCont, BasicBlock *defaultCont) {
     auto defLoc = def.loc();
 
     auto *presentNext = cctx.inWhat.freshBlock(cctx.loops);
@@ -312,7 +312,7 @@ tuple<LocalRef, BasicBlock *, BasicBlock *> CFGBuilder::walkDefault(CFGContext c
     return {result, presentNext, defaultNext};
 }
 
-BasicBlock *CFGBuilder::buildExceptionHandler(CFGContext cctx, ast::ExpressionPtr &ex, BasicBlock *caseBody,
+BasicBlock *CFGBuilder::buildExceptionHandler(CFGContext cctx, const ast::ExpressionPtr &ex, BasicBlock *caseBody,
                                               cfg::LocalRef exceptionValue, BasicBlock *rescueHandlersBlock) {
     auto loc = ex.loc();
     auto exceptionClass = cctx.newTemporary(core::Names::exceptionClassTemp());
@@ -338,7 +338,7 @@ BasicBlock *CFGBuilder::buildExceptionHandler(CFGContext cctx, ast::ExpressionPt
 /** Convert `what` into a cfg, by starting to evaluate it in `current` inside method defined by `inWhat`.
  * store result of evaluation into `target`. Returns basic block in which evaluation should proceed.
  */
-BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlock *current) {
+BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::ExpressionPtr &what, BasicBlock *current) {
     /** Try to pay additional attention not to duplicate any part of tree.
      * Though this may lead to more effictient and a better CFG if it was to be actually compiled into code
      * This will lead to duplicate typechecking and may lead to exponential explosion of typechecking time
@@ -350,7 +350,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
         BasicBlock *ret = nullptr;
         typecase(
             what,
-            [&](ast::While &a) {
+            [&](const ast::While &a) {
                 auto headerBlock = cctx.inWhat.freshBlock(cctx.loops + 1);
                 // breakNotCalledBlock is only entered if break is not called in
                 // the loop body
@@ -395,7 +395,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                  *
                  */
             },
-            [&](ast::Return &a) {
+            [&](const ast::Return &a) {
                 if (cctx.isInsideLambda) {
                     ret = walkBlockReturn(cctx, a.loc, a.expr, current);
                     return;
@@ -407,7 +407,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 jumpToDead(cont, cctx.inWhat, a.loc);
                 ret = cctx.inWhat.deadBlock();
             },
-            [&](ast::If &a) {
+            [&](const ast::If &a) {
                 LocalRef ifSym = cctx.newTemporary(core::Names::ifTemp());
                 ENFORCE(ifSym.exists(), "ifSym does not exist");
                 auto cont = walk(cctx.withTarget(ifSym), a.cond, current);
@@ -448,7 +448,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
             [&](const ast::UnresolvedConstantLit &a) {
                 Exception::raise("Should have been eliminated by namer/resolver");
             },
-            [&](ast::ConstantLit &a) {
+            [&](const ast::ConstantLit &a) {
                 auto aliasName = cctx.newTemporary(core::Names::cfgAlias());
                 auto loc = a.loc();
 
@@ -485,7 +485,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 current->exprs.emplace_back(cctx.target, a.loc, make_insn<Ident>(LocalRef::selfVariable()));
                 ret = current;
             },
-            [&](ast::Assign &a) {
+            [&](const ast::Assign &a) {
                 LocalRef lhs;
                 if (auto lhsIdent = ast::cast_tree<ast::ConstantLit>(a.lhs)) {
                     lhs = global2Local(cctx, lhsIdent->symbol());
@@ -532,14 +532,14 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 rhsCont->exprs.emplace_back(cctx.target, a.loc, make_insn<Ident>(lhs));
                 ret = rhsCont;
             },
-            [&](ast::InsSeq &a) {
+            [&](const ast::InsSeq &a) {
                 for (auto &exp : a.stats) {
                     LocalRef temp = cctx.newTemporary(core::Names::statTemp());
                     current = walk(cctx.withTarget(temp), exp, current);
                 }
                 ret = walk(cctx, a.expr, current);
             },
-            [&](ast::Send &s) {
+            [&](const ast::Send &s) {
                 LocalRef recv;
 
                 // For performance, we do the name check first (single integer comparison in the
@@ -777,9 +777,9 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
 
             [&](const ast::Block &a) { Exception::raise("should never encounter a bare Block"); },
 
-            [&](ast::Next &a) { ret = walkBlockReturn(cctx, a.loc, a.expr, current); },
+            [&](const ast::Next &a) { ret = walkBlockReturn(cctx, a.loc, a.expr, current); },
 
-            [&](ast::Break &a) {
+            [&](const ast::Break &a) {
                 LocalRef exprSym = cctx.newTemporary(core::Names::returnTemp());
                 auto afterBreak = walk(cctx.withTarget(exprSym), a.expr, current);
 
@@ -855,7 +855,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 ret = cctx.inWhat.deadBlock();
             },
 
-            [&](ast::Rescue &a) {
+            [&](const ast::Rescue &a) {
                 auto rescueHeaderBlock = cctx.inWhat.freshBlock(cctx.loops);
                 unconditionalJump(current, rescueHeaderBlock, cctx.inWhat, a.loc);
                 cctx.rescueScope = rescueHeaderBlock;
@@ -956,9 +956,9 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 conditionalJump(ensureBody, gotoDeadTemp, cctx.inWhat.deadBlock(), ret, cctx.inWhat, a.loc);
             },
 
-            [&](ast::Hash &h) { ret = walkHash(cctx, h, current, core::Names::buildHash()); },
+            [&](const ast::Hash &h) { ret = walkHash(cctx, h, current, core::Names::buildHash()); },
 
-            [&](ast::Array &a) {
+            [&](const ast::Array &a) {
                 InlinedVector<LocalRef, 2> vars;
                 InlinedVector<core::LocOffsets, 2> locs;
                 for (auto &elem : a.elems) {
@@ -977,7 +977,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 ret = current;
             },
 
-            [&](ast::Cast &c) {
+            [&](const ast::Cast &c) {
                 if (auto *kernelLambda = isKernelProcOrLambda(c.arg)) {
                     kernelLambda->fun = core::Names::lambdaTLet();
                     kernelLambda->addPosArg(move(c.typeExpr));
@@ -1025,7 +1025,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                 ret = current;
             },
 
-            [&](ast::RuntimeMethodDefinition &rmd) {
+            [&](const ast::RuntimeMethodDefinition &rmd) {
                 current->exprs.emplace_back(
                     cctx.target, rmd.loc.copyWithZeroLength(),
                     make_insn<Literal>(core::make_type<core::NamedLiteralType>(core::Symbols::Symbol(), rmd.name)));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

If we can make this operate on a `const` tree, we can keep the resolved trees
around in LSP mode (and then e.g., use them to service stale LSP queries, or at
least speed up non-stale queries after no-op edits).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests