### PR TITLE
Fix Prism `Super` location when there's a literal block arg

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -3384,6 +3384,29 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
             auto blockArgumentNode = superNode->block;
             NodeVec returnValues;
 
+            if (blockArgumentNode) { // Adjust the location to exclude the literal block argument.
+                const uint8_t *start = superNode->base.location.start;
+                const uint8_t *end;
+
+                if (superNode->rparen_loc.end) { // Try to use the location of the `)`, if any
+                    end = superNode->rparen_loc.end;
+                } else { // Otherwise, use the end of the last argument
+                    auto *argP = superNode->arguments;
+
+                    constexpr auto msg =
+                        "`PM_SUPER_NODE` must have arguments if it has no parens. If there's no args and no "
+                        "parens, then you wouldn't even have a `PM_SUPER_NODE` to begin with, but a "
+                        "`PM_FORWARDING_SUPER` instead)";
+                    ENFORCE(argP, msg);
+
+                    auto args = absl::MakeSpan(argP->arguments.nodes, argP->arguments.size);
+                    ENFORCE(!args.empty(), msg);
+                    end = args.back()->location.end;
+                }
+
+                location = translateLoc(start, end);
+            }
+
             if (blockArgumentNode != nullptr && PM_NODE_TYPE_P(blockArgumentNode, PM_BLOCK_NODE)) {
                 returnValues = translateArguments(superNode->arguments);
                 auto superNode = make_unique<parser::Super>(location, move(returnValues));

--- a/test/prism_regression/super.rb
+++ b/test/prism_regression/super.rb
@@ -7,10 +7,23 @@ def m
 
   super(1, 2, 3)
 
+  super 1, 2, 3
+
   # Invoke super with a block
   super() do
     yield
   end
+
+  super(1, 2, 3) do
+    yield
+  end
+
+  super 1, 2, 3 do
+    yield
+  end
+
+  # what about operators and square brackets?
+  # super[1, 2] = 3
 
   # Invoke super with a block, forwarding all arguments
   super do

--- a/test/prism_regression/super.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/super.rb.desugar-tree-raw.exp
@@ -51,6 +51,18 @@ ClassDef{
             flags = {privateOk}
             recv = Self
             fun = <U <super>>
+            block = nullptr
+            pos_args = 3
+            args = [
+              Literal{ value = 1 }
+              Literal{ value = 2 }
+              Literal{ value = 3 }
+            ]
+          }
+          Send{
+            flags = {privateOk}
+            recv = Self
+            fun = <U <super>>
             block = Block {
               params = [
               ]
@@ -69,6 +81,60 @@ ClassDef{
             }
             pos_args = 0
             args = [
+            ]
+          }
+          Send{
+            flags = {privateOk}
+            recv = Self
+            fun = <U <super>>
+            block = Block {
+              params = [
+              ]
+              body = Send{
+                flags = {}
+                recv = UnresolvedIdent{
+                  kind = Local
+                  name = <U <blk>>
+                }
+                fun = <U call>
+                block = nullptr
+                pos_args = 0
+                args = [
+                ]
+              }
+            }
+            pos_args = 3
+            args = [
+              Literal{ value = 1 }
+              Literal{ value = 2 }
+              Literal{ value = 3 }
+            ]
+          }
+          Send{
+            flags = {privateOk}
+            recv = Self
+            fun = <U <super>>
+            block = Block {
+              params = [
+              ]
+              body = Send{
+                flags = {}
+                recv = UnresolvedIdent{
+                  kind = Local
+                  name = <U <blk>>
+                }
+                fun = <U call>
+                block = nullptr
+                pos_args = 0
+                args = [
+                ]
+              }
+            }
+            pos_args = 3
+            args = [
+              Literal{ value = 1 }
+              Literal{ value = 2 }
+              Literal{ value = 3 }
             ]
           }
         ],

--- a/test/prism_regression/super.rb.parse-tree.exp
+++ b/test/prism_regression/super.rb.parse-tree.exp
@@ -22,9 +22,62 @@ DefMethod {
           }
         ]
       }
+      Super {
+        args = [
+          Integer {
+            val = "1"
+          }
+          Integer {
+            val = "2"
+          }
+          Integer {
+            val = "3"
+          }
+        ]
+      }
       Block {
         send = Super {
           args = [
+          ]
+        }
+        params = NULL
+        body = Yield {
+          exprs = [
+          ]
+        }
+      }
+      Block {
+        send = Super {
+          args = [
+            Integer {
+              val = "1"
+            }
+            Integer {
+              val = "2"
+            }
+            Integer {
+              val = "3"
+            }
+          ]
+        }
+        params = NULL
+        body = Yield {
+          exprs = [
+          ]
+        }
+      }
+      Block {
+        send = Super {
+          args = [
+            Integer {
+              val = "1"
+            }
+            Integer {
+              val = "2"
+            }
+            Integer {
+              val = "3"
+            }
           ]
         }
         params = NULL


### PR DESCRIPTION
### Motivation

Part of #9065 and https://github.com/Shopify/sorbet/issues/730.

The location should include the arguments, not including the literal block argument.

### Test plan

Fixes the newly-added test examples.