### PR TITLE
Fix RBS comment association for chained methods with blocks

### DIFF
--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -394,10 +394,9 @@ void CommentsAssociator::walkNode(parser::Node *node) {
         },
         [&](parser::Block *block) {
             auto beginLine = core::Loc::pos2Detail(ctx.file.data(ctx), block->send->loc.beginPos()).line;
-            consumeCommentsUntilLine(beginLine);
-
             associateAssertionCommentsToNode(node);
             walkNode(block->send.get());
+            consumeCommentsUntilLine(beginLine);
             block->body = walkBody(block, move(block->body));
             auto endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
             consumeCommentsBetweenLines(beginLine, endLine, "block");

--- a/test/testdata/rbs/assertions_block.rb
+++ b/test/testdata/rbs/assertions_block.rb
@@ -74,3 +74,7 @@ b7 += take_block do |x|
   x #: as !nil
 end #: String # error: Expected `Integer` but found `String` for argument `arg0`
 T.reveal_type(b7) # error: Revealed type: `Integer`
+
+Object.new #: Object
+  .tap {}
+  .tap {}

--- a/test/testdata/rbs/assertions_block.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_block.rb.rewrite-tree.exp
@@ -98,4 +98,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end, <todo sym>, <emptyTree>::<C String>))
 
   <emptyTree>::<C T>.reveal_type(b7)
+
+  <cast:let>(<emptyTree>::<C Object>.new(), <todo sym>, <emptyTree>::<C Object>).tap() do ||
+    <emptyTree>
+  end.tap() do ||
+    <emptyTree>
+  end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
We need to walk the `send` associated with a block before consuming the comments within the block.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Resolves https://sorbet.run/?arg=--print&arg=rewrite-tree&arg=--enable-experimental-rbs-comments#%23%20typed%3A%20true%0A%0AObject.new%20%23%3A%20Object%0A%20%20.tap%20%7B%7D%0A%20%20.tap%20%7B%7D%0A

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
