### PR TITLE
Add standard library Gem::SpecFetcher to rubygems.rbi

### DIFF
--- a/rbi/stdlib/rubygems.rbi
+++ b/rbi/stdlib/rubygems.rbi
@@ -7549,6 +7549,29 @@ end
 module Gem::UriParsing
 end
 
+# SpecFetcher handles metadata updates from remote gem repositories.
+class Gem::SpecFetcher
+  # Default fetcher instance. Use this instead of ::new to reduce object allocation.
+  def self.fetcher; end
+
+  # Returns a list of gems available for each source in Gem::sources
+  def available_specs(type); end
+
+  # Return all gem name tuples who’s names match obj
+  def detect(type=:complete); end
+
+  # Find and fetch gem name tuples that match dependency.
+  # If matching_platform is false, gems for all platforms are returned.
+  def search_for_dependency(dependency, matching_platform=true); end
+
+  # Find and fetch specs that match dependency.
+  # If matching_platform is false, gems for all platforms are returned.
+  def spec_for_dependency(dependency, matching_platform=true); end
+
+  # Suggests gems based on the supplied gem_name. Returns an array of alternative gem names.
+  def suggest_gems_from_name(gem_name, type = :latest, num_results = 5); end
+end
+
 # This module contains various utility methods as module methods.
 module Gem::Util
   # Corrects `path` (usually returned by `URI.parse().path` on Windows), that


### PR DESCRIPTION
Noticed in testing on a large application that Sorbet does not include `Gem::SpecFetcher` which is part of Ruby's [standard library](https://docs.ruby-lang.org/en/3.4/Gem/SpecFetcher.html).

This PR adds `Gem::SpecFetcher` to `rbi/stdlib/rubygems.rbi`.

Please note, I manually added documentation because I could not successfully run [sync-rdoc.rb](https://github.com/sorbet/sorbet/blob/2e1fa8115f6e91031fcaa8280e1dd4fdcdd6c0a7/rbi/tools/sync-rdoc.rb#L443).

### Motivation
See comparison between Sorbet playground and local Ruby (version 3.4):

<img width="1901" height="534" alt="SpecFetcher-Sorbet" src="https://github.com/user-attachments/assets/a0227257-74d5-4b96-a5f2-b0a3794a3e49" />

### Test plan
Followed the pattern of adding other stdlib modules.

See included automated tests.