### PR TITLE
Fix `T.let` autocorrect for instance variables at the top-level

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3034,7 +3034,7 @@ public:
             auto fieldName = fieldNameTy.name.show(gs);
 
             auto suggestType = res.returnType;
-            if (definingMethodName != core::Names::initialize() && definingMethodName != core::Names::staticInit() &&
+            if (definingMethodName != core::Names::initialize() && !definingMethodName.isAnyStaticInitName(gs) &&
                 definingMethodName != core::Names::beforeAngles()) {
                 suggestType = core::Types::any(gs, Types::nilClass(), suggestType);
             }

--- a/test/testdata/infer/toplevel_var.rb.autocorrects.exp
+++ b/test/testdata/infer/toplevel_var.rb.autocorrects.exp
@@ -1,4 +1,4 @@
 # -- test/testdata/infer/toplevel_var.rb --
 # typed: strict
-@foo = T.let(1, T.nilable(Integer)) # error: The singleton class instance variable `@foo` must be declared using `T.let` when specifying `# typed: strict`
+@foo = T.let(1, Integer) # error: The singleton class instance variable `@foo` must be declared using `T.let` when specifying `# typed: strict`
 # ------------------------------


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We were needlessly excluding file static inits, and only allowing class
static inits to be non-nil.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.