### PR TITLE
Make copying `ConstantLit::Storage` impossible

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -1311,6 +1311,10 @@ private:
         // `delete` of `original` in the `~Storage()` destructor (one for each copy).
         Storage(const Storage &) = delete;
         Storage &operator=(const Storage &) = delete;
+        // TODO: We could also consider defining move constructors here?
+        // But it's not clear how you should reasonably get access to a `ConstantLit`, and not a `ConstantLit *` or
+        // `ConstantLit &` such that you would want to be able to move it. We're not using it yet,
+        // so let's just let there be no implicitly defined move constructors until we realize we need it.
 
         ~Storage() {
             switch (tag()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

For ~all other node types, the copy constructor is implicitly deleted because
they all have fields that hold other `ExpressionPtr`'s, and those have deleted
copy constructors.

For `ConstantLit` we want to explicitly delete the copy constructor because it's
backed by a bunch of `uint64_t` that are liberally reinterpreted as pointers.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested that attempting to do

```cpp
auto recv = ast::cast_tree_nonnull<ast::ConstantLit>(send.recv);
```

fails the build with an error about a deleted copy constructor.