### PR TITLE
Document that sigils have no effect in runtime checks

### DIFF
--- a/website/docs/runtime.md
+++ b/website/docs/runtime.md
@@ -17,7 +17,7 @@ In this doc we'll answer:
 
 Adding a method signature opts that method into runtime typechecks (in addition to opting it into [more static checks](static.md)). In this sense, `sorbet-runtime` is similar to libraries for adding runtime contracts.
 
-> Sigils are for static analysis only, they have no effect in runtime checks. For example, methods with signatures have their calls checked at runtime, even if defined in files with `# typed: ignore`.
+Sigils are for static analysis only: they have no effect on runtime behavior. For example, methods with signatures have their calls checked at runtime, even if defined in files with `# typed: ignore`. (See [Enabling Static Checks](static.md) for more on sigils.)
 
 Concretely, adding a `sig` wraps the method defined beneath it in a new method that:
 


### PR DESCRIPTION
### Motivation

I read the docs from cover to cover, and somehow I did not make this connection.

Was precisely trying a `sig` in a `# typed: ignore` file and was surprised it was checked at all.

I believe saying this explicitly may be didactic, what do you think?