### PR TITLE
Add types to T::Struct from_hash methods

### DIFF
--- a/rbi/sorbet/tprops.rbi
+++ b/rbi/sorbet/tprops.rbi
@@ -177,6 +177,8 @@ module T::Props::Serializable::DecoratorMethods
 end
 
 module T::Props::Serializable::ClassMethods
+  extend T::Generic
+
   has_attached_class!(:out) { { upper: T::Struct } }
 
   sig { params(hash: T::Hash[String, T.untyped]).returns(T.attached_class) }

--- a/test/testdata/compiler/struct_from_hash.rb
+++ b/test/testdata/compiler/struct_from_hash.rb
@@ -9,8 +9,8 @@ class MyStruct < T::Struct
   const :percent, Float
   const :hash_by, Symbol
 
-  sig {override.params(struct: T::Hash[String, T.untyped]).returns(MyStruct)}
-  def self.from_hash(struct)
+  sig {override.params(struct: T::Hash[String, T.untyped], strict: T::Boolean).returns(T.attached_class)}
+  def self.from_hash(struct, strict = false)
     if struct.key?('hash_by')
       struct = struct.merge({'hash_by' => struct['hash_by'].to_sym})
     end

--- a/test/testdata/infer/t_module.rb
+++ b/test/testdata/infer/t_module.rb
@@ -20,10 +20,10 @@ def example2(mod)
   end
 
   if mod < T::Props::Serializable && mod.is_a?(T::Props::Serializable::ClassMethods)
-    T.reveal_type(mod) # error: `T.all(T::Module[T::Props::Serializable], T::Props::Serializable::ClassMethods)`
+    T.reveal_type(mod) # error: `T.all(T::Module[T::Props::Serializable], T::Props::Serializable::ClassMethods[T::Struct])`
 
     if mod.is_a?(Class)
-      T.reveal_type(mod) # error: `T.all(T::Class[T::Props::Serializable], T::Props::Serializable::ClassMethods)`
+      T.reveal_type(mod) # error: `T.all(T::Class[T::Props::Serializable], T::Props::Serializable::ClassMethods[T::Struct])`
       inst = mod.new
       T.reveal_type(inst) # error: `T::Props::Serializable`
     end

--- a/test/testdata/infer/t_module_all.rb
+++ b/test/testdata/infer/t_module_all.rb
@@ -3,11 +3,11 @@ extend T::Sig
 
 sig do
   params(
-    mod1: T.all(T::Module[T::Props::Serializable], T::Props::Serializable::ClassMethods, T::Class[T.anything]),
-    mod2: T.all(T::Class[T.anything], T::Module[T::Props::Serializable], T::Props::Serializable::ClassMethods)
+    mod1: T.all(T::Module[T::Props::Serializable], T::Props::Serializable::ClassMethods[T::Struct], T::Class[T.anything]),
+    mod2: T.all(T::Class[T.anything], T::Module[T::Props::Serializable], T::Props::Serializable::ClassMethods[T::Struct])
   ).void
 end
 def collapse(mod1, mod2)
-  T.reveal_type(mod1) # error: `T.all(T::Class[T::Props::Serializable], T::Props::Serializable::ClassMethods)`
-  T.reveal_type(mod2) # error: `T.all(T::Class[T::Props::Serializable], T::Props::Serializable::ClassMethods)`
+  T.reveal_type(mod1) # error: `T.all(T::Class[T::Props::Serializable], T::Props::Serializable::ClassMethods[T::Struct])`
+  T.reveal_type(mod2) # error: `T.all(T::Class[T::Props::Serializable], T::Props::Serializable::ClassMethods[T::Struct])`
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
type safety 📈 

I don't reach for this often, but I have a hard time remembering that it wants a String-keyed hash when I do.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
