### PR TITLE
Include `end` in `elsif` location

### DIFF
--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -2155,13 +2155,14 @@ array_premature_end: eof
                       DIAGCHECK();
                     }
                 | lambda
-                | kIF expr_value then compstmt if_tail kend_or_eof
+                | kIF expr_value then compstmt if_tail
                     {
                       auto &else_ = $5;
+                      auto end_t = else_ ? else_->tok : nullptr;
                       $$ = driver.build.condition(self, $1, $2, $3, $4->body,
-                        else_ ? else_->tok : nullptr,
-                        else_ ? else_->nod : nullptr, $6);
-                      driver.rewind_if_dedented($1, $6);
+                        nullptr,
+                        else_ ? else_->nod : nullptr, end_t);
+                      driver.rewind_if_dedented($1, end_t);
                     }
                 | kIF error
                     {
@@ -2169,13 +2170,14 @@ array_premature_end: eof
                       $$ = driver.build.condition(self, $1, err, nullptr, nullptr, nullptr, nullptr, nullptr);
                       driver.replace_last_diagnostic(dlevel::ERROR, dclass::UnexpectedToken, $1, driver.token_name($1->type()));
                     }
-                | kIF strings kDO compstmt if_tail kEND
+                | kIF strings kDO compstmt if_tail
                     {
                       driver.diagnostics.emplace_back(dlevel::ERROR, dclass::IfInsteadOfItForTest, diagnostic::range(@1.beginPos(), @1.endPos()));
                       auto &else_ = $5;
+                      auto end_t = else_ ? else_->tok : nullptr;
                       $$ = driver.build.condition(self, $1, $2, $3, $4->body,
-                        else_ ? else_->tok : nullptr,
-                        else_ ? else_->nod : nullptr, $6);
+                        nullptr,
+                        else_ ? else_->nod : nullptr, end_t);
                     }
                 | kUNLESS expr_value then compstmt opt_else kend_or_eof
                     {
@@ -2461,16 +2463,20 @@ array_premature_end: eof
               do: term
                 | kDO_COND
 
-         if_tail: opt_else
+         if_tail: opt_else kend_or_eof
+                    {
+                      $$ = driver.alloc.node_with_token($2, $1 ? $1->nod : nullptr);
+                    }
                 | kELSIF expr_value then compstmt if_tail
                     {
                       auto elsif_t = $1;
                       auto &else_ = $5;
-                      $$ = driver.alloc.node_with_token(elsif_t,
+                      auto end_t = else_ ? else_->tok : nullptr;
+                      $$ = driver.alloc.node_with_token(end_t,
                         driver.build.condition(self,
                           elsif_t, $2, $3, $4->body,
-                          else_ ? else_->tok : nullptr,
-                          else_ ? else_->nod : nullptr, nullptr)
+                          nullptr,
+                          else_ ? else_->nod : nullptr, end_t)
                       );
                     }
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -133,7 +133,6 @@ prism_location_test_suite(
         exclude = [
             "prism_regression/case_match_variable_pinning.rb",
             "prism_regression/error_recovery/assign.rb",
-            "prism_regression/if_elsif.rb",
             "prism_regression/lambda.rb",
             "prism_regression/multi_target.rb",
             "prism_regression/multi_write.rb",


### PR DESCRIPTION
### Motivation

The `If` parser nodes representing `elsif` blocks used to end at the end of the last expression of the body, not including the `end`. This is unusual, and inconsistent with the way the "main" `if` includes its end.

[Sorbet.run](https://sorbet.run/?arg=--print&arg=desugar-tree-raw-with-locs#%23%20typed%3A%20true%0A%0Aif%20true%0A%20%20%20%201%0Aelsif%20true%0A%20%20%20%202%0Aelsif%20true%0A%20%20%20%203%0Aelse%0A%20%20%20%204%0Aend)

```ruby
# typed: true

if true
    1
elsif true
    2
elsif true
    3
else
    4
end
```
`./bazel run //main:sorbet --config=dbg -- --stop-after desugarer --print=parse-tree-json-with-locs --parser=original demo.rb`:

```diff
 ClassDef{
   loc = 3:1-11:4
   kind = class
   name = EmptyTree
   symbol = <C <U <root>>>
   ancestors = [ConstantLit{
       loc = 15-69
       symbol = (class ::<todo sym>)
       orig = nullptr
     }]
   rhs = [
     If{
       loc = 3:1-11:4
       cond = Literal{ loc = 3:4-3:8, value = true }
       thenp = Literal{ loc = 4:3-4:4, value = 1 }
       elsep = If{
-        loc = 5:1-10:4
+        loc = 5:1-11:4
         cond = Literal{ loc = 5:7-5:11, value = true }
         thenp = Literal{ loc = 6:3-6:4, value = 2 }
         elsep = If{
-          loc = 7:1-10:4
+          loc = 7:1-11:4
           cond = Literal{ loc = 7:7-7:11, value = true }
           thenp = Literal{ loc = 8:3-8:4, value = 3 }
           elsep = Literal{ loc = 10:3-10:4, value = 4 }
         }
       }
     }
   ]
 }
 ```

### Test plan

This matches the location behaviour of Prism, and makes `//test:prism_regression/if_elsif_location_test` pass.
