### PR TITLE
Compare directly instead of subtracting

### DIFF
--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -223,7 +223,7 @@ string Loc::toStringWithTabs(const GlobalState &gs, int tabs) const {
             buf << ' ';
         }
         buf << rang::fg::cyan;
-        if (details.second.column - details.first.column > 0) {
+        if (details.second.column > details.first.column) {
             for (; p < details.second.column; p++) {
                 buf << '^';
             }


### PR DESCRIPTION
Instead of subtracting unsigned values, let's compare them directly.

### Motivation
Simplification.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
