### PR TITLE
avoid copying `TypeAndOrigins.origins` when converting to procs

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2628,7 +2628,7 @@ private:
         }
 
         if (Types::isSubType(gs, Types::nilClass(), blockType.type)) {
-            nonNilBlockType = TypeAndOrigins{Types::dropNil(gs, blockType.type), blockType.origins};
+            nonNilBlockType.type = Types::dropNil(gs, blockType.type);
             typeIsNilable = true;
 
             if (nonNilBlockType.type.isBottom()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We just copied the locs here from `blockType` a couple of lines earlier, we don't need to destroy that copy and then copy the locs again.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
