### PR TITLE
add watchman namespace support for Stripe's monorepo

### DIFF
--- a/common/FileOps.h
+++ b/common/FileOps.h
@@ -27,6 +27,7 @@ public:
     static bool writeIfDifferent(const std::string &filename, std::string_view text);
     static bool dirExists(const std::string &path);
     static void createDir(const std::string &path);
+    static std::optional<std::string> realpath(const std::string &path);
 
     // This differs from createDir, as it will not raise an exception if the directory already exists. Returns true when
     // the directory was created, and false if it already existed.

--- a/common/common.cc
+++ b/common/common.cc
@@ -104,6 +104,14 @@ void sorbet::FileOps::removeDir(const string &path) {
     }
 }
 
+optional<string> sorbet::FileOps::realpath(const string &path) {
+    unique_ptr<char[], void (*)(void *)> resolved(::realpath(path.c_str(), nullptr), free);
+    if (resolved == nullptr) {
+        return nullopt;
+    }
+    return string(resolved.get());
+}
+
 void sorbet::FileOps::removeFile(const string &path) {
     auto err = remove(path.c_str());
     if (err) {

--- a/main/lsp/BUILD
+++ b/main/lsp/BUILD
@@ -67,6 +67,7 @@ cc_library(
         "//payload:interface",
         "//payload/binary",
         "//payload/text",
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
         "@cpp_subprocess",
         "@rapidjson",

--- a/main/lsp/LSPLoop.cc
+++ b/main/lsp/LSPLoop.cc
@@ -222,7 +222,7 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> inp
 
         watchmanProcess = make_unique<watchman::WatchmanProcess>(
             logger, opts.watchmanPath, opts.rawInputDirNames.at(0), vector<string>({"rb", "rbi"}), messageQueue,
-            messageQueueMutex, initializedNotification, this->config);
+            messageQueueMutex, initializedNotification, this->config, opts.watchmanNamespace);
     }
 
     auto readerThread =

--- a/main/lsp/watchman/WatchmanProcess.h
+++ b/main/lsp/watchman/WatchmanProcess.h
@@ -35,6 +35,7 @@ private:
     absl::Mutex &messageQueueMutex;
     absl::Notification &initializedNotification;
     const std::shared_ptr<const LSPConfiguration> config;
+    std::string watchmanNamespace;
 
     /**
      * Starts up a Watchman subprocess and begins processing file changes. Runs in a dedicated thread.
@@ -63,7 +64,7 @@ public:
     WatchmanProcess(std::shared_ptr<spdlog::logger> logger, std::string_view watchmanPath, std::string_view workSpace,
                     std::vector<std::string> extensions, MessageQueueState &messageQueue,
                     absl::Mutex &messageQueueMutex, absl::Notification &initializedNotification,
-                    std::shared_ptr<const LSPConfiguration> config);
+                    std::shared_ptr<const LSPConfiguration> config, std::string_view watchmanNamespace);
 
     ~WatchmanProcess();
 

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -530,6 +530,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options(section)("watchman-pause-state-name",
                                  "Name of watchman state that halts processing for its duration",
                                  cxxopts::value<string>()->default_value(empty.watchmanPauseStateName), "<state>");
+    options.add_options(section)("watchman-namespace", "Namespace for watchman",
+                                 cxxopts::value<string>()->default_value(empty.watchmanNamespace), "<namespace>");
     options.add_options(section)(
         "lsp-directories-missing-from-client",
         "Directory prefixes that only exist where the LSP server is running, not on the client. "
@@ -1065,6 +1067,7 @@ void readOptions(Options &opts,
             logger->error("watchman-pause-state-name must be used with watchman enabled");
             throw EarlyReturnWithCode(1);
         }
+        opts.watchmanNamespace = raw["watchman-namespace"].as<string>();
 
         // Certain features only need certain passes
         auto isAutogen =

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -145,6 +145,7 @@ struct Options {
     bool suppressNonCriticalErrors = false;
     bool runLSP = false;
     bool disableWatchman = false;
+    std::string watchmanNamespace;
     std::string watchmanPath = "watchman";
     std::string watchmanPauseStateName;
     bool stressIncrementalResolver = false;

--- a/website/docs/cli-ref.md
+++ b/website/docs/cli-ref.md
@@ -204,6 +204,8 @@ Usage:
       --watchman-pause-state-name <state>
                                 Name of watchman state that halts processing for its
                                 duration (default: "")
+      --watchman-namespace <namespace>
+                                Namespace for watchman (default: "")
       --lsp-directories-missing-from-client <path>
                                 Directory prefixes that only exist where the LSP server
                                 is running, not on the client. Useful when running Sorbet


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Stripe is merging its main repos into a monorepo.  During this merge, the monorepo contains the main repos in "namespaces"; we are not using git submodules, and there is bidirectional syncing between the monorepo and the main repos.

This setup causes problems for watchman; when you ask watchman to watch a project, it follows a [well-defined procedure](https://facebook.github.io/watchman/docs/cmd/watch-project#whats-a-project-path) for where the watch should really be established.  Typically this is where a version control directory lives, but there is also a provision for stopping in a directory where a `.watchmanconfig` file is.

For performance reasons and kernel resource consumption reasons, we would like all watches to be established from the root of the monorepo.  Except that in the monorepo setup, we have this awkward situation where each of the namespaces contains a `.watchmanconfig` file -- since the namespaces are copies of the original repos:

```
<root>
  .watchmanconfig
  .git
  <namespace1>/
    .watchmanconfig
    ...stuff
  <namespace2>/
    .watchmanconfig
    ...stuff
...and so forth
```

Given the current setup, when asking for a watch on e.g. `<namespace1>`, we will get a watch on `<root>/<namespace1>`, rather than `<root>`, which duplicates file watches unnecessarily, etc.

The path that we've chosen is to modify all of our watchman clients to be aware of this namespacing: the clients have to work correctly on a monorepo setup and a non-monorepo setup during the transition period.  So if a client detects that they are operating in the monorepo, their watchman root paths need to be set to the root of the monorepo, rather than the namespaced directory in the monorepo.  And, correspondingly, all their queries need to munge the returned list of files so that it looks like they are properly watching the namespaced directory.

Which is the behavior this PR intends to implement.  Ideally this is a transitional thing only and there will be a PR sometime next year to delete this weird behavior.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Testing on Stripe devboxes, non-monorepo and monorepo versions alike.
