### PR TITLE
move `cfg::Send`'s args et al to trailing objects

### DIFF
--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -112,8 +112,8 @@ CFG::ReadsAndWrites CFG::findAllReadsAndWrites(core::Context ctx) {
                 blockReads.add(v->what.id());
             } else if (auto v = cast_instruction<Send>(bind.value)) {
                 blockReads.add(v->recv.variable.id());
-                for (auto &arg : v->args) {
-                    blockReads.add(arg.variable.id());
+                for (auto &arg : v->argRefs()) {
+                    blockReads.add(arg.id());
                 }
             } else if (auto v = cast_instruction<TAbsurd>(bind.value)) {
                 blockReads.add(v->what.variable.id());

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -4,6 +4,7 @@
 #include "common/typecase.h"
 #include "core/Names.h"
 #include "core/TypeConstraint.h"
+#include <memory>
 #include <utility>
 
 using namespace std;
@@ -118,20 +119,40 @@ string LoadSelf::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) 
     return fmt::format("LoadSelf {{ link = {} }}", this->link->fun.showRaw(gs));
 }
 
-Send::Send(LocalRef recv, core::LocOffsets receiverLoc, core::NameRef fun, core::LocOffsets funLoc, uint16_t numPosArgs,
-           const InlinedVector<LocalRef, 2> &args, InlinedVector<core::LocOffsets, 2> &&argLocs, bool isPrivateOk,
-           shared_ptr<core::SendAndBlockLink> link)
-    : isPrivateOk(isPrivateOk), numPosArgs(numPosArgs), fun(fun), recv(recv), funLoc(funLoc), receiverLoc(receiverLoc),
-      argLocs(std::move(argLocs)), link(move(link)) {
-    ENFORCE(numPosArgs <= args.size(), "Expected {} positional arguments, but only have {} args", numPosArgs,
-            args.size());
+Send::SendInitializer::SendInitializer(Send *snd) : snd(snd), refs(snd->argRefs()), locs(snd->argLocs()) {}
 
-    this->args.reserve(args.size());
-    for (const auto &e : args) {
-        this->args.emplace_back(e);
+Send::SendInitializer Send::make(LocalRef recv, core::LocOffsets receiverLoc, core::NameRef fun,
+                                 core::LocOffsets funLoc, uint16_t numPosArgs, bool isPrivateOk, size_t numArgs) {
+    size_t totalSize = Parent::totalSizeToAlloc<LocalRef, core::TypePtr, core::LocOffsets>(numArgs, numArgs, numArgs);
+    void *p = ::operator new(totalSize);
+    Send *snd = new (p) Send(recv, receiverLoc, fun, funLoc, numPosArgs, isPrivateOk, numArgs);
+    // Go ahead and initialize all the TypePtrs; we will assign real values in infer.
+    for (auto &t : snd->argTypes()) {
+        new (&t) core::TypePtr();
     }
+    return SendInitializer(snd);
+}
+
+Send::Send(LocalRef recv, core::LocOffsets receiverLoc, core::NameRef fun, core::LocOffsets funLoc, uint16_t numPosArgs,
+           bool isPrivateOk, size_t numArgs)
+    : isPrivateOk(isPrivateOk), numPosArgs(numPosArgs), fun(fun), recv(recv), funLoc(funLoc), receiverLoc(receiverLoc),
+      numArgs(numArgs) {
+    ENFORCE(numPosArgs <= numArgs, "Expected {} positional arguments, but only have {} args", numPosArgs, numArgs);
+
     categoryCounterInc("cfg", "send");
-    histogramInc("cfg.send.args", this->args.size());
+    histogramInc("cfg.send.args", numArgs);
+}
+
+namespace {
+template <typename T> void destroySpan(absl::Span<T> span) {
+    destroy_n(span.begin(), span.size());
+}
+} // namespace
+
+Send::~Send() {
+    destroySpan(argRefs());
+    destroySpan(argTypes());
+    destroySpan(argLocs());
 }
 
 core::LocOffsets Send::locWithoutBlock(core::LocOffsets bindLoc) {

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -367,7 +367,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Send, 120, 8);
+CheckSize(Send, 64, 8);
 
 INSN(Return) : public Instruction {
 public:

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -263,12 +263,12 @@ INSN(Send) : public Instruction, private core::TrailingObjects<Send, LocalRef, c
 
 public:
     bool isPrivateOk;
-    uint16_t numPosArgs;
+    const uint16_t numPosArgs;
     core::NameRef fun;
     VariableUseSite recv;
     core::LocOffsets funLoc;
     core::LocOffsets receiverLoc;
-    size_t numArgs;
+    const size_t numArgs;
     std::shared_ptr<core::SendAndBlockLink> link;
 
     // We only need this for the first two sets of trailing types, but it's

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -284,6 +284,8 @@ public:
         // do it: it is effectively a wrapper around a pointer that knows how to
         // use placement new for assignments.
         template <typename T> class SlotInit {
+            friend SendInitializer;
+
             // Note that these point to _uninitialized_ memory.
             T *current;
             T *end;
@@ -291,7 +293,6 @@ public:
         public:
             SlotInit(absl::Span<T> span) : current(span.begin()), end(span.end()) {}
 
-        public:
             SlotInit &operator=(const T &value) {
                 new (current) T(value);
                 return *this;
@@ -330,6 +331,8 @@ public:
         SlotInit<core::LocOffsets> locs;
 
         InstructionPtr asInsnPtr() && {
+            ENFORCE(refs.current == refs.end, "must have initialized all send arguments");
+            ENFORCE(locs.current == locs.end, "must have initialized all send argument locs");
             return InstructionPtr(InsnToTag<Send>::value, snd);
         }
     };

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -67,6 +67,142 @@ private:
     friend InstructionPtr;
 };
 
+class InstructionPtr final {
+    using tagged_storage = uint64_t;
+
+    static constexpr tagged_storage TAG_MASK = 0xff;
+    static constexpr tagged_storage FLAG_MASK = 0xff00;
+    static constexpr tagged_storage SYNTHETIC_FLAG = 0x0100;
+    static_assert((TAG_MASK & FLAG_MASK) == 0, "no bits should be shared between tags and flags");
+    static constexpr tagged_storage PTR_MASK = ~(FLAG_MASK | TAG_MASK);
+
+    tagged_storage ptr;
+
+    template <typename T, typename... Args> friend InstructionPtr make_insn(Args &&...);
+    friend Send;
+
+    static tagged_storage tagPtr(Tag tag, void *i) noexcept {
+        auto val = static_cast<tagged_storage>(tag);
+        auto maskedPtr = reinterpret_cast<tagged_storage>(i) << 16;
+
+        return maskedPtr | val;
+    }
+
+    static void deleteTagged(Tag tag, void *ptr) noexcept;
+
+    InstructionPtr(Tag tag, Instruction *i) noexcept : ptr(tagPtr(tag, i)) {}
+
+    void resetTagged(tagged_storage i) noexcept {
+        Tag tagVal;
+        void *saved = nullptr;
+
+        if (ptr != 0) {
+            tagVal = tag();
+            saved = get();
+        }
+
+        ptr = i;
+
+        if (saved != nullptr) {
+            deleteTagged(tagVal, saved);
+        }
+    }
+    tagged_storage releaseTagged() noexcept {
+        auto i = ptr;
+        ptr = 0;
+        return i;
+    }
+
+    uint16_t tagMaybeZero() const noexcept {
+        return ptr & TAG_MASK;
+    }
+
+public:
+    // Required for typecase
+    template <class To> static bool isa(const InstructionPtr &insn);
+    template <class To> static const To &cast(const InstructionPtr &insn);
+    template <class To> static To &cast(InstructionPtr &insn) {
+        return const_cast<To &>(cast<To>(static_cast<const InstructionPtr &>(insn)));
+    }
+
+    constexpr InstructionPtr() noexcept : ptr(0) {}
+    constexpr InstructionPtr(std::nullptr_t) noexcept : ptr(0) {}
+    ~InstructionPtr() {
+        if (ptr != 0) {
+            deleteTagged(tag(), get());
+        }
+    }
+
+    InstructionPtr(const InstructionPtr &) = delete;
+    InstructionPtr &operator=(const InstructionPtr &) = delete;
+
+    InstructionPtr(InstructionPtr &&other) noexcept {
+        ptr = other.releaseTagged();
+    }
+    InstructionPtr &operator=(InstructionPtr &&other) noexcept {
+        if (*this == other) {
+            return *this;
+        }
+
+        resetTagged(other.releaseTagged());
+        return *this;
+    }
+
+    Instruction *operator->() const noexcept {
+        return get();
+    }
+    Instruction *get() const noexcept {
+        auto val = ptr & PTR_MASK;
+        return reinterpret_cast<Instruction *>(val >> 16);
+    }
+
+    explicit operator bool() const noexcept {
+        return ptr != 0;
+    }
+
+    bool operator==(const InstructionPtr &other) const noexcept {
+        return ptr == other.ptr;
+    }
+    bool operator==(std::nullptr_t) const noexcept {
+        return ptr == 0;
+    }
+    bool operator!=(const InstructionPtr &other) const noexcept {
+        return ptr != other.ptr;
+    }
+    bool operator!=(std::nullptr_t) const noexcept {
+        return ptr != 0;
+    }
+
+    Tag tag() const noexcept {
+        ENFORCE(ptr != 0);
+
+        return static_cast<Tag>(ptr & TAG_MASK);
+    }
+
+    bool isSynthetic() const noexcept {
+        return (this->ptr & SYNTHETIC_FLAG) != 0;
+    }
+
+    template <class To> core::UntaggedPtr<To> as_instruction() {
+        bool isValid = tagMaybeZero() == uint16_t(InsnToTag<To>::value);
+        auto *ptr = isValid ? reinterpret_cast<To *>(get()) : nullptr;
+        return core::UntaggedPtr<To>(ptr, isValid);
+    }
+
+    template <class To> core::UntaggedPtr<const To> as_instruction() const {
+        bool isValid = tagMaybeZero() == uint16_t(InsnToTag<To>::value);
+        auto *ptr = isValid ? reinterpret_cast<const To *>(get()) : nullptr;
+        return core::UntaggedPtr<const To>(ptr, isValid);
+    }
+
+    void setSynthetic() noexcept {
+        this->ptr |= SYNTHETIC_FLAG;
+    }
+
+    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
+    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
+};
+
 #define INSN(name)                              \
     class name;                                 \
     template <> struct InsnToTag<name> {        \
@@ -294,141 +430,6 @@ public:
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
 CheckSize(KeepAlive, 8, 8);
-
-class InstructionPtr final {
-    using tagged_storage = uint64_t;
-
-    static constexpr tagged_storage TAG_MASK = 0xff;
-    static constexpr tagged_storage FLAG_MASK = 0xff00;
-    static constexpr tagged_storage SYNTHETIC_FLAG = 0x0100;
-    static_assert((TAG_MASK & FLAG_MASK) == 0, "no bits should be shared between tags and flags");
-    static constexpr tagged_storage PTR_MASK = ~(FLAG_MASK | TAG_MASK);
-
-    tagged_storage ptr;
-
-    template <typename T, typename... Args> friend InstructionPtr make_insn(Args &&...);
-
-    static tagged_storage tagPtr(Tag tag, void *i) noexcept {
-        auto val = static_cast<tagged_storage>(tag);
-        auto maskedPtr = reinterpret_cast<tagged_storage>(i) << 16;
-
-        return maskedPtr | val;
-    }
-
-    static void deleteTagged(Tag tag, void *ptr) noexcept;
-
-    InstructionPtr(Tag tag, Instruction *i) noexcept : ptr(tagPtr(tag, i)) {}
-
-    void resetTagged(tagged_storage i) noexcept {
-        Tag tagVal;
-        void *saved = nullptr;
-
-        if (ptr != 0) {
-            tagVal = tag();
-            saved = get();
-        }
-
-        ptr = i;
-
-        if (saved != nullptr) {
-            deleteTagged(tagVal, saved);
-        }
-    }
-    tagged_storage releaseTagged() noexcept {
-        auto i = ptr;
-        ptr = 0;
-        return i;
-    }
-
-    uint16_t tagMaybeZero() const noexcept {
-        return ptr & TAG_MASK;
-    }
-
-public:
-    // Required for typecase
-    template <class To> static bool isa(const InstructionPtr &insn);
-    template <class To> static const To &cast(const InstructionPtr &insn);
-    template <class To> static To &cast(InstructionPtr &insn) {
-        return const_cast<To &>(cast<To>(static_cast<const InstructionPtr &>(insn)));
-    }
-
-    constexpr InstructionPtr() noexcept : ptr(0) {}
-    constexpr InstructionPtr(std::nullptr_t) noexcept : ptr(0) {}
-    ~InstructionPtr() {
-        if (ptr != 0) {
-            deleteTagged(tag(), get());
-        }
-    }
-
-    InstructionPtr(const InstructionPtr &) = delete;
-    InstructionPtr &operator=(const InstructionPtr &) = delete;
-
-    InstructionPtr(InstructionPtr &&other) noexcept {
-        ptr = other.releaseTagged();
-    }
-    InstructionPtr &operator=(InstructionPtr &&other) noexcept {
-        if (*this == other) {
-            return *this;
-        }
-
-        resetTagged(other.releaseTagged());
-        return *this;
-    }
-
-    Instruction *operator->() const noexcept {
-        return get();
-    }
-    Instruction *get() const noexcept {
-        auto val = ptr & PTR_MASK;
-        return reinterpret_cast<Instruction *>(val >> 16);
-    }
-
-    explicit operator bool() const noexcept {
-        return ptr != 0;
-    }
-
-    bool operator==(const InstructionPtr &other) const noexcept {
-        return ptr == other.ptr;
-    }
-    bool operator==(std::nullptr_t) const noexcept {
-        return ptr == 0;
-    }
-    bool operator!=(const InstructionPtr &other) const noexcept {
-        return ptr != other.ptr;
-    }
-    bool operator!=(std::nullptr_t) const noexcept {
-        return ptr != 0;
-    }
-
-    Tag tag() const noexcept {
-        ENFORCE(ptr != 0);
-
-        return static_cast<Tag>(ptr & TAG_MASK);
-    }
-
-    bool isSynthetic() const noexcept {
-        return (this->ptr & SYNTHETIC_FLAG) != 0;
-    }
-
-    template <class To> core::UntaggedPtr<To> as_instruction() {
-        bool isValid = tagMaybeZero() == uint16_t(InsnToTag<To>::value);
-        auto *ptr = isValid ? reinterpret_cast<To *>(get()) : nullptr;
-        return core::UntaggedPtr<To>(ptr, isValid);
-    }
-
-    template <class To> core::UntaggedPtr<const To> as_instruction() const {
-        bool isValid = tagMaybeZero() == uint16_t(InsnToTag<To>::value);
-        auto *ptr = isValid ? reinterpret_cast<const To *>(get()) : nullptr;
-        return core::UntaggedPtr<const To>(ptr, isValid);
-    }
-
-    void setSynthetic() noexcept {
-        this->ptr |= SYNTHETIC_FLAG;
-    }
-
-    std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
-    std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
-};
 
 template <class To> bool isa_instruction(const InstructionPtr &what) {
     return bool(what.as_instruction<To>());

--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -248,8 +248,8 @@ void CFGBuilder::dealias(core::Context ctx, CFG &cfg) {
                     v->what = maybeDealias(ctx, cfg, v->what, current);
                 } else if (auto v = cast_instruction<Send>(bind.value)) {
                     v->recv = maybeDealias(ctx, cfg, v->recv.variable, current);
-                    for (auto &arg : v->args) {
-                        arg = maybeDealias(ctx, cfg, arg.variable, current);
+                    for (auto &arg : v->argRefs()) {
+                        arg = maybeDealias(ctx, cfg, arg, current);
                     }
                 } else if (auto v = cast_instruction<TAbsurd>(bind.value)) {
                     v->what = maybeDealias(ctx, cfg, v->what.variable, current);

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -225,22 +225,23 @@ BasicBlock *CFGBuilder::walkHash(CFGContext cctx, const ast::Hash &h, BasicBlock
     LocalRef magic = cctx.newTemporary(core::Names::magic());
     InlinedVector<cfg::LocalRef, 2> vars;
     InlinedVector<core::LocOffsets, 2> locs;
+    auto isPrivateOk = false;
+    auto numArgs = 2 * h.keys.size();
+    auto snd = Send::make(magic, h.loc, method, core::LocOffsets::none(), numArgs, isPrivateOk, numArgs);
+
     for (auto [key, val] : h.kviter()) {
         LocalRef keyTmp = cctx.newTemporary(core::Names::hashTemp());
         LocalRef valTmp = cctx.newTemporary(core::Names::hashTemp());
         current = walk(cctx.withTarget(keyTmp), key, current);
         current = walk(cctx.withTarget(valTmp), val, current);
-        vars.emplace_back(keyTmp);
-        vars.emplace_back(valTmp);
-        locs.emplace_back(key.loc());
-        locs.emplace_back(val.loc());
+        *snd.refs++ = keyTmp;
+        *snd.refs++ = valTmp;
+        *snd.locs++ = key.loc();
+        *snd.locs++ = val.loc();
     }
-    synthesizeExpr(current, magic, core::LocOffsets::none(), make_insn<Alias>(core::Symbols::Magic()));
 
-    auto isPrivateOk = false;
-    current->exprs.emplace_back(cctx.target, h.loc,
-                                make_insn<Send>(magic, h.loc, method, core::LocOffsets::none(), vars.size(), vars,
-                                                std::move(locs), isPrivateOk));
+    synthesizeExpr(current, magic, core::LocOffsets::none(), make_insn<Alias>(core::Symbols::Magic()));
+    current->exprs.emplace_back(cctx.target, h.loc, std::move(snd).asInsnPtr());
     return current;
 }
 
@@ -412,15 +413,14 @@ BasicBlock *CFGBuilder::buildExceptionHandler(CFGContext cctx, const ast::Expres
     rescueHandlersBlock = walk(cctx.withTarget(exceptionClass), ex, rescueHandlersBlock);
 
     auto isaCheck = cctx.newTemporary(core::Names::isaCheckTemp());
-    InlinedVector<cfg::LocalRef, 2> args;
-    InlinedVector<core::LocOffsets, 2> argLocs = {loc};
-    args.emplace_back(exceptionValue);
-
+    const size_t numPosArgs = 1;
+    const size_t numArgs = 1;
     auto isPrivateOk = false;
-    rescueHandlersBlock->exprs.emplace_back(isaCheck, loc,
-                                            make_insn<Send>(exceptionClass, loc, core::Names::tripleEq(),
-                                                            loc.copyWithZeroLength(), args.size(), args,
-                                                            std::move(argLocs), isPrivateOk));
+    auto snd = Send::make(exceptionClass, loc, core::Names::tripleEq(), loc.copyWithZeroLength(), numPosArgs,
+                          isPrivateOk, numArgs);
+    *snd.refs++ = exceptionValue;
+    *snd.locs++ = loc;
+    rescueHandlersBlock->exprs.emplace_back(isaCheck, loc, std::move(snd).asInsnPtr());
 
     auto otherHandlerBlock = cctx.inWhat.freshBlock(cctx.loops);
     conditionalJump(rescueHandlersBlock, isaCheck, caseBody, otherHandlerBlock, cctx.inWhat, loc);
@@ -687,13 +687,17 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::ExpressionPtr &what, Ba
                 recv = cctx.newTemporary(core::Names::statTemp());
                 current = walk(cctx.withTarget(recv), s.recv, current);
 
-                InlinedVector<LocalRef, 2> args;
-                InlinedVector<core::LocOffsets, 2> argLocs;
+                // Note that we do not have to include the block in the count here,
+                // as the block is not represented as an arg.
+                const size_t numArgs = s.numNonBlockArgs();
+                auto snd =
+                    Send::make(recv, s.recv.loc(), s.fun, s.funLoc, s.numPosArgs(), !!s.flags.isPrivateOk, numArgs);
+
                 for (auto &exp : s.posArgs()) {
                     LocalRef temp = cctx.newTemporary(core::Names::statTemp());
                     current = walk(cctx.withTarget(temp), exp, current);
-                    args.emplace_back(temp);
-                    argLocs.emplace_back(exp.loc());
+                    *snd.refs++ = temp;
+                    *snd.locs++ = exp.loc();
                 }
 
                 for (auto [key, value] : s.kwArgPairs()) {
@@ -701,17 +705,17 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::ExpressionPtr &what, Ba
                     LocalRef valTmp = cctx.newTemporary(core::Names::hashTemp());
                     current = walk(cctx.withTarget(keyTmp), key, current);
                     current = walk(cctx.withTarget(valTmp), value, current);
-                    args.emplace_back(keyTmp);
-                    args.emplace_back(valTmp);
-                    argLocs.emplace_back(key.loc());
-                    argLocs.emplace_back(value.loc());
+                    *snd.refs++ = keyTmp;
+                    *snd.refs++ = valTmp;
+                    *snd.locs++ = key.loc();
+                    *snd.locs++ = value.loc();
                 }
 
                 if (auto *exp = s.kwSplat()) {
                     LocalRef temp = cctx.newTemporary(core::Names::statTemp());
                     current = walk(cctx.withTarget(temp), *exp, current);
-                    args.emplace_back(temp);
-                    argLocs.emplace_back(exp->loc());
+                    *snd.refs++ = temp;
+                    *snd.locs++ = exp->loc();
                 }
 
                 if (auto *block = s.block()) {
@@ -722,8 +726,8 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::ExpressionPtr &what, Ba
                         paramFlags.emplace_back(e.flags);
                     }
                     auto link = make_shared<core::SendAndBlockLink>(s.fun, block->loc, move(paramFlags));
-                    auto send = make_insn<Send>(recv, s.recv.loc(), s.fun, s.funLoc, s.numPosArgs(), args,
-                                                std::move(argLocs), !!s.flags.isPrivateOk, link);
+                    auto send = std::move(snd).asInsnPtr();
+                    (*cast_instruction<Send>(send)).link = link;
                     LocalRef sendTemp = cctx.newTemporary(core::Names::blockPreCallTemp());
                     auto solveConstraint = make_insn<SolveConstraint>(link, sendTemp);
                     current->exprs.emplace_back(sendTemp, s.loc, move(send));
@@ -854,9 +858,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::ExpressionPtr &what, Ba
                      *
                      */
                 } else {
-                    current->exprs.emplace_back(cctx.target, s.loc,
-                                                make_insn<Send>(recv, s.recv.loc(), s.fun, s.funLoc, s.numPosArgs(),
-                                                                args, std::move(argLocs), !!s.flags.isPrivateOk));
+                    current->exprs.emplace_back(cctx.target, s.loc, std::move(snd).asInsnPtr());
                 }
 
                 ret = current;
@@ -891,8 +893,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::ExpressionPtr &what, Ba
                     auto magic = cctx.newTemporary(core::Names::magic());
                     auto ignored = cctx.newTemporary(core::Names::blockBreak());
                     synthesizeExpr(afterBreak, magic, a.loc, make_insn<Alias>(core::Symbols::Magic()));
-                    InlinedVector<LocalRef, 2> args{exprSym};
-                    InlinedVector<core::LocOffsets, 2> locs{core::LocOffsets::none()};
+                    const size_t numArgs = 1;
                     auto isPrivateOk = false;
 
                     // This represents the throw in the Ruby VM to the appropriate control frame.
@@ -900,10 +901,12 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::ExpressionPtr &what, Ba
                     // but see above for the rationale) because the actual assignment is a) done
                     // by the VM itself; and b) may not actually happen depending on the frames
                     // that the break unwinds through.
-                    synthesizeExpr(afterBreak, ignored, core::LocOffsets::none(),
-                                   make_insn<Send>(magic, core::LocOffsets::none(), core::Names::blockBreak(),
-                                                   core::LocOffsets::none(), args.size(), args, std::move(locs),
-                                                   isPrivateOk));
+                    auto snd = Send::make(magic, core::LocOffsets::none(), core::Names::blockBreak(),
+                                          core::LocOffsets::none(), numArgs, isPrivateOk, numArgs);
+                    *snd.refs++ = exprSym;
+                    *snd.locs++ = core::LocOffsets::none();
+
+                    synthesizeExpr(afterBreak, ignored, core::LocOffsets::none(), std::move(snd).asInsnPtr());
                 }
 
                 afterBreak->exprs.emplace_back(cctx.blockBreakTarget, a.loc, make_insn<Ident>(blockBreakAssign));
@@ -933,10 +936,11 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::ExpressionPtr &what, Ba
                     auto retryTemp = cctx.newTemporary(core::Names::retryTemp());
                     InlinedVector<cfg::LocalRef, 2> args{};
                     InlinedVector<core::LocOffsets, 2> argLocs{};
+                    const size_t numArgs = 0;
                     auto isPrivateOk = false;
-                    synthesizeExpr(current, retryTemp, core::LocOffsets::none(),
-                                   make_insn<Send>(magic, what.loc(), core::Names::retry(), core::LocOffsets::none(),
-                                                   args.size(), args, std::move(argLocs), isPrivateOk));
+                    auto snd = Send::make(magic, what.loc(), core::Names::retry(), core::LocOffsets::none(), numArgs,
+                                          isPrivateOk, numArgs);
+                    synthesizeExpr(current, retryTemp, core::LocOffsets::none(), std::move(snd).asInsnPtr());
                     unconditionalJump(current, cctx.rescueScope, cctx.inWhat, a.loc);
                 }
                 ret = cctx.inWhat.deadBlock();
@@ -1049,18 +1053,19 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::ExpressionPtr &what, Ba
                 LocalRef magic = cctx.newTemporary(core::Names::magic());
                 InlinedVector<LocalRef, 2> vars;
                 InlinedVector<core::LocOffsets, 2> locs;
+                const auto numArgs = a.elems.size();
+                auto isPrivateOk = false;
+                auto snd = Send::make(magic, a.loc, core::Names::buildArray(), core::LocOffsets::none(), numArgs,
+                                      isPrivateOk, numArgs);
+
                 for (auto &elem : a.elems) {
                     LocalRef tmp = cctx.newTemporary(core::Names::arrayTemp());
                     current = walk(cctx.withTarget(tmp), elem, current);
-                    vars.emplace_back(tmp);
-                    locs.emplace_back(a.loc);
+                    *snd.refs++ = tmp;
+                    *snd.locs++ = a.loc;
                 }
                 synthesizeExpr(current, magic, core::LocOffsets::none(), make_insn<Alias>(core::Symbols::Magic()));
-                auto isPrivateOk = false;
-                current->exprs.emplace_back(cctx.target, a.loc,
-                                            make_insn<Send>(magic, a.loc, core::Names::buildArray(),
-                                                            core::LocOffsets::none(), vars.size(), vars,
-                                                            std::move(locs), isPrivateOk));
+                current->exprs.emplace_back(cctx.target, a.loc, std::move(snd).asInsnPtr());
                 ret = current;
             },
 

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -627,42 +627,40 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::ExpressionPtr &what, Ba
                     // walked that new RHS.
 
                     auto zeroLoc = a.loc.copyWithZeroLength();
-
-                    InlinedVector<LocalRef, 2> args;
-                    InlinedVector<core::LocOffsets, 2> argLocs;
-
                     auto recvTemp = cctx.newTemporary(core::Names::statTemp());
                     auto magic = ast::MK::Constant(zeroLoc, core::Symbols::Magic());
                     current = walk(cctx.withTarget(recvTemp), magic, current);
 
+                    // This must match the number of temporaries we create below.
+                    const auto numArgs = 4;
+                    const auto isPrivateOk = true;
+                    auto snd = Send::make(recvTemp, magic.loc(), core::Names::suggestFieldType(), zeroLoc, numArgs,
+                                          isPrivateOk, numArgs);
+
                     auto rhsTemp = cctx.newTemporary(core::Names::statTemp());
-                    args.emplace_back(rhsTemp);
-                    argLocs.emplace_back(a.rhs.loc());
+                    *snd.refs++ = rhsTemp;
+                    *snd.locs++ = a.rhs.loc();
                     current = walk(cctx.withTarget(rhsTemp), a.rhs, current);
 
                     auto fieldKindTemp = cctx.newTemporary(core::Names::statTemp());
-                    args.emplace_back(fieldKindTemp);
+                    *snd.refs++ = fieldKindTemp;
                     auto fieldKindStr = ast::MK::String(zeroLoc, fieldKind);
-                    argLocs.emplace_back(fieldKindStr.loc());
+                    *snd.locs++ = fieldKindStr.loc();
                     current = walk(cctx.withTarget(fieldKindTemp), fieldKindStr, current);
 
                     auto ownerTemp = cctx.newTemporary(core::Names::statTemp());
-                    args.emplace_back(ownerTemp);
+                    *snd.refs++ = ownerTemp;
                     auto ownerStr = ast::MK::String(zeroLoc, cctx.ctx.owner.asMethodRef().data(cctx.ctx)->name);
-                    argLocs.emplace_back(ownerStr.loc());
+                    *snd.locs++ = ownerStr.loc();
                     current = walk(cctx.withTarget(ownerTemp), ownerStr, current);
 
                     auto identTemp = cctx.newTemporary(core::Names::statTemp());
-                    args.emplace_back(identTemp);
+                    *snd.refs++ = identTemp;
                     auto identName = ast::MK::Symbol(zeroLoc, ident->name);
-                    argLocs.emplace_back(identName.loc());
+                    *snd.locs++ = identName.loc();
                     current = walk(cctx.withTarget(identTemp), identName, current);
 
-                    current->exprs.emplace_back(lhs, a.lhs.loc(),
-                                                make_insn<Send>(recvTemp, magic.loc(), core::Names::suggestFieldType(),
-                                                                zeroLoc, args.size(), move(args), move(argLocs),
-                                                                /* isPrivateOk */ true));
-
+                    current->exprs.emplace_back(lhs, a.lhs.loc(), std::move(snd).asInsnPtr());
                     current->exprs.emplace_back(cctx.target, a.loc, make_insn<Ident>(lhs));
                     ret = current;
                 } else {

--- a/core/Types.h
+++ b/core/Types.h
@@ -1038,7 +1038,7 @@ struct CallLocs final {
     LocOffsets call;
     LocOffsets receiver;
     LocOffsets fun;
-    InlinedVector<LocOffsets, 2> &args;
+    absl::Span<const LocOffsets> args;
 };
 
 struct DispatchArgs {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2590,7 +2590,8 @@ public:
         InlinedVector<const TypeAndOrigins *, 2> sendArgs =
             Magic_callWithSplat::generateSendArgs(posTuple, kwTuple, sendArgStore, args.argLoc(2));
         InlinedVector<LocOffsets, 2> sendArgLocs(sendArgs.size(), args.locs.args[2]);
-        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], args.locs.fun, sendArgLocs};
+        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], args.locs.fun,
+                          absl::MakeSpan(sendArgLocs)};
         DispatchArgs innerArgs{fn,
                                sendLocs,
                                numPosArgs,
@@ -2633,13 +2634,12 @@ private:
         }
 
         InlinedVector<const TypeAndOrigins *, 2> sendArgs;
-        InlinedVector<LocOffsets, 2> sendArgLocs;
         CallLocs sendLocs{
             .file = file,
             .call = blockArgLoc,
             .receiver = blockArgLoc,
             .fun = blockArgLoc.copyWithZeroLength(),
-            .args = sendArgLocs,
+            .args = absl::Span<const core::LocOffsets>(nullptr, 0),
         };
         DispatchArgs innerArgs{core::Names::toProc(),
                                sendLocs,
@@ -2837,10 +2837,9 @@ public:
 
         uint16_t numPosArgs = args.numPosArgs - 3;
         InlinedVector<const TypeAndOrigins *, 2> sendArgs;
-        InlinedVector<LocOffsets, 2> sendArgLocs;
+        absl::Span<const LocOffsets> sendArgLocs = absl::MakeSpan(args.locs.args).subspan(3);
         for (int i = 3; i < args.args.size(); i++) {
             sendArgs.emplace_back(args.args[i]);
-            sendArgLocs.emplace_back(args.locs.args[i]);
         }
         CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], args.locs.fun, sendArgLocs};
 
@@ -2958,7 +2957,8 @@ public:
         InlinedVector<const TypeAndOrigins *, 2> sendArgs =
             Magic_callWithSplat::generateSendArgs(posTuple, kwTuple, sendArgStore, args.argLoc(2));
         InlinedVector<LocOffsets, 2> sendArgLocs(sendArgs.size(), args.locs.args[2]);
-        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], args.locs.fun, sendArgLocs};
+        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.args[0], args.locs.fun,
+                          absl::MakeSpan(sendArgLocs)};
 
         auto &blockArgTpo = *args.args[4];
         auto finalBlockType = Magic_callWithBlockPass::typeToProc(gs, blockArgTpo, args.locs.file, args.locs.args[4],
@@ -3142,10 +3142,9 @@ public:
         uint16_t numPosArgs = args.numPosArgs - 3;
 
         InlinedVector<const TypeAndOrigins *, 2> sendArgStore;
-        InlinedVector<LocOffsets, 2> sendArgLocs;
+        absl::Span<const LocOffsets> sendArgLocs = absl::MakeSpan(args.locs.args).subspan(3);
         for (int i = 3; i < args.args.size(); ++i) {
             sendArgStore.emplace_back(args.args[i]);
-            sendArgLocs.emplace_back(args.locs.args[i]);
         }
         auto recvLoc = args.locs.args[0];
         CallLocs sendLocs{args.locs.file, args.locs.call, recvLoc, args.locs.fun, sendArgLocs};
@@ -3262,8 +3261,8 @@ public:
         ENFORCE(args.args.size() == 1);
 
         auto &arg = args.args[0];
-        InlinedVector<LocOffsets, 2> argLocs{args.locs.receiver};
-        CallLocs locs{args.locs.file, args.locs.call, args.locs.call, args.locs.fun, argLocs};
+        CallLocs locs{args.locs.file, args.locs.call, args.locs.call, args.locs.fun,
+                      absl::MakeSpan(&args.locs.receiver, 1)};
         InlinedVector<const TypeAndOrigins *, 2> innerArgs;
         TypeAndOrigins wrappedFullType{arg->type, args.fullType.origins};
 
@@ -3705,8 +3704,8 @@ public:
             return;
         }
 
-        InlinedVector<LocOffsets, 2> argLocs;
-        CallLocs locs{args.locs.file, args.locs.call, args.locs.call, args.locs.fun, argLocs};
+        CallLocs locs{args.locs.file, args.locs.call, args.locs.call, args.locs.fun,
+                      absl::Span<const LocOffsets>(nullptr, 0)};
         InlinedVector<const TypeAndOrigins *, 2> innerArgs;
         TypeAndOrigins wrappedFullType{argType, args.fullType.origins};
 
@@ -3743,12 +3742,11 @@ class Magic_mergeHash : public IntrinsicMethod {
         auto accType = args.args.front()->type;
 
         InlinedVector<const TypeAndOrigins *, 2> sendArgs;
-        InlinedVector<LocOffsets, 2> sendArgLocs;
 
         sendArgs.emplace_back(args.args[1]);
-        sendArgLocs.emplace_back(args.locs.args[1]);
 
-        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.receiver, args.locs.fun, sendArgLocs};
+        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.receiver, args.locs.fun,
+                          absl::MakeSpan(&args.locs.args[1], 1)};
         TypeAndOrigins wrappedFullType{accType, args.args[0]->origins};
 
         // emulate a call to `resType#merge`
@@ -3811,15 +3809,14 @@ class Magic_mergeHashValues : public IntrinsicMethod {
         }
 
         InlinedVector<const TypeAndOrigins *, 2> sendArgs;
-        InlinedVector<LocOffsets, 2> sendArgLocs;
 
         TypeAndOrigins argument{argType, InlinedVector<Loc, 1>{}};
         sendArgs.emplace_back(&argument);
 
         auto hashLoc = args.locs.args[1].join(args.locs.args.back());
-        sendArgLocs.emplace_back(hashLoc);
 
-        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.receiver, args.locs.fun, sendArgLocs};
+        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.receiver, args.locs.fun,
+                          absl::MakeSpan(&hashLoc, 1)};
         TypeAndOrigins wrappedFullType{accType, args.args[0]->origins};
 
         // emulate a call to `resType#merge` with a shape argument
@@ -3920,14 +3917,12 @@ void digImplementation(const GlobalState &gs, const DispatchArgs &args, Dispatch
         return;
     }
 
-    auto baseCaseArgLocs = InlinedVector<LocOffsets, 2>{};
-    baseCaseArgLocs.emplace_back(args.locs.args[0]);
     auto baseCaseLocs = CallLocs{
         args.locs.file,                         // file
         args.locs.call.copyWithZeroLength(),    // call
         args.locs.args[0].copyWithZeroLength(), // receiver
         args.locs.args[0].copyWithZeroLength(), // fun
-        baseCaseArgLocs,                        // args
+        absl::MakeSpan(&args.locs.args[0], 1),  // args
     };
     auto baseCaseArgTypes = InlinedVector<const TypeAndOrigins *, 2>{};
     baseCaseArgTypes.emplace_back(args.args[0]);
@@ -3975,10 +3970,7 @@ void digImplementation(const GlobalState &gs, const DispatchArgs &args, Dispatch
 
     // ---- Recursive case ----
 
-    auto digArgLocs = InlinedVector<LocOffsets, 2>{};
-    for (int i = 1; i < args.locs.args.size(); i++) {
-        digArgLocs.emplace_back(args.locs.args[i]);
-    }
+    auto digArgLocs = absl::MakeSpan(args.locs.args).subspan(1);
     auto digLocs = CallLocs{
         args.locs.file,                         // file
         args.locs.args[1],                      // call
@@ -4049,8 +4041,8 @@ class Array_flatten : public IntrinsicMethod {
         NameRef toAry = core::Names::toAry();
 
         InlinedVector<const TypeAndOrigins *, 2> sendArgs;
-        InlinedVector<LocOffsets, 2> sendArgLocs;
-        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.receiver, args.locs.fun, sendArgLocs};
+        CallLocs sendLocs{args.locs.file, args.locs.call, args.locs.receiver, args.locs.fun,
+                          absl::Span<const core::LocOffsets>(nullptr, 0)};
         TypeAndOrigins wrappedFullType{type, args.fullType.origins};
 
         DispatchArgs innerArgs{toAry,
@@ -4426,7 +4418,7 @@ public:
             /* callLoc */ args.locs.args[0].join(args.locs.args[newNumPosArgs]),
             /* receiverLoc */ args.locs.args[0],
             /* funLoc */ args.locs.args[0].copyEndWithZeroLength(),
-            newSendArgLocs,
+            absl::MakeSpan(newSendArgLocs),
         };
 
         auto newSendArgs = InlinedVector<const TypeAndOrigins *, 2>();
@@ -4473,9 +4465,8 @@ public:
         }
 
         auto hash = make_type<ClassType>(core::Symbols::Sorbet_Private_Static().data(gs)->lookupSingletonClass(gs));
-        InlinedVector<LocOffsets, 2> argLocs{args.locs.receiver};
         CallLocs locs{
-            args.locs.file, args.locs.call, args.locs.call, args.locs.fun, argLocs,
+            args.locs.file, args.locs.call, args.locs.call, args.locs.fun, absl::MakeSpan(&args.locs.receiver, 1),
         };
         TypeAndOrigins myType{args.selfType, args.receiverLoc()};
         InlinedVector<const TypeAndOrigins *, 2> innerArgs{&myType};

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -411,10 +411,14 @@ const core::TypeAndOrigins &Environment::getTypeAndOrigin(cfg::LocalRef symbol) 
     return fnd->second.typeAndOrigins;
 }
 
-const core::TypeAndOrigins &Environment::getAndFillTypeAndOrigin(cfg::VariableUseSite &symbol) const {
-    const auto &ret = getTypeAndOrigin(symbol.variable);
-    symbol.type = ret.type;
+const core::TypeAndOrigins &Environment::getAndFillTypeAndOrigin(cfg::LocalRef symbol, core::TypePtr &ty) const {
+    const auto &ret = getTypeAndOrigin(symbol);
+    ty = ret.type;
     return ret;
+}
+
+const core::TypeAndOrigins &Environment::getAndFillTypeAndOrigin(cfg::VariableUseSite &symbol) const {
+    return getAndFillTypeAndOrigin(symbol.variable, symbol.type);
 }
 
 bool Environment::getKnownTruthy(cfg::LocalRef var) const {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -98,15 +98,15 @@ KnowledgeFilter::KnowledgeFilter(core::Context ctx, cfg::CFG &cfg) {
                     }
                 } else if (auto send = cfg::cast_instruction<cfg::Send>(bind.value)) {
                     if (send->fun == core::Names::bang()) {
-                        if (send->args.empty()) {
+                        if (send->argRefs().empty()) {
                             if (isNeeded(bind.bind.variable) && !isNeeded(send->recv.variable)) {
                                 used_vars[send->recv.variable.id()] = true;
                                 changed = true;
                             }
                         }
                     } else if (send->fun == core::Names::eqeq()) {
-                        if (send->args.size() == 1) {
-                            auto arg0 = send->args[0].variable;
+                        if (send->argRefs().size() == 1) {
+                            auto arg0 = send->argRefs()[0];
                             if (isNeeded(arg0) && !isNeeded(send->recv.variable)) {
                                 used_vars[send->recv.variable.id()] = true;
                                 changed = true;
@@ -621,13 +621,13 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         return;
     }
 
-    if (send->args.empty()) {
+    if (send->argRefs().empty()) {
         return;
     }
 
     if (send->fun == core::Names::kindOf_p() || send->fun == core::Names::isA_p() ||
         send->fun == core::Names::instanceOf_p()) {
-        const auto &klassType = send->args[0].type;
+        const auto &klassType = send->argTypes()[0];
         auto ref = send->recv.variable;
         updateKnowledgeKindOf(ctx, local, loc, klassType, ref, knowledgeFilter, send->fun);
         whoKnows.sanityCheck();
@@ -635,7 +635,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
     }
 
     if (send->fun == core::Names::eqeq() || send->fun == core::Names::equal_p() || send->fun == core::Names::neq()) {
-        const auto &argType = send->args[0].type;
+        const auto &argType = send->argTypes()[0];
         const auto &recvType = send->recv.type;
 
         auto funIsEq = send->fun == core::Names::eqeq() || send->fun == core::Names::equal_p();
@@ -653,7 +653,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         }
 
         if (!recvType.isUntyped()) {
-            auto arg0 = send->args[0].variable;
+            auto arg0 = send->argRefs()[0];
             truthy.addYesTypeTest(local, typeTestsWithVar, arg0, recvType);
             if (isSingleton(ctx, recvType, includeSingletonClasses)) {
                 falsy.addNoTypeTest(local, typeTestsWithVar, arg0, recvType);
@@ -666,7 +666,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
 
     if (send->fun == core::Names::tripleEq()) {
         const auto &klassType = send->recv.type;
-        const auto ref = send->args[0].variable;
+        const auto ref = send->argRefs()[0];
         // `when` against class literal
         updateKnowledgeKindOf(ctx, local, loc, klassType, ref, knowledgeFilter, send->fun);
 
@@ -689,7 +689,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
     }
 
     if (send->fun == core::Names::lessThan() || send->fun == core::Names::leq()) {
-        auto argType = send->args[0].type;
+        auto argType = send->argTypes()[0];
         if (argType.isUntyped() ||
             (!core::isa_type<core::ClassType>(argType) && !core::isa_type<core::AppliedType>(argType))) {
             return;
@@ -729,7 +729,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
     }
 
     if (send->fun == core::Names::checkMatchArray()) {
-        auto tupleType = core::cast_type<core::TupleType>(send->args[1].type);
+        auto tupleType = core::cast_type<core::TupleType>(send->argTypes()[1]);
         if (tupleType == nullptr) {
             return;
         }
@@ -753,7 +753,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
             }
         }
 
-        auto ref = send->args[0].variable;
+        auto ref = send->argRefs()[0];
         whoKnows.truthy().addYesTypeTest(local, typeTestsWithVar, ref, typeTestType);
         whoKnows.falsy().addNoTypeTest(local, typeTestsWithVar, ref, typeTestType);
 
@@ -1032,9 +1032,9 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
 
                 InlinedVector<const core::TypeAndOrigins *, 2> args;
 
-                args.reserve(send.args.size());
-                for (cfg::VariableUseSite &arg : send.args) {
-                    args.emplace_back(&getAndFillTypeAndOrigin(arg));
+                args.reserve(send.numArgs);
+                for (auto [var, type] : send.argSpan()) {
+                    args.emplace_back(&getAndFillTypeAndOrigin(var, type));
                 }
 
                 const core::TypeAndOrigins &recvType = getAndFillTypeAndOrigin(send.recv);
@@ -1042,7 +1042,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                     checkFullyDefined = false;
                 }
                 core::CallLocs locs{
-                    ctx.file, bind.loc, send.receiverLoc, send.funLoc, send.argLocs,
+                    ctx.file, bind.loc, send.receiverLoc, send.funLoc, send.argLocs(),
                 };
 
                 // This is the main place where we type check a method, so we default by assuming
@@ -1196,15 +1196,16 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                         fun = lit.name;
                     }
                     core::lsp::QueryResponse::pushQueryResponse(
-                        ctx, core::lsp::SendResponse(
-                                 retainedResult, send.argLocs, fun, send.fun, ctx.owner.asMethodRef(), send.isPrivateOk,
-                                 send.numPosArgs, ctx.file, bind.loc, send.receiverLoc, send.funLoc, locWithoutBlock));
+                        ctx,
+                        core::lsp::SendResponse(retainedResult, send.argLocs(), fun, send.fun, ctx.owner.asMethodRef(),
+                                                send.isPrivateOk, send.numPosArgs, ctx.file, bind.loc, send.receiverLoc,
+                                                send.funLoc, locWithoutBlock));
                 }
                 if (send.link) {
                     send.link->result = move(retainedResult);
                 }
                 if (send.fun == core::Names::toHashDup()) {
-                    ENFORCE(send.args.size() == 1, "Desugar invariant");
+                    ENFORCE(send.numArgs == 1, "Desugar invariant");
                     tp.origins = args[0]->origins;
                 }
                 tp.origins.emplace_back(ctx.locAt(bind.loc));

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -218,6 +218,7 @@ public:
     const core::TypeAndOrigins &getTypeAndOrigin(cfg::LocalRef symbol) const;
 
     const core::TypeAndOrigins &getAndFillTypeAndOrigin(cfg::VariableUseSite &symbol) const;
+    const core::TypeAndOrigins &getAndFillTypeAndOrigin(cfg::LocalRef symbol, core::TypePtr &ty) const;
 
     /*
      * Create an Environment out of this one that holds if final condition in

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -219,9 +219,9 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
 
                 auto send = cfg::cast_instruction<cfg::Send>(expr.value);
                 if (send != nullptr && send->fun == core::Names::nilForSafeNavigation()) {
-                    ENFORCE(send->args.size() == 1, "Broken invariant from desugar");
+                    ENFORCE(send->argRefs().size() == 1, "Broken invariant from desugar");
                     unreachableInstruction = &expr.value;
-                    locForUnreachable = core::Loc(ctx.file, send->argLocs[0]);
+                    locForUnreachable = core::Loc(ctx.file, send->argLocs()[0]);
 
                     // The arg loc for the synthetic variable created for the purpose of this safe navigation
                     // check is a bit of a hack. It's intentionally one character too short so that for
@@ -248,7 +248,7 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
             auto send = cfg::cast_instruction<cfg::Send>(*unreachableInstruction);
             if (dueToSafeNavigation && send != nullptr) {
                 if (auto e = ctx.state.beginError(locForUnreachable, core::errors::Infer::UnnecessarySafeNavigation)) {
-                    const auto &ty = current.getAndFillTypeAndOrigin(send->args[0]);
+                    const auto &ty = current.getAndFillTypeAndOrigin(send->argRefs()[0], send->argTypes()[0]);
 
                     e.setHeader("Used `{}` operator on `{}`, which can never be nil", "&.", ty.type.show(ctx));
                     e.addErrorSection(ty.explainGot(ctx, current.locForUninitialized()));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`cfg::Send` has several problems, space-wise:

* `VariableUseSite` occupies 16 bytes, but has a "hole" of 4 bytes -- `TypePtr` is 8 bytes, and `LocalRef` is 4 bytes, but we need the structure to be 8-byte aligned.  So the `args` field of `cfg::Send` wastes 4 bytes per send arg of space in its vector, which can be quite significant.
* Both `args` and `argLocs` are always present, even in a 0-argument send (very common, think `attr_reader` calls and the like) or a 1-argument send (also quite common), which wastes space.
* Both `args` and `argLocs` are `InlinedVector`, fully generalized, but we construct every `cfg::Send` with a fixed number of arguments, which never changes, so we don't need all the storage of capacity, etc..  Nor do we need each vector to store a separate length, since both vectors are always the same length.

This PR tries to address all of these issues by altering `cfg::Send` to store its argument refs, types, and locs in trailing storage, using `core::TrailingObjects`.  This eliminates the wasted space of `VariableUseSite` -- we do waste some space for the alignment of `cfg::LocalRef`, but that's only 4 bytes per send, not 4 bytes per argument.  Each send also now allocates exactly as much space as is necessary, with no provision for dynamic memory management.

(This is not quite true, of course: the memory block for the send might have unused space at the end because the memory allocator allocates a slightly larger block.  But we already had 8 bytes of unused space for every send -- 120 bytes rounds up to 128 bytes with jemalloc bucketing -- and we had the same space wastage issue twice over with two separate vectors being allocated previously.  So this part probably comes out in the wash.)

This PR saves ~5-7% of max RSS on a typechecking run over Stripe's codebase (!).  It appears to be performance neutral, possibly even a little bit worse (something like low hundreds of ms).  The memory savings are pretty easy to explain; the timing changes are a little more challenging, as you might think the locality and memory allocation savings are a performance win on their own.  It's possible some bit of code is not getting properly inlined, or it's possible that the computation for the location of the trailing objects is just that much more complicated.  It's also possible that the `CallLocs` structure getting bigger and requiring slightly more work to initialize is responsible for some performance loss.  It's possible we might be able to win some of that back?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
