### PR TITLE
Fix Prism location of anonymous block params

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -3724,16 +3724,18 @@ Translator::translateParametersNode(pm_parameters_node *paramsNode, core::LocOff
 
     core::NameRef enclosingBlockParamName;
     if (auto *prismBlockParam = paramsNode->block) {
+        auto blockParamLoc = translateLoc(prismBlockParam->base.location);
+
         if (auto prismName = prismBlockParam->name; prismName != PM_CONSTANT_ID_UNSET) {
             // A named block parameter, like `def foo(&block)`
             enclosingBlockParamName = translateConstantName(prismName);
+
+            // The location doesn't include the `&`, only the name of the block parameter
+            constexpr uint32_t length = "&"sv.size();
+            blockParamLoc = core::LocOffsets{blockParamLoc.beginPos() + length, blockParamLoc.endPos()};
         } else { // An anonymous block parameter, like `def foo(&)`
             enclosingBlockParamName = nextUniqueParserName(core::Names::ampersand());
         }
-
-        auto blockParamLoc = translateLoc(prismBlockParam->base.location);
-        // Drop the `&` before the name of the block parameter.
-        blockParamLoc = core::LocOffsets{blockParamLoc.beginPos() + 1, blockParamLoc.endPos()};
 
         auto blockParamExpr = MK::BlockParam(blockParamLoc, MK::Local(blockParamLoc, enclosingBlockParamName));
         auto blockParamNode =

--- a/test/BUILD
+++ b/test/BUILD
@@ -143,8 +143,6 @@ prism_location_test_suite(
             "prism_regression/call_block_param.rb",
             "prism_regression/case_match.rb",
             "prism_regression/case_match_variable_pinning.rb",
-            "prism_regression/def_all_params.rb",
-            "prism_regression/def_block_param.rb",
             "prism_regression/ensure.rb",
             "prism_regression/error_recovery/assign.rb",
             "prism_regression/for_loop.rb",


### PR DESCRIPTION
### Motivation

Part of #9065 and https://github.com/Shopify/sorbet/issues/730

### Test plan

Fixes 4 tests in the `bazel test --config=dbg --test_output=errors //test:prism_location_tests` suite