### PR TITLE
Use `<restargs>` instead of `*`

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -179,7 +179,7 @@ void checkBlockRestParam(DesugarContext dctx, const MethodDef::PARAMS_store &arg
 
     auto &rest = cast_tree_nonnull<RestParam>(*it);
     if (auto local = cast_tree<UnresolvedIdent>(rest.expr)) {
-        if (local->name != core::Names::star()) {
+        if (local->name != core::Names::restargs()) {
             return;
         }
 
@@ -2275,7 +2275,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = move(res);
             },
             [&](parser::ForwardedRestArg *fra) {
-                auto var = ast::MK::Local(loc, core::Names::star());
+                auto var = ast::MK::Local(loc, core::Names::restargs());
                 result = MK::Splat(loc, move(var));
             },
             [&](parser::Alias *alias) {

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -176,7 +176,7 @@ void checkBlockRestParam(DesugarContext dctx, const MethodDef::PARAMS_store &arg
 
     auto &rest = cast_tree_nonnull<RestParam>(*it);
     if (auto local = cast_tree<UnresolvedIdent>(rest.expr)) {
-        if (local->name != core::Names::star()) {
+        if (local->name != core::Names::restargs()) {
             return;
         }
 
@@ -2121,7 +2121,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 result = move(res);
             },
             [&](parser::ForwardedRestArg *fra) {
-                auto var = ast::MK::Local(loc, core::Names::star());
+                auto var = ast::MK::Local(loc, core::Names::restargs());
                 result = MK::Splat(loc, move(var));
             },
             [&](parser::Alias *alias) {

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -1559,7 +1559,7 @@ public:
             checkReservedForNumberedParameters(name->view(), nameLoc);
         } else {
             // case like 'def m(*); end'
-            nm = core::Names::star();
+            nm = core::Names::restargs();
         }
 
         return make_unique<RestParam>(loc, nm, nameLoc);

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -3331,7 +3331,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
                 sorbetName = translateConstantName(prismName);
                 nameLoc = translateLoc(restParamNode->name_loc);
             } else { // An anonymous rest parameter, like `def foo(*)`
-                sorbetName = core::Names::star();
+                sorbetName = core::Names::restargs();
                 nameLoc = location;
             }
 
@@ -3438,7 +3438,7 @@ unique_ptr<parser::Node> Translator::translate(pm_node_t *node) {
             }
 
             if (expr == nullptr) { // An anonymous splat like `f(*)`
-                auto var = MK::Local(location, core::Names::star());
+                auto var = MK::Local(location, core::Names::restargs());
                 auto splatExpr = MK::Splat(location, move(var));
                 return make_node_with_expr<parser::ForwardedRestArg>(move(splatExpr), location);
             } else { // Splatting an expression like `f(*a)`
@@ -4542,7 +4542,7 @@ ast::ExpressionPtr Translator::desugarArray(core::LocOffsets location, absl::Spa
                 // Extract the argument from the old Send and create a new one with array's location
                 if (isAnonymousSplat) {
                     // Recreate the splat and local expr with the correct locations
-                    var = MK::Splat(location, MK::Local(location, core::Names::star()));
+                    var = MK::Splat(location, MK::Local(location, core::Names::restargs()));
                 } else {
                     // Recreate the splat with the correct location, keep the splatted expression as-is.
                     var = MK::Splat(location, move(splattedExpr));

--- a/test/prism_regression/call_rest_args.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_rest_args.rb.desugar-tree-raw.exp
@@ -55,7 +55,7 @@ ClassDef{
       name = <U has_anonymous_rest_args><<U <todo method>>>
       params = [RestParam{ expr = UnresolvedIdent{
           kind = Local
-          name = <U *>
+          name = <U <restargs>>
         } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>

--- a/test/prism_regression/call_rest_args.rb.parse-tree.exp
+++ b/test/prism_regression/call_rest_args.rb.parse-tree.exp
@@ -26,7 +26,7 @@ Begin {
       params = Params {
         params = [
           RestParam {
-            name = <U *>
+            name = <U <restargs>>
           }
         ]
       }

--- a/test/prism_regression/def_all_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_all_params.rb.desugar-tree-raw.exp
@@ -46,7 +46,7 @@ ClassDef{
       name = <U foo><<U <todo method>>>
       params = [RestParam{ expr = UnresolvedIdent{
           kind = Local
-          name = <U *>
+          name = <U <restargs>>
         } }, RestParam{ expr = KeywordArg{ expr = UnresolvedIdent{
           kind = Local
           name = <P <U **> $2>

--- a/test/prism_regression/def_all_params.rb.parse-tree.exp
+++ b/test/prism_regression/def_all_params.rb.parse-tree.exp
@@ -40,7 +40,7 @@ Begin {
       params = Params {
         params = [
           RestParam {
-            name = <U *>
+            name = <U <restargs>>
           }
           Kwrestarg {
             name = <P <U **> $2>

--- a/test/prism_regression/def_rest_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/def_rest_params.rb.desugar-tree-raw.exp
@@ -25,7 +25,7 @@ ClassDef{
       name = <U foo><<U <todo method>>>
       params = [RestParam{ expr = UnresolvedIdent{
           kind = Local
-          name = <U *>
+          name = <U <restargs>>
         } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>

--- a/test/prism_regression/def_rest_params.rb.parse-tree.exp
+++ b/test/prism_regression/def_rest_params.rb.parse-tree.exp
@@ -16,7 +16,7 @@ Begin {
       params = Params {
         params = [
           RestParam {
-            name = <U *>
+            name = <U <restargs>>
           }
         ]
       }

--- a/test/prism_regression/literal_array.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/literal_array.rb.desugar-tree-raw.exp
@@ -112,7 +112,7 @@ ClassDef{
       name = <U has_anonymous_rest_args><<U <todo method>>>
       params = [RestParam{ expr = UnresolvedIdent{
           kind = Local
-          name = <U *>
+          name = <U <restargs>>
         } }, BlockParam{ expr = UnresolvedIdent{
           kind = Local
           name = <U <blk>>
@@ -143,7 +143,7 @@ ClassDef{
               args = [
                 UnresolvedIdent{
                   kind = Local
-                  name = <U *>
+                  name = <U <restargs>>
                 }
               ]
             }

--- a/test/prism_regression/literal_array.rb.parse-tree.exp
+++ b/test/prism_regression/literal_array.rb.parse-tree.exp
@@ -102,7 +102,7 @@ Begin {
       params = Params {
         params = [
           RestParam {
-            name = <U *>
+            name = <U <restargs>>
           }
         ]
       }

--- a/test/testdata/desugar/block-implicit-rest-arg.rb
+++ b/test/testdata/desugar/block-implicit-rest-arg.rb
@@ -1,5 +1,6 @@
-# typed: true
+# typed: false
 
-call do |m, a,| # error: Method `call` does not exist
-  stuff # error: Method `stuff` does not exist
+call do |m, a,|
+#               error: Anonymous rest parameter in block args
+    stuff
 end

--- a/test/testdata/desugar/forward_args.rb.desugar-tree.exp
+++ b/test/testdata/desugar/forward_args.rb.desugar-tree.exp
@@ -26,19 +26,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           end], block)
     end
 
-    def foo5<<todo method>>(**, &<blk>)
-      [1, 2, 3].each() do |**|
+    def foo5<<todo method>>(*<restargs>, &<blk>)
+      [1, 2, 3].each() do |*<restargs>|
         ::<Magic>.<call-with-splat>(<emptyTree>::<C T>.unsafe(<self>), :p, [].concat(::T.unsafe(<fwd-args>.to_a())), nil)
       end
     end
 
     def foo6<<todo method>>(*args, &<blk>)
-      [1, 2, 3].each() do |**|
+      [1, 2, 3].each() do |*<restargs>|
         ::<Magic>.<call-with-splat>(<emptyTree>::<C T>.unsafe(<self>), :p, [].concat(::T.unsafe(<fwd-args>.to_a())), nil)
       end
     end
 
-    def foo7<<todo method>>(**, &<blk>)
+    def foo7<<todo method>>(*<restargs>, &<blk>)
       [1, 2, 3].each() do |*args|
         ::<Magic>.<call-with-splat>(<emptyTree>::<C T>.unsafe(<self>), :p, [].concat(::T.unsafe(<fwd-args>.to_a())), nil)
       end

--- a/test/testdata/desugar/forwarded_rest_args_array.rb.desugar-tree.exp
+++ b/test/testdata/desugar/forwarded_rest_args_array.rb.desugar-tree.exp
@@ -1,12 +1,12 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def forwarded_rest_args<<todo method>>(**, &<blk>)
+  def forwarded_rest_args<<todo method>>(*<restargs>, &<blk>)
     begin
-      xs = [:before].concat(::<Magic>.<splat>(*)).concat([:after])
+      xs = [:before].concat(::<Magic>.<splat>(<restargs>)).concat([:after])
       <emptyTree>::<C T>.reveal_type(xs)
     end
   end
 
-  def start_dotdotdot<<todo method>>(**, *<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
+  def start_dotdotdot<<todo method>>(*<restargs>, *<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
     <emptyTree>
   end
 end

--- a/test/testdata/desugar/forwarded_rest_args_array.rb.parse-tree.exp
+++ b/test/testdata/desugar/forwarded_rest_args_array.rb.parse-tree.exp
@@ -5,7 +5,7 @@ Begin {
       params = Params {
         params = [
           RestParam {
-            name = <U *>
+            name = <U <restargs>>
           }
         ]
       }
@@ -48,7 +48,7 @@ Begin {
       params = Params {
         params = [
           RestParam {
-            name = <U *>
+            name = <U <restargs>>
           }
           ForwardArg {
           }

--- a/test/testdata/desugar/forwarded_restarg_and_kwrestarg.rb.rewrite-tree.exp
+++ b/test/testdata/desugar/forwarded_restarg_and_kwrestarg.rb.rewrite-tree.exp
@@ -19,7 +19,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  def foo<<todo method>>(**, &<blk>)
+  def foo<<todo method>>(*<restargs>, &<blk>)
     begin
       res = ::<Magic>.<call-with-splat>(<self>, :pos_args, [].concat(::T.unsafe(<fwd-args>.to_a())), nil)
       <emptyTree>::<C T>.reveal_type(res)
@@ -62,7 +62,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  def baz<<todo method>>(**, ***$3:, &&$4)
+  def baz<<todo method>>(*<restargs>, ***$3:, &&$4)
     begin
       ::<Magic>.<call-with-splat-and-block-pass>(<self>, :all_the_args, [].concat(::T.unsafe(<fwd-args>.to_a())), [begin
             <hashTemp>$2 = ::<Magic>.<to-hash-dup>(::T.unsafe(<fwd-kwargs>))

--- a/test/testdata/parser/error_recovery/forward_args.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/forward_args.rb.desugar-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def foo<<todo method>>(**, *<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
+  def foo<<todo method>>(*<restargs>, *<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
     [1, 2, 3].each() do |_1|
       _1
     end

--- a/test/testdata/parser/implicit_block_rest_arg.rb
+++ b/test/testdata/parser/implicit_block_rest_arg.rb
@@ -7,6 +7,7 @@ def example(opts)
     T.reveal_type(k) # error: `[String, Integer] (2-tuple)`
   end
   opts.each do |k,|
+    #              error: Anonymous rest parameter in block args
     T.reveal_type(k) # error: `String`
   end
   opts.each do |k, _|

--- a/test/testdata/parser/misc.rb.desugar-tree.exp
+++ b/test/testdata/parser/misc.rb.desugar-tree.exp
@@ -217,7 +217,7 @@ rescue <emptyTree>::<C E> => x
       <emptyTree>
     end)
 
-  def sfoo<<todo method>>(**, &<blk>)
+  def sfoo<<todo method>>(*<restargs>, &<blk>)
     <emptyTree>
   end
 

--- a/test/testdata/parser/misc.rb.parse-tree.exp
+++ b/test/testdata/parser/misc.rb.parse-tree.exp
@@ -627,7 +627,7 @@ Begin {
       params = Params {
         params = [
           RestParam {
-            name = <U *>
+            name = <U <restargs>>
           }
         ]
       }

--- a/test/whitequark/test_block_arg_combinations_10.rb.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_10.rb.parse-tree-whitequark.exp
@@ -2,5 +2,5 @@ s(:block,
   s(:send, nil, :f),
   s(:params,
     s(:param, :a),
-    s(:restparam, :*),
+    s(:restparam, :<restargs>),
     s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_arg_combinations_12.rb.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_12.rb.parse-tree-whitequark.exp
@@ -2,4 +2,4 @@ s(:block,
   s(:send, nil, :f),
   s(:params,
     s(:param, :a),
-    s(:restparam, :*)), nil)
+    s(:restparam, :<restargs>)), nil)

--- a/test/whitequark/test_block_arg_combinations_14.rb.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_14.rb.parse-tree-whitequark.exp
@@ -1,5 +1,5 @@
 s(:block,
   s(:send, nil, :f),
   s(:params,
-    s(:restparam, :*),
+    s(:restparam, :<restargs>),
     s(:blockparam, :b)), nil)

--- a/test/whitequark/test_block_arg_combinations_16.rb.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_16.rb.parse-tree-whitequark.exp
@@ -1,4 +1,4 @@
 s(:block,
   s(:send, nil, :f),
   s(:params,
-    s(:restparam, :*)), nil)
+    s(:restparam, :<restargs>)), nil)

--- a/test/whitequark/test_forwarded_argument_with_restarg_0.rb.parse-tree-whitequark.exp
+++ b/test/whitequark/test_forwarded_argument_with_restarg_0.rb.parse-tree-whitequark.exp
@@ -1,7 +1,7 @@
 s(:def, :foo,
   s(:params,
     s(:param, :argument),
-    s(:restparam, :*)),
+    s(:restparam, :<restargs>)),
   s(:send, nil, :bar,
     s(:lvar, :argument),
     s(:forwarded_restarg)))

--- a/test/whitequark/test_forwarded_restarg_0.rb.parse-tree-whitequark.exp
+++ b/test/whitequark/test_forwarded_restarg_0.rb.parse-tree-whitequark.exp
@@ -1,5 +1,5 @@
 s(:def, :foo,
   s(:params,
-    s(:restparam, :*)),
+    s(:restparam, :<restargs>)),
   s(:send, nil, :bar,
     s(:forwarded_restarg)))

--- a/test/whitequark/test_kwarg_combinations_3.rb.parse-tree-whitequark.exp
+++ b/test/whitequark/test_kwarg_combinations_3.rb.parse-tree-whitequark.exp
@@ -1,4 +1,4 @@
 s(:def, :f,
   s(:params,
-    s(:restparam, :*),
+    s(:restparam, :<restargs>),
     s(:kwrestarg, :**)), nil)

--- a/test/whitequark/test_marg_combinations_4.rb.parse-tree-whitequark.exp
+++ b/test/whitequark/test_marg_combinations_4.rb.parse-tree-whitequark.exp
@@ -2,4 +2,4 @@ s(:def, :f,
   s(:params,
     s(:mlhs,
       s(:param, :a),
-      s(:restparam, :*))), nil)
+      s(:restparam, :<restargs>))), nil)

--- a/test/whitequark/test_marg_combinations_5.rb.parse-tree-whitequark.exp
+++ b/test/whitequark/test_marg_combinations_5.rb.parse-tree-whitequark.exp
@@ -2,5 +2,5 @@ s(:def, :f,
   s(:params,
     s(:mlhs,
       s(:param, :a),
-      s(:restparam, :*),
+      s(:restparam, :<restargs>),
       s(:param, :p))), nil)

--- a/test/whitequark/test_marg_combinations_8.rb.parse-tree-whitequark.exp
+++ b/test/whitequark/test_marg_combinations_8.rb.parse-tree-whitequark.exp
@@ -1,4 +1,4 @@
 s(:def, :f,
   s(:params,
     s(:mlhs,
-      s(:restparam, :*))), nil)
+      s(:restparam, :<restargs>))), nil)

--- a/test/whitequark/test_marg_combinations_9.rb.parse-tree-whitequark.exp
+++ b/test/whitequark/test_marg_combinations_9.rb.parse-tree-whitequark.exp
@@ -1,5 +1,5 @@
 s(:def, :f,
   s(:params,
     s(:mlhs,
-      s(:restparam, :*),
+      s(:restparam, :<restargs>),
       s(:param, :p))), nil)

--- a/test/whitequark/test_restarg_unnamed_0.rb.parse-tree-whitequark.exp
+++ b/test/whitequark/test_restarg_unnamed_0.rb.parse-tree-whitequark.exp
@@ -1,3 +1,3 @@
 s(:def, :f,
   s(:params,
-    s(:restparam, :*)), nil)
+    s(:restparam, :<restargs>)), nil)

--- a/test/whitequark/test_send_lambda_1.rb.parse-tree-whitequark.exp
+++ b/test/whitequark/test_send_lambda_1.rb.parse-tree-whitequark.exp
@@ -2,4 +2,4 @@ s(:block,
   s(:send,
     s(:const, nil, :Kernel), :lambda),
   s(:params,
-    s(:restparam, :*)), nil)
+    s(:restparam, :<restargs>)), nil)


### PR DESCRIPTION
### Motivation

Benefits:

- `def foo(**)` is confusing in dusugar tree output
    * Looks like an anonymous kwarg splat
    * The two asterisk have totally different meanings. The first is a *splat, the second is the name
- Improves consistency with implicit block rest args:

    ```diff
    # Desugar of `def foo(a, *)`
    -def foo(a, **, &<blk>)
    +def foo(a, *<restargs>, &<blk>)
    
    # Desugar of `call { |a, *| }`
    -<self>.call() do |a, **|
    +<self>.call() do |a, *<restargs>|
    
    # Desugar of `call { |a,| }`, no change
    <self>.call() do |a, *<restargs>|
    ```
    
  - As a result, the "Anonymous rest parameter in block args" will now be correctly applied to implicit rest arguments, which previously didn't have it (only explicit anonymous rest args did)

I have follow-up PRs that make similar changes to `**` (#9766) and `&` (#9762).

### Test plan

Covered by existing tests.
