### PR TITLE
Expand docs for `fixed` to discuss type arity

### DIFF
--- a/website/docs/generics.md
+++ b/website/docs/generics.md
@@ -702,7 +702,9 @@ The `fixed` annotation in the [example above](#type_templates-and-bounds) places
 
 - `lower`: The opposite—places a lower bound, thus requiring only supertypes of that bound.
 
-- `fixed`: Syntactic sugar for specifying both `lower` and `upper` at the same time. Effectively requires that an equivalent type be applied to the type member. Sorbet then uses this fact to never require that an explicit type argument be provided to the class.
+- `fixed`: Specifies both `lower` and `upper` at the same time. Since this effectively requires that any applied type must be equivalent to the `fixed` type, Sorbet does not allow applying an explicit type argument to a `fixed` type parameter.
+
+  To reiterate: `fixed` does two things: specifies bounds **and** changes the "type arity" for a generic class (number of generic type arguments allowed). Use `lower: SomeType, upper: SomeType` instead of `fixed: SomeType` to allow an argument to be passed (e.g. when moving from `upper` to `fixed` would introduce new type errors in any client that is already explicitly applying type arguments to this type member).
 
 ```ruby
 class NumericBox
@@ -719,8 +721,10 @@ NumericBox[String].new
 #          ^^^^^^ error: `String` is not a subtype of upper bound of `Elem`
 
 IntBox.new
-# ^ Does not need to be invoked like `IntBox[Integer]` because Sorbet can
-#   trivially infer the type argument
+# ^ Does not need to be and cannot be invoked like `IntBox[Integer]`
+#   because Sorbet infers the type argument to be `Integer`.
+IntBox[Integer].new
+#      ^^^^^^^ error: All type parameters for `IntBox` have already been fixed
 ```
 
 Placing the bound on the type member makes it an error to ever instantiate a class with that member outside the given bound.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This has always been true of `fixed`, but my mental model was always
that `fixed` was just syntactic sugar. That's not actually true: `fixed`
changes the type arity of a generic class, and that cannot be specified
any other way.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

website-change