### PR TITLE
Recover from missing comma in args list

### DIFF
--- a/parser/parser/cc/grammars/typedruby.ypp
+++ b/parser/parser/cc/grammars/typedruby.ypp
@@ -1968,6 +1968,20 @@ lbrace_cmd_block_start:
                       list->emplace_back($3);
                       $$ = list;
                     }
+                | args tCOMMA fcall user_variable
+                    {
+                      auto &list = $1;
+                      if ($3->type() == ruby_parser::token_type::tCONSTANT) {
+                        list->emplace_back(driver.build.const_(self, $3));
+                      } else {
+                        list->emplace_back(driver.build.call_method(self, nullptr, nullptr, $3, nullptr, nullptr, nullptr));
+                      }
+                      $$ = list;
+                      auto commaPos = @3.endPos(); // location where comma was expected
+                      driver.diagnostics.emplace_back(dlevel::ERROR, dclass::MissingToken, diagnostic::range(commaPos, commaPos), "\",\"");
+                      driver.rewind_and_reset(commaPos);
+                      driver.lex.emit(ruby_parser::token_type::tCOMMA, ",", commaPos);
+                    }
                 | args tCOMMA error
                     {
                       auto &list = $1;

--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -638,6 +638,11 @@ void lexer::emit(token_type type, const std::string &str, const char* start, con
   token_queue.push_back(mempool.alloc(type, offset_start, offset_end, scratch_view, line));
 }
 
+void lexer::emit(token_type type, std::string_view str, size_t offset) {
+  size_t line = line_start(type, offset);
+  token_queue.push_back(mempool.alloc(type, offset, offset, str, line));
+}
+
 void lexer::emit_do(bool do_block) {
   if (cond.active()) {
     emit(token_type::kDO_COND, "do");

--- a/parser/parser/include/ruby_parser/lexer.hh
+++ b/parser/parser/include/ruby_parser/lexer.hh
@@ -158,6 +158,12 @@ private:
     void emit(token_type type);
     void emit(token_type type, std::string_view str);
     void emit(token_type type, std::string_view str, const char *start, const char *end);
+
+public:
+    // Meant for error recovery to allow the parser to emit a token that would have been expected
+    void emit(token_type type, std::string_view str, size_t offset);
+
+private:
     // Without these overloads, emit(..., "do") would be ambiguous.
     // It's OK to store points to constants, as they live in static storage and will
     // therefore not be going away.

--- a/test/testdata/parser/error_recovery/missing_comma.rb
+++ b/test/testdata/parser/error_recovery/missing_comma.rb
@@ -1,20 +1,18 @@
 # typed: false
 
 T.any(Integer, String x)
-#                     ^ error: unexpected token tIDENTIFIER
+#                    ^ error: missing token ","
 T.any(Integer, String Float)
-#                     ^^^^^ error: unexpected token tCONSTANT
+#                    ^ error: missing token ","
 T.any(Integer, String @x)
-#                     ^^ error: unexpected token tIVAR
+#                    ^ error: missing token ","
 T.any(Integer, String puts(x))
-#                     ^^^^ error: unexpected token tIDENTIFIER
-#                            ^ error: unexpected token ")"
+#                    ^ error: missing token ","
 T.any(Integer, String T.nilable(Float))
-#                     ^ error: unexpected token tCONSTANT
-#                                     ^ error: unexpected token ")"
+#                    ^ error: missing token ","
 
 def even_missing_paren
   T.any(Integer, String x
-        #               ^ error: unexpected token tIDENTIFIER
-end
+#                      ^ error: missing token ","
+end # error: unterminated (
 

--- a/test/testdata/parser/error_recovery/missing_comma.rb
+++ b/test/testdata/parser/error_recovery/missing_comma.rb
@@ -1,0 +1,20 @@
+# typed: false
+
+T.any(Integer, String x)
+#                     ^ error: unexpected token tIDENTIFIER
+T.any(Integer, String Float)
+#                     ^^^^^ error: unexpected token tCONSTANT
+T.any(Integer, String @x)
+#                     ^^ error: unexpected token tIVAR
+T.any(Integer, String puts(x))
+#                     ^^^^ error: unexpected token tIDENTIFIER
+#                            ^ error: unexpected token ")"
+T.any(Integer, String T.nilable(Float))
+#                     ^ error: unexpected token tCONSTANT
+#                                     ^ error: unexpected token ")"
+
+def even_missing_paren
+  T.any(Integer, String x
+        #               ^ error: unexpected token tIDENTIFIER
+end
+

--- a/test/testdata/parser/error_recovery/missing_comma.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/missing_comma.rb.desugar-tree.exp
@@ -1,0 +1,3 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  nil
+end

--- a/test/testdata/parser/error_recovery/missing_comma.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/missing_comma.rb.desugar-tree.exp
@@ -1,3 +1,15 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  nil
+  <emptyTree>::<C T>.any(<emptyTree>::<C Integer>, <emptyTree>::<C String>, <self>.x())
+
+  <emptyTree>::<C T>.any(<emptyTree>::<C Integer>, <emptyTree>::<C String>, <emptyTree>::<C Float>)
+
+  <emptyTree>::<C T>.any(<emptyTree>::<C Integer>, <emptyTree>::<C String>, @x)
+
+  <emptyTree>::<C T>.any(<emptyTree>::<C Integer>, <emptyTree>::<C String>, <self>.puts(<self>.x()))
+
+  <emptyTree>::<C T>.any(<emptyTree>::<C Integer>, <emptyTree>::<C String>, <emptyTree>::<C T>.nilable(<emptyTree>::<C Float>))
+
+  def even_missing_paren<<todo method>>(&<blk>)
+    <emptyTree>::<C T>.any(<emptyTree>::<C Integer>, <emptyTree>::<C String>, <self>.x())
+  end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Realized that we could make this better after the changes in #9681

Still doesn't handle the case of

```ruby
T.any(Integer, String
x
```

very well even though it now handles

```ruby
T.any(Integer, String x
```

because I'm still struggling to deal with the newlines not producing conflicts,
but it's good enough to call it here I think. It's still a strict improvement.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tests show before+after