### PR TITLE
Add new --stop-after=visibility-checker phase

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -255,6 +255,7 @@ const vector<StopAfterOptions> stop_after_options({
     {"local-vars", Phase::LOCAL_VARS},
     {"namer", Phase::NAMER},
     {"resolver", Phase::RESOLVER},
+    {"visibility-checker", Phase::VISIBILITY_CHECKER},
     {"cfg", Phase::CFG},
     {"inferencer", Phase::INFERENCER},
 });

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -105,6 +105,7 @@ enum class Phase {
     NAMER,
     PACKAGER,
     RESOLVER,
+    VISIBILITY_CHECKER,
     CFG,
     INFERENCER,
 };

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1403,7 +1403,7 @@ void typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Op
                   bool intentionallyLeakASTs) {
     core::FileRef f = resolved.file;
 
-    if (opts.stopAfterPhase == options::Phase::NAMER) {
+    if (opts.stopAfterPhase == options::Phase::NAMER || opts.stopAfterPhase == options::Phase::VISIBILITY_CHECKER) {
         if (intentionallyLeakASTs) {
             intentionallyLeakMemory(resolved.tree.release());
         }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

After visibility checker, but before class_flatten and definition_validator.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a