### PR TITLE
Handle trailing type aliases RBS comments

### DIFF
--- a/rbs/CommentsAssociator.h
+++ b/rbs/CommentsAssociator.h
@@ -43,6 +43,7 @@ private:
     void walkNodes(parser::NodeVec &nodes);
     void walkStatements(parser::NodeVec &nodes);
     std::unique_ptr<parser::Node> walkBody(parser::Node *node, std::unique_ptr<parser::Node> body);
+    void processTrailingComments(parser::Node *node, parser::NodeVec &nodes);
     void associateAssertionCommentsToNode(parser::Node *node, bool adjustLocForHeredoc);
     void associateSignatureCommentsToNode(parser::Node *node);
     void consumeCommentsInsideNode(parser::Node *node, std::string kind);

--- a/test/testdata/rbs/signatures_type_aliases.rb
+++ b/test/testdata/rbs/signatures_type_aliases.rb
@@ -16,7 +16,7 @@ module Errors
   #: -> void
   def foo
     #: type a = Integer
-  # ^^^^^^^^^^^^^^^^^^^ error: Unexpected RBS assertion comment found in `method`
+  # ^^^^^^^^^^^^^^^^^^^ error: Unexpected RBS type alias comment
   end
 
   #: -> void
@@ -150,4 +150,14 @@ module TypeAliasWithNamespace
   def bar(x)
     T.reveal_type(x) # error: Revealed type: `T.any(Integer, String)`
   end
+end
+
+module TrailingTypeAlias
+  CONSTANT = 1
+
+  #: type a = Integer
+end
+
+module EmptyTypeAlias
+  #: type a = Integer
 end

--- a/test/testdata/rbs/signatures_type_aliases.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_type_aliases.rb.rewrite-tree.exp
@@ -238,4 +238,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of bar>
   end
+
+  module <emptyTree>::<C TrailingTypeAlias><<C <todo sym>>> < ()
+    <emptyTree>::<C CONSTANT> = 1
+
+    <emptyTree>::<C type a> = ::<root>::<C T>.type_alias() do ||
+      <emptyTree>::<C Integer>
+    end
+  end
+
+  module <emptyTree>::<C EmptyTypeAlias><<C <todo sym>>> < ()
+    <emptyTree>::<C type a> = ::<root>::<C T>.type_alias() do ||
+      <emptyTree>::<C Integer>
+    end
+  end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR extracts a `processTrailingComments` helper and uses it to fix an issue whereby trailing type assertions in an empty module were not being processed.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

While working on the Prism version of the RBS rewriter we noticed this functionality was missing in the original version:

```rb
module Foo
  #: type a = Integer
  #: type b = String
end
```

This should generate `T.type_alias` statements but they were not being generated. This commit fixes the issue for the original RBS rewriter so when we merge the Prism version the behavior matches.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Added a couple of test cases for trailing type assertion comments in empty and non-empty modules.
