### PR TITLE
Fix location of pattern matching `Pair` nodes

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -1240,7 +1240,9 @@ public:
 
     unique_ptr<Node> match_pair(unique_ptr<Node> label, unique_ptr<Node> value) {
         if (auto *pair = parser::cast_node<Pair>(label.get())) {
+            pair->loc = pair->loc.join(value->loc);
             pair->value = std::move(value);
+
             if (auto *key = parser::cast_node<Symbol>(pair->key.get())) {
                 checkDuplicatePatternKey(key->val.show(gs_), label->loc);
                 return label;


### PR DESCRIPTION
### Motivation

Fix the location of `Pair` nodes created during pattern matching, to cover the value, if there is one.

Example 1:

```ruby
nil in { a: 1 }
```

<details> Tree diff 1

Built with:

```sh
./bazel run //main:sorbet --config=dbg -- --stop-after desugarer --print=parse-tree-json-with-locs --parser=original demo.rb
```

Tree diff:

```diff
{
  "type" : "MatchPatternP",
-      "loc" : "/demo.rb:1:1-3:12",
+      "loc" : "/demo.rb:1:1-3:14",
  "lhs" : {
    "type" : "Nil",
    "loc" : "/demo.rb:1:1-3:4"
  },
  "rhs" : {
    "type" : "HashPattern",
-        "loc" : "/demo.rb:1:8-3:12",
+        "loc" : "/demo.rb:1:8-3:14",
    "pairs" : [
      {
        "type" : "Pair",
-            "loc" : "/demo.rb:1:10-3:12",
+            "loc" : "/demo.rb:1:10-3:14",
        "key" : {
          "type" : "Symbol",
          "loc" : "/demo.rb:1:10-3:11",
          "val" : "a"
        },
        "value" : {
          "type" : "Integer",
          "loc" : "/demo.rb:1:13-3:14",
          "val" : "1"
        }
      }
    ]
  }
}
```

</details>


Example 2:

```ruby
case nil
in { a: 1 }
  nil
end
```

<details> Tree diff 2

Built with:

```sh
./bazel run //main:sorbet --config=dbg -- --stop-after desugarer --print=parse-tree-json-with-locs --parser=original demo.rb
```

Tree diff:

```diff
{
  "type" : "CaseMatch",
  "loc" : "/demo.rb:1:1-8:4",
  "expr" : {
    "type" : "Nil",
    "loc" : "/demo.rb:1:6-1:9"
  },
  "inBodies" : [
    {
      "type" : "InPattern",
      "loc" : "/demo.rb:2:1-7:6",
      "pattern" : {
        "type" : "HashPattern",
-            "loc" : "/demo.rb:2:4-2:8",
+            "loc" : "/demo.rb:2:4-2:10",
        "pairs" : [
          {
            "type" : "Pair",
-                "loc" : "/demo.rb:2:6-2:8",
+                "loc" : "/demo.rb:2:6-2:10",
            "key" : {
              "type" : "Symbol",
              "loc" : "/demo.rb:2:6-2:7",
              "val" : "a"
            },
            "value" : {
              "type" : "Integer",
              "loc" : "/demo.rb:2:9-2:10",
              "val" : "1"
            }
          }
        ]
      },
      "guard" : null,
      "body" : {
        "type" : "Nil",
        "loc" : "/demo.rb:3:3-3:6"
      }
    }
  ],
  "elseBody" : null
}
```

</details>

### Test plan

This is covered by the fixed location tests in #9211. I'm fixing the errors before merging that, but it passes locally.


