### PR TITLE
use `KwPairSpan` for building hash literals during desugar

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -986,13 +986,14 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     Hash::ENTRY_store keys;
                     Hash::ENTRY_store values;
 
-                    keys.reserve(mergeValues.size() / 2);
-                    values.reserve(mergeValues.size() / 2);
-
                     // skip the first positional argument for the accumulator that would have been mutated
-                    for (auto it = mergeValues.begin() + 1; it != mergeValues.end();) {
-                        keys.emplace_back(move(*it++));
-                        values.emplace_back(move(*it++));
+                    auto args = absl::MakeSpan(mergeValues.begin() + 1, mergeValues.end());
+                    keys.reserve(args.size() / 2);
+                    values.reserve(args.size() / 2);
+
+                    for (auto [key, val] : core::KwPairSpan<ExpressionPtr>{args}) {
+                        keys.emplace_back(move(key));
+                        values.emplace_back(move(val));
                     }
 
                     return MK::Hash(loc, move(keys), move(values));

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -984,13 +984,14 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     Hash::ENTRY_store keys;
                     Hash::ENTRY_store values;
 
-                    keys.reserve(mergeValues.size() / 2);
-                    values.reserve(mergeValues.size() / 2);
-
                     // skip the first positional argument for the accumulator that would have been mutated
-                    for (auto it = mergeValues.begin() + 1; it != mergeValues.end();) {
-                        keys.emplace_back(move(*it++));
-                        values.emplace_back(move(*it++));
+                    auto args = absl::MakeSpan(mergeValues.begin() + 1, mergeValues.end());
+                    keys.reserve(args.size() / 2);
+                    values.reserve(args.size() / 2);
+
+                    for (auto [key, val] : core::KwPairSpan<ExpressionPtr>{args}) {
+                        keys.emplace_back(move(key));
+                        values.emplace_back(move(val));
                     }
 
                     return MK::Hash(loc, move(keys), move(values));

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -4616,13 +4616,14 @@ ast::ExpressionPtr Translator::desugarHash(core::LocOffsets loc, NodeVec &kvPair
         ast::Hash::ENTRY_store keys;
         ast::Hash::ENTRY_store values;
 
-        keys.reserve(mergeValues.size() / 2);
-        values.reserve(mergeValues.size() / 2);
-
         // skip the first positional argument for the accumulator that would have been mutated
-        for (auto it = mergeValues.begin() + 1; it != mergeValues.end();) {
-            keys.emplace_back(move(*it++));
-            values.emplace_back(move(*it++));
+        auto args = absl::MakeSpan(mergeValues.begin() + 1, mergeValues.end());
+        keys.reserve(args.size() / 2);
+        values.reserve(args.size() / 2);
+
+        for (auto [key, val] : core::KwPairSpan<ExpressionPtr>{args}) {
+            keys.emplace_back(move(key));
+            values.emplace_back(move(val));
         }
 
         return MK::Hash(loc, move(keys), move(values));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Just a little tidying; this might make this unusual case epsilon more efficient.

I do like that we are not relying on truncating division when reserving the keys and values, though.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.