### PR TITLE
Add note about generic type members named `T`

### DIFF
--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -662,6 +662,8 @@ box = Box.new #: Box[Integer]
 box << 42
 ```
 
+> **Note**: do not name the type member `T` to avoid confusion with the [`T` module from Sorbet](https://github.com/sorbet/sorbet/blob/master/rbi/sorbet/t.rbi).
+
 RBS generics do not use `T::Generic`, thus the `[]` method doesn't exist at runtime and Sorbet will report an error if you try to use it:
 
 ```ruby


### PR DESCRIPTION
### Motivation

With RBS comments, using `T` for a type member will create an implicit constant that shadows Sorbet's `T` module.

This can have surprising effects when using a mix with the old Sorbet syntax:

```rb
#: [T]
class Box
  def foo
    T.unsafe(nil)
      ^^^^^^ error: Call to method unsafe on `Box::T` mistakes a type for a value
  end
end
```

The same is true with the old syntax by the way, but it's easier to see that something is wrong:

```rb
class Box
  extend T::Generic
         ^^^^^^^^^^ error: Unable to resolve constant `Generic`

  T = type_member
      ^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(Box)`

  def foo
    T.unsafe(nil)
      ^^^^^^ error: Call to method unsafe on `Box::T` mistakes a type for a value
  end
end
```

We've got a few users surprised by this. Let's add a note about it.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
