### PR TITLE
Add RBS Prism Infrastructure Stubs and Parser API Improvements

### DIFF
--- a/main/options/options.h
+++ b/main/options/options.h
@@ -98,7 +98,6 @@ struct Printers {
 enum class Phase {
     INIT,
     PARSER,
-    RBS_REWRITER,
     DESUGARER,
     REWRITER,
     LOCAL_VARS,

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -255,32 +255,6 @@ parser::ParseResult runParser(core::GlobalState &gs, core::FileRef file, const o
     return result;
 }
 
-unique_ptr<parser::Node> runRBSRewrite(core::GlobalState &gs, core::FileRef file, parser::ParseResult &&parseResult,
-                                       const options::Printers &print) {
-    auto node = move(parseResult.tree);
-    auto commentLocations = move(parseResult.commentLocations);
-
-    if (gs.cacheSensitiveOptions.rbsEnabled) {
-        Timer timeit(gs.tracer(), "runRBSRewrite", {{"file", string(file.data(gs).path())}});
-        core::MutableContext ctx(gs, core::Symbols::root(), file);
-        core::UnfreezeNameTable nameTableAccess(gs);
-
-        auto associator = rbs::CommentsAssociator(ctx, commentLocations);
-        auto commentMap = associator.run(node);
-
-        auto sigsRewriter = rbs::SigsRewriter(ctx, commentMap.signaturesForNode);
-        node = sigsRewriter.run(move(node));
-
-        auto assertionsRewriter = rbs::AssertionsRewriter(ctx, commentMap.assertionsForNode);
-        node = assertionsRewriter.run(move(node));
-
-        if (print.RBSRewriteTree.enabled) {
-            print.RBSRewriteTree.fmt("{}\n", node->toStringWithTabs(gs, 0));
-        }
-    }
-    return node;
-}
-
 parser::ParseResult runPrismParser(core::GlobalState &gs, core::FileRef file, const options::Printers &print,
                                    bool preserveConcreteSyntax = false) {
     Timer timeit(gs.tracer(), "runParser", {{"file", string(file.data(gs).path())}});
@@ -291,24 +265,71 @@ parser::ParseResult runPrismParser(core::GlobalState &gs, core::FileRef file, co
         core::UnfreezeNameTable nameTableAccess(gs); // enters strings from source code as names
         // The RBS rewriter produces plain Whitequark nodes and not `NodeWithExpr` which causes errors in
         // `PrismDesugar.cc`. For now, disable all direct translation, and fallback to `Desugar.cc`.
-        auto directlyTranslate = !gs.cacheSensitiveOptions.rbsEnabled;
-        parseResult = parser::Prism::Parser::run(ctx, directlyTranslate);
+        auto source = file.data(ctx).source();
+        parser::Prism::Parser parser{source};
+        bool collectComments = gs.cacheSensitiveOptions.rbsEnabled;
+        parser::Prism::ParseResult prismResult = parser.parseWithoutTranslation(collectComments);
+
+        auto node = prismResult.getRawNodePointer();
+        if (gs.cacheSensitiveOptions.rbsEnabled) {
+            node = runPrismRBSRewrite(gs, file, node, prismResult.getCommentLocations(), print, ctx, parser);
+        }
+
+        bool directlyDesugar = !gs.cacheSensitiveOptions.rbsEnabled;
+        auto translatedTree = parser::Prism::Translator(parser, ctx, prismResult.getParseErrors(), directlyDesugar,
+                                                        preserveConcreteSyntax)
+                                  .translate(node);
+
+        parseResult = parser::ParseResult{move(translatedTree), prismResult.getCommentLocations()};
     }
 
     if (print.ParseTree.enabled) {
-        print.ParseTree.fmt("{}\n", parseResult.tree->toStringWithTabs(gs, 0));
+        if (parseResult.tree) {
+            print.ParseTree.fmt("{}\n", parseResult.tree->toStringWithTabs(gs, 0));
+        }
     }
     if (print.ParseTreeJson.enabled) {
-        print.ParseTreeJson.fmt("{}\n", parseResult.tree->toJSON(gs, 0));
+        if (parseResult.tree) {
+            print.ParseTreeJson.fmt("{}\n", parseResult.tree->toJSON(gs, 0));
+        }
     }
     if (print.ParseTreeJsonWithLocs.enabled) {
-        print.ParseTreeJson.fmt("{}\n", parseResult.tree->toJSONWithLocs(gs, file, 0));
+        if (parseResult.tree) {
+            print.ParseTreeJson.fmt("{}\n", parseResult.tree->toJSONWithLocs(gs, file, 0));
+        }
     }
     if (print.ParseTreeWhitequark.enabled) {
-        print.ParseTreeWhitequark.fmt("{}\n", parseResult.tree->toWhitequark(gs, 0));
+        if (parseResult.tree) {
+            print.ParseTreeWhitequark.fmt("{}\n", parseResult.tree->toWhitequark(gs, 0));
+        }
     }
 
     return parseResult;
+}
+
+unique_ptr<parser::Node> runRBSRewrite(core::GlobalState &gs, core::FileRef file, parser::ParseResult &&parseResult,
+                                       const options::Printers &print) {
+    auto node = move(parseResult.tree);
+    auto commentLocations = move(parseResult.commentLocations);
+
+    Timer timeit(gs.tracer(), "runRBSRewrite", {{"file", string(file.data(gs).path())}});
+    core::MutableContext ctx(gs, core::Symbols::root(), file);
+    core::UnfreezeNameTable nameTableAccess(gs);
+
+    auto associator = rbs::CommentsAssociator(ctx, commentLocations);
+    auto commentMap = associator.run(node);
+
+    auto sigsRewriter = rbs::SigsRewriter(ctx, commentMap.signaturesForNode);
+    node = sigsRewriter.run(move(node));
+
+    auto assertionsRewriter = rbs::AssertionsRewriter(ctx, commentMap.assertionsForNode);
+    node = assertionsRewriter.run(move(node));
+
+    if (print.RBSRewriteTree.enabled) {
+        print.RBSRewriteTree.fmt("{}\n", node->toStringWithTabs(gs, 0));
+    }
+
+    return node;
 }
 
 ast::ExpressionPtr runDesugar(core::GlobalState &gs, core::FileRef file, unique_ptr<parser::Node> parseTree,
@@ -388,7 +409,12 @@ ast::ExpressionPtr desugarOne(const options::Options &opts, core::GlobalState &g
         }
         auto parseResult = runParser(gs, file, print, opts.traceLexer, opts.traceParser);
 
-        auto parseTree = runRBSRewrite(gs, file, move(parseResult), print);
+        unique_ptr<parser::Node> parseTree;
+        if (gs.cacheSensitiveOptions.rbsEnabled) {
+            parseTree = runRBSRewrite(gs, file, move(parseResult), print);
+        } else {
+            parseTree = move(parseResult.tree);
+        }
 
         return runDesugar(gs, file, move(parseTree), print, preserveConcreteSyntax);
     } catch (SorbetException &) {
@@ -424,7 +450,12 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
                         return emptyParsedFile(file);
                     }
 
-                    parseTree = runRBSRewrite(lgs, file, move(parseResult), print);
+                    if (lgs.cacheSensitiveOptions.rbsEnabled) {
+                        parseTree = runRBSRewrite(lgs, file, move(parseResult), print);
+                    } else {
+                        parseTree = move(parseResult.tree);
+                    }
+
                     if (opts.stopAfterPhase == options::Phase::RBS_REWRITER) {
                         return emptyParsedFile(file);
                     }
@@ -433,7 +464,7 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
                 }
                 case options::Parser::PRISM: {
                     auto parseResult = runPrismParser(lgs, file, print);
-                    parseTree = runRBSRewrite(lgs, file, move(parseResult), print);
+                    parseTree = move(parseResult.tree);
 
                     if (opts.stopAfterPhase == options::Phase::PARSER) {
                         return emptyParsedFile(file);

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -451,10 +451,6 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
 
                     parseTree = runRBSRewrite(lgs, file, move(parseResult), print);
 
-                    if (opts.stopAfterPhase == options::Phase::RBS_REWRITER) {
-                        return emptyParsedFile(file);
-                    }
-
                     break;
                 }
                 case options::Parser::PRISM: {
@@ -468,12 +464,6 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
                     // TODO: Remove this check once runPrismRBSRewrite is no longer no-oped inside of runPrismParser
                     // https://github.com/sorbet/sorbet/issues/9065
                     parseTree = runRBSRewrite(lgs, file, move(parseResult), print);
-
-                    // TODO: Move into runPrismParser once runPrismRBSRewrite is no longer no-oped
-                    // https://github.com/sorbet/sorbet/issues/9065
-                    if (opts.stopAfterPhase == options::Phase::RBS_REWRITER) {
-                        return emptyParsedFile(file);
-                    }
 
                     break;
                 }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -280,7 +280,9 @@ parser::ParseResult runPrismParser(core::GlobalState &gs, core::FileRef file, co
 
         auto node = prismResult.getRawNodePointer();
 
-        if (gs.cacheSensitiveOptions.rbsEnabled) {
+        // TODO: Remove `&& false` once RBS rewriter with Prism AST migration is complete
+        // https://github.com/sorbet/sorbet/issues/9065
+        if (gs.cacheSensitiveOptions.rbsEnabled && false) {
             node = runPrismRBSRewrite(gs, file, node, prismResult.getCommentLocations(), print, ctx, parser);
         }
 

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -206,6 +206,10 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
 
 namespace {
 
+pm_node_t *runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file, pm_node_t *node,
+                              const vector<core::LocOffsets> &commentLocations, const options::Printers &print,
+                              core::MutableContext &ctx, const parser::Prism::Parser &parser);
+
 ast::ExpressionPtr fetchTreeFromCache(core::GlobalState &gs, core::FileRef fref, core::File &file,
                                       const unique_ptr<const OwnedKeyValueStore> &kvstore) {
     if (kvstore == nullptr) {
@@ -375,8 +379,6 @@ ast::ParsedFile emptyParsedFile(core::FileRef file) {
     return {ast::MK::EmptyTree(), file};
 }
 
-} // namespace
-
 pm_node_t *runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file, pm_node_t *node,
                               const vector<core::LocOffsets> &commentLocations, const options::Printers &print,
                               core::MutableContext &ctx, const parser::Prism::Parser &parser) {
@@ -397,6 +399,8 @@ pm_node_t *runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file, pm_node
 
     return node;
 }
+
+} // namespace
 
 ast::ExpressionPtr desugarOne(const options::Options &opts, core::GlobalState &gs, core::FileRef file,
                               bool preserveConcreteSyntax) {

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -271,11 +271,10 @@ parser::ParseResult runPrismParser(core::GlobalState &gs, core::FileRef file, co
         parser::Prism::ParseResult prismResult = parser.parseWithoutTranslation(collectComments);
 
         auto node = prismResult.getRawNodePointer();
-        // TODO: Enable once RBS Prism pipeline is fully implemented. For now, we use the legacy RBS rewrite
-        // path (see indexOne): https://github.com/sorbet/sorbet/issues/9065
-        // if (gs.cacheSensitiveOptions.rbsEnabled) {
-        //     node = runPrismRBSRewrite(gs, file, node, prismResult.getCommentLocations(), print, ctx, parser);
-        // }
+
+        if (gs.cacheSensitiveOptions.rbsEnabled) {
+            node = runPrismRBSRewrite(gs, file, node, prismResult.getCommentLocations(), print, ctx, parser);
+        }
 
         bool directlyDesugar = !gs.cacheSensitiveOptions.rbsEnabled;
         auto translatedTree = parser::Prism::Translator(parser, ctx, prismResult.getParseErrors(), directlyDesugar,
@@ -388,7 +387,7 @@ pm_node_t *runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file, pm_node
     node = assertionsRewriter.run(node);
 
     if (print.RBSRewriteTree.enabled) {
-        // TODO: print RBS rewrite tree (https://github.com/sorbet/sorbet/issues/9065)
+        print.RBSRewriteTree.fmt("{}\n", parser.prettyPrint(node));
     }
 
     return node;

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -7,6 +7,7 @@
 #include "common/kvstore/KeyValueStore.h"
 #include "core/FileHash.h"
 #include "main/options/options.h"
+#include "parser/prism/Parser.h"
 
 namespace sorbet::core::lsp {
 class PreemptionTaskManager;
@@ -112,6 +113,12 @@ void printUntypedBlames(const core::GlobalState &gs, const UnorderedMap<long, lo
 
 // Create a copy of `from` that has its symbol table reset to the payload.
 std::unique_ptr<core::GlobalState> copyForSlowPath(const core::GlobalState &from, const options::Options &opts);
+
+// RBS Prism rewriter function
+pm_node_t *runPrismRBSRewrite(sorbet::core::GlobalState &gs, sorbet::core::FileRef file, pm_node_t *node,
+                              const std::vector<sorbet::core::LocOffsets> &commentLocations,
+                              const sorbet::realmain::options::Printers &print, sorbet::core::MutableContext &ctx,
+                              const parser::Prism::Parser &parser);
 
 } // namespace sorbet::realmain::pipeline
 #endif // RUBY_TYPER_PIPELINE_H

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -7,7 +7,6 @@
 #include "common/kvstore/KeyValueStore.h"
 #include "core/FileHash.h"
 #include "main/options/options.h"
-#include "parser/prism/Parser.h"
 
 namespace sorbet::core::lsp {
 class PreemptionTaskManager;
@@ -113,12 +112,6 @@ void printUntypedBlames(const core::GlobalState &gs, const UnorderedMap<long, lo
 
 // Create a copy of `from` that has its symbol table reset to the payload.
 std::unique_ptr<core::GlobalState> copyForSlowPath(const core::GlobalState &from, const options::Options &opts);
-
-// RBS Prism rewriter function
-pm_node_t *runPrismRBSRewrite(sorbet::core::GlobalState &gs, sorbet::core::FileRef file, pm_node_t *node,
-                              const std::vector<sorbet::core::LocOffsets> &commentLocations,
-                              const sorbet::realmain::options::Printers &print, sorbet::core::MutableContext &ctx,
-                              const parser::Prism::Parser &parser);
 
 } // namespace sorbet::realmain::pipeline
 #endif // RUBY_TYPER_PIPELINE_H

--- a/parser/prism/Parser.cc
+++ b/parser/prism/Parser.cc
@@ -85,4 +85,12 @@ vector<core::LocOffsets> Parser::collectCommentLocations() {
 
     return commentLocations;
 }
+
+string Parser::prettyPrint(pm_node_t *node) const {
+    pm_buffer_t buffer{};
+    pm_prettyprint(&buffer, const_cast<pm_parser_t *>(&parser), node);
+    string result(buffer.value, buffer.length);
+    pm_buffer_free(&buffer);
+    return result;
+}
 }; // namespace sorbet::parser::Prism

--- a/parser/prism/Parser.h
+++ b/parser/prism/Parser.h
@@ -63,6 +63,7 @@ public:
     core::LocOffsets translateLocation(const uint8_t *start, const uint8_t *end) const;
     std::string_view resolveConstant(pm_constant_id_t constantId) const;
     std::string_view extractString(pm_string_t *string) const;
+    std::string prettyPrint(pm_node_t *node) const;
 
 private:
     std::vector<ParseError> collectErrors();

--- a/parser/prism/Parser.h
+++ b/parser/prism/Parser.h
@@ -58,7 +58,7 @@ public:
     static parser::ParseResult run(core::MutableContext ctx, bool directlyDesugar = true,
                                    bool preserveConcreteSyntax = false);
 
-    ParseResult parse(bool collectComments = false);
+    ParseResult parseWithoutTranslation(bool collectComments = false);
     core::LocOffsets translateLocation(pm_location_t location) const;
     core::LocOffsets translateLocation(const uint8_t *start, const uint8_t *end) const;
     std::string_view resolveConstant(pm_constant_id_t constantId) const;
@@ -87,6 +87,7 @@ class ParseResult final {
     const std::vector<ParseError> parseErrors;
     std::vector<core::LocOffsets> commentLocations;
 
+public:
     ParseResult(Parser &parser, pm_node_t *node, std::vector<ParseError> parseErrors,
                 std::vector<core::LocOffsets> commentLocations)
         : parser{parser}, node{node, NodeDeleter{parser}}, parseErrors{parseErrors}, commentLocations{
@@ -99,6 +100,14 @@ class ParseResult final {
 
     pm_node_t *getRawNodePointer() const {
         return node.get();
+    }
+
+    const std::vector<core::LocOffsets> &getCommentLocations() const {
+        return commentLocations;
+    }
+
+    const std::vector<ParseError> &getParseErrors() const {
+        return parseErrors;
     }
 };
 

--- a/rbs/BUILD
+++ b/rbs/BUILD
@@ -3,6 +3,8 @@ cc_library(
     srcs = glob([
         "*.cc",
         "*.h",
+        "prism/*.cc",
+        "prism/*.h",
     ]),
     linkstatic = select({
         "//tools/config:linkshared": 0,
@@ -14,6 +16,7 @@ cc_library(
         "//common",
         "//core",
         "//parser",
+        "//parser/prism",
         "//rewriter/util",
         "@rbs_parser",
     ],

--- a/rbs/prism/AssertionsRewriterPrism.cc
+++ b/rbs/prism/AssertionsRewriterPrism.cc
@@ -1,0 +1,15 @@
+#include "rbs/prism/AssertionsRewriterPrism.h"
+
+using namespace std;
+
+namespace sorbet::rbs {
+
+AssertionsRewriterPrism::AssertionsRewriterPrism(core::MutableContext ctx,
+                                                 std::map<pm_node_t *, std::vector<CommentNodePrism>> &commentsByNode)
+    : ctx(ctx), commentsByNode(&commentsByNode) {}
+
+pm_node_t *AssertionsRewriterPrism::run(pm_node_t *node) {
+    return node;
+}
+
+} // namespace sorbet::rbs

--- a/rbs/prism/AssertionsRewriterPrism.cc
+++ b/rbs/prism/AssertionsRewriterPrism.cc
@@ -9,6 +9,7 @@ AssertionsRewriterPrism::AssertionsRewriterPrism(core::MutableContext ctx,
     : ctx(ctx), commentsByNode(&commentsByNode) {}
 
 pm_node_t *AssertionsRewriterPrism::run(pm_node_t *node) {
+    [[maybe_unused]] auto *_commentsByNode = this->commentsByNode;
     return node;
 }
 

--- a/rbs/prism/AssertionsRewriterPrism.h
+++ b/rbs/prism/AssertionsRewriterPrism.h
@@ -19,7 +19,7 @@ public:
 
 private:
     core::MutableContext ctx;
-    [[maybe_unused]] std::map<pm_node_t *, std::vector<CommentNodePrism>> *commentsByNode;
+    std::map<pm_node_t *, std::vector<CommentNodePrism>> *commentsByNode;
 };
 
 } // namespace sorbet::rbs

--- a/rbs/prism/AssertionsRewriterPrism.h
+++ b/rbs/prism/AssertionsRewriterPrism.h
@@ -1,0 +1,27 @@
+#ifndef SORBET_RBS_ASSERTIONS_REWRITER_PRISM_H
+#define SORBET_RBS_ASSERTIONS_REWRITER_PRISM_H
+
+#include "parser/parser.h"
+#include "rbs/prism/CommentsAssociatorPrism.h"
+
+extern "C" {
+#include "prism.h"
+}
+
+namespace sorbet::rbs {
+
+class AssertionsRewriterPrism {
+public:
+    AssertionsRewriterPrism(core::MutableContext ctx,
+                            std::map<pm_node_t *, std::vector<CommentNodePrism>> &commentsByNode);
+
+    pm_node_t *run(pm_node_t *node);
+
+private:
+    core::MutableContext ctx;
+    [[maybe_unused]] std::map<pm_node_t *, std::vector<CommentNodePrism>> *commentsByNode;
+};
+
+} // namespace sorbet::rbs
+
+#endif // SORBET_RBS_ASSERTIONS_REWRITER_PRISM_H

--- a/rbs/prism/CommentsAssociatorPrism.cc
+++ b/rbs/prism/CommentsAssociatorPrism.cc
@@ -9,6 +9,8 @@ CommentsAssociatorPrism::CommentsAssociatorPrism(core::MutableContext ctx, const
     : ctx(ctx), parser(parser), commentLocations(commentLocations) {}
 
 CommentMapPrism CommentsAssociatorPrism::run(pm_node_t *node) {
+    [[maybe_unused]] auto &_parser = this->parser;
+    [[maybe_unused]] auto &_commentLocations = this->commentLocations;
     return CommentMapPrism{};
 }
 

--- a/rbs/prism/CommentsAssociatorPrism.cc
+++ b/rbs/prism/CommentsAssociatorPrism.cc
@@ -1,0 +1,15 @@
+#include "rbs/prism/CommentsAssociatorPrism.h"
+
+using namespace std;
+
+namespace sorbet::rbs {
+
+CommentsAssociatorPrism::CommentsAssociatorPrism(core::MutableContext ctx, const parser::Prism::Parser &parser,
+                                                 const std::vector<core::LocOffsets> &commentLocations)
+    : ctx(ctx), parser(parser), commentLocations(commentLocations) {}
+
+CommentMapPrism CommentsAssociatorPrism::run(pm_node_t *node) {
+    return CommentMapPrism{};
+}
+
+} // namespace sorbet::rbs

--- a/rbs/prism/CommentsAssociatorPrism.h
+++ b/rbs/prism/CommentsAssociatorPrism.h
@@ -1,0 +1,39 @@
+#ifndef SORBET_RBS_COMMENTS_ASSOCIATOR_PRISM_H
+#define SORBET_RBS_COMMENTS_ASSOCIATOR_PRISM_H
+
+#include "common/common.h"
+#include "parser/parser.h"
+#include "parser/prism/Parser.h"
+
+extern "C" {
+#include "prism.h"
+}
+
+namespace sorbet::rbs {
+
+struct CommentNodePrism {
+    core::LocOffsets loc;
+    std::string string;
+};
+
+struct CommentMapPrism {
+    std::map<pm_node_t *, std::vector<CommentNodePrism>> signaturesForNode;
+    std::map<pm_node_t *, std::vector<CommentNodePrism>> assertionsForNode;
+};
+
+class CommentsAssociatorPrism {
+public:
+    CommentsAssociatorPrism(core::MutableContext ctx, const parser::Prism::Parser &parser,
+                            const std::vector<core::LocOffsets> &commentLocations);
+
+    CommentMapPrism run(pm_node_t *node);
+
+private:
+    core::MutableContext ctx;
+    [[maybe_unused]] const parser::Prism::Parser &parser;
+    [[maybe_unused]] const std::vector<core::LocOffsets> &commentLocations;
+};
+
+} // namespace sorbet::rbs
+
+#endif // SORBET_RBS_COMMENTS_ASSOCIATOR_PRISM_H

--- a/rbs/prism/CommentsAssociatorPrism.h
+++ b/rbs/prism/CommentsAssociatorPrism.h
@@ -30,8 +30,8 @@ public:
 
 private:
     core::MutableContext ctx;
-    [[maybe_unused]] const parser::Prism::Parser &parser;
-    [[maybe_unused]] const std::vector<core::LocOffsets> &commentLocations;
+    const parser::Prism::Parser &parser;
+    const std::vector<core::LocOffsets> &commentLocations;
 };
 
 } // namespace sorbet::rbs

--- a/rbs/prism/SigsRewriterPrism.cc
+++ b/rbs/prism/SigsRewriterPrism.cc
@@ -9,6 +9,8 @@ SigsRewriterPrism::SigsRewriterPrism(core::MutableContext ctx, const parser::Pri
     : ctx(ctx), parser(parser), commentsByNode(&commentsByNode) {}
 
 pm_node_t *SigsRewriterPrism::run(pm_node_t *node) {
+    [[maybe_unused]] auto &_parser = this->parser;
+    [[maybe_unused]] auto *_commentsByNode = this->commentsByNode;
     return node;
 }
 

--- a/rbs/prism/SigsRewriterPrism.cc
+++ b/rbs/prism/SigsRewriterPrism.cc
@@ -1,0 +1,15 @@
+#include "rbs/prism/SigsRewriterPrism.h"
+
+using namespace std;
+
+namespace sorbet::rbs {
+
+SigsRewriterPrism::SigsRewriterPrism(core::MutableContext ctx, const parser::Prism::Parser &parser,
+                                     std::map<pm_node_t *, std::vector<CommentNodePrism>> &commentsByNode)
+    : ctx(ctx), parser(parser), commentsByNode(&commentsByNode) {}
+
+pm_node_t *SigsRewriterPrism::run(pm_node_t *node) {
+    return node;
+}
+
+} // namespace sorbet::rbs

--- a/rbs/prism/SigsRewriterPrism.h
+++ b/rbs/prism/SigsRewriterPrism.h
@@ -1,0 +1,29 @@
+#ifndef SORBET_RBS_SIGS_REWRITER_PRISM_H
+#define SORBET_RBS_SIGS_REWRITER_PRISM_H
+
+#include "parser/parser.h"
+#include "parser/prism/Parser.h"
+#include "rbs/prism/CommentsAssociatorPrism.h"
+
+extern "C" {
+#include "prism.h"
+}
+
+namespace sorbet::rbs {
+
+class SigsRewriterPrism {
+public:
+    SigsRewriterPrism(core::MutableContext ctx, const parser::Prism::Parser &parser,
+                      std::map<pm_node_t *, std::vector<CommentNodePrism>> &commentsByNode);
+
+    pm_node_t *run(pm_node_t *node);
+
+private:
+    core::MutableContext ctx;
+    [[maybe_unused]] const parser::Prism::Parser &parser;
+    [[maybe_unused]] std::map<pm_node_t *, std::vector<CommentNodePrism>> *commentsByNode;
+};
+
+} // namespace sorbet::rbs
+
+#endif // SORBET_RBS_SIGS_REWRITER_PRISM_H

--- a/rbs/prism/SigsRewriterPrism.h
+++ b/rbs/prism/SigsRewriterPrism.h
@@ -20,8 +20,8 @@ public:
 
 private:
     core::MutableContext ctx;
-    [[maybe_unused]] const parser::Prism::Parser &parser;
-    [[maybe_unused]] std::map<pm_node_t *, std::vector<CommentNodePrism>> *commentsByNode;
+    const parser::Prism::Parser &parser;
+    std::map<pm_node_t *, std::vector<CommentNodePrism>> *commentsByNode;
 };
 
 } // namespace sorbet::rbs


### PR DESCRIPTION
Part of #9065

This PR adds foundational infrastructure for RBS type comment support with the Prism parser. It includes:
- Stub implementations for RBS rewriting components (`CommentsAssociator`, `SigsRewriter`, `AssertionsRewriter`)
- Parser API improvements to enable intermediate Prism node processing
- Pipeline integration that calls the RBS rewriting flow
- No behavior changes - all stubs return nodes unchanged
- A new `Parser::Prism::prettyPrint()` method used to print trees parsed with prism

We will follow-up on this with future PRs that build out the stubbed methods.

<details>
<summary>More details on what has changed</summary>

- Merged `runPrismParserPrism` into `runPrismParser` to eliminate code duplication
  - The combined function now handles both RBS-enabled and non-RBS cases. This is cleaner in my opinion and removes duplicated code.
- Moved `isRbsEnabled` checks from inside `runRBSRewrite` functions to their call sites so they are conditionally called
- Removed `translateOnly` abstraction since it was not valuable in my opinion
  - Inlined `Parser::translateOnly()` at its two call sites by constructing `Translator` and calling `Translator.translate()` instead
  - As part of this change, we now construct a `ParseResult` directly in `pipeline_test_runner.cc`, necessitating visibility changes
- Removed unused static `parseOnly(ctx)` method
- Renamed instance method `parse()` → `parseWithoutTranslation()` for clarity, since it does not do any translation
- Renamed `runRBSRewritePrism` → `runPrismRBSRewrite` to follow `runPrism*` naming pattern
- Reordered functions to group related methods together

</details>

### Test plan

<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No new code is triggered, and all existing tests still pass.
