### PR TITLE
Fix parentheses with non-statement-node body in Prism

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -3104,9 +3104,13 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
                 return make_node_with_expr<parser::Begin>(MK::Nil(location), location, NodeVec{});
             }
 
-            auto inlineIfSingle = false;
-            // Override the begin node location to be the parentheses location instead of the statements location
-            return translateStatements(down_cast<pm_statements_node>(stmtsNode), inlineIfSingle, location);
+            if (PM_NODE_TYPE_P(stmtsNode, PM_STATEMENTS_NODE)) {
+                auto inlineIfSingle = false;
+                // Override the begin node location to be the parentheses location instead of the statements location
+                return translateStatements(down_cast<pm_statements_node>(stmtsNode), inlineIfSingle, location);
+            } else {
+                return translate(stmtsNode);
+            }
         }
         case PM_PRE_EXECUTION_NODE: {
             auto preExecutionNode = down_cast<pm_pre_execution_node>(node);

--- a/test/prism_regression/parentheses.rb
+++ b/test/prism_regression/parentheses.rb
@@ -5,3 +5,8 @@
 (123)
 
 (1) + (2)
+
+def (self.foo).test; end
+
+# TODO: Fix range nested statements
+# 1 in (..10)

--- a/test/prism_regression/parentheses.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/parentheses.rb.desugar-tree-raw.exp
@@ -21,5 +21,15 @@ ClassDef{
         Literal{ value = 2 }
       ]
     }
+
+    MethodDef{
+      flags = {self}
+      name = <U test><<U <todo method>>>
+      params = [BlockParam{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U <blk>>
+        } }]
+      rhs = EmptyTree
+    }
   ]
 }

--- a/test/prism_regression/parentheses.rb.parse-tree.exp
+++ b/test/prism_regression/parentheses.rb.parse-tree.exp
@@ -30,5 +30,17 @@ Begin {
         }
       ]
     }
+    DefS {
+      singleton = Send {
+        receiver = Self {
+        }
+        method = <U foo>
+        args = [
+        ]
+      }
+      name = <U test>
+      params = NULL
+      body = NULL
+    }
   ]
 }


### PR DESCRIPTION
Part of #9065.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Prism parses `(10)` as a `ParenthesesNode` with a `StatementsNode` body but in `def (10).test; end` it's a `ParehthesesNode` with an `IntegerNode` directly in the body. This commit fixes the issue by checking if the body is a statement node or not.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Added a test-case to the `prism_regression` tests. We've also added another test case based on [the example](https://github.com/ruby/prism/blob/b3d83f6400a760501a9a360afda8f68d7a4cb805/config.yml#L4072) in the Prism codebase, but it doesn't yet pass due to another issue.
