### PR TITLE
Fix verify_prism_regression_tests.sh script

### DIFF
--- a/test/prism_regression/call_conditional.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_conditional.rb.desugar-tree-raw.exp
@@ -1,0 +1,413 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    InsSeq{
+      stats = [
+        Assign{
+          lhs = UnresolvedIdent{
+            kind = Local
+            name = <D <U <assignTemp>> $2>
+          }
+          rhs = Self
+        }
+      ],
+      expr = If{
+        cond = Send{
+          flags = {}
+          recv = ConstantLit{
+            symbol = (class ::NilClass)
+            orig = nullptr
+          }
+          fun = <U ===>
+          block = nullptr
+          pos_args = 1
+          args = [
+            UnresolvedIdent{
+              kind = Local
+              name = <D <U <assignTemp>> $2>
+            }
+          ]
+        }
+        thenp = Send{
+          flags = {}
+          recv = ConstantLit{
+            symbol = (class ::<Magic>)
+            orig = nullptr
+          }
+          fun = <U <nil-for-safe-navigation>>
+          block = nullptr
+          pos_args = 1
+          args = [
+            UnresolvedIdent{
+              kind = Local
+              name = <D <U <assignTemp>> $2>
+            }
+          ]
+        }
+        elsep = Send{
+          flags = {}
+          recv = UnresolvedIdent{
+            kind = Local
+            name = <D <U <assignTemp>> $2>
+          }
+          fun = <U foo>
+          block = nullptr
+          pos_args = 0
+          args = [
+          ]
+        }
+      }
+    }
+
+    InsSeq{
+      stats = [
+        Assign{
+          lhs = UnresolvedIdent{
+            kind = Local
+            name = <D <U <assignTemp>> $3>
+          }
+          rhs = Self
+        }
+      ],
+      expr = If{
+        cond = Send{
+          flags = {}
+          recv = ConstantLit{
+            symbol = (class ::NilClass)
+            orig = nullptr
+          }
+          fun = <U ===>
+          block = nullptr
+          pos_args = 1
+          args = [
+            UnresolvedIdent{
+              kind = Local
+              name = <D <U <assignTemp>> $3>
+            }
+          ]
+        }
+        thenp = Send{
+          flags = {}
+          recv = ConstantLit{
+            symbol = (class ::<Magic>)
+            orig = nullptr
+          }
+          fun = <U <nil-for-safe-navigation>>
+          block = nullptr
+          pos_args = 1
+          args = [
+            UnresolvedIdent{
+              kind = Local
+              name = <D <U <assignTemp>> $3>
+            }
+          ]
+        }
+        elsep = Send{
+          flags = {}
+          recv = UnresolvedIdent{
+            kind = Local
+            name = <D <U <assignTemp>> $3>
+          }
+          fun = <U foo>
+          block = nullptr
+          pos_args = 1
+          args = [
+            Literal{ value = 1 }
+          ]
+        }
+      }
+    }
+
+    InsSeq{
+      stats = [
+        Assign{
+          lhs = UnresolvedIdent{
+            kind = Local
+            name = <D <U <assignTemp>> $4>
+          }
+          rhs = Self
+        }
+      ],
+      expr = If{
+        cond = Send{
+          flags = {}
+          recv = ConstantLit{
+            symbol = (class ::NilClass)
+            orig = nullptr
+          }
+          fun = <U ===>
+          block = nullptr
+          pos_args = 1
+          args = [
+            UnresolvedIdent{
+              kind = Local
+              name = <D <U <assignTemp>> $4>
+            }
+          ]
+        }
+        thenp = Send{
+          flags = {}
+          recv = ConstantLit{
+            symbol = (class ::<Magic>)
+            orig = nullptr
+          }
+          fun = <U <nil-for-safe-navigation>>
+          block = nullptr
+          pos_args = 1
+          args = [
+            UnresolvedIdent{
+              kind = Local
+              name = <D <U <assignTemp>> $4>
+            }
+          ]
+        }
+        elsep = Send{
+          flags = {}
+          recv = UnresolvedIdent{
+            kind = Local
+            name = <D <U <assignTemp>> $4>
+          }
+          fun = <U foo>
+          block = nullptr
+          pos_args = 0
+          args = [
+            Literal{ value = :a }
+            Literal{ value = 1 }
+          ]
+        }
+      }
+    }
+
+    InsSeq{
+      stats = [
+        Assign{
+          lhs = UnresolvedIdent{
+            kind = Local
+            name = <D <U <assignTemp>> $5>
+          }
+          rhs = Self
+        }
+      ],
+      expr = If{
+        cond = Send{
+          flags = {}
+          recv = ConstantLit{
+            symbol = (class ::NilClass)
+            orig = nullptr
+          }
+          fun = <U ===>
+          block = nullptr
+          pos_args = 1
+          args = [
+            UnresolvedIdent{
+              kind = Local
+              name = <D <U <assignTemp>> $5>
+            }
+          ]
+        }
+        thenp = Send{
+          flags = {}
+          recv = ConstantLit{
+            symbol = (class ::<Magic>)
+            orig = nullptr
+          }
+          fun = <U <nil-for-safe-navigation>>
+          block = nullptr
+          pos_args = 1
+          args = [
+            UnresolvedIdent{
+              kind = Local
+              name = <D <U <assignTemp>> $5>
+            }
+          ]
+        }
+        elsep = Send{
+          flags = {}
+          recv = ConstantLit{
+            symbol = (class ::<Magic>)
+            orig = nullptr
+          }
+          fun = <U <call-with-block-pass>>
+          block = nullptr
+          pos_args = 3
+          args = [
+            UnresolvedIdent{
+              kind = Local
+              name = <D <U <assignTemp>> $5>
+            }
+            Literal{ value = :foo }
+            Send{
+              flags = {privateOk}
+              recv = Self
+              fun = <U forwarded_block>
+              block = nullptr
+              pos_args = 0
+              args = [
+              ]
+            }
+          ]
+        }
+      }
+    }
+
+    InsSeq{
+      stats = [
+        Assign{
+          lhs = UnresolvedIdent{
+            kind = Local
+            name = <D <U <assignTemp>> $6>
+          }
+          rhs = Self
+        }
+      ],
+      expr = If{
+        cond = Send{
+          flags = {}
+          recv = ConstantLit{
+            symbol = (class ::NilClass)
+            orig = nullptr
+          }
+          fun = <U ===>
+          block = nullptr
+          pos_args = 1
+          args = [
+            UnresolvedIdent{
+              kind = Local
+              name = <D <U <assignTemp>> $6>
+            }
+          ]
+        }
+        thenp = Send{
+          flags = {}
+          recv = ConstantLit{
+            symbol = (class ::<Magic>)
+            orig = nullptr
+          }
+          fun = <U <nil-for-safe-navigation>>
+          block = nullptr
+          pos_args = 1
+          args = [
+            UnresolvedIdent{
+              kind = Local
+              name = <D <U <assignTemp>> $6>
+            }
+          ]
+        }
+        elsep = Send{
+          flags = {}
+          recv = UnresolvedIdent{
+            kind = Local
+            name = <D <U <assignTemp>> $6>
+          }
+          fun = <U foo>
+          block = Block {
+            params = [
+              UnresolvedIdent{
+                kind = Local
+                name = <U x>
+              }
+            ]
+            body = UnresolvedIdent{
+              kind = Local
+              name = <U x>
+            }
+          }
+          pos_args = 0
+          args = [
+          ]
+        }
+      }
+    }
+
+    InsSeq{
+      stats = [
+        Assign{
+          lhs = UnresolvedIdent{
+            kind = Local
+            name = <D <U <assignTemp>> $7>
+          }
+          rhs = Self
+        }
+      ],
+      expr = If{
+        cond = Send{
+          flags = {}
+          recv = ConstantLit{
+            symbol = (class ::NilClass)
+            orig = nullptr
+          }
+          fun = <U ===>
+          block = nullptr
+          pos_args = 1
+          args = [
+            UnresolvedIdent{
+              kind = Local
+              name = <D <U <assignTemp>> $7>
+            }
+          ]
+        }
+        thenp = Send{
+          flags = {}
+          recv = ConstantLit{
+            symbol = (class ::<Magic>)
+            orig = nullptr
+          }
+          fun = <U <nil-for-safe-navigation>>
+          block = nullptr
+          pos_args = 1
+          args = [
+            UnresolvedIdent{
+              kind = Local
+              name = <D <U <assignTemp>> $7>
+            }
+          ]
+        }
+        elsep = Send{
+          flags = {}
+          recv = ConstantLit{
+            symbol = (class ::<Magic>)
+            orig = nullptr
+          }
+          fun = <U <call-with-splat>>
+          block = nullptr
+          pos_args = 4
+          args = [
+            UnresolvedIdent{
+              kind = Local
+              name = <D <U <assignTemp>> $7>
+            }
+            Literal{ value = :foo }
+            Send{
+              flags = {}
+              recv = ConstantLit{
+                symbol = (class ::<Magic>)
+                orig = nullptr
+              }
+              fun = <U <splat>>
+              block = nullptr
+              pos_args = 1
+              args = [
+                Send{
+                  flags = {privateOk}
+                  recv = Self
+                  fun = <U args>
+                  block = nullptr
+                  pos_args = 0
+                  args = [
+                  ]
+                }
+              ]
+            }
+            Literal{ value = nil }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/prism_regression/const_pattern.rb.parse-tree.exp
+++ b/test/prism_regression/const_pattern.rb.parse-tree.exp
@@ -1,0 +1,251 @@
+CaseMatch {
+  expr = Nil {
+  }
+  inBodies = [
+    InPattern {
+      pattern = ArrayPattern {
+        elts = [
+        ]
+      }
+      guard = NULL
+      body = String {
+        val = <U Empty ArrayPattern>
+      }
+    }
+    InPattern {
+      pattern = ArrayPattern {
+        elts = [
+          Integer {
+            val = "1"
+          }
+          Integer {
+            val = "2"
+          }
+          Integer {
+            val = "3"
+          }
+          Integer {
+            val = "4"
+          }
+        ]
+      }
+      guard = NULL
+      body = String {
+        val = <U ArrayPattern>
+      }
+    }
+    InPattern {
+      pattern = ConstPattern {
+        scope = Const {
+          scope = NULL
+          name = <C <U Point>>
+        }
+        pattern = ArrayPattern {
+          elts = [
+          ]
+        }
+      }
+      guard = NULL
+      body = String {
+        val = <U ConstPattern with nested empty ArrayPattern>
+      }
+    }
+    InPattern {
+      pattern = ConstPattern {
+        scope = Const {
+          scope = NULL
+          name = <C <U Point>>
+        }
+        pattern = ArrayPattern {
+          elts = [
+            Integer {
+              val = "1"
+            }
+            Integer {
+              val = "2"
+            }
+            Integer {
+              val = "3"
+            }
+            Integer {
+              val = "4"
+            }
+          ]
+        }
+      }
+      guard = NULL
+      body = String {
+        val = <U ConstPattern with nested ArrayPattern>
+      }
+    }
+    InPattern {
+      pattern = ConstPattern {
+        scope = Const {
+          scope = NULL
+          name = <C <U Point>>
+        }
+        pattern = ArrayPattern {
+          elts = [
+          ]
+        }
+      }
+      guard = NULL
+      body = String {
+        val = <U ConstPattern with nested empty ArrayPattern>
+      }
+    }
+    InPattern {
+      pattern = ConstPattern {
+        scope = Const {
+          scope = NULL
+          name = <C <U Point>>
+        }
+        pattern = ArrayPattern {
+          elts = [
+            Integer {
+              val = "1"
+            }
+            Integer {
+              val = "2"
+            }
+            Integer {
+              val = "3"
+            }
+            Integer {
+              val = "4"
+            }
+          ]
+        }
+      }
+      guard = NULL
+      body = String {
+        val = <U ConstPattern with nested ArrayPattern>
+      }
+    }
+    InPattern {
+      pattern = HashPattern {
+        pairs = [
+          Pair {
+            key = Symbol {
+              val = <U x>
+            }
+            value = Const {
+              scope = NULL
+              name = <C <U Integer>>
+            }
+          }
+          Pair {
+            key = Symbol {
+              val = <U y>
+            }
+            value = Const {
+              scope = NULL
+              name = <C <U Integer>>
+            }
+          }
+        ]
+      }
+      guard = NULL
+      body = String {
+        val = <U HashPattern with 2 pairs>
+      }
+    }
+    InPattern {
+      pattern = HashPattern {
+        pairs = [
+          Pair {
+            key = Symbol {
+              val = <U x>
+            }
+            value = Const {
+              scope = NULL
+              name = <C <U Integer>>
+            }
+          }
+          Pair {
+            key = Symbol {
+              val = <U y>
+            }
+            value = Const {
+              scope = NULL
+              name = <C <U Integer>>
+            }
+          }
+        ]
+      }
+      guard = NULL
+      body = String {
+        val = <U HashPattern with 2 pairs>
+      }
+    }
+    InPattern {
+      pattern = ConstPattern {
+        scope = Const {
+          scope = NULL
+          name = <C <U Point>>
+        }
+        pattern = HashPattern {
+          pairs = [
+            Pair {
+              key = Symbol {
+                val = <U x>
+              }
+              value = Const {
+                scope = NULL
+                name = <C <U Integer>>
+              }
+            }
+            Pair {
+              key = Symbol {
+                val = <U y>
+              }
+              value = Const {
+                scope = NULL
+                name = <C <U Integer>>
+              }
+            }
+          ]
+        }
+      }
+      guard = NULL
+      body = String {
+        val = <U ConstPattern with nested HashPattern with 2 pairs>
+      }
+    }
+    InPattern {
+      pattern = ConstPattern {
+        scope = Const {
+          scope = NULL
+          name = <C <U Point>>
+        }
+        pattern = HashPattern {
+          pairs = [
+            Pair {
+              key = Symbol {
+                val = <U x>
+              }
+              value = Const {
+                scope = NULL
+                name = <C <U Integer>>
+              }
+            }
+            Pair {
+              key = Symbol {
+                val = <U y>
+              }
+              value = Const {
+                scope = NULL
+                name = <C <U Integer>>
+              }
+            }
+          ]
+        }
+      }
+      guard = NULL
+      body = String {
+        val = <U ConstPattern with nested HashPattern with 2 pairs>
+      }
+    }
+  ]
+  elseBody = NULL
+}

--- a/test/prism_regression/keyword_LINE.rb
+++ b/test/prism_regression/keyword_LINE.rb
@@ -1,3 +1,4 @@
 # typed: false
+# disable-stress-incremental: true
 
 __LINE__

--- a/test/prism_regression/keyword_LINE.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/keyword_LINE.rb.desugar-tree-raw.exp
@@ -1,0 +1,12 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    Literal{ value = 4 }
+  ]
+}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This commit updates the `verify_prism_regression_tests.sh` script to use the correct file names now that we renamed them in #9638.

It also verifies the `desugar-tree-raw` output, not just the `parse-tree` output. I also added missing exp files that were picked up by the script. As part of this, I needed to update the keyword_LINE.rb test to disable stress-incremental mode, to ensure the literal integer value for the __LINE__ constant is correct.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We use the `verify_prism_regression_tests.sh` script to verify that our `prism_regression` expectations match the original parser. However, when we renamed the files this script stopped working. We also had a couple of missing expectation files.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
