### PR TITLE
POC: Invert `parser::Send` and `parser::Block`

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -546,15 +546,19 @@ public:
         return UnresolvedConstantParts(loc, {core::Names::Constants::T(), core::Names::Constants::Set()});
     }
 
-    static ExpressionPtr ZSuper(core::LocOffsets loc, core::NameRef method) {
+    static ExpressionPtr ZSuper(core::LocOffsets loc, core::NameRef method, ExpressionPtr block) {
         // A ZSuper call can have a block argument. Don't include it in the location.
         const uint32_t length = "super"sv.size();
         auto superKeywordLoc = core::LocOffsets{loc.beginPos(), loc.beginPos() + length};
 
         Send::Flags flags;
         flags.isPrivateOk = true;
-        return Send(loc, Self(superKeywordLoc.copyWithZeroLength()), method, loc, 1,
-                    SendArgs(make_expression<ast::ZSuperArgs>(superKeywordLoc.copyEndWithZeroLength())), flags);
+        auto send = Send(loc, Self(superKeywordLoc.copyWithZeroLength()), method, loc, 1,
+                         SendArgs(make_expression<ast::ZSuperArgs>(superKeywordLoc.copyEndWithZeroLength())), flags);
+        if (block != nullptr) {
+            cast_tree<ast::Send>(send)->setBlock(std::move(block));
+        }
+        return send;
     }
 
     static ExpressionPtr Magic(core::LocOffsets loc) {

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -185,28 +185,6 @@ void checkBlockRestParam(DesugarContext dctx, const MethodDef::PARAMS_store &arg
 }
 
 ExpressionPtr desugarBlock(DesugarContext dctx, parser::Block *block) {
-    block->send->loc = block->send->loc.join(block->loc);
-    auto recv = node2TreeImpl(dctx, block->send);
-    Send *send;
-    ExpressionPtr res;
-    if ((send = cast_tree<Send>(recv)) != nullptr) {
-        res = move(recv);
-    } else {
-        // This must have been a csend; That will have been desugared
-        // into an insseq with an If in the expression.
-        res = move(recv);
-        auto is = cast_tree<InsSeq>(res);
-        if (!is) {
-            if (auto e = dctx.ctx.beginIndexerError(block->loc, core::errors::Desugar::UnsupportedNode)) {
-                e.setHeader("No body in block");
-            }
-            return MK::EmptyTree();
-        }
-        auto iff = cast_tree<If>(is->expr);
-        ENFORCE(iff != nullptr, "DesugarBlock: failed to find If");
-        send = cast_tree<Send>(iff->elsep);
-        ENFORCE(send != nullptr, "DesugarBlock: failed to find Send");
-    }
     auto [params, destructures] = desugarParams(dctx, block->params.get());
 
     checkBlockRestParam(dctx, params);
@@ -216,9 +194,7 @@ ExpressionPtr desugarBlock(DesugarContext dctx, parser::Block *block) {
                          dctx.enclosingMethodName, inBlock, dctx.inModule, dctx.preserveConcreteSyntax);
     auto desugaredBody = desugarBody(dctx1, block->loc, block->body, move(destructures));
 
-    // TODO the send->block's loc is too big and includes the whole send
-    send->setBlock(MK::Block(block->loc, move(desugaredBody), move(params)));
-    return res;
+    return MK::Block(block->loc, move(desugaredBody), move(params));
 }
 
 ExpressionPtr desugarBegin(DesugarContext dctx, core::LocOffsets loc, parser::NodeVec &stmts) {
@@ -948,6 +924,11 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         result = move(res);
                     }
                 }
+                if (auto sendBlock = parser::cast_node<parser::Block>(send->block.get())) {
+                    if (auto sendResult = cast_tree<ast::Send>(result)) {
+                        sendResult->setBlock(desugarBlock(dctx, sendBlock));
+                    }
+                }
             },
             [&](parser::String *string) {
                 ExpressionPtr res = MK::String(loc, string->val);
@@ -1086,7 +1067,6 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     result = MK::InsSeq(loc, move(updateStmts), MK::Local(loc, acc));
                 }
             },
-            [&](parser::Block *block) { result = desugarBlock(dctx, block); },
             [&](parser::Begin *begin) { result = desugarBegin(dctx, loc, begin->stmts); },
             [&](parser::Assign *asgn) {
                 auto lhs = node2TreeImpl(dctx, asgn->lhs);
@@ -1424,8 +1404,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     // Replace the original method name with a new special one that conveys that this is a CSend, so
                     // that a&.foo is treated as different from a.foo when checking for structural equality.
                     auto newFun = dctx.ctx.state.freshNameUnique(core::UniqueNameKind::DesugarCsend, csend->method, 1);
-                    unique_ptr<parser::Node> sendNode = make_unique<parser::Send>(loc, move(csend->receiver), newFun,
-                                                                                  csend->methodLoc, move(csend->args));
+                    unique_ptr<parser::Node> sendNode = make_unique<parser::Send>(
+                        loc, move(csend->receiver), newFun, csend->methodLoc, move(csend->args), move(csend->block));
                     auto send = node2TreeImpl(dctx, sendNode);
                     result = move(send);
                     return;
@@ -1456,7 +1436,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
 
                 unique_ptr<parser::Node> sendNode =
                     make_unique<parser::Send>(loc, make_unique<parser::LVar>(zeroLengthRecvLoc, tempRecv),
-                                              csend->method, csend->methodLoc, move(csend->args));
+                                              csend->method, csend->methodLoc, move(csend->args), move(csend->block));
                 auto send = node2TreeImpl(dctx, sendNode);
 
                 ExpressionPtr nil =
@@ -1648,8 +1628,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 // Do this by synthesizing a `Send` parse node and letting our
                 // Send desugar handle it.
                 auto method = maybeTypedSuper(dctx);
-                unique_ptr<parser::Node> send =
-                    make_unique<parser::Send>(super->loc, nullptr, method, super->loc, move(super->args));
+                unique_ptr<parser::Node> send = make_unique<parser::Send>(super->loc, nullptr, method, super->loc,
+                                                                          move(super->args), move(super->block));
                 auto res = node2TreeImpl(dctx, send);
                 result = move(res);
             },
@@ -2177,6 +2157,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 }
             },
 
+            [&](parser::Block *block) { Exception::raise("Unexpected bare block!"); },
             [&](parser::BlockPass *blockPass) { Exception::raise("Send should have already handled the BlockPass"); },
             [&](parser::Node *node) {
                 Exception::raise("Unimplemented Parser Node: PrismDesugar: {} (class: {})", node->nodeName(),

--- a/parser/NodeCopying.cc
+++ b/parser/NodeCopying.cc
@@ -47,8 +47,7 @@ std::unique_ptr<Node> deepCopy(const Node *node) {
         [&](const parser::Backref *backref) { result = std::make_unique<Backref>(backref->loc, backref->name); },
         [&](const parser::Begin *begin) { result = std::make_unique<Begin>(begin->loc, deepCopyVec(begin->stmts)); },
         [&](const parser::Block *block) {
-            result = std::make_unique<Block>(block->loc, deepCopy(block->send.get()), deepCopy(block->params.get()),
-                                             deepCopy(block->body.get()));
+            result = std::make_unique<Block>(block->loc, deepCopy(block->params.get()), deepCopy(block->body.get()));
         },
         [&](const parser::BlockParam *blockParam) {
             result = std::make_unique<BlockParam>(blockParam->loc, blockParam->name);
@@ -83,7 +82,7 @@ std::unique_ptr<Node> deepCopy(const Node *node) {
         },
         [&](const parser::CSend *cSend) {
             result = std::make_unique<CSend>(cSend->loc, deepCopy(cSend->receiver.get()), cSend->method,
-                                             cSend->methodLoc, deepCopyVec(cSend->args));
+                                             cSend->methodLoc, deepCopyVec(cSend->args), deepCopy(cSend->block.get()));
         },
         [&](const parser::CVar *cVar) { result = std::make_unique<CVar>(cVar->loc, cVar->name); },
         [&](const parser::CVarLhs *cVarLhs) { result = std::make_unique<CVarLhs>(cVarLhs->loc, cVarLhs->name); },
@@ -299,7 +298,7 @@ std::unique_ptr<Node> deepCopy(const Node *node) {
         [&](const parser::Self *self) { result = std::make_unique<Self>(self->loc); },
         [&](const parser::Send *send) {
             result = std::make_unique<Send>(send->loc, deepCopy(send->receiver.get()), send->method, send->methodLoc,
-                                            deepCopyVec(send->args));
+                                            deepCopyVec(send->args), deepCopy(send->block.get()));
         },
         [&](const parser::Shadowarg *shadowarg) {
             result = std::make_unique<Shadowarg>(shadowarg->loc, shadowarg->name);
@@ -309,7 +308,9 @@ std::unique_ptr<Node> deepCopy(const Node *node) {
             result = std::make_unique<SplatLhs>(splatLhs->loc, deepCopy(splatLhs->var.get()));
         },
         [&](const parser::String *string) { result = std::make_unique<String>(string->loc, string->val); },
-        [&](const parser::Super *super) { result = std::make_unique<Super>(super->loc, deepCopyVec(super->args)); },
+        [&](const parser::Super *super) {
+            result = std::make_unique<Super>(super->loc, deepCopyVec(super->args), deepCopy(super->block.get()));
+        },
         [&](const parser::Symbol *symbol) { result = std::make_unique<Symbol>(symbol->loc, symbol->val); },
         [&](const parser::True *true_) { result = std::make_unique<True>(true_->loc); },
         [&](const parser::Undef *undef) { result = std::make_unique<Undef>(undef->loc, deepCopyVec(undef->exprs)); },
@@ -337,7 +338,9 @@ std::unique_ptr<Node> deepCopy(const Node *node) {
             result = std::make_unique<XString>(xString->loc, deepCopyVec(xString->nodes));
         },
         [&](const parser::Yield *yield) { result = std::make_unique<Yield>(yield->loc, deepCopyVec(yield->exprs)); },
-        [&](const parser::ZSuper *zSuper) { result = std::make_unique<ZSuper>(zSuper->loc); },
+        [&](const parser::ZSuper *zSuper) {
+            result = std::make_unique<ZSuper>(zSuper->loc, deepCopy(zSuper->block.get()));
+        },
         [&](const parser::Node *other) { ENFORCE(false, "Unimplemented node type: {}", other->nodeName()); });
 
     return result;

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -460,7 +460,8 @@ unique_ptr<parser::Node> Translator::translateIndexAssignment(pm_node_t *untyped
 
     unique_ptr<parser::Node> lhs;
     if (!directlyDesugar || !hasExpr(receiver) || !hasExpr(args)) {
-        lhs = make_unique<parser::Send>(lhsLoc, move(receiver), core::Names::squareBrackets(), lBracketLoc, move(args));
+        lhs = make_unique<parser::Send>(lhsLoc, move(receiver), core::Names::squareBrackets(), lBracketLoc, move(args),
+                                        nullptr);
     } else {
         auto receiverExpr = receiver->takeDesugaredExpr();
         auto args2 = nodeVecToStore<ast::Send::ARGS_store>(args);
@@ -469,7 +470,7 @@ unique_ptr<parser::Node> Translator::translateIndexAssignment(pm_node_t *untyped
         auto send =
             MK::Send(lhsLoc, move(receiverExpr), core::Names::squareBrackets(), lBracketLoc, args.size(), move(args2));
         lhs = make_node_with_expr<parser::Send>(move(send), lhsLoc, move(receiver), core::Names::squareBrackets(),
-                                                lBracketLoc, move(args));
+                                                lBracketLoc, move(args), nullptr);
     }
 
     return translateAnyOpAssignment<PrismAssignmentNode, SorbetAssignmentNode, void>(node, location, move(lhs));
@@ -784,7 +785,7 @@ unique_ptr<parser::Node> Translator::translateCSendAssignment(PrismAssignmentNod
                                                               core::LocOffsets messageLoc) {
     if (!directlyDesugar || !hasExpr(receiver)) {
         // Fall back to CSend if we can't desugar directly
-        auto lhs = make_unique<parser::CSend>(location, move(receiver), name, messageLoc, NodeVec{});
+        auto lhs = make_unique<parser::CSend>(location, move(receiver), name, messageLoc, NodeVec{}, nullptr);
         return translateAnyOpAssignment<PrismAssignmentNode, SorbetAssignmentNode, parser::CSend>(callNode, location,
                                                                                                   move(lhs));
     }
@@ -805,7 +806,8 @@ unique_ptr<parser::Node> Translator::translateCSendAssignment(PrismAssignmentNod
                           core::Names::tripleEq(), zeroLengthRecvLoc, MK::Local(zeroLengthRecvLoc, tempRecv));
     auto send =
         MK::Send(location, MK::Local(zeroLengthRecvLoc, tempRecv), name, messageLoc, 0, ast::Send::ARGS_store{});
-    auto tempSend = make_node_with_expr<parser::Send>(move(send), location, nullptr, name, messageLoc, NodeVec{});
+    auto tempSend =
+        make_node_with_expr<parser::Send>(move(send), location, nullptr, name, messageLoc, NodeVec{}, nullptr);
 
     // Recursively handle the assignment operation on the temporary send
     auto assignmentResult = translateAnyOpAssignment<PrismAssignmentNode, SorbetAssignmentNode, parser::Send>(
@@ -818,7 +820,7 @@ unique_ptr<parser::Node> Translator::translateCSendAssignment(PrismAssignmentNod
     auto result = MK::InsSeq1(location, move(tempAssign), move(ifExpr));
 
     // Create a node that directly contains the InsSeq expression for the safe navigation pattern
-    auto lhs = make_node_with_expr<parser::Send>(move(result), location, nullptr, name, messageLoc, NodeVec{});
+    auto lhs = make_node_with_expr<parser::Send>(move(result), location, nullptr, name, messageLoc, NodeVec{}, nullptr);
     return move(lhs);
 }
 
@@ -849,7 +851,7 @@ unique_ptr<parser::Node> Translator::translateSendAssignment(pm_node_t *node, co
 
     // Handle operator assignment to the result of a method call, like `a.b += 1`
     if (!directlyDesugar || !hasExpr(receiver)) {
-        auto lhs = make_unique<parser::Send>(lhsLoc, move(receiver), name, messageLoc, NodeVec{});
+        auto lhs = make_unique<parser::Send>(lhsLoc, move(receiver), name, messageLoc, NodeVec{}, nullptr);
         auto result = translateAnyOpAssignment<PrismAssignmentNode, SorbetAssignmentNode, parser::Send>(
             callNode, location, move(lhs));
         return result;
@@ -860,7 +862,8 @@ unique_ptr<parser::Node> Translator::translateSendAssignment(pm_node_t *node, co
     flags.isPrivateOk = PM_NODE_FLAG_P(node, PM_CALL_NODE_FLAGS_IGNORE_VISIBILITY);
 
     auto send = MK::Send(lhsLoc, move(receiverExpr), name, messageLoc, 0, ast::Send::ARGS_store{}, flags);
-    auto lhs = make_node_with_expr<parser::Send>(move(send), lhsLoc, move(receiver), name, messageLoc, NodeVec{});
+    auto lhs =
+        make_node_with_expr<parser::Send>(move(send), lhsLoc, move(receiver), name, messageLoc, NodeVec{}, nullptr);
 
     return translateAnyOpAssignment<PrismAssignmentNode, SorbetAssignmentNode, parser::Send>(callNode, location,
                                                                                              move(lhs));
@@ -1445,9 +1448,11 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
                 }
 
                 if (PM_NODE_FLAG_P(callNode, PM_CALL_NODE_FLAGS_SAFE_NAVIGATION)) {
-                    sendNode = make_unique<parser::CSend>(sendLoc, move(receiver), name, messageLoc, move(args));
+                    sendNode =
+                        make_unique<parser::CSend>(sendLoc, move(receiver), name, messageLoc, move(args), nullptr);
                 } else {
-                    sendNode = make_unique<parser::Send>(sendLoc, move(receiver), name, messageLoc, move(args));
+                    sendNode =
+                        make_unique<parser::Send>(sendLoc, move(receiver), name, messageLoc, move(args), nullptr);
                 }
 
                 if (prismBlock != nullptr && PM_NODE_TYPE_P(prismBlock, PM_BLOCK_NODE)) {
@@ -1609,7 +1614,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
                         MK::Send(sendWithBlockLoc, MK::Magic(blockPassLoc), core::Names::callWithSplatAndBlockPass(),
                                  messageLoc, numPosArgs, move(magicSendArgs), flags);
                     return make_node_with_expr<parser::Send>(move(sendExpr), sendWithBlockLoc, move(receiver), name,
-                                                             messageLoc, move(args));
+                                                             messageLoc, move(args), nullptr);
                 }
 
                 if (prismBlock != nullptr) {
@@ -1649,7 +1654,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
                 auto sendExpr = MK::Send(sendWithBlockLoc, MK::Magic(sendWithBlockLoc), core::Names::callWithSplat(),
                                          messageLoc, numPosArgs, move(magicSendArgs), flags);
                 auto sendNode = make_node_with_expr<parser::Send>(move(sendExpr), sendWithBlockLoc, move(receiver),
-                                                                  name, messageLoc, move(args));
+                                                                  name, messageLoc, move(args), nullptr);
 
                 if (prismBlock != nullptr && PM_NODE_TYPE_P(prismBlock, PM_BLOCK_NODE)) {
                     // In Prism, this is modeled by a `pm_call_node` with a `pm_block_node` as a child,
@@ -1659,7 +1664,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
                     //       It just puts them at the end of the arguments list,
                     //       which is why we checked for `PM_BLOCK_NODE` specifically here.
 
-                    return make_node_with_expr<parser::Block>(sendNode->takeDesugaredExpr(), blockLoc, move(sendNode),
+                    return make_node_with_expr<parser::Block>(sendNode->takeDesugaredExpr(), blockLoc,
                                                               move(blockParameters), move(blockBody));
                 }
 
@@ -1710,7 +1715,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
                                          messageLoc, numPosArgs, move(magicSendArgs), flags);
 
                 return make_node_with_expr<parser::Send>(move(sendExpr), sendWithBlockLoc, move(receiver), name,
-                                                         messageLoc, move(args));
+                                                         messageLoc, move(args), nullptr);
             }
 
             ast::Send::ARGS_store sendArgs{};
@@ -1762,8 +1767,8 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
             auto expr =
                 MK::Send(sendWithBlockLoc, move(receiverExpr), name, messageLoc, numPosArgs, move(sendArgs), flags);
 
-            sendNode =
-                make_node_with_expr<parser::Send>(move(expr), sendLoc, move(receiver), name, messageLoc, move(args));
+            sendNode = make_node_with_expr<parser::Send>(move(expr), sendLoc, move(receiver), name, messageLoc,
+                                                         move(args), nullptr);
 
             if (prismBlock != nullptr && PM_NODE_TYPE_P(prismBlock, PM_BLOCK_NODE)) {
                 // In Prism, this is modeled by a `pm_call_node` with a `pm_block_node` as a child,
@@ -1773,7 +1778,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
                 //       It just puts them at the end of the arguments list,
                 //       which is why we checked for `PM_BLOCK_NODE` specifically here.
 
-                return make_node_with_expr<parser::Block>(sendNode->takeDesugaredExpr(), blockLoc, move(sendNode),
+                return make_node_with_expr<parser::Block>(sendNode->takeDesugaredExpr(), blockLoc,
                                                           move(blockParameters), move(blockBody));
             }
 
@@ -1796,9 +1801,9 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
             if (PM_NODE_FLAG_P(callTargetNode, PM_CALL_NODE_FLAGS_SAFE_NAVIGATION)) {
                 // Handle conditional send, e.g. `self&.target1, self&.target2 = 1, 2`
                 // It's not valid Ruby, but the parser needs to support it for the diagnostics to work
-                return make_unique<parser::CSend>(location, move(receiver), name, messageLoc, NodeVec{});
+                return make_unique<parser::CSend>(location, move(receiver), name, messageLoc, NodeVec{}, nullptr);
             } else { // Regular send, e.g. `self.target1, self.target2 = 1, 2`
-                return make_unique<parser::Send>(location, move(receiver), name, messageLoc, NodeVec{});
+                return make_unique<parser::Send>(location, move(receiver), name, messageLoc, NodeVec{}, nullptr);
             }
         }
         case PM_CASE_MATCH_NODE: { // A pattern-matching `case` statement that only uses `in` (and not `when`)
@@ -2463,8 +2468,10 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
             constexpr uint32_t length = "super"sv.size();
             auto keywordLoc = translateLoc(node->location.start, node->location.start + length);
 
-            auto expr = MK::ZSuper(location, maybeTypedSuper());
-            auto translatedNode = make_node_with_expr<parser::ZSuper>(move(expr), keywordLoc);
+            // TODO(jez) Basically all the nullptr that I have added here are just to silence the
+            // compiler errors because I can't be bothered to deal with prism rn.
+            auto expr = MK::ZSuper(location, maybeTypedSuper(), nullptr);
+            auto translatedNode = make_node_with_expr<parser::ZSuper>(move(expr), keywordLoc, nullptr);
 
             auto blockArgumentNode = forwardingSuperNode->block;
 
@@ -2573,7 +2580,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
 
                 return make_node_with_expr<parser::Send>(move(unarySend), location, move(complexNode), unaryOp,
                                                          core::LocOffsets{location.beginLoc, location.beginLoc + 1},
-                                                         NodeVec{});
+                                                         NodeVec{}, nullptr);
             }
 
             // No leading sign; return the Complex node directly
@@ -2610,7 +2617,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
 
             if (!directlyDesugar || !hasExpr(receiver, arguments)) {
                 return make_unique<parser::Send>(location, move(receiver), core::Names::squareBracketsEq(), lBracketLoc,
-                                                 move(arguments));
+                                                 move(arguments), nullptr);
             }
 
             // Build the arguments for the Send expression
@@ -2623,7 +2630,8 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
             auto expr = MK::Send(location, receiver->takeDesugaredExpr(), core::Names::squareBracketsEq(), lBracketLoc,
                                  argExprs.size(), move(argExprs));
             return make_node_with_expr<parser::Send>(move(expr), location, move(receiver),
-                                                     core::Names::squareBracketsEq(), lBracketLoc, move(arguments));
+                                                     core::Names::squareBracketsEq(), lBracketLoc, move(arguments),
+                                                     nullptr);
         }
         case PM_INSTANCE_VARIABLE_AND_WRITE_NODE: { // And-assignment to an instance variable, e.g. `@iv &&= false`
             return translateVariableAssignment<pm_instance_variable_and_write_node, parser::AndAsgn, parser::IVarLhs>(
@@ -2847,7 +2855,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
 
             auto receiver = make_unique<parser::Const>(location, nullptr, core::Names::Constants::Kernel());
             auto sendNode = make_unique<parser::Send>(location, move(receiver), core::Names::lambda(),
-                                                      translateLoc(lambdaNode->operator_loc), NodeVec{});
+                                                      translateLoc(lambdaNode->operator_loc), NodeVec{}, nullptr);
 
             return translateCallWithBlock(node, move(sendNode));
         }
@@ -3386,12 +3394,12 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveCon
 
             if (blockArgumentNode != nullptr && PM_NODE_TYPE_P(blockArgumentNode, PM_BLOCK_NODE)) {
                 returnValues = translateArguments(superNode->arguments);
-                auto superNode = make_unique<parser::Super>(location, move(returnValues));
+                auto superNode = make_unique<parser::Super>(location, move(returnValues), nullptr);
                 return translateCallWithBlock(blockArgumentNode, move(superNode));
             }
 
             returnValues = translateArguments(superNode->arguments, blockArgumentNode);
-            return make_unique<parser::Super>(location, move(returnValues));
+            return make_unique<parser::Super>(location, move(returnValues), nullptr);
         }
         case PM_SYMBOL_NODE: { // A symbol literal, e.g. `:foo`, or `a:` in `{a: 1}`
             auto symNode = down_cast<pm_symbol_node>(node);
@@ -4741,7 +4749,7 @@ unique_ptr<parser::Node> Translator::translateCallWithBlock(pm_node_t *prismBloc
         }
     }
 
-    return make_unique<parser::Block>(blockLoc, move(sendNode), move(parametersNode), move(body));
+    return make_unique<parser::Block>(blockLoc, move(parametersNode), move(body));
 }
 
 // Prism represents a `begin ... rescue ... end` construct using a `pm_begin_node` that may contain:

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -88,12 +88,10 @@ NodeDef nodes[] = {
         "begin",
         vector<FieldDef>({{"stmts", FieldType::NodeVec}}),
     },
-    // A method call with a blockis modelled as a Send node with a Block as a parent.
-    // The `send` is always a `parser::Send` node, and the `params` models the parameters of the block.
     {
         "Block",
         "block",
-        vector<FieldDef>({{"send", FieldType::Node}, {"params", FieldType::Node}, {"body", FieldType::Node}}),
+        vector<FieldDef>({{"params", FieldType::Node}, {"body", FieldType::Node}}),
     },
     // Wraps a `&foo` parameter in a parameter list
     {
@@ -168,10 +166,13 @@ NodeDef nodes[] = {
     {
         "CSend",
         "csend",
-        vector<FieldDef>({{"receiver", FieldType::Node},
-                          {"method", FieldType::Name},
-                          {"methodLoc", FieldType::Loc},
-                          {"args", FieldType::NodeVec}}),
+        vector<FieldDef>({
+            {"receiver", FieldType::Node},
+            {"method", FieldType::Name},
+            {"methodLoc", FieldType::Loc},
+            {"args", FieldType::NodeVec},
+            {"block", FieldType::Node},
+        }),
     },
     // @@foo class variable
     {
@@ -691,10 +692,13 @@ NodeDef nodes[] = {
     {
         "Send",
         "send",
-        vector<FieldDef>({{"receiver", FieldType::Node},
-                          {"method", FieldType::Name},
-                          {"methodLoc", FieldType::Loc},
-                          {"args", FieldType::NodeVec}}),
+        vector<FieldDef>({
+            {"receiver", FieldType::Node},
+            {"method", FieldType::Name},
+            {"methodLoc", FieldType::Loc},
+            {"args", FieldType::NodeVec},
+            {"block", FieldType::Node},
+        }),
     },
     // m { |;shadowarg| }
     {
@@ -722,7 +726,7 @@ NodeDef nodes[] = {
     {
         "Super",
         "super",
-        vector<FieldDef>({{"args", FieldType::NodeVec}}),
+        vector<FieldDef>({{"args", FieldType::NodeVec}, {"block", FieldType::Node}}),
     },
     // symbol literal
     {
@@ -787,7 +791,7 @@ NodeDef nodes[] = {
     {
         "ZSuper",
         "zsuper",
-        vector<FieldDef>(),
+        vector<FieldDef>({{"block", FieldType::Node}}),
     },
 };
 

--- a/rbs/AssertionsRewriter.h
+++ b/rbs/AssertionsRewriter.h
@@ -44,7 +44,7 @@ private:
     parser::NodeVec rewriteNodesAsArray(const std::unique_ptr<parser::Node> &node, parser::NodeVec nodes);
     void rewriteNodes(parser::NodeVec *nodes);
 
-    bool saveTypeParams(parser::Block *block);
+    bool saveTypeParams(parser::Send *send);
     std::unique_ptr<parser::Node> maybeInsertCast(std::unique_ptr<parser::Node> node);
     std::unique_ptr<parser::Node> replaceSyntheticBind(std::unique_ptr<parser::Node> node);
     std::unique_ptr<parser::Node>

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -393,9 +393,8 @@ void CommentsAssociator::walkNode(parser::Node *node) {
             consumeCommentsInsideNode(node, "begin");
         },
         [&](parser::Block *block) {
-            auto beginLine = core::Loc::pos2Detail(ctx.file.data(ctx), block->send->loc.beginPos()).line;
+            auto beginLine = core::Loc::pos2Detail(ctx.file.data(ctx), block->loc.beginPos()).line;
             associateAssertionCommentsToNode(node);
-            walkNode(block->send.get());
             consumeCommentsUntilLine(beginLine);
             block->body = walkBody(block, move(block->body));
             auto endLine = core::Loc::pos2Detail(ctx.file.data(ctx), node->loc.endPos()).line;
@@ -448,6 +447,7 @@ void CommentsAssociator::walkNode(parser::Node *node) {
             associateAssertionCommentsToNode(node);
             walkNode(csend->receiver.get());
             walkNodes(csend->args);
+            walkNode(csend->block.get());
             consumeCommentsInsideNode(node, "csend");
         },
         [&](parser::DefMethod *def) {
@@ -622,6 +622,7 @@ void CommentsAssociator::walkNode(parser::Node *node) {
                 associateAssertionCommentsToNode(send);
                 walkNode(send->receiver.get());
                 walkNodes(send->args);
+                walkNode(send->block.get());
                 consumeCommentsInsideNode(send, "send");
             } else if (send->method == core::Names::squareBracketsEq() || send->method.isSetter(ctx.state)) {
                 // This is an assign through a send, either: `foo[key]=(y)` or `foo.x=(y)`
@@ -651,6 +652,8 @@ void CommentsAssociator::walkNode(parser::Node *node) {
         [&](parser::Super *super_) {
             associateAssertionCommentsToNode(node);
             walkNodes(super_->args);
+            walkNode(super_->block.get());
+            walkNode(super_->block.get());
             consumeCommentsInsideNode(node, "super");
         },
         [&](parser::Until *until) {

--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -152,7 +152,7 @@ unique_ptr<parser::Node> handleAnnotations(core::MutableContext ctx, const parse
             auto args = NodeVec1(move(hash));
 
             sigBuilder = parser::MK::Send(annotation.typeLoc, move(sigBuilder), core::Names::override_(),
-                                          annotation.typeLoc, move(args));
+                                          annotation.typeLoc, move(args), nullptr);
         } else if (annotation.string == "override(allow_incompatible: :visibility)") {
             auto key = parser::MK::Symbol(annotation.typeLoc, core::Names::allowIncompatible());
             auto value = parser::MK::Symbol(annotation.typeLoc, core::Names::visibility());
@@ -162,7 +162,7 @@ unique_ptr<parser::Node> handleAnnotations(core::MutableContext ctx, const parse
             auto args = NodeVec1(move(hash));
 
             sigBuilder = parser::MK::Send(annotation.typeLoc, move(sigBuilder), core::Names::override_(),
-                                          annotation.typeLoc, move(args));
+                                          annotation.typeLoc, move(args), nullptr);
         }
     }
 
@@ -523,13 +523,14 @@ unique_ptr<parser::Node> MethodTypeToParserNode::methodSignature(const parser::N
             typeParamsVector.emplace_back(parser::MK::Symbol(param.first, param.second));
         }
         sigBuilder = parser::MK::Send(fullTypeLoc, move(sigBuilder), core::Names::typeParameters(), fullTypeLoc,
-                                      move(typeParamsVector));
+                                      move(typeParamsVector), nullptr);
     }
 
     if (sigParams.size() > 0) {
         auto hash = parser::MK::Hash(fullTypeLoc, true, move(sigParams));
         auto args = NodeVec1(move(hash));
-        sigBuilder = parser::MK::Send(fullTypeLoc, move(sigBuilder), core::Names::params(), fullTypeLoc, move(args));
+        sigBuilder =
+            parser::MK::Send(fullTypeLoc, move(sigBuilder), core::Names::params(), fullTypeLoc, move(args), nullptr);
     }
 
     rbs_node_t *returnValue = functionType->return_type;
@@ -550,10 +551,9 @@ unique_ptr<parser::Node> MethodTypeToParserNode::methodSignature(const parser::N
         sigArgs.emplace_back(parser::MK::Symbol(final->typeLoc, core::Names::final_()));
     }
 
-    auto sig = parser::MK::Send(fullTypeLoc, parser::MK::T_Sig_WithoutRuntime(firstLineTypeLoc), core::Names::sig(),
-                                firstLineTypeLoc, move(sigArgs));
-
-    return make_unique<parser::Block>(commentLoc, move(sig), nullptr, move(sigBuilder));
+    return parser::MK::Send(fullTypeLoc, parser::MK::T_Sig_WithoutRuntime(firstLineTypeLoc), core::Names::sig(),
+                            firstLineTypeLoc, move(sigArgs),
+                            make_unique<parser::Block>(commentLoc, nullptr, move(sigBuilder)));
 }
 
 unique_ptr<parser::Node> MethodTypeToParserNode::attrSignature(const parser::Send *send, const rbs_node_t *type,
@@ -601,7 +601,8 @@ unique_ptr<parser::Node> MethodTypeToParserNode::attrSignature(const parser::Sen
             make_unique<parser::Pair>(argLoc, parser::MK::Symbol(argLoc, argName), returnType->deepCopy()));
         auto hash = parser::MK::Hash(send->loc, true, move(pairs));
         auto sigArgs = parser::NodeVec1(move(hash));
-        sigBuilder = parser::MK::Send(send->loc, move(sigBuilder), core::Names::params(), send->loc, move(sigArgs));
+        sigBuilder =
+            parser::MK::Send(send->loc, move(sigBuilder), core::Names::params(), send->loc, move(sigArgs), nullptr);
     }
 
     sigBuilder =
@@ -614,10 +615,9 @@ unique_ptr<parser::Node> MethodTypeToParserNode::attrSignature(const parser::Sen
         sigArgs.emplace_back(parser::MK::Symbol(final->typeLoc, core::Names::final_()));
     }
 
-    auto sig = parser::MK::Send(fullTypeLoc, parser::MK::T_Sig_WithoutRuntime(firstLineTypeLoc), core::Names::sig(),
-                                firstLineTypeLoc, move(sigArgs));
-
-    return make_unique<parser::Block>(commentLoc, move(sig), nullptr, move(sigBuilder));
+    return parser::MK::Send(fullTypeLoc, parser::MK::T_Sig_WithoutRuntime(firstLineTypeLoc), core::Names::sig(),
+                            firstLineTypeLoc, move(sigArgs),
+                            make_unique<parser::Block>(commentLoc, nullptr, move(sigBuilder)));
 }
 
 } // namespace sorbet::rbs

--- a/rbs/SigsRewriter.cc
+++ b/rbs/SigsRewriter.cc
@@ -93,8 +93,9 @@ parser::NodeVec extractHelpers(core::MutableContext ctx, vector<Comment> annotat
                 auto body = make_unique<parser::Begin>(annotation.typeLoc, NodeVec1(move(type)));
                 auto send = parser::MK::Send0(annotation.typeLoc, parser::MK::Self(annotation.typeLoc),
                                               core::Names::requiresAncestor(), annotation.typeLoc);
-                auto block = make_unique<parser::Block>(annotation.typeLoc, move(send), nullptr, move(body));
-                helpers.emplace_back(move(block));
+                parser::cast_node<parser::Send>(send.get())->block =
+                    make_unique<parser::Block>(annotation.typeLoc, nullptr, move(body));
+                helpers.emplace_back(move(send));
             }
         }
     }

--- a/rbs/TypeParamsToParserNodes.cc
+++ b/rbs/TypeParamsToParserNodes.cc
@@ -42,8 +42,7 @@ parser::NodeVec TypeParamsToParserNode::typeParams(const rbs_node_list_t *rbsTyp
         }
 
         auto typeConst = parser::MK::Const(loc, nullptr, nameConstant);
-        auto typeSend =
-            parser::MK::Send(loc, parser::MK::SorbetPrivateStatic(loc), core::Names::typeMember(), loc, move(args));
+        unique_ptr<parser::Node> block;
 
         auto defaultType = rbsTypeParam->default_type;
         auto upperBound = rbsTypeParam->upper_bound;
@@ -69,8 +68,11 @@ parser::NodeVec TypeParamsToParserNode::typeParams(const rbs_node_list_t *rbsTyp
             }
 
             auto body = parser::MK::Hash(loc, false, move(pairs));
-            typeSend = make_unique<parser::Block>(loc, move(typeSend), nullptr, move(body));
+            block = make_unique<parser::Block>(loc, nullptr, move(body));
         }
+
+        auto typeSend = parser::MK::Send(loc, parser::MK::SorbetPrivateStatic(loc), core::Names::typeMember(), loc,
+                                         move(args), move(block));
 
         auto assign = make_unique<parser::Assign>(loc, move(typeConst), move(typeSend));
         result.emplace_back(move(assign));

--- a/rbs/TypeToParserNode.cc
+++ b/rbs/TypeToParserNode.cc
@@ -125,7 +125,8 @@ unique_ptr<parser::Node> TypeToParserNode::classInstanceType(const rbs_types_cla
             args.emplace_back(move(argType));
         }
 
-        return parser::MK::Send(loc, move(typeConstant), core::Names::syntheticSquareBrackets(), loc, move(args));
+        return parser::MK::Send(loc, move(typeConstant), core::Names::syntheticSquareBrackets(), loc, move(args),
+                                nullptr);
     }
 
     return typeConstant;


### PR DESCRIPTION
TODO

- Fill out Translator.cc
- Write the code to preserve how the trees are printed in `parse-tree`
  and `parse-tree-whitequark` output
- Test


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.