### PR TITLE
Fix ERB definitions for def_{method,module}

### DIFF
--- a/rbi/stdlib/erb.rbi
+++ b/rbi/stdlib/erb.rbi
@@ -303,7 +303,7 @@ class ERB
     )
     .returns(::T.untyped)
   end
-  def defMethod(mod, methodname, fname=T.unsafe(nil)); end
+  def def_method(mod, methodname, fname=T.unsafe(nil)); end
 
   sig do
     params(
@@ -311,7 +311,7 @@ class ERB
     )
     .returns(::T.untyped)
   end
-  def defModule(methodname=T.unsafe(nil)); end
+  def def_module(methodname=T.unsafe(nil)); end
 
   # The encoding to eval
   sig {returns(::T.untyped)}


### PR DESCRIPTION
Seems like these were accidentally renamed as part of a C++ code refactor in c205da120c8dbcfa11e21986aff38f23eede57c0