### PR TITLE
Prevent crash using `T.attached_class` inside module instance method

### DIFF
--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -341,6 +341,11 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
                         sig.bind = core::Symbols::MagicBindToSelfType();
                         validBind = true;
                     } else if (arg->fun == core::Names::attachedClass()) {
+                        auto attachedClass = checkValidAttachedClass(ctx, arg->loc);
+                        if (!attachedClass.exists()) {
+                            break;
+                        }
+
                         sig.bind = core::Symbols::MagicBindToAttachedClass();
                         validBind = true;
                     }

--- a/test/testdata/resolver/bind_attached_class.rb
+++ b/test/testdata/resolver/bind_attached_class.rb
@@ -51,12 +51,15 @@ module DoesNotHaveAttachedClass
   extend T::Sig
 
   sig { params(blk: T.proc.bind(T.attached_class).void).returns(T.attached_class) }
+  #                             ^^^^^^^^^^^^^^^^ error: `DoesNotHaveAttachedClass` must declare `has_attached_class!` before module instance methods can use `T.attached_class`
+  #                                                             ^^^^^^^^^^^^^^^^ error: `DoesNotHaveAttachedClass` must declare `has_attached_class!` before module instance methods can use `T.attached_class`
+
   def with_bind(&blk)
   end
 
   def example
     with_bind {
-      T.reveal_type(self)
+      T.reveal_type(self) # error: `DoesNotHaveAttachedClass`
     }
   end
 end
@@ -65,7 +68,7 @@ class ExtendsDoesNotHave
   extend DoesNotHaveAttachedClass
   def self.example
     with_bind {
-      T.reveal_type(self)
+      T.reveal_type(self) # error: `T.class_of(ExtendsDoesNotHave)`
     }
   end
 end
@@ -83,7 +86,7 @@ module HasAttachedClass
 
   def example
     with_bind {
-      T.reveal_type(self)
+      T.reveal_type(self) # error: `T.anything`
     }
   end
 end
@@ -92,7 +95,7 @@ class ExtendsHas
   extend HasAttachedClass
   def self.example
     with_bind {
-      T.reveal_type(self)
+      T.reveal_type(self) # error: `ExtendsHas`
     }
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes a crash.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.