### PR TITLE
Add RBS helper utilities and extract RBSArg to shared header

### DIFF
--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -8,6 +8,7 @@
 #include "core/errors/rewriter.h"
 #include "parser/helper.h"
 #include "rbs/TypeToParserNode.h"
+#include "rbs/rbs_method_common.h"
 #include "rewriter/util/Util.h"
 
 using namespace std;
@@ -15,25 +16,6 @@ using namespace std;
 namespace sorbet::rbs {
 
 namespace {
-
-struct RBSArg {
-    core::LocOffsets loc;
-    core::LocOffsets nameLoc;
-    rbs_ast_symbol_t *name;
-    rbs_node_t *type;
-
-    enum class Kind {
-        Positional,
-        OptionalPositional,
-        RestPositional,
-        Keyword,
-        OptionalKeyword,
-        RestKeyword,
-        Block,
-    };
-
-    Kind kind;
-};
 
 core::LocOffsets adjustNameLoc(const RBSDeclaration &declaration, rbs_node_t *node) {
     auto range = node->location->rg;
@@ -183,25 +165,6 @@ core::NameRef nodeName(const parser::Node *node) {
         });
 
     return name;
-}
-
-string argKindToString(RBSArg::Kind kind) {
-    switch (kind) {
-        case RBSArg::Kind::Positional:
-            return "positional";
-        case RBSArg::Kind::OptionalPositional:
-            return "optional positional";
-        case RBSArg::Kind::RestPositional:
-            return "rest positional";
-        case RBSArg::Kind::Keyword:
-            return "keyword";
-        case RBSArg::Kind::OptionalKeyword:
-            return "optional keyword";
-        case RBSArg::Kind::RestKeyword:
-            return "rest keyword";
-        case RBSArg::Kind::Block:
-            return "block";
-    }
 }
 
 string nodeKindToString(const parser::Node *node) {

--- a/rbs/rbs_method_common.h
+++ b/rbs/rbs_method_common.h
@@ -1,0 +1,53 @@
+#ifndef SORBET_RBS_METHOD_COMMON_H
+#define SORBET_RBS_METHOD_COMMON_H
+
+#include "core/LocOffsets.h"
+#include <string_view>
+
+extern "C" {
+#include "rbs.h"
+}
+
+namespace sorbet::rbs {
+
+struct RBSArg {
+    core::LocOffsets loc;
+    core::LocOffsets nameLoc;
+    rbs_ast_symbol_t *name;
+    rbs_node_t *type;
+
+    enum class Kind {
+        Positional,
+        OptionalPositional,
+        RestPositional,
+        Keyword,
+        OptionalKeyword,
+        RestKeyword,
+        Block,
+    };
+
+    Kind kind;
+};
+
+inline std::string_view argKindToString(RBSArg::Kind kind) {
+    switch (kind) {
+        case RBSArg::Kind::Positional:
+            return "positional";
+        case RBSArg::Kind::OptionalPositional:
+            return "optional positional";
+        case RBSArg::Kind::RestPositional:
+            return "rest positional";
+        case RBSArg::Kind::Keyword:
+            return "keyword";
+        case RBSArg::Kind::OptionalKeyword:
+            return "optional keyword";
+        case RBSArg::Kind::RestKeyword:
+            return "rest keyword";
+        case RBSArg::Kind::Block:
+            return "block";
+    }
+}
+
+} // namespace sorbet::rbs
+
+#endif // SORBET_RBS_METHOD_COMMON_H


### PR DESCRIPTION
Part of #9065 

Add RBS helper utilities and extract RBSArg to shared header

Prepare for Prism parser support by:
- Adding `rbs_down_cast`, `makeRBSString`, and `NULL_LOC_RANGE_P` helpers to `rbs_common.h`
- Extracting RBSArg struct to new `rbs_method_common.h `for reuse
- Refactoring `MethodTypeToParserNode.cc` to use the shared header

These utilities will be used by the upcoming `TypeToParserNodePrism` and
`MethodTypeToParserNodePrism` implementations (see https://github.com/sorbet/sorbet/pull/9771)
