### PR TITLE
Restore Prism fallback path for Regexp

### DIFF
--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -1781,7 +1781,13 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                                       move(excludeEnd));
                 result = move(send);
             },
-            [&](parser::Regexp *regexpNode) { desugaredByPrismTranslator(regexpNode); },
+            [&](parser::Regexp *regexpNode) {
+                ExpressionPtr cnst = MK::Constant(loc, core::Symbols::Regexp());
+                auto pattern = desugarDString(dctx, loc, move(regexpNode->regex));
+                auto opts = node2TreeImpl(dctx, regexpNode->opts);
+                auto send = MK::Send2(loc, move(cnst), core::Names::new_(), locZeroLen, move(pattern), move(opts));
+                result = move(send);
+            },
             [&](parser::Regopt *regopt) { desugaredByPrismTranslator(regopt); },
             [&](parser::Return *ret) {
                 if (ret->exprs.size() > 1) {

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -265,6 +265,9 @@ ast::ExpressionPtr Translator::desugarDString(core::LocOffsets loc, pm_node_list
     for (pm_node *prismNode : prismNodes) {
         auto parserNode = translate(prismNode);
         auto expr = parserNode->takeDesugaredExpr();
+        ENFORCE(expr != nullptr, "All arguments must have a desugared expression by now, failed on {}",
+                ctx.file.data(ctx).path());
+
         if (allStringsSoFar && isStringLit(expr)) {
             stringsAccumulated.emplace_back(move(expr));
         } else {
@@ -2738,7 +2741,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
             auto parts = translateMulti(interpolatedRegexNode->parts);
             auto options = translateRegexpOptions(interpolatedRegexNode->closing_loc);
 
-            if (!directlyDesugar) {
+            if (!directlyDesugar || !hasExpr(parts)) {
                 return make_unique<parser::Regexp>(location, move(parts), move(options));
             }
 


### PR DESCRIPTION
### Motivation

Part of #9065, follow-up to #9378.

This interpolated Regexp path assumed that all the segments are already directly desugared, which might not be true. E.g. crashes for `/#{a&.b}/`, because we can't directly desugar conditional sends yet.

### Test plan

There's no point testing this, it's just a consequence of what is/isn't directly desugared, which is about to completely change in the next 2 weeks.