### PR TITLE
take a less specific type for send responses

### DIFF
--- a/core/lsp/QueryResponse.h
+++ b/core/lsp/QueryResponse.h
@@ -10,12 +10,12 @@ class TypeConstraint;
 
 class SendResponse final {
 public:
-    SendResponse(std::shared_ptr<core::DispatchResult> dispatchResult, InlinedVector<core::LocOffsets, 2> argLocOffsets,
+    SendResponse(std::shared_ptr<core::DispatchResult> dispatchResult, absl::Span<const core::LocOffsets> argLocOffsets,
                  core::NameRef callerSideName, core::NameRef originalName, core::MethodRef enclosingMethod,
                  bool isPrivateOk, uint16_t numPosArgs, core::FileRef file, core::LocOffsets termLocOffsets,
                  core::LocOffsets receiverLocOffsets, core::LocOffsets funLocOffsets,
                  core::LocOffsets locOffsetsWithoutBlock)
-        : dispatchResult(std::move(dispatchResult)), argLocOffsets(std::move(argLocOffsets)),
+        : dispatchResult(std::move(dispatchResult)), argLocOffsets(argLocOffsets.begin(), argLocOffsets.end()),
           callerSideName(callerSideName), originalName(originalName), enclosingMethod(enclosingMethod),
           isPrivateOk(isPrivateOk), numPosArgs(numPosArgs), file(file), termLocOffsets(termLocOffsets),
           receiverLocOffsets(receiverLocOffsets), funLocOffsets(funLocOffsets),


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There's no reason that `SendResponse` needs to tie its argument type to its storage type.  (This doesn't make any real difference now, but it does in some forthcoming changes.)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.