### PR TITLE
Wrap file table actions up in a class

### DIFF
--- a/core/Files.cc
+++ b/core/Files.cc
@@ -136,38 +136,38 @@ const shared_ptr<const FileHash> &File::getFileHash() const {
 FileRef::FileRef(unsigned int id) : _id(id) {}
 
 const File &FileRef::data(const GlobalState &gs) const {
-    ENFORCE(gs.files[_id]);
-    ENFORCE(gs.files[_id]->sourceType != File::Type::TombStone);
-    ENFORCE(gs.files[_id]->sourceType != File::Type::NotYetRead);
+    ENFORCE(gs.files.get(_id));
+    ENFORCE(gs.files.get(_id)->sourceType != File::Type::TombStone);
+    ENFORCE(gs.files.get(_id)->sourceType != File::Type::NotYetRead);
     return dataAllowingUnsafe(gs);
 }
 
 File &FileRef::data(GlobalState &gs) const {
-    ENFORCE(gs.files[_id]);
-    ENFORCE(gs.files[_id]->sourceType != File::Type::TombStone);
-    ENFORCE(gs.files[_id]->sourceType != File::Type::NotYetRead);
+    ENFORCE(gs.files.get(_id));
+    ENFORCE(gs.files.get(_id)->sourceType != File::Type::TombStone);
+    ENFORCE(gs.files.get(_id)->sourceType != File::Type::NotYetRead);
     return dataAllowingUnsafe(gs);
 }
 
 const File &FileRef::dataAllowingUnsafe(const GlobalState &gs) const {
     ENFORCE(_id < gs.filesUsed());
-    return *(gs.files[_id]);
+    return *(gs.files.get(_id));
 }
 
 File &FileRef::dataAllowingUnsafe(GlobalState &gs) const {
     ENFORCE(_id < gs.filesUsed());
-    return *(gs.files[_id]);
+    return *(gs.files.get(_id));
 }
 
 bool FileRef::isPackage(const GlobalState &gs) const {
-    ENFORCE(gs.files[_id]);
-    ENFORCE(gs.files[_id]->sourceType != File::Type::TombStone);
+    ENFORCE(gs.files.get(_id));
+    ENFORCE(gs.files.get(_id)->sourceType != File::Type::TombStone);
     return dataAllowingUnsafe(gs).isPackage(gs);
 }
 
 bool FileRef::isTestPackage(const GlobalState &gs) const {
-    ENFORCE(gs.files[_id]);
-    ENFORCE(gs.files[_id]->sourceType != File::Type::TombStone);
+    ENFORCE(gs.files.get(_id));
+    ENFORCE(gs.files.get(_id)->sourceType != File::Type::TombStone);
     return dataAllowingUnsafe(gs).isTestPackage(gs);
 }
 

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -860,22 +860,17 @@ void SerializerImpl::pickleFileTable(Pickler &p, const GlobalState &gs, bool pay
 }
 
 void SerializerImpl::unpickleFileTable(UnPickler &p, GlobalState &result) {
+    Timer timeit(result.tracer(), "readFiles");
     result.files.clear();
-    result.fileRefByPath.clear();
 
-    {
-        Timer timeit(result.tracer(), "readFiles");
+    int filesSize = p.getU4();
 
-        // We don't count the empty file that we reserve for the invalid FileRef.
-        int filesSize = 1 + p.getU4();
-        result.files.reserve(filesSize);
+    // We don't count the empty file that we reserve for the invalid FileRef.
+    result.files.reserve(1 + filesSize);
+    result.files.initEmpty();
 
-        result.files.emplace_back();
-
-        for (int i = 1; i < filesSize; i++) {
-            auto f = result.files.emplace_back(unpickleFile(p));
-            result.fileRefByPath[string(f->path())] = FileRef(i);
-        }
+    for (int i = 0; i < filesSize; i++) {
+        result.files.emplace(unpickleFile(p));
     }
 }
 


### PR DESCRIPTION
We have been discussing ways to avoid copying the file table at the beginning of indexing, as it's surprisingly expensive for larger repositories. One idea that we came up with was to hold it in a `std::shared_ptr` so that copying would be cheap. This PR is prework for that experiment, making it easier to group together file table data by putting it all in a single type.

### Motivation
Refactoring prework.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Pure refactor, this shouldn't change any existing behavior.
