### PR TITLE
Directly desugar `it` params

### DIFF
--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -130,19 +130,8 @@ pair<MethodDef::PARAMS_store, InsSeq::STATS_store> desugarParams(DesugarContext 
         }
     } else if (auto *itParamNode = parser::NodeWithExpr::cast_node<parser::ItParam>(anyParamsNode)) {
         // The block uses the 'it' parameter (Ruby 3.4+)
-        auto *lvar = parser::NodeWithExpr::cast_node<parser::LVar>(itParamNode->decl.get());
-        if (lvar && lvar->name == core::Names::it()) {
-            // Single 'it' parameter - use the original name (not a unique one)
-            // Unlike numbered parameters, 'it' uses the actual name "it" so that
-            // local variables named 'it' in the same scope can shadow it
-            params.emplace_back(MK::Local(lvar->loc, lvar->name));
-        } else {
-            // In error cases (e.g., mixing 'it' with numbered params), we might have a numbered param here
-            // Just use it as-is to allow the error to be reported elsewhere
-            if (lvar) {
-                params.emplace_back(MK::Local(lvar->loc, lvar->name));
-            }
-        }
+        ENFORCE(itParamNode->hasDesugaredExpr(), "All ItParams should have an expression from Translator.cc already.");
+        params.emplace_back(itParamNode->takeDesugaredExpr());
     } else if (auto *numParamsNode = parser::NodeWithExpr::cast_node<parser::NumParams>(anyParamsNode)) {
         // The parse tree only contains declarations for numbered parameters that were actually used in the block or
         // lambda body, listed in the order they were encountered in the body. The desugar tree always contains all


### PR DESCRIPTION
### Motivation

Part of #9065.

This PR augments the intial implementation from #9443, so that it also directly produces the desugar tree representation during Prism translation.

This is the last direct-translation implementation we're making like this. Next up, we're going to delete all `parser::Node` creation from the Translator, and implement the remaining nodes on top of that.

### Test plan

Covered by existing desugar tests.