### PR TITLE
Avoid mutating in CFG for ivar T.let autocrorect

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -497,27 +497,6 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, ast::ExpressionPtr &what, BasicBlo
                     auto shouldReportErrorOn =
                         cctx.ctx.state.shouldReportErrorOn(cctx.ctx.file, core::errors::CFG::UndeclaredVariable);
                     if (foundError && shouldReportErrorOn) {
-                        auto zeroLoc = a.loc.copyWithZeroLength();
-                        auto magic = ast::MK::Constant(zeroLoc, core::Symbols::Magic());
-                        core::NameRef fieldKind;
-                        if (ident->kind == ast::UnresolvedIdent::Kind::Class) {
-                            fieldKind = core::Names::class_();
-                        } else {
-                            ENFORCE(cctx.ctx.owner.isMethod());
-                            auto owner = cctx.ctx.owner.owner(cctx.ctx).asClassOrModuleRef();
-                            if (owner.data(cctx.ctx)->isSingletonClass(cctx.ctx)) {
-                                fieldKind = core::Names::singletonClassInstance();
-                            } else {
-                                fieldKind = core::Names::instance();
-                            }
-                        }
-
-                        // Mutate a.rhs before walking.
-                        a.rhs =
-                            ast::MK::Send4(a.lhs.loc(), move(magic), core::Names::suggestFieldType(), zeroLoc,
-                                           move(a.rhs), ast::MK::String(zeroLoc, fieldKind),
-                                           ast::MK::String(zeroLoc, cctx.ctx.owner.asMethodRef().data(cctx.ctx)->name),
-                                           ast::MK::Symbol(zeroLoc, ident->name));
                     }
                     ENFORCE(lhs.exists());
                 } else {

--- a/core/Context.cc
+++ b/core/Context.cc
@@ -17,6 +17,10 @@ ClassOrModuleRef MutableContext::selfClass() {
 }
 
 ClassOrModuleRef MutableContext::lookupSelfClass() const {
+    return Context(*this).lookupSelfClass();
+}
+
+ClassOrModuleRef Context::lookupSelfClass() const {
     if (this->owner.isClassOrModule()) {
         return this->owner.asClassOrModuleRef().data(this->state)->lookupSingletonClass(this->state);
     }

--- a/core/Context.h
+++ b/core/Context.h
@@ -31,6 +31,9 @@ public:
 
     ErrorBuilder beginError(LocOffsets loc, ErrorClass what) const;
 
+    // Like `MutableContext::lookupSelfClass`
+    ClassOrModuleRef lookupSelfClass() const;
+
     Context withOwner(SymbolRef sym) const;
     Context withFile(FileRef file) const;
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We can avoid mutating the tree in CFG for this case by pulling the logic 
forward into resolver, where the tree is still mutable.

I'm working towards making the tree immutable in `typecheckOne`, so that we
can cache the resolved tree for IDE queries, and this is one of the few
places where builder_walk.cc is mutating the input tree.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.