### PR TITLE
fix bug in `Align` constructor

### DIFF
--- a/core/TrailingObjects.h
+++ b/core/TrailingObjects.h
@@ -147,19 +147,17 @@ private:
     // log2 of the required alignment.
     uint8_t shiftValue = 0;
 
+    explicit Align(uint64_t value) {
+        shiftValue = value;
+        ENFORCE(shiftValue < 64);
+    }
+
 public:
     constexpr Align() noexcept = default;
     constexpr Align(const Align &) = default;
     constexpr Align(Align &&) = default;
     Align &operator=(const Align &) = default;
     Align &operator=(Align &&) = default;
-
-    explicit Align(uint64_t value) {
-        ENFORCE(value > 0);
-        ENFORCE(isPowerOf2(value));
-        shiftValue = log2_64(value);
-        ENFORCE(shiftValue < 64);
-    }
 
     uint64_t value() const {
         return uint64_t(1) << shiftValue;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`Align`'s constructor was taking log2 of the value passed in, but this value was already the log2 of a constant, from `Of()`.  Which meant that we hit an `ENFORCE` later on.

`Of()` is the only caller, so we can fix the bug and make the constructor private.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This code isn't used, but it does fix an issue on an in-progress branch that I have.