### PR TITLE
Remove `getIndexed`

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -742,20 +742,6 @@ ast::ExpressionPtr LSPTypechecker::getLocalVarTrees(core::FileRef fref) const {
     return local_vars::LocalVars::run(*gs, {move(afterDesugar), fref}).tree;
 }
 
-ast::ParsedFile LSPTypechecker::getIndexed(core::FileRef fref) const {
-    const auto id = fref.id();
-    auto treeFinalGS = this->indexedFinalGS.find(id);
-    if (treeFinalGS != this->indexedFinalGS.end()) {
-        auto &indexed = treeFinalGS->second;
-        if (indexed.tree) {
-            return ast::ParsedFile{indexed.tree.deepCopy(), indexed.file};
-        }
-    }
-
-    ENFORCE(id < this->gs->filesUsed());
-    return pipeline::indexOne(this->config->opts, *this->gs, fref);
-}
-
 unique_ptr<OwnedKeyValueStore> LSPTypechecker::getKvStore() const {
     if (this->sessionCache == nullptr) {
         return nullptr;

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -103,13 +103,6 @@ class LSPTypechecker final {
                                            bool isNoopUpdateForRetypecheck) const;
 
     /**
-     * Returns a the indexed tree for the given file ref. The associated tree may be `nullptr` if the file ref given
-     * points to a payload RBI. This function will first consult the `this->indexedFinalGS` cache before falling back on
-     * re-indexing the file on disk.
-     */
-    ast::ParsedFile getIndexed(core::FileRef fref) const;
-
-    /**
      * Open the session-local kvstore.
      */
     std::unique_ptr<OwnedKeyValueStore> getKvStore() const;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm working towards making it so that we cache the resolved trees in LSP
mode, instead of the indexed trees.

Right now we have this `getIndexed` API in LSPTypechecker that
represents a "public API" for interacting with the type checker (e.g.
LSP requests can use this API freely to implement language-aware tasks).

Currently, there are no uses of this API. I thought that `getResolved`
used it, but it looks like it depends directly on the vectors storing
indexed trees directly.

Given there are no users, I'd like to remove it so that we don't get any
new ones cropping up accidentally while I work towards that larger
change.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

compile checked