### PR TITLE
Add JSON::Coder to json.rbi

### DIFF
--- a/rbi/stdlib/json.rbi
+++ b/rbi/stdlib/json.rbi
@@ -441,6 +441,9 @@ end
 class JSON::CircularDatastructure < JSON::NestingError
 end
 
+class JSON::Coder
+end
+
 # This exception is raised if a generator or unparser error occurs.
 class JSON::GeneratorError < JSON::JSONError
 end


### PR DESCRIPTION
Resolves typechecking error of tapioca-generated activesupport 8.1 shim:

```
sorbet/rbi/gems/activesupport@8.1.1.rbi:7850: Unable to resolve constant Coder https://srb.help/5002
    7850 |ActiveSupport::JSON::Encoding::JSONGemCoderEncoder::CODER = T.let(T.unsafe(nil), JSON::Coder)
```

See:
https://github.com/rails/rails/blob/56cec19ed453af52082776a42dc54a881ba3d544/activesupport/lib/active_support/json/encoding.rb#L152
https://github.com/ruby/json/blob/9c36681b173545ea0f97fdb84e2b1963fbbc0028/lib/json/common.rb#L1017