### PR TITLE
Add RBS support for `T::Module[]`

### DIFF
--- a/parser/helper.h
+++ b/parser/helper.h
@@ -192,6 +192,13 @@ public:
     }
 
     /*
+     * Create a `T::Module` constant node.
+     */
+    static std::unique_ptr<parser::Node> T_Module(core::LocOffsets loc) {
+        return Const(loc, T(loc), core::Names::Constants::Module());
+    }
+
+    /*
      * Create a `T::Set` constant node.
      */
     static std::unique_ptr<parser::Node> T_Set(core::LocOffsets loc) {

--- a/rbs/TypeToParserNode.cc
+++ b/rbs/TypeToParserNode.cc
@@ -73,6 +73,8 @@ unique_ptr<parser::Node> TypeToParserNode::typeNameType(const rbs_type_name_t *t
                 return parser::MK::T_Array(loc);
             } else if (nameConstant == core::Names::Constants::Class()) {
                 return parser::MK::T_Class(loc);
+            } else if (nameConstant == core::Names::Constants::Module()) {
+                return parser::MK::T_Module(loc);
             } else if (nameConstant == core::Names::Constants::Enumerable()) {
                 return parser::MK::T_Enumerable(loc);
             } else if (nameConstant == core::Names::Constants::Enumerator()) {

--- a/test/testdata/rbs/signatures_types.rb
+++ b/test/testdata/rbs/signatures_types.rb
@@ -123,6 +123,16 @@ T.reveal_type(generic_type_array) # error: Revealed type: `T::Array[Integer]`
 def generic_type_array_root; T.unsafe(nil); end
 T.reveal_type(generic_type_array_root) # error: Revealed type: `T::Array[Integer]`
 
+#: -> Class
+#     ^^^^^ error: Malformed type declaration. Generic class without type arguments `Class`
+def non_generic_type_class; T.unsafe(nil); end
+T.reveal_type(non_generic_type_class) # error: Revealed type: `T::Class[T.anything]`
+
+#: -> ::Class
+#     ^^^^^^^ error: Malformed type declaration. Generic class without type arguments `Class`
+def non_generic_type_class_root; T.unsafe(nil); end
+T.reveal_type(non_generic_type_class_root) # error: Revealed type: `T::Class[T.anything]`
+
 #: -> Class[Integer]
 def generic_type_class; T.unsafe(nil); end
 T.reveal_type(generic_type_class) # error: Revealed type: `T::Class[Integer]`
@@ -130,6 +140,24 @@ T.reveal_type(generic_type_class) # error: Revealed type: `T::Class[Integer]`
 #: -> ::Class[Integer]
 def generic_type_class_root; T.unsafe(nil); end
 T.reveal_type(generic_type_class_root) # error: Revealed type: `T::Class[Integer]`
+
+#: -> Module
+#     ^^^^^^ error: Malformed type declaration. Generic class without type arguments `Module`
+def non_generic_type_module; T.unsafe(nil); end
+T.reveal_type(non_generic_type_module) # error: Revealed type: `T::Module[T.anything]`
+
+#: -> ::Module
+#     ^^^^^^^^ error: Malformed type declaration. Generic class without type arguments `Module`
+def non_generic_type_module_root; T.unsafe(nil); end
+T.reveal_type(non_generic_type_module_root) # error: Revealed type: `T::Module[T.anything]`
+
+#: -> Module[Integer]
+def generic_type_module; T.unsafe(nil); end
+T.reveal_type(generic_type_module) # error: Revealed type: `T::Module[Integer]`
+
+#: -> ::Module[Integer]
+def generic_type_module_root; T.unsafe(nil); end
+T.reveal_type(generic_type_module_root) # error: Revealed type: `T::Module[Integer]`
 
 #: -> Enumerable[Integer]
 def generic_type_enumerable; T.unsafe(nil); end

--- a/test/testdata/rbs/signatures_types.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_types.rb.rewrite-tree.exp
@@ -176,6 +176,22 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.returns(<emptyTree>::<C Class>)
+  end
+
+  def non_generic_type_class<<todo method>>(&<blk>)
+    <emptyTree>::<C T>.unsafe(nil)
+  end
+
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.returns(::<root>::<C Class>)
+  end
+
+  def non_generic_type_class_root<<todo method>>(&<blk>)
+    <emptyTree>::<C T>.unsafe(nil)
+  end
+
+  ::T::Sig::WithoutRuntime.sig() do ||
     <self>.returns(::<root>::<C T>::<C Class>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
   end
 
@@ -188,6 +204,38 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   def generic_type_class_root<<todo method>>(&<blk>)
+    <emptyTree>::<C T>.unsafe(nil)
+  end
+
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.returns(<emptyTree>::<C Module>)
+  end
+
+  def non_generic_type_module<<todo method>>(&<blk>)
+    <emptyTree>::<C T>.unsafe(nil)
+  end
+
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.returns(::<root>::<C Module>)
+  end
+
+  def non_generic_type_module_root<<todo method>>(&<blk>)
+    <emptyTree>::<C T>.unsafe(nil)
+  end
+
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.returns(::<root>::<C T>::<C Module>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
+  end
+
+  def generic_type_module<<todo method>>(&<blk>)
+    <emptyTree>::<C T>.unsafe(nil)
+  end
+
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.returns(::<root>::<C T>::<C Module>.<syntheticSquareBrackets>(<emptyTree>::<C Integer>))
+  end
+
+  def generic_type_module_root<<todo method>>(&<blk>)
     <emptyTree>::<C T>.unsafe(nil)
   end
 
@@ -571,6 +619,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   <emptyTree>::<C T>.reveal_type(<self>.generic_type_array_root())
 
+  <runtime method definition of non_generic_type_class>
+
+  <emptyTree>::<C T>.reveal_type(<self>.non_generic_type_class())
+
+  <runtime method definition of non_generic_type_class_root>
+
+  <emptyTree>::<C T>.reveal_type(<self>.non_generic_type_class_root())
+
   <runtime method definition of generic_type_class>
 
   <emptyTree>::<C T>.reveal_type(<self>.generic_type_class())
@@ -578,6 +634,22 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <runtime method definition of generic_type_class_root>
 
   <emptyTree>::<C T>.reveal_type(<self>.generic_type_class_root())
+
+  <runtime method definition of non_generic_type_module>
+
+  <emptyTree>::<C T>.reveal_type(<self>.non_generic_type_module())
+
+  <runtime method definition of non_generic_type_module_root>
+
+  <emptyTree>::<C T>.reveal_type(<self>.non_generic_type_module_root())
+
+  <runtime method definition of generic_type_module>
+
+  <emptyTree>::<C T>.reveal_type(<self>.generic_type_module())
+
+  <runtime method definition of generic_type_module_root>
+
+  <emptyTree>::<C T>.reveal_type(<self>.generic_type_module_root())
 
   <runtime method definition of generic_type_enumerable>
 


### PR DESCRIPTION
### Motivation

Translate generic `Module` types to `T::Module`:

```rb
#: -> Module[Foo]
def foo; T.unsafe(nil); end
```

is equivalent to:

```rb
sig { returns(T::Module[Foo]) }
def foo; T.unsafe(nil); end
```

In the same way we rewrite `Class[Foo]` as `T::Class[Foo]`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
