### PR TITLE
Avoid an intermediate SymbolRef value

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -2084,10 +2084,10 @@ public:
         }
 
         bool isTypeTemplate = send->fun == core::Names::typeTemplate();
-        auto onSymbol =
-            isTypeTemplate ? ctx.owner.asClassOrModuleRef().data(ctx)->lookupSingletonClass(ctx) : ctx.owner;
+        auto onSymbol = isTypeTemplate ? ctx.owner.asClassOrModuleRef().data(ctx)->lookupSingletonClass(ctx)
+                                       : ctx.owner.asClassOrModuleRef();
         ENFORCE(onSymbol.exists());
-        core::SymbolRef sym = ctx.state.lookupTypeMemberSymbol(onSymbol.asClassOrModuleRef(), typeName->cnst);
+        core::SymbolRef sym = ctx.state.lookupTypeMemberSymbol(onSymbol, typeName->cnst);
         ENFORCE(sym.exists());
 
         // Simulates how squashNames in handleAssignment also creates a ConstantLit


### PR DESCRIPTION
Moves a use of `asClassOrModuleRef` to the definition of a symbol intermediate, rather than at its usage site.

### Motivation
Refactoring: I'm using this value in a separate PR as a `ClassOrModuleRef`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
