### PR TITLE
Fix implicit BeginNode in module/class body

### DIFF
--- a/test/prism_regression/class_and_module_rescue.rb
+++ b/test/prism_regression/class_and_module_rescue.rb
@@ -1,0 +1,11 @@
+# typed: false
+
+# Implicit BeginNode
+class B
+rescue
+end
+
+# Implicit BeginNode
+module A
+rescue
+end

--- a/test/prism_regression/class_and_module_rescue.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/class_and_module_rescue.rb.desugar-tree-raw.exp
@@ -1,0 +1,69 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    ClassDef{
+      kind = class
+      name = UnresolvedConstantLit{
+        cnst = <C <U B>>
+        scope = EmptyTree
+      }
+      symbol = <C <U <todo sym>>>
+      ancestors = [ConstantLit{
+          symbol = (class ::<todo sym>)
+          orig = nullptr
+        }]
+      rhs = [
+        Rescue{
+          body = EmptyTree
+          rescueCases = [
+            RescueCase{
+              exceptions = [
+              ]
+              var = UnresolvedIdent{
+                kind = Local
+                name = <D <U <rescueTemp>> $2>
+              }
+              body = EmptyTree
+            }
+          ]
+          else = EmptyTree
+          ensure = EmptyTree
+        }
+      ]
+    }
+
+    ClassDef{
+      kind = module
+      name = UnresolvedConstantLit{
+        cnst = <C <U A>>
+        scope = EmptyTree
+      }
+      symbol = <C <U <todo sym>>>
+      ancestors = []
+      rhs = [
+        Rescue{
+          body = EmptyTree
+          rescueCases = [
+            RescueCase{
+              exceptions = [
+              ]
+              var = UnresolvedIdent{
+                kind = Local
+                name = <D <U <rescueTemp>> $2>
+              }
+              body = EmptyTree
+            }
+          ]
+          else = EmptyTree
+          ensure = EmptyTree
+        }
+      ]
+    }
+  ]
+}

--- a/test/prism_regression/class_and_module_rescue.rb.parse-tree.exp
+++ b/test/prism_regression/class_and_module_rescue.rb.parse-tree.exp
@@ -1,0 +1,47 @@
+Begin {
+  stmts = [
+    Class {
+      name = Const {
+        scope = NULL
+        name = <C <U B>>
+      }
+      superclass = NULL
+      body = Kwbegin {
+        stmts = [
+          Rescue {
+            body = NULL
+            rescue = [
+              Resbody {
+                exception = NULL
+                var = NULL
+                body = NULL
+              }
+            ]
+            else_ = NULL
+          }
+        ]
+      }
+    }
+    Module {
+      name = Const {
+        scope = NULL
+        name = <C <U A>>
+      }
+      body = Kwbegin {
+        stmts = [
+          Rescue {
+            body = NULL
+            rescue = [
+              Resbody {
+                exception = NULL
+                var = NULL
+                body = NULL
+              }
+            ]
+            else_ = NULL
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/scripts/verify_prism_regression_tests.sh
+++ b/tools/scripts/verify_prism_regression_tests.sh
@@ -11,6 +11,7 @@ skip_files=(
   "call_kw_nil_args"
   "call_block_param_and_forwarding"
   "constants_invalid"
+  "class_and_module_rescue"
 )
 
 mismatched_parse_tree_files=()


### PR DESCRIPTION
```ruby
module Test
rescue
end
```

Prism parses the `ModuleNode` body as an implicit `BeginNode`:

```
@ ModuleNode
├── body:
│   @ BeginNode (location: (1,2)-(3,5))
│   ├── rescue_clause:
│   │   @ RescueNode (location: (2,0)-(2,6))
│   └── end_keyword_loc: (3,2)-(3,5) = "end"
```

The `desugarScopeBodyToRHSStore` function expected the scope body to be a `PM_STATEMENTS_NODE` but received a `PM_BEGIN_NODE` instead, causing the ENFORCE assertion to fail.

This commit fixes the crash by handling both `PM_STATEMENTS_NODE` and the implicit `PM_BEGIN_NODE`. This results in a slightly different parse-tree than the original parser, which doesn't insert the implicit begin node.

Original parse tree:

    Module {
      name = Const {
        scope = NULL
        name = <C <U Test>>
      }
      body = Rescue {
        body = NULL
        rescue = [
          Resbody {
            exception = NULL
            var = NULL
            body = NULL
          }
        ]
        else_ = NULL
      }
    }

Prism parse tree:

    Module {
      name = Const {
        scope = NULL
        name = <C <U Test>>
      }
      body = Kwbegin {
        stmts = [
          Rescue {
            body = NULL
            rescue = [
              Resbody {
                exception = NULL
                var = NULL
                body = NULL
              }
            ]
            else_ = NULL
          }
        ]
      }
    }

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
