### PR TITLE
Directly ban using `T.self_type` in type member bounds

### DIFF
--- a/test/testdata/infer/type_member_self_type.rb
+++ b/test/testdata/infer/type_member_self_type.rb
@@ -20,14 +20,15 @@ class A
   extend T::Sig, T::Generic
 
   X = type_member { { fixed: T.self_type} }
+  #                          ^^^^^^^^^^^ error: `T.self_type` is not supported inside generic type bounds
 
   sig { returns(X) }
-  def my_dup = self # error: Expression does not have a fully-defined type
+  def my_dup = self
 end
 
-p(A) # error: Expression does not have a fully-defined type
-a = A.new # error: Expression does not have a fully-defined type
-T.reveal_type(a) # error: `T.untyped`
+p(A)
+a = A.new
+T.reveal_type(a) # error: `A`
 
 class ChildABad < A # error: Type `X` declared by parent `A` must be re-declared in `ChildABad`
 end
@@ -36,18 +37,20 @@ class ChildA < A
   # should this be allowed?
   # it almost seems like you should be required to do `fixed: A`
   X = type_member { {fixed: T.self_type} }
+  #                         ^^^^^^^^^^^ error: `T.self_type` is not supported inside generic type bounds
 end
 
 res = ChildA.new.my_dup
-#     ^^^^^^ error: Expression does not have a fully-defined type
 T.reveal_type(res) # error: `T.untyped`
 
 class B
   extend T::Sig, T::Generic
   X = type_member { {lower: T.self_type, upper: T.self_type} }
+  #                         ^^^^^^^^^^^ error: `T.self_type` is not supported inside generic type bounds
+  #                                             ^^^^^^^^^^^ error: `T.self_type` is not supported inside generic type bounds
 
   sig { returns(X) }
-  def my_dup = self # error: Expected `B::X` but found `B[B::X]` for method result type
+  def my_dup = self
 end
 
 p(B)
@@ -56,18 +59,20 @@ T.reveal_type(b) # error: `B[T.untyped]`
 
 class ChildB < B
   X = type_member { {lower: T.self_type, upper: T.self_type} }
+  #                         ^^^^^^^^^^^ error: `T.self_type` is not supported inside generic type bounds
+  #                                             ^^^^^^^^^^^ error: `T.self_type` is not supported inside generic type bounds
 end
 
 class C
   extend T::Sig, T::Generic
   X = type_member(:out) { {lower: T.self_type, upper: T.self_type} }
+  #                               ^^^^^^^^^^^ error: `T.self_type` is not supported inside generic type bounds
+  #                                                   ^^^^^^^^^^^ error: `T.self_type` is not supported inside generic type bounds
 
   sig { returns(X) }
-  def my_dup = self # error: Expected `C::X` but found `C[C::X]`
+  def my_dup = self
 end
 
 p(C)
-# ^ error: does not have a fully-defined type
 b = C.new
-#   ^ error: does not have a fully-defined type
-T.reveal_type(b) # error: `T.untyped`
+T.reveal_type(b) # error: `C[T.untyped]`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was already unusable in practice, because you'd get "is not fully
defined" type errors.

On my work-in-progress `T.self_type` branch, using `T.self_type` in type
member bounds causes invariants to be violated inside the
`processBinding` instruction for the `Cast` instruction that sets up the
type of `<self>` (because it tries to create a type like `A[LambdaParam
{ T.self_type }]`, which is not fully defined).

We do want to allow this code eventually, but it's not clear to me what
the best way to do it is, and I don't want to block building better
support for `T.self_type` on also solving this problem.

I had been hoping that the `T.self_type` branch would somehow magically
solve this, but it's clear that it makes it worse, which is a little
unlucky. Maybe it's not actually worse, maybe it's directionally
accurate and we just need to keep following that direction such that we
maintain the invariants we need to.

But in any case, this unblocks the `T.self_type` work until we can think
through what a better behavior would be here.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

We already had a test for this, which I added in a test-only change when a long
time ago I happened to wonder what the behavior of Sorbet was on such a snippet (see #9375).