### PR TITLE
Fix Prism Block parameters' locations

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1331,20 +1331,20 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
                                 // Like the `|x|` in `foo { |x| ... }`
                                 auto paramsNode = down_cast<pm_block_parameters_node>(blockNode->parameters);
 
+                                auto paramsLoc = translateLoc(paramsNode->base.location);
+
                                 if (paramsNode->parameters == nullptr) {
                                     // This can happen if the block declares block-local variables, but no parameters.
                                     // e.g. `foo { |; block_local_var| ... }`
 
-                                    auto location = translateLoc(paramsNode->base.location);
-
                                     // TODO: future follow up, ensure we add the block local variables ("shadowargs"),
                                     // if any.
-                                    blockParameters = make_unique<parser::Params>(location, NodeVec{});
+                                    blockParameters = make_unique<parser::Params>(paramsLoc, NodeVec{});
                                     didDesugarBlockParams = true;
                                 } else {
                                     unique_ptr<parser::Params> params;
                                     std::tie(params, std::ignore) =
-                                        translateParametersNode(paramsNode->parameters, sendLoc);
+                                        translateParametersNode(paramsNode->parameters, paramsLoc);
 
                                     // Sorbet's legacy parser inserts locals ("Shadowargs") at the end of the block's
                                     // Params node, after all other parameters.

--- a/test/BUILD
+++ b/test/BUILD
@@ -131,7 +131,6 @@ prism_location_test_suite(
     srcs = glob(
         ["prism_regression/**/*.rb"],
         exclude = [
-            "prism_regression/call_block_param.rb",
             "prism_regression/case_match_variable_pinning.rb",
             "prism_regression/error_recovery/assign.rb",
             "prism_regression/if_elsif.rb",


### PR DESCRIPTION
### Motivation

Part of #9065 and https://github.com/Shopify/sorbet/issues/730.

The locations of block parameters were just flat wrong (the send location)

```ruby
  foo { |a, b| ... }
# ^^^ old
#       ^^^^^^ fixed
```

### Test plan

Fixes `//test:prism_regression/call_block_param_location_test`
