### PR TITLE
Fix `ZSuper` Prism locations

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -7,6 +7,8 @@
 
 namespace sorbet::ast {
 
+using namespace std::literals::string_view_literals;
+
 class MK {
 public:
     static ExpressionPtr EmptyTree() {
@@ -545,10 +547,14 @@ public:
     }
 
     static ExpressionPtr ZSuper(core::LocOffsets loc, core::NameRef method) {
+        // A ZSuper call can have a block argument. Don't include it in the location.
+        const uint32_t len = std::size("super"sv);
+        auto superKeywordLoc = core::LocOffsets{loc.beginPos(), loc.beginPos() + len};
+
         Send::Flags flags;
         flags.isPrivateOk = true;
-        return Send(loc, Self(loc), method, loc, 1,
-                    SendArgs(make_expression<ast::ZSuperArgs>(loc.copyEndWithZeroLength())), flags);
+        return Send(loc, Self(superKeywordLoc.copyWithZeroLength()), method, loc, 1,
+                    SendArgs(make_expression<ast::ZSuperArgs>(superKeywordLoc.copyEndWithZeroLength())), flags);
     }
 
     static ExpressionPtr Magic(core::LocOffsets loc) {


### PR DESCRIPTION
### Motivation

Part of https://github.com/sorbet/sorbet/issues/9065 and https://github.com/Shopify/sorbet/issues/730

This PR:

1. Fixes the location of `ZSuper` receiver 
    * Every other implicit `self` receiver is zero-length, but this one was as long as the whole `ZSuper` node.
2. Fixes the location of the `ZSuperArgs` when there's a block

    Turns out `ZSuper` calls can have a literal block argument, like so:

    ```ruby
    # typed: true
    
    def m
      super do
        true
      end
    end
    ```

    Before of this block, the end of the `ZSuper` node is not the same as the end of the `super` keyword, which distorts the location of the `ZSuperArgs`

    <details><summary>Desugar tree diff</summary>

    ```diff
    --- before.txt	2025-10-31 10:26:10
    +++ after.txt	2025-10-31 10:26:22
    @@ -1,39 +1,39 @@
     ClassDef{
       loc = 3:1-7:4
       kind = class
       name = EmptyTree
       symbol = <C <U <root>>>
       ancestors = [ConstantLit{
           loc = 15-50
           symbol = (class ::<todo sym>)
           orig = nullptr
         }]
       rhs = [
         MethodDef{
           loc = 3:1-7:4
           flags = {}
           name = <U m><<U <todo method>>>
           args = [BlockParam{ loc = , expr = UnresolvedIdent{
               loc =
               kind = Local
               name = <U <blk>>
             } }]
           rhs = Send{
             loc = 4:3-6:6
             flags = {privateOk}
    -        recv = Self{ loc = 4:3-6:6 }
    +        recv = Self{ loc = 4:3-4:3 }
             fun = <U <super>>
             block = Block {
               loc = 4:9-6:6
               params = [
               ]
               body = Literal{ loc = 5:5-5:9, value = true }
             }
             pos_args = 1
             args = [
    -          ZSuperArgs{ loc = 6:6-6:6 }
    +          ZSuperArgs{ loc = 4:8-4:8 }
             ]
           }
         }
       ]
     }
    ```
    
    </details>

### Test plan

This will be tested in a follow-up PR, which makes Prism's `//test:test_PrismPosTests/prism_regression/super` test pass