### PR TITLE
Remove preserveConcreteSyntax parameter from Prism translate

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -878,7 +878,7 @@ unique_ptr<parser::Node> Translator::translateSendAssignment(pm_node_t *node, co
                                                                                              move(lhs));
 }
 
-unique_ptr<parser::Node> Translator::translate(pm_node_t *node, bool preserveConcreteSyntax) {
+unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
     if (node == nullptr)
         return nullptr;
 

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -60,7 +60,7 @@ public:
           desugarUniqueCounter(this->desugarUniqueCounterStorage) {}
 
     // Translates the given AST from Prism's node types into the equivalent AST in Sorbet's legacy parser node types.
-    std::unique_ptr<parser::Node> translate(pm_node_t *node, bool preserveConcreteSyntax = false);
+    std::unique_ptr<parser::Node> translate(pm_node_t *node);
 
 private:
     // This private constructor is used for creating child translators with modified context.


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
- this was intended as a temporary placeholder and has been superseded by an instance variable
- this is a very simple cleanup

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
