### PR TITLE
Fix double block parameter in Prism parser mode

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -134,6 +134,7 @@ prism_location_test_suite(
             "prism_regression/error_recovery/assign.rb",
             "prism_regression/lambda.rb",
             "prism_regression/call_kw_nil_args.rb",
+            "prism_regression/call_block_param_and_forwarding.rb",
         ],
     ),
 )

--- a/test/prism_regression/call_block_param_and_forwarding.rb
+++ b/test/prism_regression/call_block_param_and_forwarding.rb
@@ -1,0 +1,3 @@
+# typed: false
+
+def foo(&, ...); end

--- a/test/prism_regression/call_block_param_and_forwarding.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_block_param_and_forwarding.rb.desugar-tree-raw.exp
@@ -1,0 +1,26 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    MethodDef{
+      flags = {}
+      name = <U foo><<U <todo method>>>
+      params = [RestParam{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U <fwd-args>>
+        } }, RestParam{ expr = KeywordArg{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U <fwd-kwargs>>
+        } } }, BlockParam{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U <fwd-block>>
+        } }]
+      rhs = EmptyTree
+    }
+  ]
+}

--- a/test/prism_regression/call_block_param_and_forwarding.rb.parse-tree.exp
+++ b/test/prism_regression/call_block_param_and_forwarding.rb.parse-tree.exp
@@ -1,0 +1,10 @@
+DefMethod {
+  name = <U foo>
+  params = Params {
+    params = [
+      ForwardArg {
+      }
+    ]
+  }
+  body = NULL
+}

--- a/tools/scripts/verify_prism_regression_tests.sh
+++ b/tools/scripts/verify_prism_regression_tests.sh
@@ -7,7 +7,10 @@ echo "Building Sorbet..."
 echo "Verifying parse trees and desugar trees..."
 
 # Files to skip (known behavior mismatches)
-skip_files=("call_kw_nil_args")
+skip_files=(
+  "call_kw_nil_args"
+  "call_block_param_and_forwarding"
+)
 
 mismatched_parse_tree_files=()
 mismatched_desugar_tree_files=()


### PR DESCRIPTION
Part of https://github.com/sorbet/sorbet/issues/9065.

The Prism parser mode was causing a crash with the following code:

```ruby
def foo(&, ...); end
```

This is invalid Ruby because the forwarding parameter `...` already includes block forwarding. Prism reports the error as "unexpected parameter order" but it doesn't remove or modify either of the parameter nodes.

     @ DefNode (location: (1,0)-(1,20))
     ├── flags: newline
     ├── name: :foo
     ├── name_loc: (1,4)-(1,7) = "foo"
     ├── receiver: ∅
     ├── parameters:
     │   @ ParametersNode (location: (1,8)-(1,14))
     │   ├── flags: ∅
     │   ├── requireds: (length: 0)
     │   ├── optionals: (length: 0)
     │   ├── rest: ∅
     │   ├── posts: (length: 0)
     │   ├── keywords: (length: 0)
     │   ├── keyword_rest:
     │   │   @ ForwardingParameterNode (location: (1,11)-(1,14))
     │   │   └── flags: ∅
     │   └── block:
     │       @ BlockParameterNode (location: (1,8)-(1,9))
     │       ├── flags: ∅
     │       ├── name: ∅
     │       ├── name_loc: ∅
     │       └── operator_loc: (1,8)-(1,9) = "&"
     ├── body: ∅
     ├── locals: []
     ├── def_keyword_loc: (1,0)-(1,3) = "def"
     ├── operator_loc: ∅
     ├── lparen_loc: (1,7)-(1,8) = "("
     ├── rparen_loc: (1,14)-(1,15) = ")"
     ├── equal_loc: ∅
     └── end_keyword_loc: (1,17)-(1,20) = "end"

This commit fixes the issue by skipping adding the block parameter when a forwarding parameter is present. This is different behavior from the original parser, which removes the def node entirely (or rather returns the body which in this example is nothing).

Original desugar tree and errors:

     class <emptyTree><<C <root>>> < (::<todo sym>)
       nil
     end

```
-e:1: unexpected token "," https://srb.help/2001
     1 |def foo(&, ...); end
```

Prism desugar tree and errors:

     class <emptyTree><<C <root>>> < (::<todo sym>)
       def foo<<todo method>>(*<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
         <emptyTree>
       end
     end

```
-e:1: unexpected parameter order https://srb.help/2001
     1 |def foo(&, ...); end
                   ^^^
```

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm working on ensuring the Prism parser mode is robust and doesn't crash on invalid syntax like this.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
