### PR TITLE
Fix "go to definition" on it_behaves_like

### DIFF
--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -911,17 +911,17 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::
             // This wraps the shared examples in a new context so their definitions
             // (like let-defined methods) don't clobber the outer context's definitions.
             auto testName = fmt::format("<it_behaves_like '{}'>", argString);
-            auto isolatedClassName =
-                ast::MK::UnresolvedConstantParts(arg.loc(), {ctx.state.enterNameConstant(testName)});
+            auto isolatedClassName = ast::MK::UnresolvedConstantParts(send->loc.copyWithZeroLength(),
+                                                                      {ctx.state.enterNameConstant(testName)});
 
             // Inherit from self to maintain access to outer context
             ast::ClassDef::ANCESTORS_store ancestors;
-            ancestors.emplace_back(ast::MK::Self(arg.loc()));
+            ancestors.emplace_back(ast::MK::Self(send->loc.copyWithZeroLength()));
 
             // Include the shared examples module in this isolated context
             auto sharedExamplesName = makeSharedExamplesConstant(ctx, arg);
             auto includeStmt = ast::MK::Send1(send->loc, ast::MK::Self(send->recv.loc()), core::Names::include(),
-                                              send->funLoc, move(sharedExamplesName));
+                                              arg.loc(), move(sharedExamplesName));
 
             ast::ClassDef::RHS_store rhs;
             rhs.emplace_back(move(includeStmt));

--- a/test/testdata/rewriter/rspec_it_behaves_like_isolation.rb
+++ b/test/testdata/rewriter/rspec_it_behaves_like_isolation.rb
@@ -20,6 +20,7 @@ class MyClass < RSpec::Core::ExampleGroup
 
     # Define a shared example with a let variable
     shared_examples "shared behavior" do
+    #                ^^^^^^^^^^^^^^^^ def: shared_behavior
       extend T::Sig
 
       sig { returns(String) }
@@ -36,8 +37,13 @@ class MyClass < RSpec::Core::ExampleGroup
     sig { returns(Integer) }
     let(:shared_value) { 100 }
 
-    # Test that it_behaves_like creates an isolated nested context
+    # Test that include_context jumps to the shared examples definition
+    include_context "shared behavior"
+    #                ^^^^^^^^^^^^^^^^ usage: shared_behavior
+
+    # Test that it_behaves_like also jumps to the shared examples definition
     it_behaves_like "shared behavior"
+    #                ^^^^^^^^^^^^^^^^ usage: shared_behavior
 
     # Test that the outer context still has its own value and type (not clobbered by shared behavior)
     it 'outer context has its own value' do
@@ -51,6 +57,7 @@ class MyClass < RSpec::Core::ExampleGroup
       extend T::Sig
 
       shared_examples "defines helper method" do
+      #                ^^^^^^^^^^^^^^^^^^^^^^ def: defines_helper_method
         extend T::Sig
 
         sig { returns(String) }
@@ -72,6 +79,7 @@ class MyClass < RSpec::Core::ExampleGroup
 
       # it_behaves_like should not let the shared helper_method clobber the outer one
       it_behaves_like "defines helper method"
+      #                ^^^^^^^^^^^^^^^^^^^^^^ usage: defines_helper_method
 
       it 'outer helper_method is not clobbered' do
         result = helper_method
@@ -82,21 +90,26 @@ class MyClass < RSpec::Core::ExampleGroup
 
     # Test parameterized it_behaves_like
     shared_examples "parameterized behavior" do |expected_value|
+    #                ^^^^^^^^^^^^^^^^^^^^^^^ def: parameterized_behavior
       it 'receives parameter' do
         expect(expected_value).to eq('param_value')
       end
     end
 
     it_behaves_like "parameterized behavior", 'param_value'
+    #                ^^^^^^^^^^^^^^^^^^^^^^^ usage: parameterized_behavior
 
     # Test multiple it_behaves_like calls with different parameters
     shared_examples "math behavior" do |a, b, result|
+    #                ^^^^^^^^^^^^^^ def: math_behavior
       it 'performs calculation' do
         expect(a + b).to eq(result)
       end
     end
 
     it_behaves_like "math behavior", 1, 2, 3
+    #                ^^^^^^^^^^^^^^ usage: math_behavior
     it_behaves_like "math behavior", 5, 10, 15
+    #                ^^^^^^^^^^^^^^ usage: math_behavior
   end
 end

--- a/test/testdata/rewriter/rspec_it_behaves_like_isolation.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_it_behaves_like_isolation.rb.rewrite-tree.exp
@@ -65,6 +65,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
       <runtime method definition of shared_value>
 
+      <self>.include(<emptyTree>::<C <shared_examples 'shared behavior'>>)
+
       class <emptyTree>::<C <it_behaves_like 'shared behavior'>><<C <todo sym>>> < (<self>)
         <self>.include(<emptyTree>::<C <shared_examples 'shared behavior'>>)
       end


### PR DESCRIPTION
Follow up to https://github.com/sorbet/sorbet/pull/9523

cc @elliottt 