### PR TITLE
Fix Prism `LVarLHS` locations for dynamic constant assignments

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -4671,6 +4671,13 @@ unique_ptr<parser::Node> Translator::translateConst(PrismLhsNode *node, bool rep
     auto name = translateConstantName(node->name);
 
     if (this->isInMethodDef() && replaceWithDynamicConstAssign) {
+        if constexpr (is_same_v<PrismLhsNode, pm_constant_write_node> ||
+                      is_same_v<PrismLhsNode, pm_constant_operator_write_node> ||
+                      is_same_v<PrismLhsNode, pm_constant_and_write_node> ||
+                      is_same_v<PrismLhsNode, pm_constant_or_write_node>) {
+            location = translateLoc(node->name_loc);
+        }
+
         // Check if this is a dynamic constant assignment (SyntaxError at runtime)
         // This is a copy of a workaround from `Desugar.cc`, which substitues in a fake assignment,
         // so the parsing can continue. See other usages of `dynamicConstAssign` for more details.

--- a/test/BUILD
+++ b/test/BUILD
@@ -131,7 +131,6 @@ prism_location_test_suite(
     srcs = glob(
         ["prism_regression/**/*.rb"],
         exclude = [
-            "prism_regression/assign_to_constant.rb",
             "prism_regression/call_block_param.rb",
             "prism_regression/case_match.rb",
             "prism_regression/case_match_variable_pinning.rb",


### PR DESCRIPTION
### Motivation

Part of #9065 and https://github.com/Shopify/sorbet/issues/730.

### Test plan

Fixes `//test:prism_regression/assign_to_constant_location_test`