### PR TITLE
Fix kwnil handling in Prism parser mode

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -133,6 +133,7 @@ prism_location_test_suite(
         exclude = [
             "prism_regression/error_recovery/assign.rb",
             "prism_regression/lambda.rb",
+            "prism_regression/call_kw_nil_args.rb",
         ],
     ),
 )

--- a/test/prism_regression/call_kw_nil_args.rb
+++ b/test/prism_regression/call_kw_nil_args.rb
@@ -1,0 +1,7 @@
+# typed: false
+
+def f1(**nil, **nil); end # error: unexpected token ","
+def f2(*args, **kwargs, **nil); end # error: unexpected token ","
+def f3(*args, a:, **nil); end # error: unexpected token "nil"
+def f4(a:, **nil); end # error: unexpected token "nil"
+def f5(**nil: 10); end # error: unexpected token tLABEL

--- a/test/prism_regression/call_kw_nil_args.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_kw_nil_args.rb.desugar-tree-raw.exp
@@ -1,0 +1,87 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    MethodDef{
+      flags = {}
+      name = <U f1><<U <todo method>>>
+      params = [BlockParam{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U <blk>>
+        } }]
+      rhs = EmptyTree
+    }
+
+    MethodDef{
+      flags = {}
+      name = <U f2><<U <todo method>>>
+      params = [RestParam{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U args>
+        } }, RestParam{ expr = KeywordArg{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U kwargs>
+        } } }, BlockParam{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U <blk>>
+        } }]
+      rhs = EmptyTree
+    }
+
+    MethodDef{
+      flags = {}
+      name = <U f3><<U <todo method>>>
+      params = [RestParam{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U args>
+        } }, KeywordArg{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U a>
+        } }, BlockParam{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U <blk>>
+        } }]
+      rhs = EmptyTree
+    }
+
+    MethodDef{
+      flags = {}
+      name = <U f4><<U <todo method>>>
+      params = [KeywordArg{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U a>
+        } }, BlockParam{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U <blk>>
+        } }]
+      rhs = EmptyTree
+    }
+
+    MethodDef{
+      flags = {}
+      name = <U f5><<U <todo method>>>
+      params = [BlockParam{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U <blk>>
+        } }]
+      rhs = InsSeq{
+        stats = [
+          UnresolvedConstantLit{
+            cnst = <C <U <ErrorNode>>>
+            scope = EmptyTree
+          }
+          Literal{ value = 10 }
+        ],
+        expr = UnresolvedConstantLit{
+          cnst = <C <U <ErrorNode>>>
+          scope = EmptyTree
+        }
+      }
+    }
+  ]
+}

--- a/test/prism_regression/call_kw_nil_args.rb.parse-tree.exp
+++ b/test/prism_regression/call_kw_nil_args.rb.parse-tree.exp
@@ -1,0 +1,81 @@
+Begin {
+  stmts = [
+    DefMethod {
+      name = <U f1>
+      params = Params {
+        params = [
+          Kwnilarg {
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U f2>
+      params = Params {
+        params = [
+          RestParam {
+            name = <U args>
+          }
+          Kwrestarg {
+            name = <U kwargs>
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U f3>
+      params = Params {
+        params = [
+          RestParam {
+            name = <U args>
+          }
+          Kwarg {
+            name = <U a>
+          }
+          Kwnilarg {
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U f4>
+      params = Params {
+        params = [
+          Kwarg {
+            name = <U a>
+          }
+          Kwnilarg {
+          }
+        ]
+      }
+      body = NULL
+    }
+    DefMethod {
+      name = <U f5>
+      params = Params {
+        params = [
+          Kwnilarg {
+          }
+        ]
+      }
+      body = Begin {
+        stmts = [
+          Const {
+            scope = NULL
+            name = <C <U <ErrorNode>>>
+          }
+          Integer {
+            val = "10"
+          }
+          Const {
+            scope = NULL
+            name = <C <U <ErrorNode>>>
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/scripts/verify_prism_regression_tests.sh
+++ b/tools/scripts/verify_prism_regression_tests.sh
@@ -6,12 +6,20 @@ echo "Building Sorbet..."
 
 echo "Verifying parse trees and desugar trees..."
 
+# Files to skip (known behavior mismatches)
+skip_files=("call_kw_nil_args")
+
 mismatched_parse_tree_files=()
 mismatched_desugar_tree_files=()
 
 # Iterate through Ruby files in test/prism_regression
 for file in test/prism_regression/*.rb; do
   file_name=$(basename "$file" .rb)
+
+  if [[ " ${skip_files[@]} " =~ " ${file_name} " ]]; then
+    echo "⏭️  ${file_name}.rb (skipped)"
+    continue
+  fi
 
   # Generate parse tree
   set +e # Disable exit on error for the next command


### PR DESCRIPTION
Part of https://github.com/sorbet/sorbet/issues/9065.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This commit adds handling for `**nil` post parameters for the Prism parser mode. The original parser recognizes this as invalid Ruby and removes the entire def node. We can do slightly better with Prism and still return the method definition, throwing away only the invalid post parameter.

```ruby
def foo(**nil, **nil)
end
```

     @ ParametersNode (location: (3,8)-(3,20))
     ├── flags: ∅
     ├── requireds: (length: 0)
     ├── optionals: (length: 0)
     ├── rest: ∅
     ├── posts: (length: 1)
     │   └── @ NoKeywordsParameterNode (location: (3,15)-(3,20))
     │       ├── flags: ∅
     │       ├── operator_loc: (3,15)-(3,17) = "**"
     │       └── keyword_loc: (3,17)-(3,20) = "nil"
     ├── keywords: (length: 0)
     ├── keyword_rest:
     │   @ NoKeywordsParameterNode (location: (3,8)-(3,13))
     │   ├── flags: ∅
     │   ├── operator_loc: (3,8)-(3,10) = "**"
     │   └── keyword_loc: (3,10)-(3,13) = "nil"
     └── block: ∅

Original desugar tree:

     class <emptyTree><<C <root>>> < (::<todo sym>)
       nil
     end

Prism desugar tree:

     class <emptyTree><<C <root>>> < (::<todo sym>)
       def foo<<todo method>>(&<blk>)
         <emptyTree>
       end
     end

The implementation is quite straightforward: we just skip the `NoKeywordsParameterNode` in the posts list. This means we throw away bare minimum invalid nodes, leaving the rest of the method definition intact.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Running the fuzzer with Prism parser crashes on [this file](https://github.com/sorbet/sorbet/blob/0758aa11e0c6d63565882cde6b403e501c2cc028/test/testdata/parser/kwnil_errors.rb) due to the invalid syntax `def f1(**nil, **nil); end`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Add a test to `prism_regression` but since the behavior is different from the original parser, I updated the `verify_prism_regression_tests.sh` script to skip it. I'm not sure what the preferred approach is when there is a legitimate parse/desugar difference between the original parser and Prism.
