### PR TITLE
stop copying `shared_ptr`s when walking new contexts

### DIFF
--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -51,7 +51,7 @@ public:
     BasicBlock *nextScope;
     BasicBlock *breakScope;
     BasicBlock *rescueScope;
-    std::shared_ptr<core::SendAndBlockLink> link;
+    std::shared_ptr<core::SendAndBlockLink> *link = nullptr;
     UnorderedMap<core::SymbolRef, LocalRef> &aliases;
     UnorderedMap<core::NameRef, LocalRef> &discoveredUndeclaredFields;
 
@@ -61,7 +61,7 @@ public:
     CFGContext withBlockBreakTarget(LocalRef blockBreakTarget);
     CFGContext withLoopBreakTarget(LocalRef blockBreakTarget);
     CFGContext withLoopScope(BasicBlock *nextScope, BasicBlock *breakScope, bool insideRubyBlock = false);
-    CFGContext withSendAndBlockLink(std::shared_ptr<core::SendAndBlockLink> link);
+    CFGContext withSendAndBlockLink(std::shared_ptr<core::SendAndBlockLink> &link);
 
     LocalRef newTemporary(core::NameRef name);
 

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -210,9 +210,9 @@ CFGContext CFGContext::withLoopScope(BasicBlock *nextScope, BasicBlock *breakSco
     return ret;
 }
 
-CFGContext CFGContext::withSendAndBlockLink(shared_ptr<core::SendAndBlockLink> link) {
+CFGContext CFGContext::withSendAndBlockLink(shared_ptr<core::SendAndBlockLink> &link) {
     auto ret = CFGContext(*this);
-    ret.link = std::move(link);
+    ret.link = &link;
     return ret;
 }
 

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -255,8 +255,9 @@ BasicBlock *CFGBuilder::walkBlockReturn(CFGContext cctx, core::LocOffsets loc, a
     auto afterNext = walk(cctx.withTarget(exprSym), expr, current);
     if (afterNext != cctx.inWhat.deadBlock() && cctx.isInsideRubyBlock) {
         LocalRef dead = cctx.newTemporary(core::Names::nextTemp());
-        ENFORCE(cctx.link.get() != nullptr);
-        afterNext->exprs.emplace_back(dead, loc, make_insn<BlockReturn>(cctx.link, exprSym));
+        ENFORCE(cctx.link != nullptr);
+        ENFORCE(cctx.link->get() != nullptr);
+        afterNext->exprs.emplace_back(dead, loc, make_insn<BlockReturn>(*cctx.link, exprSym));
     }
 
     if (cctx.nextScope == nullptr) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

When we create a new `CFGContext`, we copy the `shared_ptr` that holds a reference to the most recent `SendAndBlockLink`.  Copying a `shared_ptr` means incrementing the (atomic) reference count, and decrementing it when we destroy the copied context.  This is pure overhead, and we shouldn't need to do this.

This PR switches things so we just have a pointer to the most recent `shared_ptr` instead, which is cheap to copy.  It is maybe not the most elegant thing, but it does remove the overhead.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
