### PR TITLE
Add Prism AST node factory

### DIFF
--- a/parser/prism/BUILD
+++ b/parser/prism/BUILD
@@ -1,10 +1,12 @@
 cc_library(
     name = "prism",
     srcs = [
+        "Factory.cc",
         "Parser.cc",
         "Translator.cc",
     ],
     hdrs = [
+        "Factory.h",
         "Helpers.h",
         "Parser.h",
         "Translator.h",

--- a/parser/prism/Factory.cc
+++ b/parser/prism/Factory.cc
@@ -1,4 +1,5 @@
 #include "parser/prism/Factory.h"
+#include "absl/types/span.h"
 #include "parser/prism/Helpers.h"
 #include "parser/prism/Parser.h"
 #include <array>
@@ -27,7 +28,7 @@ pm_node_list_t Factory::copyNodesToList(absl::Span<const pm_node_t *> nodes) con
 
     auto result = static_cast<pm_node_t **>(this->calloc(size, sizeof(pm_node_t *)));
     for (size_t i = 0; i < size; i++) {
-        result[i] = nodes[i];
+        result[i] = const_cast<pm_node_t *>(nodes[i]);
     }
     return (pm_node_list_t){.size = size, .capacity = size, .nodes = result};
 }
@@ -99,8 +100,8 @@ pm_node_t *Factory::ConstantPathNode(core::LocOffsets loc, pm_node_t *parent, st
 pm_node_t *Factory::SingleArgumentNode(pm_node_t *arg) const {
     ENFORCE(arg, "SingleArgumentNode: arg is required");
 
-    array<pm_node_t *, 1> args = {arg};
-    pm_arguments_node_t *arguments = createArgumentsNode(args, arg->location);
+    array<const pm_node_t *, 1> args = {arg};
+    pm_arguments_node_t *arguments = createArgumentsNode(absl::MakeSpan(args), arg->location);
 
     return up_cast(arguments);
 }
@@ -355,8 +356,8 @@ pm_node_t *Factory::Send2(core::LocOffsets loc, pm_node_t *receiver, string_view
                           pm_node_t *arg2) const {
     ENFORCE(receiver && !method.empty() && arg1 && arg2, "Receiver or method or arguments are null");
 
-    array<pm_node_t *, 2> args = {arg1, arg2};
-    return Send(loc, receiver, method, args);
+    array<const pm_node_t *, 2> args = {arg1, arg2};
+    return Send(loc, receiver, method, absl::MakeSpan(args));
 }
 
 pm_node_t *Factory::TLet(core::LocOffsets loc, pm_node_t *value, pm_node_t *type) const {

--- a/parser/prism/Factory.cc
+++ b/parser/prism/Factory.cc
@@ -1,6 +1,7 @@
 #include "parser/prism/Factory.h"
 #include "parser/prism/Helpers.h"
 #include "parser/prism/Parser.h"
+#include <array>
 
 namespace sorbet::parser::Prism {
 
@@ -17,7 +18,7 @@ inline constexpr auto prismFree = [](void *p) { xfree(p); };
 // * In the event of an exception, will be freed correctly using Prism's `xfree()`.
 template <typename T> using PrismUniquePtr = std::unique_ptr<T, decltype(prismFree)>;
 
-pm_node_list_t Factory::copyNodesToList(const vector<pm_node_t *> &nodes) const {
+pm_node_list_t Factory::copyNodesToList(absl::Span<const pm_node_t *> nodes) const {
     auto size = nodes.size();
 
     if (size == 0) {
@@ -31,7 +32,7 @@ pm_node_list_t Factory::copyNodesToList(const vector<pm_node_t *> &nodes) const 
     return (pm_node_list_t){.size = size, .capacity = size, .nodes = result};
 }
 
-pm_arguments_node_t *Factory::createArgumentsNode(vector<pm_node_t *> args, const pm_location_t loc) const {
+pm_arguments_node_t *Factory::createArgumentsNode(absl::Span<const pm_node_t *> args, const pm_location_t loc) const {
     pm_arguments_node_t *arguments = allocateNode<pm_arguments_node_t>();
 
     pm_node_list_t argNodes = copyNodesToList(args);
@@ -98,7 +99,7 @@ pm_node_t *Factory::ConstantPathNode(core::LocOffsets loc, pm_node_t *parent, st
 pm_node_t *Factory::SingleArgumentNode(pm_node_t *arg) const {
     ENFORCE(arg, "SingleArgumentNode: arg is required");
 
-    vector<pm_node_t *> args = {arg};
+    array<pm_node_t *, 1> args = {arg};
     pm_arguments_node_t *arguments = createArgumentsNode(args, arg->location);
 
     return up_cast(arguments);
@@ -189,7 +190,7 @@ pm_node_t *Factory::AssocNode(core::LocOffsets loc, pm_node_t *key, pm_node_t *v
     return up_cast(assocNode);
 }
 
-pm_node_t *Factory::Hash(core::LocOffsets loc, const vector<pm_node_t *> &pairs) const {
+pm_node_t *Factory::Hash(core::LocOffsets loc, absl::Span<const pm_node_t *> pairs) const {
     pm_hash_node_t *hashNode = allocateNode<pm_hash_node_t>();
 
     pm_node_list_t elements = copyNodesToList(pairs);
@@ -206,7 +207,7 @@ pm_node_t *Factory::Hash(core::LocOffsets loc, const vector<pm_node_t *> &pairs)
     return up_cast(hashNode);
 }
 
-pm_node_t *Factory::KeywordHash(core::LocOffsets loc, const vector<pm_node_t *> &pairs) const {
+pm_node_t *Factory::KeywordHash(core::LocOffsets loc, absl::Span<const pm_node_t *> pairs) const {
     pm_keyword_hash_node_t *hashNode = allocateNode<pm_keyword_hash_node_t>();
 
     pm_node_list_t elements = copyNodesToList(pairs);
@@ -262,8 +263,8 @@ pm_node_t *Factory::Send1(core::LocOffsets loc, pm_node_t *receiver, string_view
     return up_cast(createSendNode(receiver, methodId, arguments, tinyLoc, fullLoc, tinyLoc));
 }
 
-pm_node_t *Factory::Send(core::LocOffsets loc, pm_node_t *receiver, string_view method, const vector<pm_node_t *> &args,
-                         pm_node_t *block) const {
+pm_node_t *Factory::Send(core::LocOffsets loc, pm_node_t *receiver, string_view method,
+                         absl::Span<const pm_node_t *> args, pm_node_t *block) const {
     ENFORCE(receiver && !method.empty(), "Receiver or method is null");
 
     pm_constant_id_t methodId = addConstantToPool(method);
@@ -296,7 +297,7 @@ pm_node_t *Factory::TNilable(core::LocOffsets loc, pm_node_t *type) const {
     return Send1(loc, T(loc), "nilable"sv, type);
 }
 
-pm_node_t *Factory::TAny(core::LocOffsets loc, const vector<pm_node_t *> &args) const {
+pm_node_t *Factory::TAny(core::LocOffsets loc, absl::Span<const pm_node_t *> args) const {
     ENFORCE(!args.empty(), "Args is empty");
 
     pm_constant_id_t methodId = addConstantToPool("any"sv);
@@ -307,7 +308,7 @@ pm_node_t *Factory::TAny(core::LocOffsets loc, const vector<pm_node_t *> &args) 
     return up_cast(createSendNode(T(loc), methodId, up_cast(arguments), tinyLoc, fullLoc, tinyLoc));
 }
 
-pm_node_t *Factory::TAll(core::LocOffsets loc, const vector<pm_node_t *> &args) const {
+pm_node_t *Factory::TAll(core::LocOffsets loc, absl::Span<const pm_node_t *> args) const {
     ENFORCE(!args.empty(), "Args is empty");
 
     pm_constant_id_t methodId = addConstantToPool("all"sv);
@@ -354,14 +355,8 @@ pm_node_t *Factory::Send2(core::LocOffsets loc, pm_node_t *receiver, string_view
                           pm_node_t *arg2) const {
     ENFORCE(receiver && !method.empty() && arg1 && arg2, "Receiver or method or arguments are null");
 
-    pm_constant_id_t methodId = addConstantToPool(method);
-    vector<pm_node_t *> args = {arg1, arg2};
-    pm_arguments_node_t *arguments = createArgumentsNode(args, parser.convertLocOffsets(loc));
-
-    pm_location_t fullLoc = parser.convertLocOffsets(loc);
-    pm_location_t tinyLoc = parser.convertLocOffsets(loc.copyWithZeroLength());
-
-    return up_cast(createSendNode(receiver, methodId, up_cast(arguments), tinyLoc, fullLoc, tinyLoc));
+    array<pm_node_t *, 2> args = {arg1, arg2};
+    return Send(loc, receiver, method, args);
 }
 
 pm_node_t *Factory::TLet(core::LocOffsets loc, pm_node_t *value, pm_node_t *type) const {
@@ -412,7 +407,7 @@ pm_node_t *Factory::TTypeAlias(core::LocOffsets loc, pm_node_t *type) const {
     return send;
 }
 
-pm_node_t *Factory::Array(core::LocOffsets loc, const vector<pm_node_t *> &elements) const {
+pm_node_t *Factory::Array(core::LocOffsets loc, absl::Span<const pm_node_t *> elements) const {
     pm_array_node_t *array = allocateNode<pm_array_node_t>();
 
     pm_node_list_t elemNodes = copyNodesToList(elements);
@@ -468,14 +463,11 @@ pm_node_t *Factory::T_Range(core::LocOffsets loc) const {
     return ConstantPathNode(loc, T(loc), "Range"sv);
 }
 
-pm_node_t *Factory::StatementsNode(core::LocOffsets loc, const vector<pm_node_t *> &body) const {
+pm_node_t *Factory::StatementsNode(core::LocOffsets loc, absl::Span<const pm_node_t *> body) const {
     pm_statements_node_t *stmts = allocateNode<pm_statements_node_t>();
+    pm_node_list_t nodes = copyNodesToList(body);
     *stmts = (pm_statements_node_t){.base = initializeBaseNode(PM_STATEMENTS_NODE, parser.convertLocOffsets(loc)),
-                                    .body = {.size = 0, .capacity = 0, .nodes = nullptr}};
-
-    for (auto *node : body) {
-        pm_node_list_append(&stmts->body, node);
-    }
+                                    .body = nodes};
 
     return up_cast(stmts);
 }

--- a/parser/prism/Factory.cc
+++ b/parser/prism/Factory.cc
@@ -29,7 +29,7 @@ pm_node_list_t Factory::copyNodesToList(const absl::Span<pm_node_t *> nodes) con
         return (pm_node_list_t){.size = 0, .capacity = 0, .nodes = nullptr};
     }
 
-    auto result = static_cast<pm_node_t **>(this->calloc(size, sizeof(pm_node_t *)));
+    auto result = this->calloc<pm_node_t *>(size);
     for (size_t i = 0; i < size; i++) {
         result[i] = nodes[i];
     }
@@ -146,7 +146,7 @@ pm_node_t *Factory::Nil(core::LocOffsets loc) const {
 pm_constant_id_t Factory::addConstantToPool(string_view name) const {
     pm_parser_t *prismParser = parser.getRawParserPointer();
     size_t nameLen = name.size();
-    PrismUniquePtr<uint8_t> stable{reinterpret_cast<uint8_t *>(this->calloc(nameLen, sizeof(uint8_t))), prismFree};
+    PrismUniquePtr<uint8_t> stable{this->calloc<uint8_t>(nameLen), prismFree};
 
     memcpy(stable.get(), name.data(), nameLen);
     pm_constant_id_t id = pm_constant_pool_insert_owned(&prismParser->constant_pool, stable.release(), nameLen);
@@ -196,7 +196,7 @@ pm_node_t *Factory::String(core::LocOffsets nameLoc, string_view name) const {
 
     size_t nameSize = name.size();
 
-    PrismUniquePtr<uint8_t> stable{reinterpret_cast<uint8_t *>(this->calloc(nameSize, sizeof(uint8_t))), prismFree};
+    PrismUniquePtr<uint8_t> stable{this->calloc<uint8_t>(nameSize), prismFree};
     memcpy(stable.get(), name.data(), nameSize);
 
     pm_string_node_t *stringNode = allocateNode<pm_string_node_t>();
@@ -527,14 +527,6 @@ pm_node_t *Factory::StatementsNode(core::LocOffsets loc, const absl::Span<pm_nod
 
 void *Factory::malloc(size_t size) const {
     void *p = ::xmalloc(size); // see Prism's `include/prism/defines.h`
-    if (!p) {
-        throw std::bad_alloc{};
-    };
-    return p;
-}
-
-void *Factory::calloc(size_t count, size_t size) const {
-    void *p = ::xcalloc(count, size); // see Prism's `include/prism/defines.h`
     if (!p) {
         throw std::bad_alloc{};
     };

--- a/parser/prism/Factory.cc
+++ b/parser/prism/Factory.cc
@@ -1,0 +1,512 @@
+#include "parser/prism/Factory.h"
+#include "parser/prism/Helpers.h"
+#include "parser/prism/Parser.h"
+
+namespace sorbet::parser::Prism {
+
+using namespace std;
+using namespace std::literals::string_view_literals;
+
+// See Prism's `include/prism/defines.h`
+inline constexpr auto prismFree = [](void *p) { xfree(p); };
+
+// A unique_ptr to memory that will be owned by Prism.
+// * Must be allocated from one of the Prism allocator functions
+//   See Prism's `include/prism/defines.h`
+// * Ownership can be transfered to a Prism-owned AST via `release()`.
+// * In the event of an exception, will be freed correctly using Prism's `xfree()`.
+template <typename T> using PrismUniquePtr = std::unique_ptr<T, decltype(prismFree)>;
+
+pm_node_list_t Factory::copyNodesToList(const vector<pm_node_t *> &nodes) const {
+    auto size = nodes.size();
+
+    if (size == 0) {
+        return (pm_node_list_t){.size = 0, .capacity = 0, .nodes = nullptr};
+    }
+
+    auto result = static_cast<pm_node_t **>(this->calloc(size, sizeof(pm_node_t *)));
+    for (size_t i = 0; i < size; i++) {
+        result[i] = nodes[i];
+    }
+    return (pm_node_list_t){.size = size, .capacity = size, .nodes = result};
+}
+
+pm_arguments_node_t *Factory::createArgumentsNode(vector<pm_node_t *> args, const pm_location_t loc) const {
+    pm_arguments_node_t *arguments = allocateNode<pm_arguments_node_t>();
+
+    pm_node_list_t argNodes = copyNodesToList(args);
+
+    *arguments = (pm_arguments_node_t){.base = initializeBaseNode(PM_ARGUMENTS_NODE, loc), .arguments = argNodes};
+
+    return arguments;
+}
+
+pm_node_t Factory::initializeBaseNode(pm_node_type_t type, const pm_location_t loc) const {
+    pm_parser_t *prismParser = parser.getRawParserPointer();
+    prismParser->node_id++;
+    uint32_t nodeId = prismParser->node_id;
+
+    return (pm_node_t){.type = type, .flags = 0, .node_id = nodeId, .location = loc};
+}
+
+pm_node_t *Factory::ConstantReadNode(string_view name, core::LocOffsets loc) const {
+    pm_constant_id_t constantId = addConstantToPool(name);
+    return ConstantReadNode(constantId, loc);
+}
+
+pm_node_t *Factory::ConstantReadNode(pm_constant_id_t constantId, core::LocOffsets loc) const {
+    pm_constant_read_node_t *node = allocateNode<pm_constant_read_node_t>();
+
+    pm_location_t pmLoc = parser.convertLocOffsets(loc);
+    *node = (pm_constant_read_node_t){.base = initializeBaseNode(PM_CONSTANT_READ_NODE, pmLoc), .name = constantId};
+
+    return up_cast(node);
+}
+
+pm_node_t *Factory::ConstantWriteNode(core::LocOffsets loc, pm_constant_id_t nameId, pm_node_t *value) const {
+    ENFORCE(value, "ConstantWriteNode: value is required");
+
+    pm_constant_write_node_t *node = allocateNode<pm_constant_write_node_t>();
+
+    pm_location_t pmLoc = parser.convertLocOffsets(loc);
+    pm_location_t zeroLoc = parser.getZeroWidthLocation();
+
+    *node = (pm_constant_write_node_t){.base = initializeBaseNode(PM_CONSTANT_WRITE_NODE, pmLoc),
+                                       .name = nameId,
+                                       .name_loc = pmLoc,
+                                       .value = value,
+                                       .operator_loc = zeroLoc};
+
+    return up_cast(node);
+}
+
+pm_node_t *Factory::ConstantPathNode(core::LocOffsets loc, pm_node_t *parent, string_view name) const {
+    pm_constant_id_t nameId = addConstantToPool(name);
+    pm_constant_path_node_t *node = allocateNode<pm_constant_path_node_t>();
+
+    pm_location_t pmLoc = parser.convertLocOffsets(loc);
+
+    *node = (pm_constant_path_node_t){.base = initializeBaseNode(PM_CONSTANT_PATH_NODE, pmLoc),
+                                      .parent = parent,
+                                      .name = nameId,
+                                      .delimiter_loc = pmLoc,
+                                      .name_loc = pmLoc};
+
+    return up_cast(node);
+}
+
+pm_node_t *Factory::SingleArgumentNode(pm_node_t *arg) const {
+    ENFORCE(arg, "SingleArgumentNode: arg is required");
+
+    vector<pm_node_t *> args = {arg};
+    pm_arguments_node_t *arguments = createArgumentsNode(args, arg->location);
+
+    return up_cast(arguments);
+}
+
+pm_node_t *Factory::Self(core::LocOffsets loc) const {
+    ENFORCE(loc.exists(), "Self: location is required");
+
+    pm_self_node_t *selfNode = allocateNode<pm_self_node_t>();
+
+    *selfNode = (pm_self_node_t){.base = initializeBaseNode(PM_SELF_NODE, parser.convertLocOffsets(loc))};
+
+    return up_cast(selfNode);
+}
+
+pm_node_t *Factory::True(core::LocOffsets loc) const {
+    ENFORCE(loc.exists(), "True: location is required");
+
+    pm_true_node_t *trueNode = allocateNode<pm_true_node_t>();
+
+    *trueNode = (pm_true_node_t){.base = initializeBaseNode(PM_TRUE_NODE, parser.convertLocOffsets(loc))};
+
+    return up_cast(trueNode);
+}
+
+pm_constant_id_t Factory::addConstantToPool(string_view name) const {
+    pm_parser_t *prismParser = parser.getRawParserPointer();
+    size_t nameLen = name.size();
+    PrismUniquePtr<uint8_t> stable{reinterpret_cast<uint8_t *>(this->calloc(nameLen, sizeof(uint8_t))), prismFree};
+
+    memcpy(stable.get(), name.data(), nameLen);
+    pm_constant_id_t id = pm_constant_pool_insert_owned(&prismParser->constant_pool, stable.release(), nameLen);
+    return id;
+}
+
+pm_call_node_t *Factory::createSendNode(pm_node_t *receiver, pm_constant_id_t methodId, pm_node_t *arguments,
+                                        pm_location_t messageLoc, pm_location_t fullLoc, pm_location_t tinyLoc,
+                                        pm_node_t *block) const {
+    pm_call_node_t *call = allocateNode<pm_call_node_t>();
+
+    *call = (pm_call_node_t){.base = initializeBaseNode(PM_CALL_NODE, fullLoc),
+                             .receiver = receiver,
+                             .call_operator_loc = tinyLoc,
+                             .name = methodId,
+                             .message_loc = messageLoc,
+                             .opening_loc = tinyLoc,
+                             .arguments = down_cast<pm_arguments_node_t>(arguments),
+                             .closing_loc = tinyLoc,
+                             .block = block};
+
+    return call;
+}
+
+pm_node_t *Factory::SymbolFromConstant(core::LocOffsets nameLoc, pm_constant_id_t nameId) const {
+    auto nameView = parser.resolveConstant(nameId);
+    size_t nameSize = nameView.size();
+
+    PrismUniquePtr<uint8_t> stable{reinterpret_cast<uint8_t *>(this->calloc(nameSize, sizeof(uint8_t))), prismFree};
+    memcpy(stable.get(), nameView.data(), nameSize);
+
+    pm_symbol_node_t *symbolNode = allocateNode<pm_symbol_node_t>();
+
+    pm_location_t location = parser.convertLocOffsets(nameLoc.copyWithZeroLength());
+
+    pm_string_t unescapedString;
+    // Mark string as owned so it'll be freed when the node is destroyed
+    pm_string_owned_init(&unescapedString, stable.release(), nameSize);
+
+    *symbolNode = (pm_symbol_node_t){.base = initializeBaseNode(PM_SYMBOL_NODE, location),
+                                     .opening_loc = location,
+                                     .value_loc = location,
+                                     .closing_loc = location,
+                                     .unescaped = unescapedString};
+
+    return up_cast(symbolNode);
+}
+
+pm_node_t *Factory::AssocNode(core::LocOffsets loc, pm_node_t *key, pm_node_t *value) const {
+    ENFORCE(key && value, "Key or value is null");
+
+    pm_assoc_node_t *assocNode = allocateNode<pm_assoc_node_t>();
+
+    pm_location_t location = parser.convertLocOffsets(loc.copyWithZeroLength());
+
+    *assocNode = (pm_assoc_node_t){
+        .base = initializeBaseNode(PM_ASSOC_NODE, location), .key = key, .value = value, .operator_loc = location};
+
+    return up_cast(assocNode);
+}
+
+pm_node_t *Factory::Hash(core::LocOffsets loc, const vector<pm_node_t *> &pairs) const {
+    pm_hash_node_t *hashNode = allocateNode<pm_hash_node_t>();
+
+    pm_node_list_t elements = copyNodesToList(pairs);
+
+    pm_location_t baseLoc = parser.convertLocOffsets(loc);
+    pm_location_t openingLoc = {.start = nullptr, .end = nullptr};
+    pm_location_t closingLoc = {.start = nullptr, .end = nullptr};
+
+    *hashNode = (pm_hash_node_t){.base = initializeBaseNode(PM_HASH_NODE, baseLoc),
+                                 .opening_loc = openingLoc,
+                                 .elements = elements,
+                                 .closing_loc = closingLoc};
+
+    return up_cast(hashNode);
+}
+
+pm_node_t *Factory::KeywordHash(core::LocOffsets loc, const vector<pm_node_t *> &pairs) const {
+    pm_keyword_hash_node_t *hashNode = allocateNode<pm_keyword_hash_node_t>();
+
+    pm_node_list_t elements = copyNodesToList(pairs);
+
+    pm_location_t baseLoc = parser.convertLocOffsets(loc);
+
+    *hashNode =
+        (pm_keyword_hash_node_t){.base = initializeBaseNode(PM_KEYWORD_HASH_NODE, baseLoc), .elements = elements};
+
+    return up_cast(hashNode);
+}
+
+pm_node_t *Factory::SorbetPrivateStatic(core::LocOffsets loc) const {
+    // Build a root-anchored constant path ::Sorbet::Private::Static
+    pm_node_t *sorbet = ConstantPathNode(loc, nullptr, "Sorbet"sv);
+    pm_node_t *sorbetPrivate = ConstantPathNode(loc, sorbet, "Private"sv);
+    return ConstantPathNode(loc, sorbetPrivate, "Static"sv);
+}
+
+pm_node_t *Factory::TSigWithoutRuntime(core::LocOffsets loc) const {
+    // Build a root-anchored constant path ::T::Sig::WithoutRuntime
+    pm_node_t *tConst = ConstantPathNode(loc, nullptr, "T"sv);
+    pm_node_t *tSig = ConstantPathNode(loc, tConst, "Sig"sv);
+    return ConstantPathNode(loc, tSig, "WithoutRuntime"sv);
+}
+
+pm_node_t *Factory::Symbol(core::LocOffsets nameLoc, string_view name) const {
+    ENFORCE(!name.empty(), "Name is empty");
+
+    pm_constant_id_t nameId = addConstantToPool(name);
+    return SymbolFromConstant(nameLoc, nameId);
+}
+
+pm_node_t *Factory::Send0(core::LocOffsets loc, pm_node_t *receiver, string_view method) const {
+    ENFORCE(receiver && !method.empty(), "Receiver or method is null");
+
+    pm_constant_id_t methodId = addConstantToPool(method);
+    pm_location_t fullLoc = parser.convertLocOffsets(loc);
+    pm_location_t tinyLoc = parser.convertLocOffsets(loc.copyWithZeroLength());
+
+    return up_cast(createSendNode(receiver, methodId, nullptr, tinyLoc, fullLoc, tinyLoc));
+}
+
+pm_node_t *Factory::Send1(core::LocOffsets loc, pm_node_t *receiver, string_view method, pm_node_t *arg1) const {
+    ENFORCE(receiver && !method.empty() && arg1, "Receiver or method or argument is null");
+
+    pm_constant_id_t methodId = addConstantToPool(method);
+    pm_node_t *arguments = SingleArgumentNode(arg1);
+
+    pm_location_t fullLoc = parser.convertLocOffsets(loc);
+    pm_location_t tinyLoc = parser.convertLocOffsets(loc.copyWithZeroLength());
+
+    return up_cast(createSendNode(receiver, methodId, arguments, tinyLoc, fullLoc, tinyLoc));
+}
+
+pm_node_t *Factory::Send(core::LocOffsets loc, pm_node_t *receiver, string_view method, const vector<pm_node_t *> &args,
+                         pm_node_t *block) const {
+    ENFORCE(receiver && !method.empty(), "Receiver or method is null");
+
+    pm_constant_id_t methodId = addConstantToPool(method);
+    pm_arguments_node_t *arguments = nullptr;
+    if (!args.empty()) {
+        pm_location_t pmLoc = parser.convertLocOffsets(loc);
+        arguments = createArgumentsNode(args, pmLoc);
+    }
+
+    pm_location_t fullLoc = parser.convertLocOffsets(loc);
+    pm_location_t tinyLoc = parser.convertLocOffsets(loc.copyWithZeroLength());
+
+    return up_cast(createSendNode(receiver, methodId, up_cast(arguments), tinyLoc, fullLoc, tinyLoc, block));
+}
+
+pm_node_t *Factory::T(core::LocOffsets loc) const {
+    return ConstantPathNode(loc, nullptr, "T");
+}
+
+pm_node_t *Factory::THelpers(core::LocOffsets loc) const {
+    return ConstantPathNode(loc, T(loc), "Helpers");
+}
+
+pm_node_t *Factory::TUntyped(core::LocOffsets loc) const {
+    return Send0(loc, T(loc), "untyped"sv);
+}
+
+pm_node_t *Factory::TNilable(core::LocOffsets loc, pm_node_t *type) const {
+    ENFORCE(type, "TNilable: type parameter is required");
+    return Send1(loc, T(loc), "nilable"sv, type);
+}
+
+pm_node_t *Factory::TAny(core::LocOffsets loc, const vector<pm_node_t *> &args) const {
+    ENFORCE(!args.empty(), "Args is empty");
+
+    pm_constant_id_t methodId = addConstantToPool("any"sv);
+    pm_location_t fullLoc = parser.convertLocOffsets(loc);
+    pm_location_t tinyLoc = parser.convertLocOffsets(loc.copyWithZeroLength());
+    pm_arguments_node_t *arguments = createArgumentsNode(args, fullLoc);
+
+    return up_cast(createSendNode(T(loc), methodId, up_cast(arguments), tinyLoc, fullLoc, tinyLoc));
+}
+
+pm_node_t *Factory::TAll(core::LocOffsets loc, const vector<pm_node_t *> &args) const {
+    ENFORCE(!args.empty(), "Args is empty");
+
+    pm_constant_id_t methodId = addConstantToPool("all"sv);
+    pm_location_t fullLoc = parser.convertLocOffsets(loc);
+    pm_location_t tinyLoc = parser.convertLocOffsets(loc.copyWithZeroLength());
+    pm_arguments_node_t *arguments = createArgumentsNode(args, fullLoc);
+
+    return up_cast(createSendNode(T(loc), methodId, up_cast(arguments), tinyLoc, fullLoc, tinyLoc));
+}
+
+pm_node_t *Factory::TTypeParameter(core::LocOffsets loc, pm_node_t *name) const {
+    ENFORCE(name, "Name is null");
+
+    return Send1(loc, T(loc), "type_parameter"sv, name);
+}
+
+pm_node_t *Factory::TProc(core::LocOffsets loc, pm_node_t *args, pm_node_t *returnType) const {
+    ENFORCE(returnType, "Return type is null");
+
+    pm_node_t *builder = T(loc);
+
+    builder = Send0(loc, builder, "proc"sv);
+
+    if (args != nullptr) {
+        builder = Send1(loc, builder, "params"sv, args);
+    }
+
+    return Send1(loc, builder, "returns"sv, returnType);
+}
+
+pm_node_t *Factory::TProcVoid(core::LocOffsets loc, pm_node_t *args) const {
+    pm_node_t *builder = T(loc);
+
+    builder = Send0(loc, builder, "proc"sv);
+
+    if (args != nullptr) {
+        builder = Send1(loc, builder, "params"sv, args);
+    }
+
+    return Send0(loc, builder, "void"sv);
+}
+
+pm_node_t *Factory::Send2(core::LocOffsets loc, pm_node_t *receiver, string_view method, pm_node_t *arg1,
+                          pm_node_t *arg2) const {
+    ENFORCE(receiver && !method.empty() && arg1 && arg2, "Receiver or method or arguments are null");
+
+    pm_constant_id_t methodId = addConstantToPool(method);
+    vector<pm_node_t *> args = {arg1, arg2};
+    pm_arguments_node_t *arguments = createArgumentsNode(args, parser.convertLocOffsets(loc));
+
+    pm_location_t fullLoc = parser.convertLocOffsets(loc);
+    pm_location_t tinyLoc = parser.convertLocOffsets(loc.copyWithZeroLength());
+
+    return up_cast(createSendNode(receiver, methodId, up_cast(arguments), tinyLoc, fullLoc, tinyLoc));
+}
+
+pm_node_t *Factory::TLet(core::LocOffsets loc, pm_node_t *value, pm_node_t *type) const {
+    ENFORCE(value && type, "Value or type is null");
+    return Send2(loc, T(loc), "let"sv, value, type);
+}
+
+pm_node_t *Factory::TCast(core::LocOffsets loc, pm_node_t *value, pm_node_t *type) const {
+    ENFORCE(value && type, "Value or type is null");
+    return Send2(loc, T(loc), "cast"sv, value, type);
+}
+
+pm_node_t *Factory::TMust(core::LocOffsets loc, pm_node_t *value) const {
+    ENFORCE(value, "Value is null");
+    return Send1(loc, T(loc), "must"sv, value);
+}
+
+pm_node_t *Factory::TUnsafe(core::LocOffsets loc, pm_node_t *value) const {
+    ENFORCE(value, "Value is null");
+    return Send1(loc, T(loc), "unsafe"sv, value);
+}
+
+pm_node_t *Factory::TAbsurd(core::LocOffsets loc, pm_node_t *value) const {
+    ENFORCE(value, "Value is null");
+    return Send1(loc, T(loc), "absurd"sv, value);
+}
+pm_node_t *Factory::TBindSelf(core::LocOffsets loc, pm_node_t *type) const {
+    ENFORCE(type, "Type is null");
+
+    return Send2(loc, T(loc), "bind"sv, Self(loc), type);
+}
+
+pm_node_t *Factory::TTypeAlias(core::LocOffsets loc, pm_node_t *type) const {
+    ENFORCE(type, "Type is null");
+
+    pm_node_t *send = Send0(loc, T(loc), "type_alias"sv);
+
+    pm_statements_node_t *stmts = allocateNode<pm_statements_node_t>();
+    *stmts = (pm_statements_node_t){.base = initializeBaseNode(PM_STATEMENTS_NODE, parser.convertLocOffsets(loc)),
+                                    .body = {.size = 0, .capacity = 0, .nodes = nullptr}};
+    pm_node_list_append(&stmts->body, type);
+
+    pm_node_t *block = Block(loc, up_cast(stmts));
+
+    auto *call = down_cast<pm_call_node_t>(send);
+    call->block = block;
+
+    return send;
+}
+
+pm_node_t *Factory::Array(core::LocOffsets loc, const vector<pm_node_t *> &elements) const {
+    pm_array_node_t *array = allocateNode<pm_array_node_t>();
+
+    pm_node_list_t elemNodes = copyNodesToList(elements);
+
+    *array = (pm_array_node_t){.base = initializeBaseNode(PM_ARRAY_NODE, parser.convertLocOffsets(loc)),
+                               .elements = elemNodes,
+                               .opening_loc = parser.convertLocOffsets(loc.copyWithZeroLength()),
+                               .closing_loc = parser.convertLocOffsets(loc.copyEndWithZeroLength())};
+
+    return up_cast(array);
+}
+
+pm_node_t *Factory::Block(core::LocOffsets loc, pm_node_t *body) const {
+    pm_block_node_t *block = allocateNode<pm_block_node_t>();
+
+    pm_location_t zeroLoc = parser.getZeroWidthLocation();
+
+    *block = (pm_block_node_t){.base = initializeBaseNode(PM_BLOCK_NODE, parser.convertLocOffsets(loc)),
+                               .locals = {.size = 0, .capacity = 0, .ids = nullptr},
+                               .parameters = nullptr,
+                               .body = body,
+                               .opening_loc = zeroLoc,
+                               .closing_loc = zeroLoc};
+
+    return up_cast(block);
+}
+
+pm_node_t *Factory::T_Array(core::LocOffsets loc) const {
+    return ConstantPathNode(loc, T(loc), "Array"sv);
+}
+
+pm_node_t *Factory::T_Class(core::LocOffsets loc) const {
+    return ConstantPathNode(loc, T(loc), "Class"sv);
+}
+
+pm_node_t *Factory::T_Enumerable(core::LocOffsets loc) const {
+    return ConstantPathNode(loc, T(loc), "Enumerable"sv);
+}
+
+pm_node_t *Factory::T_Enumerator(core::LocOffsets loc) const {
+    return ConstantPathNode(loc, T(loc), "Enumerator"sv);
+}
+
+pm_node_t *Factory::T_Hash(core::LocOffsets loc) const {
+    return ConstantPathNode(loc, T(loc), "Hash"sv);
+}
+
+pm_node_t *Factory::T_Set(core::LocOffsets loc) const {
+    return ConstantPathNode(loc, T(loc), "Set"sv);
+}
+
+pm_node_t *Factory::T_Range(core::LocOffsets loc) const {
+    return ConstantPathNode(loc, T(loc), "Range"sv);
+}
+
+pm_node_t *Factory::StatementsNode(core::LocOffsets loc, const vector<pm_node_t *> &body) const {
+    pm_statements_node_t *stmts = allocateNode<pm_statements_node_t>();
+    *stmts = (pm_statements_node_t){.base = initializeBaseNode(PM_STATEMENTS_NODE, parser.convertLocOffsets(loc)),
+                                    .body = {.size = 0, .capacity = 0, .nodes = nullptr}};
+
+    for (auto *node : body) {
+        pm_node_list_append(&stmts->body, node);
+    }
+
+    return up_cast(stmts);
+}
+
+void *Factory::malloc(size_t size) const {
+    void *p = ::xmalloc(size); // see Prism's `include/prism/defines.h`
+    if (!p) {
+        throw std::bad_alloc{};
+    };
+    return p;
+}
+
+void *Factory::calloc(size_t count, size_t size) const {
+    void *p = ::xcalloc(count, size); // see Prism's `include/prism/defines.h`
+    if (!p) {
+        throw std::bad_alloc{};
+    };
+    return p;
+}
+
+void *Factory::realloc(void *ptr, size_t size) const {
+    void *p = ::xrealloc(ptr, size); // see Prism's `include/prism/defines.h`
+    if (!p) {
+        throw std::bad_alloc{};
+    };
+    return p;
+}
+
+void Factory::free(void *ptr) const { // see Prism's `include/prism/defines.h`
+    ENFORCE(ptr);
+    ::xfree(ptr);
+}
+
+} // namespace sorbet::parser::Prism

--- a/parser/prism/Factory.h
+++ b/parser/prism/Factory.h
@@ -1,0 +1,109 @@
+#ifndef SORBET_PARSER_PRISM_FACTORY_H
+#define SORBET_PARSER_PRISM_FACTORY_H
+
+#include "common/common.h"
+#include "core/LocOffsets.h"
+#include <string_view>
+#include <vector>
+extern "C" {
+#include "prism.h"
+}
+
+namespace sorbet::parser::Prism {
+
+// Forward declarations
+class Parser;
+
+class Factory {
+private:
+    Parser &parser;
+
+public:
+    Factory(Parser &parser) : parser(parser) {}
+
+    template <typename T> T *allocateNode() const {
+        return new T{};
+    }
+
+    pm_node_t initializeBaseNode(pm_node_type_t type, const pm_location_t loc) const;
+
+    // Basic node creators
+    pm_node_t *ConstantReadNode(std::string_view name, core::LocOffsets loc) const;
+    pm_node_t *ConstantReadNode(pm_constant_id_t constantId, core::LocOffsets loc) const;
+    pm_node_t *ConstantWriteNode(core::LocOffsets loc, pm_constant_id_t nameId, pm_node_t *value) const;
+    pm_node_t *ConstantPathNode(core::LocOffsets loc, pm_node_t *parent, std::string_view name) const;
+    pm_node_t *SingleArgumentNode(pm_node_t *arg) const;
+    pm_node_t *Self(core::LocOffsets loc) const;
+    pm_node_t *True(core::LocOffsets loc) const;
+
+    // Symbol and hash node creators
+    pm_node_t *Symbol(core::LocOffsets nameLoc, std::string_view name) const;
+    pm_node_t *SymbolFromConstant(core::LocOffsets nameLoc, pm_constant_id_t nameId) const;
+    pm_node_t *AssocNode(core::LocOffsets loc, pm_node_t *key, pm_node_t *value) const;
+    pm_node_t *Hash(core::LocOffsets loc, const std::vector<pm_node_t *> &pairs) const;
+    pm_node_t *KeywordHash(core::LocOffsets loc, const std::vector<pm_node_t *> &pairs) const;
+
+    // Low-level method call creation
+    pm_call_node_t *createSendNode(pm_node_t *receiver, pm_constant_id_t method_id, pm_node_t *arguments,
+                                   pm_location_t message_loc, pm_location_t full_loc, pm_location_t tiny_loc,
+                                   pm_node_t *block = nullptr) const;
+
+    // High-level method call builders (similar to ast::MK)
+    pm_node_t *Send(core::LocOffsets loc, pm_node_t *receiver, std::string_view method,
+                    const std::vector<pm_node_t *> &args, pm_node_t *block = nullptr) const;
+    pm_node_t *Send0(core::LocOffsets loc, pm_node_t *receiver, std::string_view method) const;
+    pm_node_t *Send1(core::LocOffsets loc, pm_node_t *receiver, std::string_view method, pm_node_t *arg1) const;
+    pm_node_t *Send2(core::LocOffsets loc, pm_node_t *receiver, std::string_view method, pm_node_t *arg1,
+                     pm_node_t *arg2) const;
+
+    // Utility functions
+    pm_constant_id_t addConstantToPool(std::string_view name) const;
+
+    // High-level node creators
+    pm_node_t *SorbetPrivateStatic(core::LocOffsets loc) const;
+    pm_node_t *TSigWithoutRuntime(core::LocOffsets loc) const;
+
+    // T constant and method helpers
+    pm_node_t *T(core::LocOffsets loc) const;
+    pm_node_t *THelpers(core::LocOffsets loc) const;
+    pm_node_t *TUntyped(core::LocOffsets loc) const;
+    pm_node_t *TNilable(core::LocOffsets loc, pm_node_t *type) const;
+    pm_node_t *TAny(core::LocOffsets loc, const std::vector<pm_node_t *> &args) const;
+    pm_node_t *TAll(core::LocOffsets loc, const std::vector<pm_node_t *> &args) const;
+    pm_node_t *TTypeParameter(core::LocOffsets loc, pm_node_t *name) const;
+    pm_node_t *TProc(core::LocOffsets loc, pm_node_t *args, pm_node_t *returnType) const;
+    pm_node_t *TProcVoid(core::LocOffsets loc, pm_node_t *args) const;
+    pm_node_t *TLet(core::LocOffsets loc, pm_node_t *value, pm_node_t *type) const;
+    pm_node_t *TCast(core::LocOffsets loc, pm_node_t *value, pm_node_t *type) const;
+    pm_node_t *TMust(core::LocOffsets loc, pm_node_t *value) const;
+    pm_node_t *TUnsafe(core::LocOffsets loc, pm_node_t *value) const;
+    pm_node_t *TAbsurd(core::LocOffsets loc, pm_node_t *value) const;
+    pm_node_t *TBindSelf(core::LocOffsets loc, pm_node_t *type) const;
+    pm_node_t *TTypeAlias(core::LocOffsets loc, pm_node_t *type) const;
+    pm_node_t *T_Array(core::LocOffsets loc) const;
+    pm_node_t *T_Class(core::LocOffsets loc) const;
+    pm_node_t *T_Enumerable(core::LocOffsets loc) const;
+    pm_node_t *T_Enumerator(core::LocOffsets loc) const;
+    pm_node_t *T_Hash(core::LocOffsets loc) const;
+    pm_node_t *T_Set(core::LocOffsets loc) const;
+    pm_node_t *T_Range(core::LocOffsets loc) const;
+
+    pm_node_t *Array(core::LocOffsets loc, const std::vector<pm_node_t *> &elements) const;
+    pm_node_t *Block(core::LocOffsets loc, pm_node_t *body) const;
+    pm_node_t *StatementsNode(core::LocOffsets loc, const std::vector<pm_node_t *> &body) const;
+
+    // Wrappers around Prism's allocator functions, which raise `std::bad_alloc` instead of returning `nullptr`.
+    // Use these to allocate memory that will be owned by Prism.
+    void *malloc(size_t size) const;
+    void *calloc(size_t count, size_t size) const;
+    void *realloc(void *ptr, size_t size) const;
+    void free(void *ptr) const;
+
+private:
+    pm_node_list_t copyNodesToList(const std::vector<pm_node_t *> &nodes) const;
+    pm_arguments_node_t *createArgumentsNode(std::vector<pm_node_t *> args, const pm_location_t loc) const;
+};
+
+} // namespace sorbet::parser::Prism
+
+#endif // SORBET_PARSER_PRISM_FACTORY_H

--- a/parser/prism/Factory.h
+++ b/parser/prism/Factory.h
@@ -1,8 +1,10 @@
 #ifndef SORBET_PARSER_PRISM_FACTORY_H
 #define SORBET_PARSER_PRISM_FACTORY_H
 
+#include "absl/types/span.h"
 #include "common/common.h"
 #include "core/LocOffsets.h"
+#include <new>
 #include <string_view>
 #include <vector>
 extern "C" {
@@ -22,7 +24,8 @@ public:
     Factory(Parser &parser) : parser(parser) {}
 
     template <typename T> T *allocateNode() const {
-        return new T{};
+        void *memory = this->malloc(sizeof(T));
+        return new (memory) T{};
     }
 
     pm_node_t initializeBaseNode(pm_node_type_t type, const pm_location_t loc) const;
@@ -40,8 +43,8 @@ public:
     pm_node_t *Symbol(core::LocOffsets nameLoc, std::string_view name) const;
     pm_node_t *SymbolFromConstant(core::LocOffsets nameLoc, pm_constant_id_t nameId) const;
     pm_node_t *AssocNode(core::LocOffsets loc, pm_node_t *key, pm_node_t *value) const;
-    pm_node_t *Hash(core::LocOffsets loc, const std::vector<pm_node_t *> &pairs) const;
-    pm_node_t *KeywordHash(core::LocOffsets loc, const std::vector<pm_node_t *> &pairs) const;
+    pm_node_t *Hash(core::LocOffsets loc, absl::Span<const pm_node_t *> pairs) const;
+    pm_node_t *KeywordHash(core::LocOffsets loc, absl::Span<const pm_node_t *> pairs) const;
 
     // Low-level method call creation
     pm_call_node_t *createSendNode(pm_node_t *receiver, pm_constant_id_t method_id, pm_node_t *arguments,
@@ -50,7 +53,7 @@ public:
 
     // High-level method call builders (similar to ast::MK)
     pm_node_t *Send(core::LocOffsets loc, pm_node_t *receiver, std::string_view method,
-                    const std::vector<pm_node_t *> &args, pm_node_t *block = nullptr) const;
+                    absl::Span<const pm_node_t *> args, pm_node_t *block = nullptr) const;
     pm_node_t *Send0(core::LocOffsets loc, pm_node_t *receiver, std::string_view method) const;
     pm_node_t *Send1(core::LocOffsets loc, pm_node_t *receiver, std::string_view method, pm_node_t *arg1) const;
     pm_node_t *Send2(core::LocOffsets loc, pm_node_t *receiver, std::string_view method, pm_node_t *arg1,
@@ -68,8 +71,8 @@ public:
     pm_node_t *THelpers(core::LocOffsets loc) const;
     pm_node_t *TUntyped(core::LocOffsets loc) const;
     pm_node_t *TNilable(core::LocOffsets loc, pm_node_t *type) const;
-    pm_node_t *TAny(core::LocOffsets loc, const std::vector<pm_node_t *> &args) const;
-    pm_node_t *TAll(core::LocOffsets loc, const std::vector<pm_node_t *> &args) const;
+    pm_node_t *TAny(core::LocOffsets loc, absl::Span<const pm_node_t *> args) const;
+    pm_node_t *TAll(core::LocOffsets loc, absl::Span<const pm_node_t *> args) const;
     pm_node_t *TTypeParameter(core::LocOffsets loc, pm_node_t *name) const;
     pm_node_t *TProc(core::LocOffsets loc, pm_node_t *args, pm_node_t *returnType) const;
     pm_node_t *TProcVoid(core::LocOffsets loc, pm_node_t *args) const;
@@ -88,9 +91,9 @@ public:
     pm_node_t *T_Set(core::LocOffsets loc) const;
     pm_node_t *T_Range(core::LocOffsets loc) const;
 
-    pm_node_t *Array(core::LocOffsets loc, const std::vector<pm_node_t *> &elements) const;
+    pm_node_t *Array(core::LocOffsets loc, absl::Span<const pm_node_t *> elements) const;
     pm_node_t *Block(core::LocOffsets loc, pm_node_t *body) const;
-    pm_node_t *StatementsNode(core::LocOffsets loc, const std::vector<pm_node_t *> &body) const;
+    pm_node_t *StatementsNode(core::LocOffsets loc, absl::Span<const pm_node_t *> body) const;
 
     // Wrappers around Prism's allocator functions, which raise `std::bad_alloc` instead of returning `nullptr`.
     // Use these to allocate memory that will be owned by Prism.
@@ -100,8 +103,8 @@ public:
     void free(void *ptr) const;
 
 private:
-    pm_node_list_t copyNodesToList(const std::vector<pm_node_t *> &nodes) const;
-    pm_arguments_node_t *createArgumentsNode(std::vector<pm_node_t *> args, const pm_location_t loc) const;
+    pm_node_list_t copyNodesToList(absl::Span<const pm_node_t *> nodes) const;
+    pm_arguments_node_t *createArgumentsNode(absl::Span<const pm_node_t *> args, pm_location_t loc) const;
 };
 
 } // namespace sorbet::parser::Prism

--- a/parser/prism/Factory.h
+++ b/parser/prism/Factory.h
@@ -4,7 +4,6 @@
 #include "absl/types/span.h"
 #include "common/common.h"
 #include "core/LocOffsets.h"
-#include <new>
 #include <string_view>
 #include <vector>
 extern "C" {

--- a/parser/prism/Factory.h
+++ b/parser/prism/Factory.h
@@ -27,6 +27,14 @@ public:
         return new (memory) T{};
     }
 
+    template <typename T> T *calloc(size_t count) const {
+        void *p = ::xcalloc(count, sizeof(T));
+        if (!p) {
+            throw std::bad_alloc{};
+        }
+        return static_cast<T *>(p);
+    }
+
     pm_node_t initializeBaseNode(pm_node_type_t type, const pm_location_t loc) const;
 
     // Basic node creators
@@ -105,7 +113,6 @@ public:
     // Wrappers around Prism's allocator functions, which raise `std::bad_alloc` instead of returning `nullptr`.
     // Use these to allocate memory that will be owned by Prism.
     void *malloc(size_t size) const;
-    void *calloc(size_t count, size_t size) const;
     void *realloc(void *ptr, size_t size) const;
     void free(void *ptr) const;
 

--- a/parser/prism/Factory.h
+++ b/parser/prism/Factory.h
@@ -32,30 +32,33 @@ public:
     // Basic node creators
     pm_node_t *ConstantReadNode(std::string_view name, core::LocOffsets loc) const;
     pm_node_t *ConstantReadNode(pm_constant_id_t constantId, core::LocOffsets loc) const;
+    pm_node_t *ConstantReadNode(pm_constant_id_t constantId, pm_location_t loc) const;
     pm_node_t *ConstantWriteNode(core::LocOffsets loc, pm_constant_id_t nameId, pm_node_t *value) const;
     pm_node_t *ConstantPathNode(core::LocOffsets loc, pm_node_t *parent, std::string_view name) const;
+    pm_node_t *ConstantPathNode(pm_location_t loc, pm_node_t *parent, pm_constant_id_t nameId) const;
     pm_node_t *SingleArgumentNode(pm_node_t *arg) const;
     pm_node_t *Self(core::LocOffsets loc) const;
+    pm_node_t *Nil(core::LocOffsets loc) const;
     pm_node_t *True(core::LocOffsets loc) const;
-
-    // Symbol and hash node creators
     pm_node_t *Symbol(core::LocOffsets nameLoc, std::string_view name) const;
     pm_node_t *SymbolFromConstant(core::LocOffsets nameLoc, pm_constant_id_t nameId) const;
+    pm_node_t *String(core::LocOffsets nameLoc, std::string_view name) const;
     pm_node_t *AssocNode(core::LocOffsets loc, pm_node_t *key, pm_node_t *value) const;
-    pm_node_t *Hash(core::LocOffsets loc, absl::Span<const pm_node_t *> pairs) const;
-    pm_node_t *KeywordHash(core::LocOffsets loc, absl::Span<const pm_node_t *> pairs) const;
+    pm_node_t *Hash(core::LocOffsets loc, const absl::Span<pm_node_t *> pairs) const;
+    pm_node_t *KeywordHash(core::LocOffsets loc, const absl::Span<pm_node_t *> pairs) const;
 
     // Low-level method call creation
-    pm_call_node_t *createSendNode(pm_node_t *receiver, pm_constant_id_t method_id, pm_node_t *arguments,
+    pm_call_node_t *createCallNode(pm_node_t *receiver, pm_constant_id_t method_id, pm_node_t *arguments,
                                    pm_location_t message_loc, pm_location_t full_loc, pm_location_t tiny_loc,
                                    pm_node_t *block = nullptr) const;
+    pm_arguments_node_t *createArgumentsNode(const absl::Span<pm_node_t *> args, pm_location_t loc) const;
 
     // High-level method call builders (similar to ast::MK)
-    pm_node_t *Send(core::LocOffsets loc, pm_node_t *receiver, std::string_view method,
-                    absl::Span<const pm_node_t *> args, pm_node_t *block = nullptr) const;
-    pm_node_t *Send0(core::LocOffsets loc, pm_node_t *receiver, std::string_view method) const;
-    pm_node_t *Send1(core::LocOffsets loc, pm_node_t *receiver, std::string_view method, pm_node_t *arg1) const;
-    pm_node_t *Send2(core::LocOffsets loc, pm_node_t *receiver, std::string_view method, pm_node_t *arg1,
+    pm_node_t *Call(core::LocOffsets loc, pm_node_t *receiver, std::string_view method,
+                    const absl::Span<pm_node_t *> args, pm_node_t *block = nullptr) const;
+    pm_node_t *Call0(core::LocOffsets loc, pm_node_t *receiver, std::string_view method) const;
+    pm_node_t *Call1(core::LocOffsets loc, pm_node_t *receiver, std::string_view method, pm_node_t *arg1) const;
+    pm_node_t *Call2(core::LocOffsets loc, pm_node_t *receiver, std::string_view method, pm_node_t *arg1,
                      pm_node_t *arg2) const;
 
     // Utility functions
@@ -70,8 +73,8 @@ public:
     pm_node_t *THelpers(core::LocOffsets loc) const;
     pm_node_t *TUntyped(core::LocOffsets loc) const;
     pm_node_t *TNilable(core::LocOffsets loc, pm_node_t *type) const;
-    pm_node_t *TAny(core::LocOffsets loc, absl::Span<const pm_node_t *> args) const;
-    pm_node_t *TAll(core::LocOffsets loc, absl::Span<const pm_node_t *> args) const;
+    pm_node_t *TAny(core::LocOffsets loc, const absl::Span<pm_node_t *> args) const;
+    pm_node_t *TAll(core::LocOffsets loc, const absl::Span<pm_node_t *> args) const;
     pm_node_t *TTypeParameter(core::LocOffsets loc, pm_node_t *name) const;
     pm_node_t *TProc(core::LocOffsets loc, pm_node_t *args, pm_node_t *returnType) const;
     pm_node_t *TProcVoid(core::LocOffsets loc, pm_node_t *args) const;
@@ -81,18 +84,23 @@ public:
     pm_node_t *TUnsafe(core::LocOffsets loc, pm_node_t *value) const;
     pm_node_t *TAbsurd(core::LocOffsets loc, pm_node_t *value) const;
     pm_node_t *TBindSelf(core::LocOffsets loc, pm_node_t *type) const;
+    pm_node_t *TSelfType(core::LocOffsets loc) const;
+    pm_node_t *TAnything(core::LocOffsets loc) const;
+    pm_node_t *TAttachedClass(core::LocOffsets loc) const;
     pm_node_t *TTypeAlias(core::LocOffsets loc, pm_node_t *type) const;
     pm_node_t *T_Array(core::LocOffsets loc) const;
+    pm_node_t *T_Boolean(core::LocOffsets loc) const;
     pm_node_t *T_Class(core::LocOffsets loc) const;
+    pm_node_t *T_Module(core::LocOffsets loc) const;
     pm_node_t *T_Enumerable(core::LocOffsets loc) const;
     pm_node_t *T_Enumerator(core::LocOffsets loc) const;
     pm_node_t *T_Hash(core::LocOffsets loc) const;
     pm_node_t *T_Set(core::LocOffsets loc) const;
     pm_node_t *T_Range(core::LocOffsets loc) const;
 
-    pm_node_t *Array(core::LocOffsets loc, absl::Span<const pm_node_t *> elements) const;
+    pm_node_t *Array(core::LocOffsets loc, const absl::Span<pm_node_t *> elements) const;
     pm_node_t *Block(core::LocOffsets loc, pm_node_t *body) const;
-    pm_node_t *StatementsNode(core::LocOffsets loc, absl::Span<const pm_node_t *> body) const;
+    pm_node_t *StatementsNode(core::LocOffsets loc, const absl::Span<pm_node_t *> body) const;
 
     // Wrappers around Prism's allocator functions, which raise `std::bad_alloc` instead of returning `nullptr`.
     // Use these to allocate memory that will be owned by Prism.
@@ -102,8 +110,7 @@ public:
     void free(void *ptr) const;
 
 private:
-    pm_node_list_t copyNodesToList(absl::Span<const pm_node_t *> nodes) const;
-    pm_arguments_node_t *createArgumentsNode(absl::Span<const pm_node_t *> args, pm_location_t loc) const;
+    pm_node_list_t copyNodesToList(const absl::Span<pm_node_t *> nodes) const;
 };
 
 } // namespace sorbet::parser::Prism

--- a/parser/prism/Helpers.h
+++ b/parser/prism/Helpers.h
@@ -7,6 +7,9 @@ extern "C" {
 #include "prism.h"
 }
 
+#include "ast/ast.h"
+#include "parser/Node.h"
+
 template <> struct fmt::formatter<pm_node_type> : formatter<const char *> {
     auto format(pm_node_type type, format_context &ctx) const {
         return formatter<const char *>::format(pm_node_type_to_str(type), ctx);

--- a/parser/prism/Parser.cc
+++ b/parser/prism/Parser.cc
@@ -51,6 +51,14 @@ string_view Parser::extractString(pm_string_t *string) const {
     return cast_prism_string(pm_string_source(string), pm_string_length(string));
 }
 
+pm_location_t Parser::getZeroWidthLocation() const {
+    return {.start = parser.start, .end = parser.start};
+}
+
+pm_location_t Parser::convertLocOffsets(core::LocOffsets loc) const {
+    return {.start = parser.start + loc.beginPos(), .end = parser.start + loc.endPos()};
+}
+
 vector<ParseError> Parser::collectErrors() {
     vector<ParseError> parseErrors;
     parseErrors.reserve(parser.error_list.size);

--- a/parser/prism/Parser.h
+++ b/parser/prism/Parser.h
@@ -15,6 +15,7 @@ extern "C" {
 
 namespace sorbet::parser::Prism {
 
+class Factory;
 class ParseResult;
 
 class ParseError {
@@ -37,6 +38,7 @@ class Parser final {
 
     friend class ParseResult;
     friend struct NodeDeleter;
+    friend class Factory;
 
 public:
     Parser(std::string_view sourceCode) : parser{}, options{} {
@@ -63,6 +65,9 @@ public:
     core::LocOffsets translateLocation(const uint8_t *start, const uint8_t *end) const;
     std::string_view resolveConstant(pm_constant_id_t constantId) const;
     std::string_view extractString(pm_string_t *string) const;
+
+    pm_location_t getZeroWidthLocation() const;
+    pm_location_t convertLocOffsets(core::LocOffsets loc) const;
 
 private:
     std::vector<ParseError> collectErrors();


### PR DESCRIPTION
Part of #9065 

This PR introduces a `parser::Prism::Factory` class that provides high-level helpers for constructing Prism AST nodes, mirroring the functionality of `ast::MK` helpers but for raw Prism nodes (`pm_node_t*`)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Will be covered by existing tests once used in RBS rewriting 
