### PR TITLE
Fix `Pin` node's `Begin` location

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -3974,7 +3974,9 @@ unique_ptr<parser::Node> Translator::patternTranslate(pm_node_t *node) {
             // Sorbet's parser always wraps the pinned expression in a `Begin` node.
             NodeVec statements;
             statements.emplace_back(move(expr));
-            auto beginNode = make_node_with_expr<parser::Begin>(MK::Nil(location), location, move(statements));
+            auto beginNodeLocation = translateLoc(pinnedExprNode->lparen_loc.start, pinnedExprNode->rparen_loc.end);
+            auto beginNode =
+                make_node_with_expr<parser::Begin>(MK::Nil(beginNodeLocation), beginNodeLocation, move(statements));
 
             if (!directlyDesugar || !hasExpr(beginNode)) {
                 return make_unique<Pin>(location, move(beginNode));

--- a/test/BUILD
+++ b/test/BUILD
@@ -131,7 +131,6 @@ prism_location_test_suite(
     srcs = glob(
         ["prism_regression/**/*.rb"],
         exclude = [
-            "prism_regression/case_match_variable_pinning.rb",
             "prism_regression/error_recovery/assign.rb",
             "prism_regression/if_elsif.rb",
             "prism_regression/lambda.rb",


### PR DESCRIPTION
### Motivation

Part of #9065 and https://github.com/Shopify/sorbet/issues/730.

It should include the `()`, but not the `^`:

```ruby
nil in ^(123)
#      ^^^^^^ old
#       ^^^^^ fixed
```

### Test plan

Fixes `//test:prism_regression/case_match_variable_pinning_location_test`
