### PR TITLE
Make parser option cache sensitive

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -1044,8 +1044,8 @@ void readOptions(Options &opts,
         }
         opts.stopAfterPhase = extractStopAfter(raw, logger);
 
-        opts.parser = extractParser(raw["parser"].as<string>(), logger).value_or(Parser::ORIGINAL);
-        opts.cacheSensitiveOptions.usePrismParser = (opts.parser == Parser::PRISM);
+        auto parser = extractParser(raw["parser"].as<string>(), logger).value_or(Parser::ORIGINAL);
+        opts.cacheSensitiveOptions.usePrismParser = (parser == Parser::PRISM);
         opts.silenceErrors = raw["quiet"].as<bool>();
         opts.autocorrect = raw["autocorrect"].as<bool>();
         opts.didYouMean = raw["did-you-mean"].as<bool>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -127,7 +127,6 @@ constexpr size_t MAX_CACHE_SIZE_BYTES = 1L * 1024 * 1024 * 1024; // 1 GiB
 struct Options {
     Printers print;
     Phase stopAfterPhase = Phase::INFERENCER;
-    Parser parser = Parser::ORIGINAL;
 
     // Should we monitor STDOUT for HUP and exit if it hangs up. This is a
     // workaround for https://bugzilla.mindrot.org/show_bug.cgi?id=2863

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -84,7 +84,7 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
     if (opts.noErrorSections) {
         gs.includeErrorSections = false;
     }
-    gs.parseWithPrism = opts.parser == options::Parser::PRISM;
+    gs.parseWithPrism = opts.cacheSensitiveOptions.usePrismParser;
     gs.ruby3KeywordArgs = opts.ruby3KeywordArgs;
     gs.suppressPayloadSuperclassRedefinitionFor = opts.suppressPayloadSuperclassRedefinitionFor;
     if (!opts.uniquelyDefinedBehavior) {
@@ -430,7 +430,7 @@ ast::ExpressionPtr desugarOne(const options::Options &opts, core::GlobalState &g
 ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, core::FileRef file,
                          ast::ExpressionPtr tree) {
     auto &print = opts.print;
-    auto parser = opts.parser;
+    auto parser = opts.cacheSensitiveOptions.usePrismParser ? options::Parser::PRISM : options::Parser::ORIGINAL;
 
     ast::ParsedFile rewritten{nullptr, file};
     rewritten.setCached(tree != nullptr);

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -416,7 +416,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     auto opts = RangeAssertion::parseOptions(assertions);
     opts.censorForSnapshotTests = true;
     opts.sorbetPackagesHint = "PACKAGE_ERROR_HINT";
-    opts.parser = sorbet::test::parser;
+    opts.cacheSensitiveOptions.usePrismParser = (sorbet::test::parser == realmain::options::Parser::PRISM);
 
     auto logger = spdlog::stderr_color_mt("fixtures: " + inputPath);
     auto workers = WorkerPool::create(0, *logger);
@@ -534,7 +534,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     if (!test.minimizeRBI.empty()) {
         auto gsForMinimize = emptyGs->deepCopyGlobalState();
         auto opts = realmain::options::Options{};
-        opts.parser = parser;
+        opts.cacheSensitiveOptions.usePrismParser = (parser == realmain::options::Parser::PRISM);
         auto minimizeRBI = test.folder + test.minimizeRBI;
         realmain::Minimize::indexAndResolveForMinimize(*gs, *gsForMinimize, opts, *workers, minimizeRBI);
         auto printerConfig = realmain::options::PrinterConfig{};


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This commit ensures we do not share the cache between original and prism parser modes by adding it to the cache sensitive options.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I noticed while testing that running `tc` first with `--parser=prism` changed the output of `tc` when running with `--parser=original`. Given the two parsers produce ever so slightly different desugared representations of the same source code, this is not surprising.

Although we'd like for the desugared representation to be identical, in some cases we may opt to produce a different AST, e.g. in error recovery cases where the parsers work quite differently. At least for now, while the Prism parser mode is still experimental, it makes sense to not share the cache between the two parser modes.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I couldn't see any existing tests for cache invalidation, but I tested manually.