### PR TITLE
Remove `const` from `absl::Span` uses

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1100,7 +1100,7 @@ class PackageDBPackageGraph {
 public:
     PackageDBPackageGraph(PackageDB &packageDB) : packageDB(packageDB) {}
 
-    const absl::Span<const Import> getImports(MangledName packageName) const {
+    absl::Span<const Import> getImports(MangledName packageName) const {
         ENFORCE(packageDB.getPackageInfo(packageName).exists());
         return packageDB.getPackageInfo(packageName).importedPackageNames;
     }

--- a/parser/prism/Factory.cc
+++ b/parser/prism/Factory.cc
@@ -18,7 +18,7 @@ inline constexpr auto prismFree = [](void *p) { xfree(p); };
 // * In the event of an exception, will be freed correctly using Prism's `xfree()`.
 template <typename T> using PrismUniquePtr = std::unique_ptr<T, decltype(prismFree)>;
 
-pm_node_list_t Factory::copyNodesToList(const absl::Span<pm_node_t *> nodes) const {
+pm_node_list_t Factory::copyNodesToList(absl::Span<pm_node_t *> nodes) const {
     if (nodes.empty()) {
         return (pm_node_list_t){.size = 0, .capacity = 0, .nodes = nullptr};
     }
@@ -36,7 +36,7 @@ pm_node_list_t Factory::copyNodesToList(const absl::Span<pm_node_t *> nodes) con
     return (pm_node_list_t){.size = size, .capacity = size, .nodes = result};
 }
 
-pm_arguments_node_t *Factory::createArgumentsNode(const absl::Span<pm_node_t *> args, pm_location_t loc) const {
+pm_arguments_node_t *Factory::createArgumentsNode(absl::Span<pm_node_t *> args, pm_location_t loc) const {
     pm_arguments_node_t *arguments = allocateNode<pm_arguments_node_t>();
 
     pm_node_list_t argNodes = copyNodesToList(args);
@@ -230,7 +230,7 @@ pm_node_t *Factory::AssocNode(core::LocOffsets loc, pm_node_t *key, pm_node_t *v
     return up_cast(assocNode);
 }
 
-pm_node_t *Factory::Hash(core::LocOffsets loc, const absl::Span<pm_node_t *> pairs) const {
+pm_node_t *Factory::Hash(core::LocOffsets loc, absl::Span<pm_node_t *> pairs) const {
     pm_hash_node_t *hashNode = allocateNode<pm_hash_node_t>();
 
     pm_node_list_t elements = copyNodesToList(pairs);
@@ -247,7 +247,7 @@ pm_node_t *Factory::Hash(core::LocOffsets loc, const absl::Span<pm_node_t *> pai
     return up_cast(hashNode);
 }
 
-pm_node_t *Factory::KeywordHash(core::LocOffsets loc, const absl::Span<pm_node_t *> pairs) const {
+pm_node_t *Factory::KeywordHash(core::LocOffsets loc, absl::Span<pm_node_t *> pairs) const {
     pm_keyword_hash_node_t *hashNode = allocateNode<pm_keyword_hash_node_t>();
 
     pm_node_list_t elements = copyNodesToList(pairs);
@@ -303,8 +303,8 @@ pm_node_t *Factory::Call1(core::LocOffsets loc, pm_node_t *receiver, string_view
     return up_cast(createCallNode(receiver, methodId, arguments, tinyLoc, fullLoc, tinyLoc));
 }
 
-pm_node_t *Factory::Call(core::LocOffsets loc, pm_node_t *receiver, string_view method,
-                         const absl::Span<pm_node_t *> args, pm_node_t *block) const {
+pm_node_t *Factory::Call(core::LocOffsets loc, pm_node_t *receiver, string_view method, absl::Span<pm_node_t *> args,
+                         pm_node_t *block) const {
     ENFORCE(receiver && !method.empty(), "Receiver or method is null");
 
     pm_constant_id_t methodId = addConstantToPool(method);
@@ -338,7 +338,7 @@ pm_node_t *Factory::TNilable(core::LocOffsets loc, pm_node_t *type) const {
     return Call1(loc, T(loc), "nilable"sv, type);
 }
 
-pm_node_t *Factory::TAny(core::LocOffsets loc, const absl::Span<pm_node_t *> args) const {
+pm_node_t *Factory::TAny(core::LocOffsets loc, absl::Span<pm_node_t *> args) const {
     ENFORCE(!args.empty(), "Args is empty");
 
     pm_constant_id_t methodId = addConstantToPool("any"sv);
@@ -349,7 +349,7 @@ pm_node_t *Factory::TAny(core::LocOffsets loc, const absl::Span<pm_node_t *> arg
     return up_cast(createCallNode(T(loc), methodId, up_cast(arguments), tinyLoc, fullLoc, tinyLoc));
 }
 
-pm_node_t *Factory::TAll(core::LocOffsets loc, const absl::Span<pm_node_t *> args) const {
+pm_node_t *Factory::TAll(core::LocOffsets loc, absl::Span<pm_node_t *> args) const {
     ENFORCE(!args.empty(), "Args is empty");
 
     pm_constant_id_t methodId = addConstantToPool("all"sv);
@@ -454,7 +454,7 @@ pm_node_t *Factory::TTypeAlias(core::LocOffsets loc, pm_node_t *type) const {
     return typeAliasCall;
 }
 
-pm_node_t *Factory::Array(core::LocOffsets loc, const absl::Span<pm_node_t *> elements) const {
+pm_node_t *Factory::Array(core::LocOffsets loc, absl::Span<pm_node_t *> elements) const {
     pm_array_node_t *array = allocateNode<pm_array_node_t>();
 
     pm_node_list_t elemNodes = copyNodesToList(elements);
@@ -518,7 +518,7 @@ pm_node_t *Factory::T_Range(core::LocOffsets loc) const {
     return ConstantPathNode(loc, T(loc), "Range"sv);
 }
 
-pm_node_t *Factory::StatementsNode(core::LocOffsets loc, const absl::Span<pm_node_t *> body) const {
+pm_node_t *Factory::StatementsNode(core::LocOffsets loc, absl::Span<pm_node_t *> body) const {
     pm_statements_node_t *stmts = allocateNode<pm_statements_node_t>();
     *stmts = (pm_statements_node_t){.base = initializeBaseNode(PM_STATEMENTS_NODE, parser.convertLocOffsets(loc)),
                                     .body = copyNodesToList(body)};

--- a/parser/prism/Factory.h
+++ b/parser/prism/Factory.h
@@ -52,18 +52,18 @@ public:
     pm_node_t *SymbolFromConstant(core::LocOffsets nameLoc, pm_constant_id_t nameId) const;
     pm_node_t *String(core::LocOffsets nameLoc, std::string_view name) const;
     pm_node_t *AssocNode(core::LocOffsets loc, pm_node_t *key, pm_node_t *value) const;
-    pm_node_t *Hash(core::LocOffsets loc, const absl::Span<pm_node_t *> pairs) const;
-    pm_node_t *KeywordHash(core::LocOffsets loc, const absl::Span<pm_node_t *> pairs) const;
+    pm_node_t *Hash(core::LocOffsets loc, absl::Span<pm_node_t *> pairs) const;
+    pm_node_t *KeywordHash(core::LocOffsets loc, absl::Span<pm_node_t *> pairs) const;
 
     // Low-level method call creation
     pm_call_node_t *createCallNode(pm_node_t *receiver, pm_constant_id_t method_id, pm_node_t *arguments,
                                    pm_location_t message_loc, pm_location_t full_loc, pm_location_t tiny_loc,
                                    pm_node_t *block = nullptr) const;
-    pm_arguments_node_t *createArgumentsNode(const absl::Span<pm_node_t *> args, pm_location_t loc) const;
+    pm_arguments_node_t *createArgumentsNode(absl::Span<pm_node_t *> args, pm_location_t loc) const;
 
     // High-level method call builders (similar to ast::MK)
-    pm_node_t *Call(core::LocOffsets loc, pm_node_t *receiver, std::string_view method,
-                    const absl::Span<pm_node_t *> args, pm_node_t *block = nullptr) const;
+    pm_node_t *Call(core::LocOffsets loc, pm_node_t *receiver, std::string_view method, absl::Span<pm_node_t *> args,
+                    pm_node_t *block = nullptr) const;
     pm_node_t *Call0(core::LocOffsets loc, pm_node_t *receiver, std::string_view method) const;
     pm_node_t *Call1(core::LocOffsets loc, pm_node_t *receiver, std::string_view method, pm_node_t *arg1) const;
     pm_node_t *Call2(core::LocOffsets loc, pm_node_t *receiver, std::string_view method, pm_node_t *arg1,
@@ -81,8 +81,8 @@ public:
     pm_node_t *THelpers(core::LocOffsets loc) const;
     pm_node_t *TUntyped(core::LocOffsets loc) const;
     pm_node_t *TNilable(core::LocOffsets loc, pm_node_t *type) const;
-    pm_node_t *TAny(core::LocOffsets loc, const absl::Span<pm_node_t *> args) const;
-    pm_node_t *TAll(core::LocOffsets loc, const absl::Span<pm_node_t *> args) const;
+    pm_node_t *TAny(core::LocOffsets loc, absl::Span<pm_node_t *> args) const;
+    pm_node_t *TAll(core::LocOffsets loc, absl::Span<pm_node_t *> args) const;
     pm_node_t *TTypeParameter(core::LocOffsets loc, pm_node_t *name) const;
     pm_node_t *TProc(core::LocOffsets loc, pm_node_t *args, pm_node_t *returnType) const;
     pm_node_t *TProcVoid(core::LocOffsets loc, pm_node_t *args) const;
@@ -106,9 +106,9 @@ public:
     pm_node_t *T_Set(core::LocOffsets loc) const;
     pm_node_t *T_Range(core::LocOffsets loc) const;
 
-    pm_node_t *Array(core::LocOffsets loc, const absl::Span<pm_node_t *> elements) const;
+    pm_node_t *Array(core::LocOffsets loc, absl::Span<pm_node_t *> elements) const;
     pm_node_t *Block(core::LocOffsets loc, pm_node_t *body) const;
-    pm_node_t *StatementsNode(core::LocOffsets loc, const absl::Span<pm_node_t *> body) const;
+    pm_node_t *StatementsNode(core::LocOffsets loc, absl::Span<pm_node_t *> body) const;
 
     // Wrappers around Prism's allocator functions, which raise `std::bad_alloc` instead of returning `nullptr`.
     // Use these to allocate memory that will be owned by Prism.
@@ -117,7 +117,7 @@ public:
     void free(void *ptr) const;
 
 private:
-    pm_node_list_t copyNodesToList(const absl::Span<pm_node_t *> nodes) const;
+    pm_node_list_t copyNodesToList(absl::Span<pm_node_t *> nodes) const;
 };
 
 } // namespace sorbet::parser::Prism

--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -21,7 +21,7 @@ class Translator final {
     core::MutableContext ctx;
 
     // The errors that were found by Prism during parsing
-    const absl::Span<const ParseError> parseErrors;
+    absl::Span<const ParseError> parseErrors;
 
     // Whether to directly desugar during in the Translator, or wait until the usual `Desugar.cc` code path.
     const bool directlyDesugar;
@@ -52,7 +52,7 @@ class Translator final {
     Translator &operator=(Translator &&) = delete;      // Move assignment
     Translator &operator=(const Translator &) = delete; // Copy assignment
 public:
-    Translator(const Parser &parser, core::MutableContext ctx, const absl::Span<const ParseError> parseErrors,
+    Translator(const Parser &parser, core::MutableContext ctx, absl::Span<const ParseError> parseErrors,
                bool directlyDesugar, bool preserveConcreteSyntax)
         : parser(parser), ctx(ctx), parseErrors(parseErrors), directlyDesugar(directlyDesugar),
           preserveConcreteSyntax(preserveConcreteSyntax), parserUniqueCounterStorage(1), desugarUniqueCounterStorage(1),


### PR DESCRIPTION
### Motivation

> `const Span<T>` is not a useful type, because it doesn't mean anything beyond `Span<T>`, as the containing elements can be freely modified in both types: `operator[]` has the signature `T& operator[](size_t) const`, for instance.
> 
> 
> 
> The only thing that matters is the `const` qualifier on the contained type. 

 _Originally posted by @froydnj in [#9772](https://github.com/sorbet/sorbet/pull/9772/changes#r2629289077)_

### Test plan

Pure refactor