### PR TITLE
Fix Prism `Masgn` node locations

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -2966,6 +2966,10 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
             auto multiLhsNode = translateMultiTargetLhs(multiWriteNode, lhsLoc);
             auto rhsValue = translate(multiWriteNode->value);
 
+            // Sorbet's legacy parser doesn't include the opening `(` (see`mlhsLocation()` for details),
+            // so we can't just use the entire Prism location for the Masgn node.
+            location = lhsLoc.join(translateLoc(multiWriteNode->value->location));
+
             if (!directlyDesugar || !hasExpr(rhsValue, multiLhsNode->exprs)) {
                 return make_unique<parser::Masgn>(location, move(multiLhsNode), move(rhsValue));
             }

--- a/test/BUILD
+++ b/test/BUILD
@@ -135,7 +135,6 @@ prism_location_test_suite(
             "prism_regression/if_elsif.rb",
             "prism_regression/lambda.rb",
             "prism_regression/multi_target.rb",
-            "prism_regression/multi_write.rb",
         ],
     ),
 )


### PR DESCRIPTION
### Motivation

Part of #9065 and https://github.com/Shopify/sorbet/issues/730.

I say "fix", but it's more like "break in the same way". The legacy parser locations for `Mlhs` (and a parent `Masgn`, by extension), does not include the parens (bug #9630).

### Test plan

* Completely fixes `//test:prism_regression/multi_write_location_test`
* Fixes the 1 Masgn error in `//test:prism_regression/multi_target_location_test`
