### PR TITLE
Remove dead code from lexer

### DIFF
--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -2906,13 +2906,6 @@ void lexer::set_state_expr_value() {
         cond.pop();
         cmdarg.pop();
 
-        if (ts[0] == '}' || ts[0] == ']') {
-          fnext expr_end;
-        } else { // ')'
-          // this was commented out in the original lexer.rl:
-          // fnext expr_endfn; ?
-        }
-
         fbreak;
       };
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Pretty sure that this code is dead because we're already in `expr_end`, so
there's no use in transitioning to it explicitly.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.