### PR TITLE
Disable RSpec rewriter in `# typed: false` files

### DIFF
--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -460,7 +460,8 @@ ast::ExpressionPtr runUnderParameterized(core::MutableContext ctx, core::NameRef
 
         case core::Names::includeExamples().rawId():
         case core::Names::includeContext().rawId(): {
-            if (send->hasBlock() || !insideDescribe || send->numPosArgs() < 1) {
+            if (send->hasBlock() || !insideDescribe || send->numPosArgs() < 1 ||
+                ctx.file.data(ctx).strictLevel <= core::StrictLevel::False) {
                 return nullptr;
             }
 
@@ -645,6 +646,10 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::
                 return nullptr;
             }
 
+            if (recvIsRSpec && ctx.file.data(ctx).strictLevel <= core::StrictLevel::False) {
+                return nullptr;
+            }
+
             if (requiresSecondFactor(send->fun) && !recvIsRSpec && !insideDescribe) {
                 return nullptr;
             }
@@ -820,7 +825,8 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::
         case core::Names::sharedContext().rawId():
         case core::Names::sharedExamplesFor().rawId(): {
             ENFORCE(isSharedExamplesName(send->fun));
-            if (block == nullptr || send->numPosArgs() != 1) {
+            if (block == nullptr || send->numPosArgs() != 1 ||
+                ctx.file.data(ctx).strictLevel <= core::StrictLevel::False) {
                 return nullptr;
             }
 
@@ -884,7 +890,8 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::
 
         case core::Names::includeExamples().rawId():
         case core::Names::includeContext().rawId(): {
-            if (block != nullptr || !send->recv.isSelfReference() || !insideDescribe || send->numPosArgs() < 1) {
+            if (block != nullptr || !send->recv.isSelfReference() || !insideDescribe || send->numPosArgs() < 1 ||
+                ctx.file.data(ctx).strictLevel <= core::StrictLevel::False) {
                 return nullptr;
             }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The RSpec rewriter changes are proving to be more broken than we initially
hoped. In particular, issues like #9537 are showing how this affects constant
resolution, so users can't even mark a file `# typed: false` to opt out of RSpec
weirdness.

I spoke with @dduugg who mentioned that RSpec tests are typically `# typed:
false` anyways, because of how heavily they tend to define methods inside a
block scope, which causes problems.

Given that, it seems like it would be better to only do the RSpec rewrites when
the file is at least `# typed: true`. That way, people can opt into this RSpec
support on a file-by-file basis, hopefully with much more minimal disruption.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->