### PR TITLE
Allow enum instances to be passed to deserialization methods

### DIFF
--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -78,6 +78,8 @@ class T::Enum
       raise "Attempting to access serialization map of #{self.class} before it has been initialized." \
         " Enums are not initialized until the 'enums do' block they are defined in has finished running."
     end
+    # Allow enum instances to be passed directly
+    return serialized_val if serialized_val.is_a?(self)
     @mapping[serialized_val]
   end
 

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -133,6 +133,10 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
         CardSuit.from_serialized('whoopsies')
       end
     end
+
+    it 'allows deserialized enum values to be used' do
+      assert_equal(CardSuit::HEART, CardSuit.from_serialized(CardSuit::HEART))
+    end
   end
 
   describe 'has_serialized?' do
@@ -161,6 +165,10 @@ class T::Enum::Test::EnumTest < Critic::Unit::UnitTest
     it 'returns nil for an invalid serialization' do
       suit = CardSuit.try_deserialize('blerg')
       assert_nil(suit)
+    end
+
+    it 'allows deserialized enum values to be used' do
+      assert_equal(CardSuit::HEART, CardSuit.try_deserialize(CardSuit::HEART))
     end
   end
 


### PR DESCRIPTION
The from_serialized and try_deserialize methods now accept already- deserialized enum instances and return them unchanged. This makes these methods more forgiving when the input may already be deserialized.

This is particularly helpful when you have a Struct class containing an enum whose value you want to modify in a copy, e.g.:

```ruby
class UnitOfMeasure
  class Unit < T::Enum
    enums do
      CREDITS = new('Credits')
      BYTES = new('Bytes')
    end
  end
end

class UsageData < T::Struct
  const :description, String
  const :uom, T.nilable(UnitOfMeasure::Unit)
end

usage = UsageData.new(
  description: "Sample Usage",
  uom: UnitOfMeasure::Unit::CREDITS
)

# Copy the struct and change the uom to BYTES — currently fails, need to add
# `.serialize` to the enum value which seems pretty roundabout.
new_usage = UsageData.with(uom: UnitOfMeasure::Unit::BYTES)
```

### Motivation
As described above, usage of enums in methods like `with` is kind of clunky.


### Test plan

See included automated tests.
