### PR TITLE
Combine printing trees in verify_prism_regression_tests script

### DIFF
--- a/tools/scripts/verify_prism_regression_tests.sh
+++ b/tools/scripts/verify_prism_regression_tests.sh
@@ -15,12 +15,7 @@ for file in test/prism_regression/*.rb; do
 
   # Generate parse tree
   set +e # Disable exit on error for the next command
-  ./bazel-bin/main/sorbet --stop-after=parser --print=parse-tree "$file" > temp_parse_tree.txt 2> /dev/null
-  set -e # Re-enable exit on error
-
-  # Generate desugar tree
-  set +e # Disable exit on error for the next command
-  ./bazel-bin/main/sorbet --stop-after=desugarer --print=desugar-tree-raw "$file" > temp_desugar_tree.txt 2> /dev/null
+  ./bazel-bin/main/sorbet --stop-after=desugarer --print=parse-tree:temp_parse_tree.txt --print=desugar-tree-raw:temp_desugar_tree.txt "$file" 2>/dev/null
   set -e # Re-enable exit on error
 
   parse_tree_match=true
@@ -56,16 +51,16 @@ done
 # Clean up temporary files
 rm temp_parse_tree.txt temp_desugar_tree.txt
 
-if [ ${#mismatched_parse_tree_files[@]:-0} -gt 0 ] || [ ${#mismatched_desugar_tree_files[@]:-0} -gt 0 ]; then
+if [ ${#mismatched_parse_tree_files[@]} -gt 0 ] || [ ${#mismatched_desugar_tree_files[@]} -gt 0 ]; then
   echo ""
   echo "Some of your test files are out of date. Run the following commands to regenerate them:"
   echo ""
 
-  for file in "${mismatched_parse_tree_files[@]+"${mismatched_parse_tree_files[@]}"}"; do
+  for file in "${mismatched_parse_tree_files[@]}"; do
     echo "bazel-bin/main/sorbet --stop-after=parser --print=parse-tree test/prism_regression/${file}.rb > test/prism_regression/${file}.rb.parse-tree.exp"
   done
 
-  for file in "${mismatched_desugar_tree_files[@]+"${mismatched_desugar_tree_files[@]}"}"; do
+  for file in "${mismatched_desugar_tree_files[@]}"; do
     echo "bazel-bin/main/sorbet --stop-after=desugarer --print=desugar-tree-raw test/prism_regression/${file}.rb > test/prism_regression/${file}.rb.desugar-tree-raw.exp"
   done
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This commit combines printing the `parse-tree` and `desugar-tree-raw` into a single sorbet command for the verify_prism_regression_tests script. It also fixes some bash array handling which was working locally but not on our GitHub workflow.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was suggested by @froydnj in #9652 and I needed to fix the array handling issue too. I would have fixed up into that PR but it was merged already (thank you!).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No tests here.
