### PR TITLE
Fix crash with unterminated regular expressions in Prism parser mode

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -5377,6 +5377,8 @@ core::NameRef Translator::nextUniqueDesugarName(core::NameRef original) {
 unique_ptr<parser::Node> Translator::translateRegexpOptions(pm_location_t closingLoc) {
     ENFORCE(closingLoc.start && closingLoc.end);
 
+    auto prismLoc = closingLoc;
+
     // Chop off Regexp's closing delimiter from the start of the Regopt location,
     // so the location only spans the options themselves:
     //     /foo/im
@@ -5387,7 +5389,9 @@ unique_ptr<parser::Node> Translator::translateRegexpOptions(pm_location_t closin
     //            ^^
     //     $r{foo}im
     //            ^^
-    auto prismLoc = pm_location_t{.start = closingLoc.start + 1, .end = closingLoc.end};
+    if (closingLoc.start < closingLoc.end) {
+        prismLoc.start = closingLoc.start + 1;
+    }
     auto location = translateLoc(prismLoc);
 
     string_view options = sliceLocation(prismLoc);

--- a/test/BUILD
+++ b/test/BUILD
@@ -136,6 +136,7 @@ prism_location_test_suite(
             "prism_regression/call_kw_nil_args.rb",
             "prism_regression/call_block_param_and_forwarding.rb",
             "prism_regression/constants_invalid.rb",
+            "prism_regression/invalid/unterminated_regex.rb",
 
             # Sorbet's parser includes the last newline in the `<ErrorNode>`, but Prism doesn't.
             "prism_regression/invalid/missing_node.rb",

--- a/test/prism_regression/invalid/unterminated_regex.rb
+++ b/test/prism_regression/invalid/unterminated_regex.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+/foo

--- a/test/prism_regression/invalid/unterminated_regex.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/invalid/unterminated_regex.rb.desugar-tree-raw.exp
@@ -1,0 +1,25 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    Send{
+      flags = {}
+      recv = ConstantLit{
+        symbol = (class ::Regexp)
+        orig = nullptr
+      }
+      fun = <U new>
+      block = nullptr
+      pos_args = 2
+      args = [
+        Literal{ value = "foo\n" }
+        Literal{ value = 0 }
+      ]
+    }
+  ]
+}

--- a/test/prism_regression/invalid/unterminated_regex.rb.parse-tree.exp
+++ b/test/prism_regression/invalid/unterminated_regex.rb.parse-tree.exp
@@ -1,0 +1,11 @@
+Regexp {
+  regex = [
+    String {
+      val = <U foo
+>
+    }
+  ]
+  opts = Regopt {
+    opts = ""
+  }
+}


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

The Prism parser was causing a crash with code containing unterminated regular expression literals:

```ruby
/foo
```

Prism's error recovery includes the rest of the file content in the regex pattern:

```
@ InterpolatedRegularExpressionNode (location: (1,0)-(1,4))
├── flags: newline, static_literal
├── opening_loc: (1,0)-(1,1) = "/"
├── parts: (length: 1)
│   └── @ StringNode (location: (1,1)-(1,4))
│       ├── flags: static_literal, frozen
│       ├── opening_loc: ∅
│       ├── content_loc: (1,1)-(1,4) = "foo"
│       ├── closing_loc: ∅
│       └── unescaped: "foo"
└── closing_loc: (1,4)-(1,4) = ""
```

The `closing_loc` has has both start and end at the same position. When translating regexp options, we increment the `closingLoc.start` by 1 to skip past the closing regex delimiter. However, in the case of an unterminated regex there is no closing deliter, so the start offset is greater than the end offset, causing an assertion failure.

This commit fixes the issue by using the original 0 length location and only incrementing the start offset if appropriate.

Original desugar tree:

    class <emptyTree><<C <root>>> < (::<todo sym>)
      ::Regexp.new("", 0)
    end

Prism desugar tree:

    class <emptyTree><<C <root>>> < (::<todo sym>)
      ::Regexp.new("foo\n# typed: true", 0)
    end

The resulting behavior is different from the original parser, since the remainder of the file is captured as part of the regex rather than discarded. As such, we're skipping verifying the exp trees match the original parser outputs.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm working to make the Prism parser mode as robust as the original parser for invalid syntax.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.