### PR TITLE
Ignore blocks on index assignments

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -737,13 +737,17 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 // Meanwhile, the blockPassArg will use its own loc, which is the expression to the right of the `&`.
                 core::LocOffsets blockPassLoc;
                 if (!send->args.empty() && parser::isa_node<parser::BlockPass>(send->args.back().get())) {
-                    auto *bp = parser::cast_node<parser::BlockPass>(send->args.back().get());
-                    blockPassLoc = bp->loc;
-                    if (bp->block == nullptr) {
-                        // Replace an anonymous block pass like `f(&)` with a local variable reference, like `f(&&)`.
-                        blockPassArg = MK::Local(bp->loc.copyEndWithZeroLength(), core::Names::ampersand());
-                    } else {
-                        blockPassArg = node2TreeImpl(dctx, bp->block);
+                    // Edge case: ignore blocks in assignment to an index, like `target[&block] = c`
+                    if (send->method != core::Names::squareBracketsEq()) {
+                        auto *bp = parser::cast_node<parser::BlockPass>(send->args.back().get());
+                        blockPassLoc = bp->loc;
+                        if (bp->block == nullptr) {
+                            // Replace an anonymous block pass like `f(&)` with a local variable reference, like
+                            // `f(&&)`.
+                            blockPassArg = MK::Local(bp->loc.copyEndWithZeroLength(), core::Names::ampersand());
+                        } else {
+                            blockPassArg = node2TreeImpl(dctx, bp->block);
+                        }
                     }
 
                     send->args.pop_back();

--- a/test/prism_regression/assign_to_index.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/assign_to_index.rb.desugar-tree-raw.exp
@@ -3638,33 +3638,19 @@ ClassDef{
         }
         Send{
           flags = {}
-          recv = ConstantLit{
-            symbol = (class ::<Magic>)
-            orig = nullptr
+          recv = Send{
+            flags = {privateOk}
+            recv = Self
+            fun = <U target>
+            block = nullptr
+            pos_args = 0
+            args = [
+            ]
           }
-          fun = <U <call-with-block-pass>>
+          fun = <U []=>
           block = nullptr
-          pos_args = 4
+          pos_args = 1
           args = [
-            Send{
-              flags = {privateOk}
-              recv = Self
-              fun = <U target>
-              block = nullptr
-              pos_args = 0
-              args = [
-              ]
-            }
-            Literal{ value = :[]= }
-            Send{
-              flags = {privateOk}
-              recv = Self
-              fun = <U blk>
-              block = nullptr
-              pos_args = 0
-              args = [
-              ]
-            }
             Send{
               flags = {}
               recv = UnresolvedIdent{


### PR DESCRIPTION
### Motivation

The legacy Sorbet parser already crashes on this:

```ruby
a[&block] = 1
# ^^^^^^
# Failed to process tree (backtrace is above) https://srb.help/1001
```

[Sorbet.run](https://sorbet.run/?arg=--print=desugar-tree-raw-with-locs&arg=--parser=original#%23%20typed%3A%20false%0A%0Aa%5B%26block%5D%20%3D%201)

This PR just ignores silently drops it, from both the legacy parser and Prism.

When we [switch Prism to its 3.4 parsing mode](https://github.com/sorbet/sorbet/pull/9443#discussion_r2501336759), it'll detect this case automatically and diagnose an error.

### Test plan

Change the existing tests.