### PR TITLE
optimize redundant lookups in `environment.cc`

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -974,9 +974,10 @@ void Environment::populateFrom(core::Context ctx, const Environment &other) {
     this->isDead = other.isDead;
     for (auto &pair : _vars) {
         auto var = pair.first;
-        pair.second.typeAndOrigins = other.getTypeAndOrigin(var);
-        pair.second.knowledge.replace(var, typeTestsWithVar, other.getKnowledge(var, false));
-        pair.second.knownTruthy = other.getKnownTruthy(var);
+        auto info = other.getRefInfo(var);
+        pair.second.typeAndOrigins = info.typeAndOrigins;
+        pair.second.knowledge.replace(var, typeTestsWithVar, info.knowledge);
+        pair.second.knownTruthy = info.knownTruthy;
     }
 
     this->pinnedTypes = other.pinnedTypes;

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -153,6 +153,13 @@ class Environment {
         TestedKnowledge knowledge;
         bool knownTruthy;
     };
+    struct VariableInfo {
+        const core::TypeAndOrigins &typeAndOrigins;
+        const TestedKnowledge &knowledge;
+        bool knownTruthy;
+        bool wasFound;
+    };
+
     // TODO(jvilk): Use vectors.
     UnorderedMap<cfg::LocalRef, VariableState> _vars;
 
@@ -162,6 +169,10 @@ class Environment {
     TypeTestReverseIndex typeTestsWithVar;
 
     bool hasType(core::Context ctx, cfg::LocalRef symbol) const;
+
+    // This is almost `_vars[symbol]` except with special handling
+    // in the case that `symbol` does not exist.
+    VariableInfo getRefInfo(cfg::LocalRef symbol) const;
 
     TestedKnowledge &getKnowledge(cfg::LocalRef symbol, bool shouldFail = true) {
         return const_cast<TestedKnowledge &>(const_cast<const Environment *>(this)->getKnowledge(symbol, shouldFail));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The functions in `environment.cc` handling control flow do a number of redundant lookups to `_vars`; this is easiest to see in `populateFrom` and tracing where the relevant values being copied actually come from, but it happens to a lesser degree in `mergeWith`.

This PR introduces an abstraction that looks up the relevant information once and stores enough to answer any relevant queries without a second lookup.

Comparing `-c opt` disassembly on arm64 darwin shows a nice reduction of instructions in `populateFrom`.  I think the compiler has not been quite as smart in `mergeWith`, but I need to take a closer look.  It's entirely possible that LTO would change the choices the compiler would make, and if it doesn't, then perhaps some judicious `inline` declarations will convince the compiler to do the right thing.

You should be able to review commit by commit.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
