### PR TITLE
Upgrade to LLVM 16.0.5

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -138,11 +138,11 @@ build:release-linux-aarch64   --copt=-march=armv8.1a
 build:release-mac --config=release-common --config=shared-libs
 
 build:cross-to-darwin-x86_64 --platforms=@//tools/platforms:darwin_x86_64
-build:cross-to-darwin-x86_64 --extra_toolchains=@llvm_toolchain_15_0_7//:cc-toolchain-x86_64-darwin
+build:cross-to-darwin-x86_64 --extra_toolchains=@llvm_toolchain_16_0_5//:cc-toolchain-x86_64-darwin
 build:cross-to-darwin-x86_64 --copt=-stdlib=libc++ --linkopt=-lc++
 
 build:cross-to-darwin-arm64 --platforms=@//tools/platforms:darwin_arm64
-build:cross-to-darwin-arm64 --extra_toolchains=@llvm_toolchain_15_0_7//:cc-toolchain-aarch64-darwin
+build:cross-to-darwin-arm64 --extra_toolchains=@llvm_toolchain_16_0_5//:cc-toolchain-aarch64-darwin
 build:cross-to-darwin-arm64 --copt=-stdlib=libc++ --linkopt=-lc++
 
 build:release-debug-linux --config=release-linux
@@ -245,9 +245,9 @@ build:ubsan --copt=-DHAS_SANITIZER
 # because we're using the toolchain's lld linker now.
 # We could consider replacing this with something more typical.
 # Original motivation: Bazel links C++ files with $CC, not $CXX, this breaks UBSan
-build:sanitize-linux --linkopt=../../external/llvm_toolchain_15_0_7_llvm/lib/clang/15.0.7/lib/x86_64-unknown-linux-gnu/libclang_rt.asan_cxx.a
-build:sanitize-linux --linkopt=../../external/llvm_toolchain_15_0_7_llvm/lib/clang/15.0.7/lib/x86_64-unknown-linux-gnu/libclang_rt.ubsan_standalone_cxx.a
-build:sanitize-linux --linkopt=../../external/llvm_toolchain_15_0_7_llvm/lib/clang/15.0.7/lib/x86_64-unknown-linux-gnu/libclang_rt.ubsan_standalone.a
+build:sanitize-linux --linkopt=../../external/llvm_toolchain_16_0_5_llvm/lib/clang/16/lib/x86_64-unknown-linux-gnu/libclang_rt.asan_cxx.a
+build:sanitize-linux --linkopt=../../external/llvm_toolchain_16_0_5_llvm/lib/clang/16/lib/x86_64-unknown-linux-gnu/libclang_rt.ubsan_standalone_cxx.a
+build:sanitize-linux --linkopt=../../external/llvm_toolchain_16_0_5_llvm/lib/clang/16/lib/x86_64-unknown-linux-gnu/libclang_rt.ubsan_standalone.a
 build:sanitize-linux --config=sanitize
 
 build:sanitize-mac --config=sanitize

--- a/README.md
+++ b/README.md
@@ -1053,7 +1053,7 @@ You are encouraged to play around with various clang-based tools which use the
 
     After successfully compiling Sorbet, point your editor to use the
     `clangd` executable located in
-    `bazel-sorbet/external/llvm_toolchain_15_0_7/bin/clangd`.
+    `bazel-sorbet/external/llvm_toolchain_16_0_5/bin/clangd`.
 
 -   [clang-format] -- Clang-based source code formatter
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,12 +36,12 @@ bazel_toolchain_dependencies()
 load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain")
 
 llvm_toolchain(
-    name = "llvm_toolchain_15_0_7",
+    name = "llvm_toolchain_16_0_5",
     absolute_paths = True,
     alternative_llvm_sources = [
         "https://github.com/sorbet/llvm-project/releases/download/llvmorg-{llvm_version}/{basename}",
     ],
-    llvm_version = "15.0.7",
+    llvm_version = "16.0.5",
     # The sysroots are needed for cross-compiling
     sysroot = {
         "": "",
@@ -50,7 +50,7 @@ llvm_toolchain(
     },
 )
 
-load("@llvm_toolchain_15_0_7//:toolchains.bzl", "llvm_register_toolchains")
+load("@llvm_toolchain_16_0_5//:toolchains.bzl", "llvm_register_toolchains")
 
 llvm_register_toolchains()
 

--- a/test/cli/test_one.sh
+++ b/test/cli/test_one.sh
@@ -3,7 +3,7 @@ script="$1"
 expect="$2"
 update="$3"
 
-export ASAN_SYMBOLIZER_PATH=`pwd`/external/llvm_toolchain_15_0_7/bin/llvm-symbolizer
+export ASAN_SYMBOLIZER_PATH=`pwd`/external/llvm_toolchain_16_0_5/bin/llvm-symbolizer
 
 if ! diff "$expect" -u <("$script"); then
   cat <<EOF

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -13,7 +13,7 @@ def dropExtension(p):
     return p.partition(".")[0]
 
 _TEST_SCRIPT = """#!/usr/bin/env bash
-export ASAN_SYMBOLIZER_PATH=`pwd`/external/llvm_toolchain_15_0_7/bin/llvm-symbolizer
+export ASAN_SYMBOLIZER_PATH=`pwd`/external/llvm_toolchain_16_0_5/bin/llvm-symbolizer
 set -x
 exec {runner} --single_test="{test}" {parser}
 """

--- a/tools/clang.bzl
+++ b/tools/clang.bzl
@@ -30,6 +30,6 @@ _clang_tool = rule(
 def clang_tool(name):
     _clang_tool(
         name = name,
-        tool = "@llvm_toolchain_15_0_7//:bin/" + name,
+        tool = "@llvm_toolchain_16_0_5//:bin/" + name,
         visibility = ["//visibility:public"],
     )

--- a/tools/scripts/fuzz.sh
+++ b/tools/scripts/fuzz.sh
@@ -28,7 +28,7 @@ echo "building $target"
 ./bazel build "//test/fuzz:$target" --config=fuzz -c opt
 
 # we want the bazel build command to run before this check so that bazel can download itself.
-export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain_15_0_7/bin"
+export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain_16_0_5/bin"
 if ! command -v llvm-symbolizer >/dev/null; then
   echo "fatal: command not found: llvm-symbolizer"
   exit 1

--- a/tools/scripts/fuzz_minimize_crash.sh
+++ b/tools/scripts/fuzz_minimize_crash.sh
@@ -72,7 +72,7 @@ handle_TERM() {
 trap handle_INT SIGINT
 trap handle_TERM SIGTERM
 
-export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain_15_0_7/bin"
+export PATH="$PATH:$PWD/bazel-sorbet/external/llvm_toolchain_16_0_5/bin"
 if ! command -v llvm-symbolizer >/dev/null; then
   echo "fatal: command not found: llvm-symbolizer"
   exit 1


### PR DESCRIPTION
## Motivation

Sorbet builds have been failing on MacOS 26 (Tahoe) with the following error:

```
 __DATA_CONST segment missing SG_READ_ONLY flag in /private/var/tmp/_bazel_emilysamp/d4f9f1bf3df434d7445caa2e7e6c895e/execroot/com_stripe_ruby_typer/bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/parser/parser/generate_diagnostics
```

This is because [LLVM 15's linker doesn't apply the `SG_READ_ONLY` flag](https://github.com/llvm/llvm-project/commit/f7b752d27766ecf0241edfbdc4d7142fc40e7621) to these segments, and that is now required on the latest versions of MacOS.

We are able to build again after upgrading LLVM to 16.0.5.

### Test plan
Existing tests should all pass as normal. If somebody on Linux would like to test this, it would be much appreciated.
