### PR TITLE
Fix crash with constant path without name in Prism parser mode

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -5271,6 +5271,13 @@ unique_ptr<parser::Node> Translator::translateConst(PrismLhsNode *node) {
     static_assert(is_same_v<SorbetLHSNode, parser::Const> || is_same_v<SorbetLHSNode, parser::ConstLhs>,
                   "Invalid LHS type. Must be one of `parser::Const` or `parser::ConstLhs`.");
 
+    // Constant name might be unset, e.g. `::`.
+    if (node->name == PM_CONSTANT_ID_UNSET) {
+        auto location = translateLoc(node->base.location);
+        auto expr = MK::UnresolvedConstant(location, MK::EmptyTree(), core::Names::empty());
+        return make_node_with_expr<SorbetLHSNode>(move(expr), location, nullptr, core::Names::empty());
+    }
+
     // It's important that in all branches `enterNameUTF8` is called, which `translateConstantName` does,
     // so that the name is available for the rest of the pipeline.
     auto name = translateConstantName(node->name);

--- a/test/BUILD
+++ b/test/BUILD
@@ -135,6 +135,7 @@ prism_location_test_suite(
             "prism_regression/lambda.rb",
             "prism_regression/call_kw_nil_args.rb",
             "prism_regression/call_block_param_and_forwarding.rb",
+            "prism_regression/constants_invalid.rb",
         ],
     ),
 )

--- a/test/prism_regression/constants_invalid.rb
+++ b/test/prism_regression/constants_invalid.rb
@@ -1,0 +1,5 @@
+# typed: false
+
+def test_invalid_constant(x)
+  ::
+end

--- a/test/prism_regression/constants_invalid.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/constants_invalid.rb.desugar-tree-raw.exp
@@ -1,0 +1,26 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    MethodDef{
+      flags = {}
+      name = <U test_invalid_constant><<U <todo method>>>
+      params = [UnresolvedIdent{
+          kind = Local
+          name = <U x>
+        }, BlockParam{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U <blk>>
+        } }]
+      rhs = UnresolvedConstantLit{
+        cnst = <U >
+        scope = EmptyTree
+      }
+    }
+  ]
+}

--- a/test/prism_regression/constants_invalid.rb.parse-tree.exp
+++ b/test/prism_regression/constants_invalid.rb.parse-tree.exp
@@ -1,0 +1,14 @@
+DefMethod {
+  name = <U test_invalid_constant>
+  params = Params {
+    params = [
+      Param {
+        name = <U x>
+      }
+    ]
+  }
+  body = Const {
+    scope = NULL
+    name = <U >
+  }
+}

--- a/tools/scripts/verify_prism_regression_tests.sh
+++ b/tools/scripts/verify_prism_regression_tests.sh
@@ -10,6 +10,7 @@ echo "Verifying parse trees and desugar trees..."
 skip_files=(
   "call_kw_nil_args"
   "call_block_param_and_forwarding"
+  "constants_invalid"
 )
 
 mismatched_parse_tree_files=()


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Part of https://github.com/sorbet/sorbet/issues/9065.

The Prism parser was causing a crash with the following code:

```ruby
::
```

This is invalid Ruby (a constant path with no constant name) and Prism reports the error differently depending on the surrounding code.

This commit fixes the issue by checking for `PM_CONSTANT_ID_UNSET` before attempting to resolve the constant name, and returning an unresolved constant literal with an empty name instead.

This is slightly different behavior from the original parser, which just removes the constant from the tree.

Original desugar tree and errors:

     class <emptyTree><<C <root>>> < (::<todo sym>)
       nil
     end

```
test/prism_regression/constants_invalid.rb:5: unexpected token "end" https://srb.help/2001
     5 |end
        ^^^
```

Prism desugar tree:

     class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>::
     end

```
test/prism_regression/constants_invalid.rb:4: expected a constant after the `::` operator https://srb.help/2001
     4 |  ::
            ^

test/prism_regression/constants_invalid.rb:4: Unable to resolve constant  https://srb.help/5002
     4 |  ::
          ^^
```


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm working on ensuring the Prism parser mode is robust and doesn't crash on invalid syntax like this.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. We skip verifying that they match the original parser output, because the behavior is slightly different, as outlined above.
