### PR TITLE
Fix end loc of Array and Hash patterns

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -313,7 +313,7 @@ public:
             loc = tokLoc(begin).join(loc);
         }
         if (end != nullptr) {
-            loc = loc.join(tokLoc(begin));
+            loc = loc.join(tokLoc(end));
         }
         if (trailingComma) {
             return make_unique<ArrayPatternWithTail>(loc, std::move(res));
@@ -1008,7 +1008,7 @@ public:
             loc = tokLoc(begin).join(loc);
         }
         if (end != nullptr) {
-            loc = loc.join(tokLoc(begin));
+            loc = loc.join(tokLoc(end));
         }
         return make_unique<HashPattern>(loc, std::move(kwargs));
     }


### PR DESCRIPTION
### Motivation

Similar to #9520.

Fixes two small typos from #3444, where Array and Hash patterns would end at the end of their last element, like:

```ruby
case nil
in [1, 2     ]
#  ^^^^^  
in { a:, b:  }
#  ^^^^^^^^
end
```

This change makes it correctly extend up to and including the `]`/`}`.


### Test plan

This is covered by the fixed location tests in https://github.com/sorbet/sorbet/pull/9211. I'm fixing the errors before merging that, but it passes locally.