### PR TITLE
add some `static_assert`s around deserializing bitfield data structures

### DIFF
--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -94,8 +94,10 @@ public:
 
         uint16_t serialize() const {
             static_assert(sizeof(Flags) == sizeof(uint16_t));
+            static_assert(sizeof(Flags) == sizeof(VALID_BITS_MASK));
             // Can replace this with std::bit_cast in C++20
             auto rawBits = *reinterpret_cast<const uint16_t *>(this);
+            static_assert(sizeof(Flags) == sizeof(rawBits));
 
             // We need to mask the valid bits since uninitialized memory isn't zeroed in C++.
             return rawBits & VALID_BITS_MASK;
@@ -244,8 +246,10 @@ public:
 
         uint8_t serialize() const {
             static_assert(sizeof(Flags) == sizeof(uint8_t));
+            static_assert(sizeof(Flags) == sizeof(VALID_BITS_MASK));
             // Can replace this with std::bit_cast in C++20
             auto rawBits = *reinterpret_cast<const uint8_t *>(this);
+            static_assert(sizeof(Flags) == sizeof(rawBits));
             // We need to mask the valid bits since uninitialized memory isn't zeroed in C++.
             return rawBits & VALID_BITS_MASK;
         }
@@ -317,8 +321,10 @@ public:
 
         uint8_t serialize() const {
             static_assert(sizeof(Flags) == sizeof(uint8_t));
+            static_assert(sizeof(Flags) == sizeof(VALID_BITS_MASK));
             // Can replace this with std::bit_cast in C++20
             auto rawBits = *reinterpret_cast<const uint8_t *>(this);
+            static_assert(sizeof(Flags) == sizeof(rawBits));
             // Mask the valid bits since uninitialized bits can be any value.
             return rawBits & VALID_BITS_MASK;
         }
@@ -409,8 +415,10 @@ public:
 
         uint16_t serialize() const {
             static_assert(sizeof(Flags) == sizeof(uint16_t));
+            static_assert(sizeof(Flags) == sizeof(VALID_BITS_MASK));
             // Can replace this with std::bit_cast in C++20
             auto rawBits = *reinterpret_cast<const uint16_t *>(this);
+            static_assert(sizeof(Flags) == sizeof(rawBits));
             // Mask the valid bits since uninitialized bits can be any value.
             return rawBits & VALID_BITS_MASK;
         }

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -218,8 +218,10 @@ struct Options {
 
         uint8_t serialize() const {
             static_assert(sizeof(CacheSensitiveOptions) == sizeof(uint8_t));
+            static_assert(sizeof(CacheSensitiveOptions) == sizeof(VALID_BITS_MASK));
             // Can replace this with std::bit_cast in C++20
             auto rawBits = *reinterpret_cast<const uint8_t *>(this);
+            static_assert(sizeof(CacheSensitiveOptions) == sizeof(rawBits));
             // Mask the valid bits since uninitialized bits can be any value.
             return rawBits & VALID_BITS_MASK;
         }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I noticed when reviewing #9752 that we don't have any provision for ensuring that we resize `VALID_BITS_MASK` for several bitfield data structures.  I suspect such mistakes would be quite hard to debug, so I added these asserts to try and ensure all the relevant things are changed.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

If it compiles, we are good.
