### PR TITLE
Upgrade to Prism 1.6.0

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1181,18 +1181,6 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
                 if (PM_NODE_TYPE_P(callNode->block, PM_BLOCK_ARGUMENT_NODE)) {
                     auto blockPassArgLoc = translateLoc(callNode->block->location);
                     sendLoc = sendLoc.join(blockPassArgLoc);
-
-                    // Prism bug: https://github.com/ruby/prism/issues/3708
-                    // If there's a block pass argument, Prism fails to include the closing paren in the call location.
-                    //     foo(&block)
-                    //     ^^^^^^^^^^  Prism call location
-                    //     ^^^^^^^^^^^ Fixed location
-                    if (callNode->closing_loc.end) {
-                        ENFORCE(callNode->closing_loc.start)
-                        auto closingLoc = translateLoc(callNode->closing_loc);
-                        sendWithBlockLoc = sendWithBlockLoc.join(closingLoc);
-                        blockLoc = blockLoc.join(closingLoc);
-                    }
                 }
             }
             auto sendLoc0 = sendLoc.copyWithZeroLength();

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -10,8 +10,8 @@ def register_sorbet_dependencies():
 
     http_archive(
         name = "prism",
-        url = "https://github.com/ruby/prism/releases/download/v1.3.0/libprism-src.tar.gz",
-        sha256 = "8f17e209e2a4c026a72f3bfbac541f7dbe898ec56dc8bc06abce5db6886f9b2e",
+        url = "https://github.com/ruby/prism/releases/download/v1.6.0/libprism-src.tar.gz",
+        sha256 = "a643517b910c510c998a518e45a66f7f3460e5b32f80d64aa0021fed7c967d0f",
         build_file = "@com_stripe_ruby_typer//third_party:prism.BUILD",
         strip_prefix = "libprism-src",
     )


### PR DESCRIPTION
### Motivation

Upgrade to the latest release of Prism, [Prism 1.6.0](https://github.com/ruby/prism/releases/tag/v1.6.0).

Part of #9065.

### Test plan

None