### PR TITLE
`--single_test=file` → `--single_test file`

### DIFF
--- a/docs/lsp-dev-guide.md
+++ b/docs/lsp-dev-guide.md
@@ -42,7 +42,7 @@ There are two main kinds of LSP tests you're likely to interact with:
     flag. If the test fails, you'll be see a line that looks like
 
     ```
-    + exec test/lsp_test_runner --single_test=test/testdata/lsp/completion/alias_method.rb
+    + exec test/lsp_test_runner --single_test test/testdata/lsp/completion/alias_method.rb
     ```
 
     somewhere in the output. This is the actual binary that Bazel built and ran
@@ -50,7 +50,7 @@ There are two main kinds of LSP tests you're likely to interact with:
     exec` part and add `lldb -- bazel-bin/` in front:
 
     ```
-    lldb -- bazel-bin/test/lsp_test_runner --single_test=test/testdata/lsp/completion/alias_method.rb
+    lldb -- bazel-bin/test/lsp_test_runner --single_test test/testdata/lsp/completion/alias_method.rb
     ```
 
     This is the easiest way to debug LSP things, because you can set breakpoints

--- a/test/fuzz/fuzz_hover.cc
+++ b/test/fuzz/fuzz_hover.cc
@@ -17,7 +17,7 @@ extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv) {
     auto res = options.parse(*argc, *argv);
 
     if (res.count("single_test") != 1) {
-        printf("--single_test=<filename> argument expected\n");
+        printf("--single_test <filename> argument expected\n");
         return 1;
     }
 

--- a/test/helpers/expectations.cc
+++ b/test/helpers/expectations.cc
@@ -170,7 +170,7 @@ Expectations getExpectationsForTest(string_view parentDir, string_view testName)
 
 Expectations Expectations::getExpectations(string singleTest) {
     if (singleTest.empty()) {
-        Exception::raise("No test specified. Pass one with --single_test=<test_path>");
+        Exception::raise("No test specified. Pass one with --single_test <test_path>");
     }
 
     if (FileOps::dirExists(singleTest)) {

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -978,7 +978,7 @@ int main(int argc, char *argv[]) {
     auto res = options.parse(argc, argv);
 
     if (res.count("single_test") != 1) {
-        printf("--single_test=<filename> argument expected\n");
+        printf("--single_test <filename> argument expected\n");
         return 1;
     }
 

--- a/test/parser_test_runner.cc
+++ b/test/parser_test_runner.cc
@@ -191,7 +191,7 @@ int main(int argc, char *argv[]) {
     auto res = options.parse(argc, argv);
 
     if (res.count("single_test") != 1) {
-        printf("--single_test=<filename> argument expected\n");
+        printf("--single_test <filename> argument expected\n");
         return 1;
     }
 

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -15,7 +15,7 @@ def dropExtension(p):
 _TEST_SCRIPT = """#!/usr/bin/env bash
 export ASAN_SYMBOLIZER_PATH=`pwd`/external/llvm_toolchain_15_0_7/bin/llvm-symbolizer
 set -x
-exec {runner} --single_test="{test}" {parser}
+exec {runner} --single_test "{test}" {parser}
 """
 
 def _exp_test_impl(ctx):

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -890,7 +890,7 @@ int main(int argc, char *argv[]) {
     auto res = options.parse(argc, argv);
 
     if (res.count("single_test") != 1) {
-        printf("--single_test=<filename> argument expected\n");
+        printf("--single_test <filename> argument expected\n");
         return 1;
     }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Copy the underlying test runner invocation out of a failing bazel test
target, which looks something like this:

    ==================== Test output for //test:test_LSPTests/testdata/lsp/fast_path/shuffle_and_change:
    + exec test/lsp_test_runner --single_test test/testdata/lsp/fast_path/shuffle_and_change.rb

Then I paste this into the terminal, prefix it with
`lldb -- bazel-bin/`, and that's how I quickly run a test under the
debugger.

Sometimes, I want to run a different test. It's a little easier for tab
completion by editing a previous `lldb --` command from my history. But
when I do that, I don't get tab completion, because there is no special
tab completion for the `lldb --` that would let it know that what
follows after `--single_test` is a filename.

So instead, let's just use a space, so that tab completion works.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.