### PR TITLE
Fix Prism counter reset

### DIFF
--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -32,7 +32,7 @@ class Translator final {
 
     // Unique counters used to create synthetic names via `ctx.state.freshNameUnique`.
     // - The storage integers either store an "active" count used by a translator and some of its children,
-    //   or a dummy value (int min).
+    //   or a dummy value.
     // - The pointer variables point to the "active" count for each translator,
     //   which is either pointing to its own storage, or to a parent's storage.
     uint16_t parserUniqueCounterStorage;  // Minics the `Builder::Impl.uniqueCounter_` in `parser/Builder.cc`
@@ -64,14 +64,13 @@ public:
 
 private:
     // This private constructor is used for creating child translators with modified context.
-    // uniqueCounterStorage is passed as the minimum integer value and is never used
+    // uniqueCounterStorage is passed as a dummy value and is never used
     Translator(const Translator &parent, bool resetDesugarUniqueCounter, core::LocOffsets enclosingMethodLoc,
                core::NameRef enclosingMethodName, core::NameRef enclosingBlockParamName, bool isInModule,
                bool isInAnyBlock)
         : parser(parent.parser), ctx(parent.ctx), parseErrors(parent.parseErrors),
           directlyDesugar(parent.directlyDesugar), preserveConcreteSyntax(parent.preserveConcreteSyntax),
-          parserUniqueCounterStorage(std::numeric_limits<uint16_t>::min()),
-          desugarUniqueCounterStorage(resetDesugarUniqueCounter ? 1 : std::numeric_limits<uint32_t>::min()),
+          parserUniqueCounterStorage(9999), desugarUniqueCounterStorage(resetDesugarUniqueCounter ? 1 : 999999),
           parserUniqueCounter(parent.parserUniqueCounter),
           desugarUniqueCounter(resetDesugarUniqueCounter ? this->desugarUniqueCounterStorage
                                                          : parent.desugarUniqueCounter),


### PR DESCRIPTION
This PR ensures the Prism unique counters are reset to 1 (matching the original counters) rather than incorrectly to 0 (a dummy/sentinel value). Previously the condition was the wrong way around. As suggested by @amomchilov, I also updated the dummy value to be more obviously wrong rather than just showing numbers as off-by-one.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This ensures unique counters match between Prism and the original parser. For example:

```rb
def foo; a, b = 1, 2; end
```

Original desugar-tree:

```
class <emptyTree><<C <root>>> < (::<todo sym>)
  def foo<<todo method>>(&<blk>)
    begin
      <assignTemp>$2 = [1, 2]
      <assignTemp>$3 = ::<Magic>.<expand-splat>(<assignTemp>$2, 2, 0)
      a = <assignTemp>$3.[](0)
      b = <assignTemp>$3.[](1)
      <assignTemp>$2
    end
  end
end
```

Prism desugar-tree before (counter is off by one):

```
class <emptyTree><<C <root>>> < (::<todo sym>)
  def foo<<todo method>>(&<blk>)
    begin
      <assignTemp>$1 = [1, 2]
      <assignTemp>$2 = ::<Magic>.<expand-splat>(<assignTemp>$1, 2, 0)
      a = <assignTemp>$2.[](0)
      b = <assignTemp>$2.[](1)
      <assignTemp>$1
    end
  end
end
```

Prism desugar-tree after (counter matches original):

```
class <emptyTree><<C <root>>> < (::<todo sym>)
  def foo<<todo method>>(&<blk>)
    begin
      <assignTemp>$2 = [1, 2]
      <assignTemp>$3 = ::<Magic>.<expand-splat>(<assignTemp>$2, 2, 0)
      a = <assignTemp>$3.[](0)
      b = <assignTemp>$3.[](1)
      <assignTemp>$2
    end
  end
end
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This fixes some tests that we haven't pushed yet as part of the ongoing Prism work.
