### PR TITLE
Fix Prism `IfGuard`/`UnlessGuard` locations

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -3760,10 +3760,13 @@ unique_ptr<parser::Node> Translator::patternTranslate(pm_node_t *node) {
                 if (PM_NODE_TYPE_P(prismPattern, PM_IF_NODE)) {
                     auto ifNode = down_cast<pm_if_node>(prismPattern);
                     conditionalStatements = ifNode->statements;
+                    auto location = translateLoc(ifNode->if_keyword_loc.start, ifNode->base.location.end);
                     sorbetGuard = make_unique<parser::IfGuard>(location, translate(ifNode->predicate));
                 } else { // PM_UNLESS_NODE
+                    ENFORCE(PM_NODE_TYPE_P(prismPattern, PM_UNLESS_NODE));
                     auto unlessNode = down_cast<pm_unless_node>(prismPattern);
                     conditionalStatements = unlessNode->statements;
+                    auto location = translateLoc(unlessNode->keyword_loc.start, unlessNode->base.location.end);
                     sorbetGuard = make_unique<parser::UnlessGuard>(location, translate(unlessNode->predicate));
                 }
 


### PR DESCRIPTION


### Motivation

Part of #9065 and https://github.com/Shopify/sorbet/issues/730.

### Test plan

Fixes all `IfGuard and `UnlessGuard` location errors (2 of each) in `//test:prism_regression/case_match_location_test`
