### PR TITLE
Fix conditional send with kwargs in Prism parser

### DIFF
--- a/test/prism_regression/call_conditional.parse-tree.exp
+++ b/test/prism_regression/call_conditional.parse-tree.exp
@@ -1,0 +1,90 @@
+Begin {
+  stmts = [
+    CSend {
+      receiver = Self {
+      }
+      method = <U foo>
+      args = [
+      ]
+    }
+    CSend {
+      receiver = Self {
+      }
+      method = <U foo>
+      args = [
+        Integer {
+          val = "1"
+        }
+      ]
+    }
+    CSend {
+      receiver = Self {
+      }
+      method = <U foo>
+      args = [
+        Hash {
+          kwargs = true
+          pairs = [
+            Pair {
+              key = Symbol {
+                val = <U a>
+              }
+              value = Integer {
+                val = "1"
+              }
+            }
+          ]
+        }
+      ]
+    }
+    CSend {
+      receiver = Self {
+      }
+      method = <U foo>
+      args = [
+        BlockPass {
+          block = Send {
+            receiver = NULL
+            method = <U forwarded_block>
+            args = [
+            ]
+          }
+        }
+      ]
+    }
+    Block {
+      send = CSend {
+        receiver = Self {
+        }
+        method = <U foo>
+        args = [
+        ]
+      }
+      params = Params {
+        params = [
+          Param {
+            name = <U x>
+          }
+        ]
+      }
+      body = LVar {
+        name = <U x>
+      }
+    }
+    CSend {
+      receiver = Self {
+      }
+      method = <U foo>
+      args = [
+        Splat {
+          var = Send {
+            receiver = NULL
+            method = <U args>
+            args = [
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/prism_regression/call_conditional.rb
+++ b/test/prism_regression/call_conditional.rb
@@ -1,0 +1,13 @@
+# typed: false
+
+self&.foo
+
+self&.foo(1)
+
+self&.foo(a: 1)
+
+self&.foo(&forwarded_block)
+
+self&.foo { |x| x }
+
+self&.foo(*args)


### PR DESCRIPTION
Part of #9065.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This commit ensures kwargs are handled correctly in the Prism parser for conditional sends, e.g. `a&.foo(b: 1)`. The conditional send logic was missing [this step](https://github.com/sorbet/sorbet/blob/11ef5bc220a7aa2442a26758195145d57469cb47/parser/prism/Translator.cc#L1494-L1498) that pushes the kwargs hash into the argument list. We could do the same thing, but @amomchilov suggested we instead collapse the conditional send logic into the regular send logic.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Conditional sends using keyword args were not working with the Prism parser mode ([sorbet.run](https://sorbet.run/?arg=--parser&arg=prism#%23%20typed%3A%20true%0Aextend%20T%3A%3ASig%0A%0Aclass%20Foo%0A%20%20def%20update%28attributes%29%3B%20end%0Aend%0A%0Aa%20%3D%20Foo.new%0Aa.update%28hi%3A%20%22there%22%29%0A%0Ab%20%3D%20T.let%28Foo.new%2C%20T.nilable%28Foo%29%29%0Ab%26.update%28hi%3A%20%22there%22%29)):

```rb
# typed: true
extend T::Sig

class Foo
  def update(attributes); end
end

a = Foo.new
a.update(hi: "there") # This works

b = T.let(Foo.new, T.nilable(Foo))
b&.update(hi: "there") # Not enough arguments provided for method Foo#update. Expected: 1, got: 0
```


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I added an expectation test to the `prism_regression` tests covering a few different conditional sends, including one with kwargs.
