### PR TITLE
Fix two comments

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -3095,12 +3095,15 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
             auto rescue = translate(rescueModifierNode->rescue_expression);
             auto keywordLoc = translateLoc(rescueModifierNode->keyword_loc);
 
-            // In rescue modifiers, users can't specify exceptions and the variable name so they're null
             auto resbodyLoc = core::LocOffsets{keywordLoc.beginPos(), location.endPos()};
 
             if (!directlyDesugar || !hasExpr(body, rescue)) {
+                // In rescue modifiers, users can't specify exception classes or names, so they're always null.
+                std::unique_ptr<Node> rescuedExceptions = nullptr;
+                auto resBody = make_unique<parser::Resbody>(resbodyLoc, move(rescuedExceptions), nullptr, move(rescue));
+
                 NodeVec cases;
-                cases.emplace_back(make_unique<parser::Resbody>(resbodyLoc, nullptr, nullptr, move(rescue)));
+                cases.emplace_back(move(resBody));
                 return make_unique<parser::Rescue>(location, move(body), move(cases), nullptr);
             }
 


### PR DESCRIPTION
### Motivation

1. Fix a todo from #9574 to link to this new Prism bug: https://github.com/ruby/prism/issues/3708
2. Fix a misplaced comment from #9582, extracting a local variable to better clarify it.
