### PR TITLE
Recover from mismatched parens

### DIFF
--- a/parser/Parser.cc
+++ b/parser/Parser.cc
@@ -74,6 +74,12 @@ void explainError(core::GlobalState &gs, core::FileRef file, core::ErrorBuilder 
             e.addErrorLine(rangeToLoc(gs, file, diag.extra_location().value()),
                            "Matching `{}` found here but is not indented as far", "end");
             break;
+        case ruby_parser::dclass::UnterminatedToken:
+            if (diag.extra_location().has_value()) {
+                e.addErrorLine(rangeToLoc(gs, file, diag.extra_location().value()), "Corresponding `{}` was here",
+                               diag.data());
+            }
+            break;
         default:
             break;
     }

--- a/parser/parser/cc/driver.cc
+++ b/parser/parser/cc/driver.cc
@@ -48,6 +48,22 @@ const char *const base_driver::token_name(token_type type) {
     }
 }
 
+void base_driver::enrich_diagnostic_at(dclass type, diagnostic::range location, diagnostic::range extra_location) {
+    for (auto it = this->diagnostics.rbegin(); it != this->diagnostics.rend(); it++) {
+        if (it->error_class() == type && it->location() == location) {
+            it->set_extra_location(extra_location);
+        }
+    }
+}
+
+void base_driver::enrich_rparen_diagnostic(ruby_parser::token_t rparen, ruby_parser::location extra_location) {
+    if (rparen->type() == ruby_parser::token_type::tRPAREN) {
+        return;
+    }
+
+    enrich_diagnostic_at(dclass::UnterminatedToken, diagnostic::range(rparen), diagnostic::range(extra_location));
+}
+
 void base_driver::rewind_and_reset(size_t newPos) {
     this->clear_lookahead();
     this->lex.rewind_and_reset_to_expr_end(newPos);

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -519,7 +519,7 @@ void parser::error(const ruby_parser::location &lloc, const std::string &msg) {
 
   driver.diagnostics.emplace_back(
     dlevel::ERROR, dclass::UnexpectedToken,
-    diagnostic::range(lloc.beginPos(), lloc.endPos()),
+    diagnostic::range(lloc),
     error_message);
 }
 
@@ -2074,7 +2074,7 @@ array_premature_end: eof
                     {
                       $$ = driver.build.constFetchError(self, $1, $2);
                       driver.rewind_and_reset(@2.endPos());
-                      driver.replace_last_diagnostic(dlevel::ERROR, dclass::ConstWithoutName, diagnostic::range(@2.beginPos(), @2.endPos()));
+                      driver.replace_last_diagnostic(dlevel::ERROR, dclass::ConstWithoutName, diagnostic::range(@2));
                     }
                 | tCOLON3 tCONSTANT
                     {
@@ -2087,7 +2087,7 @@ array_premature_end: eof
                 | tLBRACK aref_args array_premature_end
                     {
                       $$ = driver.build.array(self, $1, $2, $3);
-                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::UnterminatedToken, diagnostic::range(@1.beginPos(), @1.endPos()), "\"[\"");
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::UnterminatedToken, diagnostic::range(@1), "\"[\"");
                       driver.rewind_and_reset(@2.endPos());
                     }
                 | tLBRACE assoc_list tRCURLY
@@ -2172,7 +2172,7 @@ array_premature_end: eof
                     }
                 | kIF strings kDO compstmt if_tail
                     {
-                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::IfInsteadOfItForTest, diagnostic::range(@1.beginPos(), @1.endPos()));
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::IfInsteadOfItForTest, diagnostic::range(@1));
                       auto &else_ = $5;
                       auto end_t = else_ ? else_->tok : nullptr;
                       $$ = driver.build.condition(self, $1, $2, $3, $4->body,
@@ -4121,7 +4121,7 @@ f_opt_paren_args: f_paren_args
                 | f_arg tCOMMA error
                     {
                       $$ = $1;
-                      driver.replace_last_diagnostic(dlevel::ERROR, dclass::UnexpectedToken, diagnostic::range(@2.beginPos(), @2.endPos()), "\",\"");
+                      driver.replace_last_diagnostic(dlevel::ERROR, dclass::UnexpectedToken, diagnostic::range(@2), "\",\"");
                     }
 
          f_label: tLABEL
@@ -4324,7 +4324,7 @@ f_opt_paren_args: f_paren_args
                 | tCOMMA error
                     {
                       $$ = driver.alloc.node_list();
-                      driver.replace_last_diagnostic(dlevel::ERROR, dclass::UnexpectedToken, diagnostic::range(@1.beginPos(), @1.endPos()), "\",\"");
+                      driver.replace_last_diagnostic(dlevel::ERROR, dclass::UnexpectedToken, diagnostic::range(@1), "\",\"");
                     }
                 |
                     {
@@ -4365,7 +4365,7 @@ f_opt_paren_args: f_paren_args
                 | assocs tCOMMA error
                     {
                       $$ = $1;
-                      driver.replace_last_diagnostic(dlevel::ERROR, dclass::UnexpectedToken, diagnostic::range(@2.beginPos(), @2.endPos()), "\",\"");
+                      driver.replace_last_diagnostic(dlevel::ERROR, dclass::UnexpectedToken, diagnostic::range(@2), "\",\"");
                     }
                 | assocs tCOMMA tIDENTIFIER error
                     {
@@ -4373,7 +4373,7 @@ f_opt_paren_args: f_paren_args
                       auto err = driver.build.call_method(self, nullptr, nullptr, $3, nullptr, nullptr, nullptr);
                       list->emplace_back(driver.build.pair_keyword(self, $3, err));
                       $$ = list;
-                      driver.replace_last_diagnostic(dlevel::ERROR, dclass::PositionalAfterKeyword, diagnostic::range(@3.beginPos(), @3.endPos()), $3->asString());
+                      driver.replace_last_diagnostic(dlevel::ERROR, dclass::PositionalAfterKeyword, diagnostic::range(@3), $3->asString());
                       driver.rewind_and_reset_to_beg(@3.endPos());
                       driver.lex.unadvance($2);
                     }

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -1128,6 +1128,7 @@ lbrace_cmd_block_start:
                     }
                 | tLPAREN mlhs_inner rparen
                     {
+                      driver.enrich_rparen_diagnostic($3, @1);
                       $$ = driver.build.begin(self, $1, $2, $3);
                     }
 
@@ -1137,6 +1138,7 @@ lbrace_cmd_block_start:
                     }
                 | tLPAREN mlhs_inner rparen
                     {
+                      driver.enrich_rparen_diagnostic($3, @1);
                       $$ = driver.build.multi_lhs1(self, $1, $2, $3);
                     }
 
@@ -1197,6 +1199,7 @@ lbrace_cmd_block_start:
        mlhs_item: mlhs_node
                 | tLPAREN mlhs_inner rparen
                     {
+                      driver.enrich_rparen_diagnostic($3, @1);
                       $$ = driver.build.begin(self, $1, $2, $3);
                     }
 
@@ -1811,16 +1814,19 @@ lbrace_cmd_block_start:
 
       paren_args: tLPAREN2 opt_call_args rparen
                     {
+                      driver.enrich_rparen_diagnostic($3, @1);
                       $$ = driver.alloc.delimited_node_list($1, $2, $3);
                     }
                 | tLPAREN2 args tCOMMA args_forward rparen
                     {
+                      driver.enrich_rparen_diagnostic($5, @1);
                       auto forwarded_args = driver.build.forwarded_args(self, $4);
                       $2->emplace_back(forwarded_args);
                       $$ = driver.alloc.delimited_node_list($1, $2, $5);
                     }
                 | tLPAREN2 args_forward rparen
                     {
+                      driver.enrich_rparen_diagnostic($3, @1);
                       auto forwarded_args = driver.build.forwarded_args(self, $2);
                       auto node_list = driver.alloc.node_list(forwarded_args);
                       $$ = driver.alloc.delimited_node_list($1, node_list, $3);
@@ -2058,6 +2064,7 @@ lbrace_cmd_block_start:
                     }
                     rparen
                     {
+                      driver.enrich_rparen_diagnostic($4, @1);
                       $$ = driver.build.begin(self, $1, $2, $4);
                     }
                 | tLPAREN_ARG
@@ -2112,11 +2119,13 @@ lbrace_cmd_block_start:
                     }
                 | kYIELD tLPAREN2 call_args rparen
                     {
+                      driver.enrich_rparen_diagnostic($4, @2);
                       $$ = driver.build.keywordYield(self, $1, $2, $3, $4);
                       DIAGCHECK();
                     }
                 | kYIELD tLPAREN2 rparen
                     {
+                      driver.enrich_rparen_diagnostic($3, @2);
                       node_list tmp;
                       $$ = driver.build.keywordYield(self, $1, $2, &tmp, $3);
                       DIAGCHECK();
@@ -2132,16 +2141,19 @@ lbrace_cmd_block_start:
                     }
                   expr rparen
                     {
+                      driver.enrich_rparen_diagnostic($6, @3);
                       driver.lex.context.inDefined = false;
                       $$ = driver.build.keywordDefined(self, $1, $3, $5, $6);
                     }
 
                 | kNOT tLPAREN2 expr rparen
                     {
+                      driver.enrich_rparen_diagnostic($4, @2);
                       $$ = driver.build.not_op(self, $1, $2, $3, $4);
                     }
                 | kNOT tLPAREN2 rparen
                     {
+                      driver.enrich_rparen_diagnostic($3, @2);
                       $$ = driver.build.not_op(self, $1, $2, nullptr, $3);
                     }
                 | fcall brace_block
@@ -2510,6 +2522,7 @@ lbrace_cmd_block_start:
                     }
                 | tLPAREN f_margs rparen
                     {
+                      driver.enrich_rparen_diagnostic($3, @1);
                       $$ = driver.build.multi_lhs(self, $1, $2, $3);
                     }
 
@@ -3198,24 +3211,28 @@ lcurly_block_start:
                 | p_variable
                 | p_const p_lparen p_args rparen
                     {
+                      driver.enrich_rparen_diagnostic($4, @2);
                       driver.pattern_hash_keys.pop();
                       auto pattern = driver.build.array_pattern(self, $2, $3, $4);
                       $$ = driver.build.const_pattern(self, $1, $2, pattern, $4);
                     }
                 | p_const p_lparen p_find rparen
                     {
+                      driver.enrich_rparen_diagnostic($4, @2);
                       driver.pattern_hash_keys.pop();
                       auto pattern = driver.build.find_pattern(self, $2, $3, $4);
                       $$ = driver.build.const_pattern(self, $1, $2, pattern, $4);
                     }
                 | p_const p_lparen p_kwargs rparen
                     {
+                      driver.enrich_rparen_diagnostic($4, @2);
                       driver.pattern_hash_keys.pop();
                       auto pattern = driver.build.hash_pattern(self, $2, $3, $4);
                       $$ = driver.build.const_pattern(self, $1, $2, pattern, $4);
                     }
                 | p_const tLPAREN2 rparen
                     {
+                      driver.enrich_rparen_diagnostic($3, @2);
                       auto list = driver.alloc.node_list();
                       auto pattern = driver.build.array_pattern(self, $2, list, $3);
                       $$ = driver.build.const_pattern(self, $1, $2, pattern, $3);
@@ -3280,6 +3297,7 @@ lcurly_block_start:
                     }
                   p_expr rparen
                     {
+                      driver.enrich_rparen_diagnostic($4, @1);
                       driver.pattern_hash_keys.pop();
                       $$ = driver.build.begin(self, $1, $3, $4);
                     }
@@ -3485,6 +3503,7 @@ lcurly_block_start:
                     }
       p_expr_ref: tCARET tLPAREN expr_value rparen
                     {
+                      driver.enrich_rparen_diagnostic($4, @2);
                       auto expr = driver.build.begin(self, $2, $3, $4);
                       $$ = driver.build.pin(self, $1, expr);
                     }
@@ -3895,6 +3914,7 @@ f_opt_paren_args: f_paren_args
 
        f_paren_args: tLPAREN2 f_args rparen
                     {
+                      driver.enrich_rparen_diagnostic($3, @1);
                       driver.lex.set_state_expr_value();
                       $$ = driver.build.args(self, $1, $2, $3, true);
                       driver.lex.context.inArgDef = false;
@@ -4117,6 +4137,7 @@ f_opt_paren_args: f_paren_args
                     }
                 | tLPAREN f_margs rparen
                     {
+                      driver.enrich_rparen_diagnostic($3, @1);
                       $$ = driver.build.multi_lhs(self, $1, $2, $3);
                     }
 
@@ -4346,6 +4367,7 @@ f_opt_paren_args: f_paren_args
        singleton: var_ref
                 | tLPAREN2 expr rparen
                     {
+                      driver.enrich_rparen_diagnostic($3, @1);
                       $$ = $2;
                     }
 

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -350,6 +350,7 @@ using namespace std::string_literals;
   args_forward
   premature_end_k
   premature_rbrack
+  premature_rparen
   blkarg_mark
   call_op
   cname
@@ -382,6 +383,7 @@ using namespace std::string_literals;
   kend_or_eof
   until
   while
+  opt_nl
 
 %type <delimited_list>
   defs_head_pre
@@ -2019,6 +2021,9 @@ lbrace_cmd_block_start:
                    | kWHEN
                    | kIN
    premature_rbrack: tRPAREN
+                   | tRCURLY
+                   | tCOLON
+   premature_rparen: tRBRACK
                    | tRCURLY
                    | tCOLON
 
@@ -4465,10 +4470,34 @@ f_opt_paren_args: f_paren_args
                       $$ = $1;
                     }
        opt_terms:  | terms
-          opt_nl:  | tNL
+          opt_nl: // nothing
+                   {
+                     // @1 doesn't get updated here because there is no location to update to, which means
+                     // that any rule which would otherwise want to access @1 for an opt_nl will actually
+                     // be accessing the location of whatever came before this `opt_nl`. By making opt_nl
+                     // return a token, we can at least detect this case in those rules.
+                     $$ = nullptr;
+                   }
+                | tNL
+                   {
+                     $$ = $1;
+                   }
+
           rparen: opt_nl tRPAREN
                     {
                       $$ = $2;
+                    }
+                | opt_nl premature_end_k
+                    {
+                      $$ = $2;
+                      driver.rewind_and_reset(($1 != nullptr ? @1 : @2).beginPos());
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::UnterminatedToken, $2, "\"(\"");
+                    }
+                | opt_nl premature_rparen
+                    {
+                      $$ = $2;
+                      driver.rewind_and_reset(($1 != nullptr ? @1 : @2).beginPos());
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::UnterminatedToken, $2, "\"(\"");
                     }
         rbracket: opt_nl tRBRACK
                     {

--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -348,7 +348,8 @@ using namespace std::string_literals;
 
 %type <token>
   args_forward
-  array_premature_end
+  premature_end_k
+  premature_rbrack
   blkarg_mark
   call_op
   cname
@@ -2008,7 +2009,7 @@ lbrace_cmd_block_start:
 
                      // While scanning an array, if we hit any of these tokens in places where a terminating `]` would
                      // fit, we should stop scanning the array and report an error.
-array_premature_end: eof
+    premature_end_k: eof
                    | kRESCUE
                    | kENSURE
                    | kEND
@@ -2017,7 +2018,7 @@ array_premature_end: eof
                    | kELSE
                    | kWHEN
                    | kIN
-                   | tRPAREN
+   premature_rbrack: tRPAREN
                    | tRCURLY
                    | tCOLON
 
@@ -2084,7 +2085,13 @@ array_premature_end: eof
                     {
                       $$ = driver.build.array(self, $1, $2, $3);
                     }
-                | tLBRACK aref_args array_premature_end
+                | tLBRACK aref_args premature_end_k
+                    {
+                      $$ = driver.build.array(self, $1, $2, $3);
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::UnterminatedToken, diagnostic::range(@1), "\"[\"");
+                      driver.rewind_and_reset(@2.endPos());
+                    }
+                | tLBRACK aref_args premature_rbrack
                     {
                       $$ = driver.build.array(self, $1, $2, $3);
                       driver.diagnostics.emplace_back(dlevel::ERROR, dclass::UnterminatedToken, diagnostic::range(@1), "\"[\"");

--- a/parser/parser/include/ruby_parser/diagnostic.hh
+++ b/parser/parser/include/ruby_parser/diagnostic.hh
@@ -22,12 +22,16 @@ enum class dlevel {
 class diagnostic {
 public:
     struct range {
-        const size_t beginPos;
-        const size_t endPos;
+        size_t beginPos;
+        size_t endPos;
 
         range(size_t beginPos, size_t endPos) : beginPos(beginPos), endPos(endPos) {}
         explicit range(token_t token) : beginPos(token->start()), endPos(token->end()) {}
         explicit range(location loc) : beginPos(loc.beginPos()), endPos(loc.endPos()) {}
+
+        bool operator==(const range &rhs) const {
+            return this->beginPos == rhs.beginPos && this->endPos == rhs.endPos;
+        }
     };
 
 private:
@@ -65,6 +69,10 @@ public:
 
     const std::optional<range> &extra_location() const {
         return extra_location_;
+    }
+
+    void set_extra_location(range extra_location) {
+        this->extra_location_ = extra_location;
     }
 };
 

--- a/parser/parser/include/ruby_parser/diagnostic.hh
+++ b/parser/parser/include/ruby_parser/diagnostic.hh
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "diagnostic_class.hh"
+#include "location.hh"
 #include "token.hh"
 
 namespace ruby_parser {
@@ -26,6 +27,7 @@ public:
 
         range(size_t beginPos, size_t endPos) : beginPos(beginPos), endPos(endPos) {}
         explicit range(token_t token) : beginPos(token->start()), endPos(token->end()) {}
+        explicit range(location loc) : beginPos(loc.beginPos()), endPos(loc.endPos()) {}
     };
 
 private:

--- a/parser/parser/include/ruby_parser/driver.hh
+++ b/parser/parser/include/ruby_parser/driver.hh
@@ -361,6 +361,12 @@ public:
 
     const char *const token_name(token_type type);
 
+    // Find the latest diagnostic reported at `location` with `type` and update it to include the
+    // specified `extra_location`.
+    void enrich_diagnostic_at(dclass type, diagnostic::range location, diagnostic::range extra_location);
+
+    void enrich_rparen_diagnostic(ruby_parser::token_t rparen, ruby_parser::location extra_location);
+
     // We've patched the lexer to break compatibility with Ruby w.r.t. method calls
     // for methods sharing names with ruby reserved words. See this PR:
     //   https://github.com/sorbet/sorbet/pull/1993

--- a/test/cli/rparen/rparen_other.rb
+++ b/test/cli/rparen/rparen_other.rb
@@ -1,0 +1,16 @@
+# typed: false
+
+def ex1
+  puts('before')
+  foo( 0
+end
+
+def ex2
+  puts('before')
+  not ( 0
+end
+
+def ex3
+  puts('before')
+  yield ( 0
+end

--- a/test/cli/rparen/test.out
+++ b/test/cli/rparen/test.out
@@ -1,24 +1,43 @@
-test/cli/rparen/rparen_other.rb:6: unexpected token "end" https://srb.help/2001
+test/cli/rparen/rparen_other.rb:6: unterminated "(" https://srb.help/2001
      6 |end
         ^^^
+    test/cli/rparen/rparen_other.rb:5: Corresponding `"("` was here
+     5 |  foo( 0
+             ^
 
-test/cli/rparen/rparen_other.rb:11: unexpected token "end" https://srb.help/2001
+test/cli/rparen/rparen_other.rb:11: unterminated "(" https://srb.help/2001
     11 |end
         ^^^
+    test/cli/rparen/rparen_other.rb:10: Corresponding `"("` was here
+    10 |  not ( 0
+              ^
 
-test/cli/rparen/rparen_other.rb:16: unexpected token "end" https://srb.help/2001
+test/cli/rparen/rparen_other.rb:16: unterminated "(" https://srb.help/2001
     16 |end
         ^^^
+    test/cli/rparen/rparen_other.rb:15: Corresponding `"("` was here
+    15 |  yield ( 0
+                ^
 Errors: 3
 class <emptyTree><<C <root>>> < (::<todo sym>)
   def ex1<<todo method>>(&<blk>)
-    <emptyTree>
+    begin
+      <self>.puts("before")
+      <self>.foo(0)
+    end
+  end
+
+  def ex2<<todo method>>(&<blk>)
+    begin
+      <self>.puts("before")
+      0.!()
+    end
   end
 
   def ex3<<todo method>>(&<blk>)
     begin
       <self>.puts("before")
-      <blk>.call(<emptyTree>::<C <ErrorNode>>)
+      <blk>.call(0)
     end
   end
 end

--- a/test/cli/rparen/test.out
+++ b/test/cli/rparen/test.out
@@ -1,0 +1,24 @@
+test/cli/rparen/rparen_other.rb:6: unexpected token "end" https://srb.help/2001
+     6 |end
+        ^^^
+
+test/cli/rparen/rparen_other.rb:11: unexpected token "end" https://srb.help/2001
+    11 |end
+        ^^^
+
+test/cli/rparen/rparen_other.rb:16: unexpected token "end" https://srb.help/2001
+    16 |end
+        ^^^
+Errors: 3
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def ex1<<todo method>>(&<blk>)
+    <emptyTree>
+  end
+
+  def ex3<<todo method>>(&<blk>)
+    begin
+      <self>.puts("before")
+      <blk>.call(<emptyTree>::<C <ErrorNode>>)
+    end
+  end
+end

--- a/test/cli/rparen/test.sh
+++ b/test/cli/rparen/test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+inputs=(test/cli/rparen/rparen_other.rb)
+
+if main/sorbet --print=desugar-tree --max-threads=0 --censor-for-snapshot-tests --silence-dev-message "${inputs[@]}" 2>&1 ; then
+  echo 'expected to fail!'
+  exit 1
+fi

--- a/test/testdata/parser/error_recovery/rparen_1.rb
+++ b/test/testdata/parser/error_recovery/rparen_1.rb
@@ -1,0 +1,8 @@
+# typed: false
+
+def foo
+  puts 'before'
+  T::Array[T.any(Integer, String]
+                 #              ^ error: unexpected token "]"
+  puts 'after'
+end

--- a/test/testdata/parser/error_recovery/rparen_1.rb
+++ b/test/testdata/parser/error_recovery/rparen_1.rb
@@ -3,6 +3,6 @@
 def foo
   puts 'before'
   T::Array[T.any(Integer, String]
-                 #              ^ error: unexpected token "]"
+                 #              ^ error: unterminated "("
   puts 'after'
 end

--- a/test/testdata/parser/error_recovery/rparen_1.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/rparen_1.rb.desugar-tree.exp
@@ -1,3 +1,9 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  nil
+  def foo<<todo method>>(&<blk>)
+    begin
+      <self>.puts("before")
+      <emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C T>.any(<emptyTree>::<C Integer>, <emptyTree>::<C String>))
+      <self>.puts("after")
+    end
+  end
 end

--- a/test/testdata/parser/error_recovery/rparen_1.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/rparen_1.rb.desugar-tree.exp
@@ -1,0 +1,3 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  nil
+end

--- a/test/testdata/parser/error_recovery/rparen_2.rb
+++ b/test/testdata/parser/error_recovery/rparen_2.rb
@@ -3,6 +3,6 @@
 def foo
   puts 'before'
   {key: T.any(Integer, String}
-              #              ^ error: unexpected token tRCURLY
+              #              ^ error: unterminated "("
   puts 'after'
 end

--- a/test/testdata/parser/error_recovery/rparen_2.rb
+++ b/test/testdata/parser/error_recovery/rparen_2.rb
@@ -1,0 +1,8 @@
+# typed: false
+
+def foo
+  puts 'before'
+  {key: T.any(Integer, String}
+              #              ^ error: unexpected token tRCURLY
+  puts 'after'
+end

--- a/test/testdata/parser/error_recovery/rparen_2.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/rparen_2.rb.desugar-tree.exp
@@ -1,3 +1,9 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  nil
+  def foo<<todo method>>(&<blk>)
+    begin
+      <self>.puts("before")
+      {:key => <emptyTree>::<C T>.any(<emptyTree>::<C Integer>, <emptyTree>::<C String>)}
+      <self>.puts("after")
+    end
+  end
 end

--- a/test/testdata/parser/error_recovery/rparen_2.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/rparen_2.rb.desugar-tree.exp
@@ -1,0 +1,3 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  nil
+end

--- a/test/testdata/parser/error_recovery/rparen_3.rb
+++ b/test/testdata/parser/error_recovery/rparen_3.rb
@@ -1,0 +1,8 @@
+# typed: false
+
+  def foo
+    puts 'before'
+    T.any(Integer, String
+    puts 'after'
+  # ^^^^ error: unexpected token tIDENTIFIER
+  end

--- a/test/testdata/parser/error_recovery/rparen_3.rb
+++ b/test/testdata/parser/error_recovery/rparen_3.rb
@@ -6,3 +6,4 @@
     puts 'after'
   # ^^^^ error: unexpected token tIDENTIFIER
   end
+# ^^^ error: unterminated "("

--- a/test/testdata/parser/error_recovery/rparen_3.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/rparen_3.rb.desugar-tree.exp
@@ -1,3 +1,8 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  nil
+  def foo<<todo method>>(&<blk>)
+    begin
+      <self>.puts("before")
+      <emptyTree>::<C T>.any(<emptyTree>::<C <ErrorNode>>)
+    end
+  end
 end

--- a/test/testdata/parser/error_recovery/rparen_3.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/rparen_3.rb.desugar-tree.exp
@@ -1,0 +1,3 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  nil
+end

--- a/test/testdata/parser/error_recovery/rparen_4.rb
+++ b/test/testdata/parser/error_recovery/rparen_4.rb
@@ -8,5 +8,6 @@ class A
     puts 'after'
   # ^^^^ error: unexpected token tIDENTIFIER
   end
+# ^^^ error: unterminated "("
   def after; end
 end

--- a/test/testdata/parser/error_recovery/rparen_4.rb
+++ b/test/testdata/parser/error_recovery/rparen_4.rb
@@ -1,0 +1,12 @@
+# typed: false
+
+class A
+  def before; end
+  def foo
+    puts 'before'
+    T.any(Integer, String
+    puts 'after'
+  # ^^^^ error: unexpected token tIDENTIFIER
+  end
+  def after; end
+end

--- a/test/testdata/parser/error_recovery/rparen_4.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/rparen_4.rb.desugar-tree.exp
@@ -1,3 +1,18 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  nil
+  class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
+    def before<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    def foo<<todo method>>(&<blk>)
+      begin
+        <self>.puts("before")
+        <emptyTree>::<C T>.any(<emptyTree>::<C <ErrorNode>>)
+      end
+    end
+
+    def after<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+  end
 end

--- a/test/testdata/parser/error_recovery/rparen_4.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/rparen_4.rb.desugar-tree.exp
@@ -1,0 +1,3 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  nil
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is basically the same change as #5273 but for `(` instead of `[`.

It shares all the downsides of that approach, but it's better than nothing.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.