### PR TITLE
Fix content location of `Regexp` literals

### DIFF
--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -116,8 +116,8 @@ private:
                                                       core::LocOffsets overrideLocation = core::LocOffsets::none());
 
     std::unique_ptr<parser::Node> translateRegexpOptions(pm_location_t closingLoc);
-    std::unique_ptr<parser::Node> translateRegexp(pm_string_t unescaped, core::LocOffsets location,
-                                                  pm_location_t closingLoc);
+    std::unique_ptr<parser::Node> translateRegexp(core::LocOffsets location, core::LocOffsets contentLoc,
+                                                  pm_string_t content, pm_location_t closingLoc);
 
     template <typename PrismNode>
     std::unique_ptr<parser::Mlhs> translateMultiTargetLhs(PrismNode *node, core::LocOffsets location);


### PR DESCRIPTION
### Motivation

Part of #9065 and https://github.com/Shopify/sorbet/issues/730

### Test plan

Doesn't fully fix any test cases, but resolves 7 `String` location errors (23 → 16) in the `//test:prism_location_tests` test suite