### PR TITLE
Fix bug preventing use of `T.any` in upper bound of type member

### DIFF
--- a/test/testdata/infer/generics/or_all_upper_lower.rb
+++ b/test/testdata/infer/generics/or_all_upper_lower.rb
@@ -21,11 +21,9 @@ class Upper
   sig { params(x: X, y: Y, z: Z).void }
   def example(x, y, z)
     takes_any(x)
-    #         ^ error: Expected `T.any(Integer, String)` but found `Upper::X` for argument `x`
     takes_all(y)
 
     takes_any(z)
-    #         ^ error: Expected `T.any(Integer, String)` but found `Upper::Z` for argument `x`
     takes_all(z)
   end
 end
@@ -58,14 +56,11 @@ class Lower
   }
   def example(mn, i_or_s, mn_or_i_or_s)
     takes_x(mn)
-    #       ^^ error: Expected `Lower::X` but found `T.all(M, N)` for argument `x`
     takes_z(mn)
-    #       ^^ error: Expected `Lower::Z` but found `T.all(M, N)` for argument `z`
 
     takes_y(i_or_s)
     takes_z(i_or_s)
 
     takes_z(mn_or_i_or_s)
-    #       ^^^^^^^^^^^^ error: Expected `Lower::Z` but found `T.any(Integer, T.all(M, N), String)` for argument `z`
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #6990




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.