### PR TITLE
Use mint path resolver for sorbet path

### DIFF
--- a/tools/scripts/remote-script
+++ b/tools/scripts/remote-script
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# cd so we pick up pay-server's .ruby-version, not Sorbet's .ruby-version.
+cd $HOME/stripe/pay-server
+
+SORBET_DIR=$(pay exec /pay/deploy/mint-path-resolver-hosts/current/mint-path-resolver --repo sorbet)
+# We have to manually specify --dir because remote-script hard-codes pay-server for backwards compatibility.
+#    https://git.corp.stripe.com/stripe-internal/pay-server/pull/196272/files#diff-3476184fa78de8564df28ff68cf18631R89
+# I think we should fix remote-script to stop doing that.
+exec $HOME/stripe/pay-server/scripts/bin/remote-script --dir "$SORBET_DIR" "$@"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This replaces the sorbet path with the mint-path-resolver. We will be migrating to the monorepo (mint), and it'll be cloned directly as `/pay/src` on mint boxes. We want to move non-monorepo-related files out of this path. The mint-path-resolver will return either `/pay/src/{path}` or `~/stripe/{path}` depending on whether they exist. If neither exist, it will return the `~/` path if it's a mint box and `/pay/src` if it's a non-mint box.

[DEVE-5894](https://jira.corp.stripe.com/browse/DEVE-5894)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->
Ran the script:
```
st-kliang1:sorbet kliang$ tools/scripts/remote-script echo hi
hi
```
