### PR TITLE
Fix Prism some `Begin` location edge cases

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -134,7 +134,6 @@ prism_location_test_suite(
             "prism_regression/error_recovery/assign.rb",
             "prism_regression/if_elsif.rb",
             "prism_regression/lambda.rb",
-            "prism_regression/multi_target.rb",
         ],
     ),
 )

--- a/test/prism_regression/begin_node_weird_locs.parse-tree.exp
+++ b/test/prism_regression/begin_node_weird_locs.parse-tree.exp
@@ -1,0 +1,34 @@
+DefMethod {
+  name = <U multi_assign_parens_not_in_location>
+  params = NULL
+  body = Begin {
+    stmts = [
+      Masgn {
+        lhs = Mlhs {
+          exprs = [
+            LVarLhs {
+              name = <U a>
+            }
+            LVarLhs {
+              name = <U b>
+            }
+          ]
+        }
+        rhs = Array {
+          elts = [
+            Integer {
+              val = "1"
+            }
+            Integer {
+              val = "2"
+            }
+          ]
+        }
+      }
+      Const {
+        scope = NULL
+        name = <C <U FILLER_LINE>>
+      }
+    ]
+  }
+}

--- a/test/prism_regression/begin_node_weird_locs.rb
+++ b/test/prism_regression/begin_node_weird_locs.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+# Important! To correct test the location of the `Begin` locations:
+#   1. This method needs to have multiple lines (otherwise the `Begin` nodes is skipped)
+#   2. The node with a problematic start/end location needs to be the first or last node in the body
+
+# TODO: Delete when https://github.com/sorbet/sorbet/issues/9630 is fixed
+def multi_assign_parens_not_in_location
+  (a, b) = 1, 2
+  FILLER_LINE
+end

--- a/test/prism_regression/begin_node_weird_locs.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/begin_node_weird_locs.rb.desugar-tree-raw.exp
@@ -1,0 +1,109 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    MethodDef{
+      flags = {}
+      name = <U multi_assign_parens_not_in_location><<U <todo method>>>
+      params = [BlockParam{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U <blk>>
+        } }]
+      rhs = InsSeq{
+        stats = [
+          InsSeq{
+            stats = [
+              Assign{
+                lhs = UnresolvedIdent{
+                  kind = Local
+                  name = <D <U <assignTemp>> $2>
+                }
+                rhs = Array{
+                  elems = [
+                    Literal{ value = 1 }
+                    Literal{ value = 2 }
+                  ]
+                }
+              }
+              Assign{
+                lhs = UnresolvedIdent{
+                  kind = Local
+                  name = <D <U <assignTemp>> $3>
+                }
+                rhs = Send{
+                  flags = {}
+                  recv = ConstantLit{
+                    symbol = (class ::<Magic>)
+                    orig = nullptr
+                  }
+                  fun = <U <expand-splat>>
+                  block = nullptr
+                  pos_args = 3
+                  args = [
+                    UnresolvedIdent{
+                      kind = Local
+                      name = <D <U <assignTemp>> $2>
+                    }
+                    Literal{ value = 2 }
+                    Literal{ value = 0 }
+                  ]
+                }
+              }
+              Assign{
+                lhs = UnresolvedIdent{
+                  kind = Local
+                  name = <U a>
+                }
+                rhs = Send{
+                  flags = {}
+                  recv = UnresolvedIdent{
+                    kind = Local
+                    name = <D <U <assignTemp>> $3>
+                  }
+                  fun = <U []>
+                  block = nullptr
+                  pos_args = 1
+                  args = [
+                    Literal{ value = 0 }
+                  ]
+                }
+              }
+              Assign{
+                lhs = UnresolvedIdent{
+                  kind = Local
+                  name = <U b>
+                }
+                rhs = Send{
+                  flags = {}
+                  recv = UnresolvedIdent{
+                    kind = Local
+                    name = <D <U <assignTemp>> $3>
+                  }
+                  fun = <U []>
+                  block = nullptr
+                  pos_args = 1
+                  args = [
+                    Literal{ value = 1 }
+                  ]
+                }
+              }
+            ],
+            expr = UnresolvedIdent{
+              kind = Local
+              name = <D <U <assignTemp>> $2>
+            }
+          }
+        ],
+        expr = UnresolvedConstantLit{
+          cnst = <C <U FILLER_LINE>>
+          scope = EmptyTree
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

Part of #9065 and https://github.com/Shopify/sorbet/issues/730.

Related: #9629, #9630

Adds new infrastructure for handling nodes with special-cased start/end locations, and uses it to fix `Begin` nodes that start with an `Masgn`.

### Test plan

Fixes `//test:prism_regression/multi_target_location_test`
