### PR TITLE
Collapse `T.all` types with impossibly-bound generics

### DIFF
--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -892,7 +892,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             return t2;
         }
 
-        if (isa_type<ClassType>(t1) || isa_type<AppliedType>(t1)) {
+        if (isa_type<ClassType>(t1) || isa_type<AppliedType>(t1) || isa_type<SelfTypeParam>(t1)) {
             auto lft = Types::all(gs, t1, o2->left);
             if (Types::isAsSpecificAs(gs, lft, o2->right) && !lft.isBottom()) {
                 categoryCounterInc("glb", "ZZZorClass");
@@ -1054,6 +1054,8 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             if (const auto lambdaParam = cast_type<LambdaParam>(selfTypeT2.definition.resultType(gs))) {
                 if (!lambdaParam->upperBound.isUntyped() && isSubType(gs, lambdaParam->upperBound, t1)) {
                     return t2;
+                } else if (glb(gs, t1, lambdaParam->upperBound).isBottom()) {
+                    return bottom();
                 }
             }
             return AndType::make_shared(t1, t2);

--- a/test/testdata/infer/generics/type_member_all_bottom.rb
+++ b/test/testdata/infer/generics/type_member_all_bottom.rb
@@ -28,8 +28,8 @@ class A
     if x
       return x.to_s
     else
-      T.reveal_type(x) # error: `T.nilable(T.all(FalseClass, A::X))`
-      return x # error: Expected `T.nilable(String)` but found `T.nilable(T.all(FalseClass, A::X))` for method result type
+      T.reveal_type(x) # error: `NilClass`
+      return x
     end
   end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sometimes we construct a `T.all(SomeClass, SomeTypeMember)`, but that type is
actually uninhabited, because `SomeTypeMember` has an upper bound that prevents
it every taking on a value of `SomeClass`.

For example, `upper: AbstractModel` but then `T.all` with `NilClass` or
`FalseClass`, which do not inherit from `AbstractModel` and thus cannot overlap.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See tests before+after