### PR TITLE
Early return optimizations to RBS rewriter pipeline

### DIFF
--- a/rbs/AssertionsRewriter.h
+++ b/rbs/AssertionsRewriter.h
@@ -33,6 +33,7 @@ private:
     std::map<parser::Node *, std::vector<CommentNode>> &commentsByNode;
     std::vector<std::pair<core::LocOffsets, core::NameRef>> typeParams = {};
     std::set<std::pair<uint32_t, uint32_t>> consumedComments = {};
+    size_t totalComments = 0;
 
     void consumeComment(core::LocOffsets loc);
     bool hasConsumedComment(core::LocOffsets loc);

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -354,6 +354,11 @@ void CommentsAssociator::walkNode(parser::Node *node) {
         return;
     }
 
+    // If all RBS comments have been processed and associated with nodes, we can skip walking the rest of the tree.
+    if (commentByLine.empty()) {
+        return;
+    }
+
     typecase(
         node,
 

--- a/rbs/SigsRewriter.cc
+++ b/rbs/SigsRewriter.cc
@@ -590,6 +590,10 @@ unique_ptr<parser::Node> SigsRewriter::rewriteNode(unique_ptr<parser::Node> node
 }
 
 unique_ptr<parser::Node> SigsRewriter::run(unique_ptr<parser::Node> node) {
+    // If there are no signature comments to process, we can skip the entire tree walk.
+    if (commentsByNode.empty()) {
+        return node;
+    }
     return rewriteBody(move(node));
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Return early when there are no more RBS comments to process

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Results in a 10% speed up locally in type checking time for our monolith when using RBS.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
