### PR TITLE
[Bugfix] check for `self` on desugared tree

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -707,7 +707,7 @@ bool isCallToBlockGivenP(parser::Send *sendNode, ast::ExpressionPtr &receiverExp
         return false;
     }
 
-    if (sendNode->receiver == nullptr || parser::isa_node<parser::Self>(sendNode->receiver.get())) {
+    if (receiverExpr == nullptr || receiverExpr.isSelfReference()) {
         return true;
     }
 

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -687,7 +687,7 @@ bool isCallToBlockGivenP(parser::Send *sendNode, ast::ExpressionPtr &receiverExp
         return false;
     }
 
-    if (sendNode->receiver == nullptr || parser::isa_node<parser::Self>(sendNode->receiver.get())) {
+    if (receiverExpr == nullptr || receiverExpr.isSelfReference()) {
         return true;
     }
 

--- a/test/testdata/desugar/block_given.rb.desugar-tree.exp
+++ b/test/testdata/desugar/block_given.rb.desugar-tree.exp
@@ -20,22 +20,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       else
         false
       end
-      if the_block_name
-        ::<root>::<C Kernel>.block_given?()
-      else
-        false
-      end
+      ::<root>::<C Kernel>.block_given?()
       <emptyTree>
-      if the_block_name
-        <emptyTree>::<C Object>.block_given?()
-      else
-        false
-      end
-      if the_block_name
-        <emptyTree>::<C SomethingElse>.block_given?()
-      else
-        false
-      end
+      <emptyTree>::<C Object>.block_given?()
+      <emptyTree>::<C SomethingElse>.block_given?()
       <self>.block_given?("with parameter")
     end
   end
@@ -57,22 +45,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       else
         false
       end
-      if &$2
-        ::<root>::<C Kernel>.block_given?()
-      else
-        false
-      end
+      ::<root>::<C Kernel>.block_given?()
       <emptyTree>
-      if &$2
-        <emptyTree>::<C Object>.block_given?()
-      else
-        false
-      end
-      if &$2
-        <emptyTree>::<C SomethingElse>.block_given?()
-      else
-        false
-      end
+      <emptyTree>::<C Object>.block_given?()
+      <emptyTree>::<C SomethingElse>.block_given?()
       <self>.block_given?("with parameter")
     end
   end
@@ -94,22 +70,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       else
         false
       end
-      if <blk>
-        ::<root>::<C Kernel>.block_given?()
-      else
-        false
-      end
+      ::<root>::<C Kernel>.block_given?()
       <emptyTree>
-      if <blk>
-        <emptyTree>::<C Object>.block_given?()
-      else
-        false
-      end
-      if <blk>
-        <emptyTree>::<C SomethingElse>.block_given?()
-      else
-        false
-      end
+      <emptyTree>::<C Object>.block_given?()
+      <emptyTree>::<C SomethingElse>.block_given?()
       <self>.block_given?("with parameter")
     end
   end


### PR DESCRIPTION
### Motivation

Fixes a bug from #9718

The `sendNode->receiver` has already been moved out by this point, so it's always `nullptr`. 

As a result, `isCallToBlockGivenP()` was effectively ignoring the receiver.

### Test plan

Uses the new tests from #9723
