### PR TITLE
More precise type for `Enumerable#grep`

### DIFF
--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -751,14 +751,14 @@ module Enumerable
   sig do
     type_parameters(:Instance)
       .params(
-          arg0: T::Class[T.type_parameter(:Instance)],
+          arg0: T::Module[T.type_parameter(:Instance)],
       )
       .returns(T::Array[T.all(Elem, T.type_parameter(:Instance))])
   end
   sig do
     type_parameters(:Instance, :U)
       .params(
-          arg0: T::Class[T.type_parameter(:Instance)],
+          arg0: T::Module[T.type_parameter(:Instance)],
           blk: T.proc.params(arg0: T.type_parameter(:Instance)).returns(T.type_parameter(:U)),
       )
       .returns(T::Array[T.type_parameter(:U)])

--- a/rbi/core/enumerator.rbi
+++ b/rbi/core/enumerator.rbi
@@ -808,14 +808,14 @@ class Enumerator::Lazy < Enumerator
   sig do
     type_parameters(:Instance)
       .params(
-          arg0: T::Class[T.type_parameter(:Instance)],
+          arg0: T::Module[T.type_parameter(:Instance)],
       )
       .returns(T::Enumerator::Lazy[T.all(Elem, T.type_parameter(:Instance))])
   end
   sig do
     type_parameters(:Instance, :U)
       .params(
-          arg0: T::Class[T.type_parameter(:Instance)],
+          arg0: T::Module[T.type_parameter(:Instance)],
           blk: T.proc.params(arg0: T.type_parameter(:Instance)).returns(T.type_parameter(:U)),
       )
       .returns(T::Enumerator::Lazy[T.type_parameter(:U)])


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested on Stripe's codebase.

There are four errors, and all of them are "redundant T.cast" errors because Sorbet knows more statically than it did before.