### PR TITLE
Don't insert a duplicate import in the "Apply All" autocorrect in LSP

### DIFF
--- a/core/AutocorrectSuggestion.h
+++ b/core/AutocorrectSuggestion.h
@@ -20,9 +20,12 @@ struct AutocorrectSuggestion {
 
     bool hideEdit;
 
+    bool shouldSkipWhenAggregated;
+
     AutocorrectSuggestion(std::string_view title, std::vector<Edit> edits, bool isDidYouMean = false,
-                          bool hideEdit = false)
-        : title(title), edits(edits), isDidYouMean(isDidYouMean), hideEdit(hideEdit) {}
+                          bool hideEdit = false, bool shouldSkipWhenAggregated = false)
+        : title(title), edits(edits), isDidYouMean(isDidYouMean), hideEdit(hideEdit),
+          shouldSkipWhenAggregated(shouldSkipWhenAggregated) {}
 
     // Reads all the files to be edited, and then accumulates all the edits that need to be applied
     // to those files into a resulting string with all edits applied. Does not write those back out

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -608,9 +608,24 @@ core::packages::ImportType PackageInfo::fileToImportType(const core::GlobalState
     }
 }
 
-std::optional<core::AutocorrectSuggestion> PackageInfo::aggregateMissingImports(const core::GlobalState &gs) const {
+std::vector<core::AutocorrectSuggestion::Edit>
+computeImportEdits(const core::GlobalState &gs, const core::packages::PackageInfo &thisPkgInfo,
+                   UnorderedMap<core::packages::MangledName, core::packages::ImportType> toImport) {
     std::vector<core::AutocorrectSuggestion::Edit> allEdits;
+    for (auto &[packageName, importType] : toImport) {
+        auto &otherPkgInfo = gs.packageDB().getPackageInfo(packageName);
+        auto autocorrect = thisPkgInfo.addImport(gs, otherPkgInfo, importType);
+        if (autocorrect.has_value()) {
+            allEdits.insert(allEdits.end(), make_move_iterator(autocorrect.value().edits.begin()),
+                            make_move_iterator(autocorrect.value().edits.end()));
+        }
+    }
+    return allEdits;
+}
+
+std::optional<core::AutocorrectSuggestion> PackageInfo::aggregateMissingImports(const core::GlobalState &gs) const {
     UnorderedMap<core::packages::MangledName, core::packages::ImportType> toImport;
+    std::vector<core::AutocorrectSuggestion::Edit> allEdits;
 
     for (auto &import : importedPackageNames) {
         auto &pkgInfo = gs.packageDB().getPackageInfo(import.mangledName);
@@ -654,14 +669,8 @@ std::optional<core::AutocorrectSuggestion> PackageInfo::aggregateMissingImports(
             }
         }
     }
-    for (auto &[packageName, importType] : toImport) {
-        auto &pkgInfo = gs.packageDB().getPackageInfo(packageName);
-        auto autocorrect = this->addImport(gs, pkgInfo, importType);
-        if (autocorrect.has_value()) {
-            allEdits.insert(allEdits.end(), make_move_iterator(autocorrect.value().edits.begin()),
-                            make_move_iterator(autocorrect.value().edits.end()));
-        }
-    }
+    auto importEdits = computeImportEdits(gs, *this, toImport);
+    allEdits.insert(allEdits.end(), make_move_iterator(importEdits.begin()), make_move_iterator(importEdits.end()));
     if (allEdits.empty()) {
         return nullopt;
     }

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -304,7 +304,8 @@ optional<core::AutocorrectSuggestion> PackageInfo::addImport(const core::GlobalS
         suggestionTitle = fmt::format("Convert existing import to `{}`", importTypeMethod);
     }
 
-    core::AutocorrectSuggestion suggestion(suggestionTitle, edits);
+    core::AutocorrectSuggestion suggestion(suggestionTitle, edits, false /* isDidYouMean */, false /* hideEdit */,
+                                           true /* shouldSkipWhenAggregated */);
     return {suggestion};
 }
 
@@ -351,7 +352,8 @@ optional<core::AutocorrectSuggestion> PackageInfo::addExport(const core::GlobalS
 
     core::AutocorrectSuggestion suggestion(
         fmt::format("Export `{}` in package `{}`", newExportName, mangledName_.owner.show(gs)),
-        {{insertionLoc, fmt::format("\n  {}", exportLine)}});
+        {{insertionLoc, fmt::format("\n  {}", exportLine)}}, false /* isDidYouMean */, false /* hideEdit */,
+        false /* shouldSkipWhenAggregated */);
     return {suggestion};
 }
 
@@ -676,6 +678,31 @@ std::optional<core::AutocorrectSuggestion> PackageInfo::aggregateMissingImports(
     }
     AutocorrectSuggestion::mergeAdjacentEdits(allEdits);
     return core::AutocorrectSuggestion{"Add missing imports", std::move(allEdits)};
+}
+
+std::optional<core::AutocorrectSuggestion> PackageInfo::aggregateMissingImportsForFile(const core::GlobalState &gs,
+                                                                                       const core::FileRef fref) const {
+    auto it = packagesReferencedByFile.find(fref);
+    if (it == packagesReferencedByFile.end()) {
+        return std::nullopt;
+    }
+
+    UnorderedMap<core::packages::MangledName, core::packages::ImportType> toImport;
+    for (auto &[packageName, packageReferenceInfo] : it->second) {
+        auto &pkgInfo = gs.packageDB().getPackageInfo(packageName);
+        if (!packageReferenceInfo.importNeeded || packageReferenceInfo.causesModularityError || !pkgInfo.exists()) {
+            continue;
+        }
+        auto importType = fileToImportType(gs, fref);
+        toImport[packageName] = importType;
+    }
+
+    auto allEdits = computeImportEdits(gs, *this, toImport);
+    if (allEdits.empty()) {
+        return nullopt;
+    }
+    AutocorrectSuggestion::mergeAdjacentEdits(allEdits);
+    return core::AutocorrectSuggestion{"Add missing imports for this file", std::move(allEdits)};
 }
 
 std::optional<core::AutocorrectSuggestion>

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -330,6 +330,8 @@ public:
                                 std::vector<std::pair<core::packages::MangledName, PackageReferenceInfo>> &references);
 
     std::optional<core::AutocorrectSuggestion> aggregateMissingImports(const core::GlobalState &gs) const;
+    std::optional<core::AutocorrectSuggestion> aggregateMissingImportsForFile(const core::GlobalState &gs,
+                                                                              const core::FileRef fref) const;
     std::optional<core::AutocorrectSuggestion> aggregateMissingExports(const core::GlobalState &gs,
                                                                        std::vector<core::SymbolRef> &toExport) const;
     std::optional<core::AutocorrectSuggestion>

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -152,6 +152,9 @@ unique_ptr<ResponseMessage> CodeActionTask::runRequest(LSPTypecheckerDelegate &t
             // Collect all autocorrects regardless of range to compile into a "source" autocorrect whose scope is
             // the whole file.
             for (auto &autocorrect : error->autocorrects) {
+                if (autocorrect.shouldSkipWhenAggregated) {
+                    continue;
+                }
                 allEdits.insert(allEdits.end(), autocorrect.edits.begin(), autocorrect.edits.end());
             }
 
@@ -189,6 +192,20 @@ unique_ptr<ResponseMessage> CodeActionTask::runRequest(LSPTypecheckerDelegate &t
     auto last =
         unique(result.begin(), result.end(), [](const auto &l, const auto &r) -> bool { return l->title == r->title; });
     result.erase(last, result.end());
+
+    if (config.opts.cacheSensitiveOptions.sorbetPackages) {
+        auto packageName = gs.packageDB().getPackageNameForFile(file);
+        if (packageName.exists()) {
+            auto &pkgInfo = gs.packageDB().getPackageInfo(packageName);
+            if (pkgInfo.exists()) {
+                auto importsAutocorrect = pkgInfo.aggregateMissingImportsForFile(gs, file);
+                if (importsAutocorrect.has_value()) {
+                    allEdits.insert(allEdits.end(), make_move_iterator(importsAutocorrect->edits.begin()),
+                                    make_move_iterator(importsAutocorrect->edits.end()));
+                }
+            }
+        }
+    }
 
     // Perform _after_ sorting so these appear at the end of the list.
     if (!allEdits.empty()) {

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -535,7 +535,9 @@ class VisibilityCheckerPass final {
             importAutocorrect->edits.insert(importAutocorrect->edits.end(),
                                             make_move_iterator(exportAutocorrect->edits.begin()),
                                             make_move_iterator(exportAutocorrect->edits.end()));
-            e.addAutocorrect(core::AutocorrectSuggestion{combinedTitle, move(importAutocorrect->edits)});
+            e.addAutocorrect(core::AutocorrectSuggestion{combinedTitle, move(importAutocorrect->edits),
+                                                         false /* isDidYouMean */, false /* hideEdit */,
+                                                         false /* shouldSkipWhenAggregated */});
         } else if (importAutocorrect.has_value()) {
             e.addAutocorrect(std::move(importAutocorrect.value()));
         } else if (exportAutocorrect.has_value()) {

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -927,26 +927,26 @@ public:
             barrier.DecrementCount();
         });
 
-        if (gs.packageDB().genPackagesMode() != core::packages::GenPackagesMode::Disabled) {
-            std::optional<ThreadResult> threadResult;
-            for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer());
-                 !result.done();
-                 result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
-                if (result.gotItem() && threadResult.has_value()) {
-                    auto &file = threadResult->file;
-                    auto pkgName = gs.packageDB().getPackageNameForFile(file);
-                    if (!pkgName.exists()) {
-                        continue;
-                    }
+        std::optional<ThreadResult> threadResult;
+        for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer());
+             !result.done();
+             result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer())) {
+            if (result.gotItem() && threadResult.has_value()) {
+                auto &file = threadResult->file;
+                auto pkgName = gs.packageDB().getPackageNameForFile(file);
+                if (!pkgName.exists()) {
+                    continue;
+                }
 
-                    auto nonConstPackageInfo = nonConstPackageDB.getPackageInfoNonConst(pkgName);
-                    vector<pair<core::packages::MangledName, core::packages::PackageReferenceInfo>> references;
-                    auto &referencedPackages = threadResult->referencedPackages;
-                    for (auto &[packageName, packageReferenceInfo] : referencedPackages) {
-                        references.emplace_back(make_pair(packageName, packageReferenceInfo));
-                    }
-                    nonConstPackageInfo->trackPackageReferences(file, references);
+                auto nonConstPackageInfo = nonConstPackageDB.getPackageInfoNonConst(pkgName);
+                vector<pair<core::packages::MangledName, core::packages::PackageReferenceInfo>> references;
+                auto &referencedPackages = threadResult->referencedPackages;
+                for (auto &[packageName, packageReferenceInfo] : referencedPackages) {
+                    references.emplace_back(make_pair(packageName, packageReferenceInfo));
+                }
+                nonConstPackageInfo->trackPackageReferences(file, references);
 
+                if (gs.packageDB().genPackagesMode() != core::packages::GenPackagesMode::Disabled) {
                     auto &referencedSymbols = threadResult->referencedSymbols;
                     nonConstGs.setSymbolsReferencedByFile(file, referencedSymbols);
                 }

--- a/test/testdata/packager/apply-all-fixes/a/__package.A.rbedited
+++ b/test/testdata/packager/apply-all-fixes/a/__package.A.rbedited
@@ -1,0 +1,9 @@
+# typed: strict
+# enable-packager: true
+# packager-layers: lib, app
+
+class A < PackageSpec
+  layer 'lib'
+  strict_dependencies 'layered'
+  import B
+end

--- a/test/testdata/packager/apply-all-fixes/a/__package.B.rbedited
+++ b/test/testdata/packager/apply-all-fixes/a/__package.B.rbedited
@@ -1,0 +1,10 @@
+# typed: strict
+# enable-packager: true
+# packager-layers: lib, app
+
+class A < PackageSpec
+  layer 'lib'
+  strict_dependencies 'layered'
+  import B
+  import C
+end

--- a/test/testdata/packager/apply-all-fixes/a/__package.C.rbedited
+++ b/test/testdata/packager/apply-all-fixes/a/__package.C.rbedited
@@ -1,0 +1,9 @@
+# typed: strict
+# enable-packager: true
+# packager-layers: lib, app
+
+class A < PackageSpec
+  layer 'lib'
+  strict_dependencies 'layered'
+  import B
+end

--- a/test/testdata/packager/apply-all-fixes/a/__package.D.rbedited
+++ b/test/testdata/packager/apply-all-fixes/a/__package.D.rbedited
@@ -1,0 +1,10 @@
+# typed: strict
+# enable-packager: true
+# packager-layers: lib, app
+
+class A < PackageSpec
+  layer 'lib'
+  strict_dependencies 'layered'
+  import B
+  import C
+end

--- a/test/testdata/packager/apply-all-fixes/a/__package.E.rbedited
+++ b/test/testdata/packager/apply-all-fixes/a/__package.E.rbedited
@@ -1,0 +1,9 @@
+# typed: strict
+# enable-packager: true
+# packager-layers: lib, app
+
+class A < PackageSpec
+  layer 'lib'
+  strict_dependencies 'layered'
+  import C
+end

--- a/test/testdata/packager/apply-all-fixes/a/__package.F.rbedited
+++ b/test/testdata/packager/apply-all-fixes/a/__package.F.rbedited
@@ -1,0 +1,10 @@
+# typed: strict
+# enable-packager: true
+# packager-layers: lib, app
+
+class A < PackageSpec
+  layer 'lib'
+  strict_dependencies 'layered'
+  import B
+  import C
+end

--- a/test/testdata/packager/apply-all-fixes/a/__package.G.rbedited
+++ b/test/testdata/packager/apply-all-fixes/a/__package.G.rbedited
@@ -1,0 +1,9 @@
+# typed: strict
+# enable-packager: true
+# packager-layers: lib, app
+
+class A < PackageSpec
+  layer 'lib'
+  strict_dependencies 'layered'
+  test_import B, only: "test_rb"
+end

--- a/test/testdata/packager/apply-all-fixes/a/__package.H.rbedited
+++ b/test/testdata/packager/apply-all-fixes/a/__package.H.rbedited
@@ -1,0 +1,10 @@
+# typed: strict
+# enable-packager: true
+# packager-layers: lib, app
+
+class A < PackageSpec
+  layer 'lib'
+  strict_dependencies 'layered'
+  test_import B, only: "test_rb"
+  test_import C, only: "test_rb"
+end

--- a/test/testdata/packager/apply-all-fixes/a/__package.I.rbedited
+++ b/test/testdata/packager/apply-all-fixes/a/__package.I.rbedited
@@ -1,0 +1,9 @@
+# typed: strict
+# enable-packager: true
+# packager-layers: lib, app
+
+class A < PackageSpec
+  layer 'lib'
+  strict_dependencies 'layered'
+  test_import B, only: "test_rb"
+end

--- a/test/testdata/packager/apply-all-fixes/a/__package.J.rbedited
+++ b/test/testdata/packager/apply-all-fixes/a/__package.J.rbedited
@@ -1,0 +1,10 @@
+# typed: strict
+# enable-packager: true
+# packager-layers: lib, app
+
+class A < PackageSpec
+  layer 'lib'
+  strict_dependencies 'layered'
+  test_import B, only: "test_rb"
+  test_import C, only: "test_rb"
+end

--- a/test/testdata/packager/apply-all-fixes/a/__package.K.rbedited
+++ b/test/testdata/packager/apply-all-fixes/a/__package.K.rbedited
@@ -1,0 +1,9 @@
+# typed: strict
+# enable-packager: true
+# packager-layers: lib, app
+
+class A < PackageSpec
+  layer 'lib'
+  strict_dependencies 'layered'
+  test_import C, only: "test_rb"
+end

--- a/test/testdata/packager/apply-all-fixes/a/__package.L.rbedited
+++ b/test/testdata/packager/apply-all-fixes/a/__package.L.rbedited
@@ -1,0 +1,10 @@
+# typed: strict
+# enable-packager: true
+# packager-layers: lib, app
+
+class A < PackageSpec
+  layer 'lib'
+  strict_dependencies 'layered'
+  test_import B, only: "test_rb"
+  test_import C, only: "test_rb"
+end

--- a/test/testdata/packager/apply-all-fixes/a/__package.rb
+++ b/test/testdata/packager/apply-all-fixes/a/__package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+# enable-packager: true
+# packager-layers: lib, app
+
+class A < PackageSpec
+  layer 'lib'
+  strict_dependencies 'layered'
+end

--- a/test/testdata/packager/apply-all-fixes/a/foo.rb
+++ b/test/testdata/packager/apply-all-fixes/a/foo.rb
@@ -1,0 +1,18 @@
+# typed: true
+# selective-apply-code-action: quickfix
+# omit-apply-all-quickfix: false
+
+class A::Foo
+  B::Foo.new
+# ^^^^^^ error: `B::Foo` resolves but its package is not imported
+# ^^^^^^ apply-code-action: [A] Import `B` in package `A`
+# ^^^^^^ apply-code-action: [B] Apply all Sorbet fixes for file
+  B::Foo.new
+# ^^^^^^ error: `B::Foo` resolves but its package is not imported
+# ^^^^^^ apply-code-action: [C] Import `B` in package `A`
+# ^^^^^^ apply-code-action: [D] Apply all Sorbet fixes for file
+  C::Foo.new
+# ^^^^^^ error: `C::Foo` resolves but its package is not imported
+# ^^^^^^ apply-code-action: [E] Import `C` in package `A`
+# ^^^^^^ apply-code-action: [F] Apply all Sorbet fixes for file
+end

--- a/test/testdata/packager/apply-all-fixes/a/foo.test.rb
+++ b/test/testdata/packager/apply-all-fixes/a/foo.test.rb
@@ -1,0 +1,18 @@
+# typed: true
+# selective-apply-code-action: quickfix
+# omit-apply-all-quickfix: false
+
+class Test::A::FooTest
+  B::Foo.new
+# ^^^^^^ error: `B::Foo` resolves but its package is not imported
+# ^^^^^^ apply-code-action: [G] Test Import `B` in package `A`
+# ^^^^^^ apply-code-action: [H] Apply all Sorbet fixes for file
+  B::Foo.new
+# ^^^^^^ error: `B::Foo` resolves but its package is not imported
+# ^^^^^^ apply-code-action: [I] Test Import `B` in package `A`
+# ^^^^^^ apply-code-action: [J] Apply all Sorbet fixes for file
+  C::Foo.new
+# ^^^^^^ error: `C::Foo` resolves but its package is not imported
+# ^^^^^^ apply-code-action: [K] Test Import `C` in package `A`
+# ^^^^^^ apply-code-action: [L] Apply all Sorbet fixes for file
+end

--- a/test/testdata/packager/apply-all-fixes/b/__package.rb
+++ b/test/testdata/packager/apply-all-fixes/b/__package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+class B < PackageSpec
+  layer 'lib'
+  strict_dependencies 'layered'
+
+  export B::Foo
+end

--- a/test/testdata/packager/apply-all-fixes/b/foo.rb
+++ b/test/testdata/packager/apply-all-fixes/b/foo.rb
@@ -1,0 +1,4 @@
+# typed: true
+
+class B::Foo
+end

--- a/test/testdata/packager/apply-all-fixes/c/__package.rb
+++ b/test/testdata/packager/apply-all-fixes/c/__package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+class C < PackageSpec
+  layer 'lib'
+  strict_dependencies 'layered'
+
+  export C::Foo
+end

--- a/test/testdata/packager/apply-all-fixes/c/foo.rb
+++ b/test/testdata/packager/apply-all-fixes/c/foo.rb
@@ -1,0 +1,4 @@
+# typed: true
+
+class C::Foo
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

A common problem when using the "Apply all Sorbet fixes for file" autocorrect in a file with references to an unimported package is that multiple imports will be inserted (one for each reference in that file). This PR addresses that by:

- adding a flag on `AutocorrectSuggestion` called `shouldSkipWhenAggregated`, and setting it for autocorrects that add an import
- using the `packagesReferencedByFile` map added in #9682 to craft an edit that aggregates the missing imports for a given file

This PR only handles deduplication for imports. #9818 handles exports.

Note that this PR also enables tracking of package reference and symbol references always, rather than only when `--gen-packages` is set.

Review commit-by-commit.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Improve autocorrects.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
