### PR TITLE
Fix `dropSubtypesOf` on `T.anything`

### DIFF
--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -209,7 +209,7 @@ TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from, absl::
         },
         [&](const ClassType &c) {
             auto cdata = c.symbol.data(gs);
-            if (c.symbol == core::Symbols::untyped()) {
+            if (c.symbol == core::Symbols::untyped() || c.symbol == core::Symbols::top()) {
                 result = from;
             } else if (absl::c_any_of(klasses,
                                       [&](auto klass) { return c.symbol == klass || c.derivesFrom(gs, klass); })) {

--- a/test/testdata/infer/drop_subtypes_top.rb
+++ b/test/testdata/infer/drop_subtypes_top.rb
@@ -9,7 +9,7 @@ class A
     when Object
       T.reveal_type(x) # error: `Object`
     else
-      T.reveal_type(x) # error: This code is unreachable
+      T.reveal_type(x) # error: `T.anything`
     end
   end
 end
@@ -25,7 +25,7 @@ class Box
     when Object
       T.reveal_type(x) # error: `T.all(Object, Box::X)`
     else
-      T.reveal_type(x) # error: This code is unreachable
+      T.reveal_type(x) # error: `Box::X`
     end
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #9603

Sorbet does a weird thing and makes the class symbol `<top>` descend from
`Object`. It would be much better if `<top>` did not have a superclass, and
`BasicObject` descended from `<top>`.

I have tried to make that refactor in the past and got hung up on various snags
to the point that I just dropped it.

But we see another case where that bites us here: `derivesFrom`, which normally
wants to be "like isSubType, but when you know you have two `ClassType`so" is
broken for the pairing of `Object`/`BasicObject` and `T.anything`.

This bug was made more obvious after #9535, which added a `dropSubtypesOf` case
for type members, which often have `T.anything` as their `upperBound` (e.g.,
`T.anything` is far more common in generic classes than it is in normal code,
because people rarely type `T.anything` manually). But we can see that the bug
was orthogonal: the bug manifests even if you use `T.anything` directly and then
write `when Object`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

The before commit shows that this was not unique to #9535.