### PR TITLE
copy less when dispatching `Magic.callWithBlockPass`

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2838,16 +2838,11 @@ public:
         }
 
         uint16_t numPosArgs = args.numPosArgs - 3;
-        InlinedVector<TypeAndOrigins, 2> sendArgStore;
+        InlinedVector<const TypeAndOrigins *, 2> sendArgs;
         InlinedVector<LocOffsets, 2> sendArgLocs;
         for (int i = 3; i < args.args.size(); i++) {
-            sendArgStore.emplace_back(*args.args[i]);
+            sendArgs.emplace_back(args.args[i]);
             sendArgLocs.emplace_back(args.locs.args[i]);
-        }
-        InlinedVector<const TypeAndOrigins *, 2> sendArgs;
-        sendArgs.reserve(sendArgStore.size());
-        for (auto &arg : sendArgStore) {
-            sendArgs.emplace_back(&arg);
         }
         CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], args.locs.fun, sendArgLocs};
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We don't need to whip up fresh copies of `TypeAndOrigins` here, we can just reuse the original pointers.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
