### PR TITLE
lift out some indexing into `cfg::Send::args`

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -105,11 +105,12 @@ KnowledgeFilter::KnowledgeFilter(core::Context ctx, cfg::CFG &cfg) {
                         }
                     } else if (send->fun == core::Names::eqeq()) {
                         if (send->args.size() == 1) {
-                            if (isNeeded(send->args[0].variable) && !isNeeded(send->recv.variable)) {
+                            auto arg0 = send->args[0].variable;
+                            if (isNeeded(arg0) && !isNeeded(send->recv.variable)) {
                                 used_vars[send->recv.variable.id()] = true;
                                 changed = true;
-                            } else if (isNeeded(send->recv.variable) && !isNeeded(send->args[0].variable)) {
-                                used_vars[send->args[0].variable.id()] = true;
+                            } else if (isNeeded(send->recv.variable) && !isNeeded(arg0)) {
+                                used_vars[arg0.id()] = true;
                                 changed = true;
                             }
                         }
@@ -652,9 +653,10 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         }
 
         if (!recvType.isUntyped()) {
-            truthy.addYesTypeTest(local, typeTestsWithVar, send->args[0].variable, recvType);
+            auto arg0 = send->args[0].variable;
+            truthy.addYesTypeTest(local, typeTestsWithVar, arg0, recvType);
             if (isSingleton(ctx, recvType, includeSingletonClasses)) {
-                falsy.addNoTypeTest(local, typeTestsWithVar, send->args[0].variable, recvType);
+                falsy.addNoTypeTest(local, typeTestsWithVar, arg0, recvType);
             }
         }
 
@@ -664,7 +666,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
 
     if (send->fun == core::Names::tripleEq()) {
         const auto &klassType = send->recv.type;
-        auto ref = send->args[0].variable;
+        const auto ref = send->args[0].variable;
         // `when` against class literal
         updateKnowledgeKindOf(ctx, local, loc, klassType, ref, knowledgeFilter, send->fun);
 
@@ -679,8 +681,8 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         // `updateKnowledge`, excluding Module objects.
         auto includeSingletonClasses = false;
         if (isSingleton(ctx, klassType, includeSingletonClasses)) {
-            whoKnows.truthy().addYesTypeTest(local, typeTestsWithVar, send->args[0].variable, klassType);
-            whoKnows.falsy().addNoTypeTest(local, typeTestsWithVar, send->args[0].variable, klassType);
+            whoKnows.truthy().addYesTypeTest(local, typeTestsWithVar, ref, klassType);
+            whoKnows.falsy().addNoTypeTest(local, typeTestsWithVar, ref, klassType);
         }
         whoKnows.sanityCheck();
         return;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is just a tiny bit more efficient -- the accesses look like the compiler should be able to combine them, but indexing into `InlinedVector` actually creates a bunch of control flow which is difficult for the compiler to see through.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
