### PR TITLE
Add splatSlice intrinsic for precise splat variable typing

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -452,11 +452,11 @@ ExpressionPtr unsupportedNode(DesugarContext dctx, parser::Node *node) {
 // ```rb
 // tmp = ::<Magic>.expandSplat(arr, 1, 0)
 // a = tmp[0]
-// b = tmp.to_ary
+// b = ::<Magic>.splatSlice(tmp, 1, 0)
 // ```
 //
-// While calling `to_ary` doesn't return the correct value if we were to execute this code,
-// it returns the correct type from a static point of view.
+// The splatSlice intrinsic extracts the correct slice of elements for the splat variable,
+// allowing for precise type inference of the splat portion.
 ExpressionPtr desugarMlhs(DesugarContext dctx, core::LocOffsets loc, parser::Mlhs *lhs, ExpressionPtr rhs) {
     InsSeq::STATS_store stats;
 
@@ -478,14 +478,11 @@ ExpressionPtr desugarMlhs(DesugarContext dctx, core::LocOffsets loc, parser::Mlh
             int left = i;
             int right = lhs->exprs.size() - left - 1;
             if (!isa_tree<EmptyTree>(lh)) {
-                if (right == 0) {
-                    right = 1;
-                }
                 auto lhloc = lh.loc();
                 auto zlhloc = lhloc.copyWithZeroLength();
-                // Calling `to_ary` is not faithful to the runtime behavior,
-                // but that it is faithful to the expected static type-checking behavior.
-                auto ary = MK::Send0(zloc, MK::Local(zloc, tempExpanded), core::Names::toAry(), zlhloc);
+                // Use splatSlice to extract the correct slice of elements for this splat variable
+                auto ary = MK::Send3(zloc, MK::Magic(zloc), core::Names::splatSlice(), zlhloc,
+                                     MK::Local(zloc, tempExpanded), MK::Int(zloc, left), MK::Int(zloc, right));
                 stats.emplace_back(MK::Assign(lhloc, move(lh), move(ary)));
             }
             i = -right;

--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -435,11 +435,11 @@ ExpressionPtr symbol2Proc(DesugarContext dctx, ExpressionPtr expr) {
 // ```rb
 // tmp = ::<Magic>.expandSplat(arr, 1, 0)
 // a = tmp[0]
-// b = tmp.to_ary
+// b = ::<Magic>.splatSlice(tmp, 1, 0)
 // ```
 //
-// While calling `to_ary` doesn't return the correct value if we were to execute this code,
-// it returns the correct type from a static point of view.
+// The splatSlice intrinsic extracts the correct slice of elements for the splat variable,
+// allowing for precise type inference of the splat portion.
 ExpressionPtr desugarMlhs(DesugarContext dctx, core::LocOffsets loc, parser::Mlhs *lhs, ExpressionPtr rhs) {
     InsSeq::STATS_store stats;
 
@@ -461,14 +461,11 @@ ExpressionPtr desugarMlhs(DesugarContext dctx, core::LocOffsets loc, parser::Mlh
             int left = i;
             int right = lhs->exprs.size() - left - 1;
             if (!isa_tree<EmptyTree>(lh)) {
-                if (right == 0) {
-                    right = 1;
-                }
                 auto lhloc = lh.loc();
                 auto zlhloc = lhloc.copyWithZeroLength();
-                // Calling `to_ary` is not faithful to the runtime behavior,
-                // but that it is faithful to the expected static type-checking behavior.
-                auto ary = MK::Send0(zloc, MK::Local(zloc, tempExpanded), core::Names::toAry(), zlhloc);
+                // Use splatSlice to extract the correct slice of elements for this splat variable
+                auto ary = MK::Send3(zloc, MK::Magic(zloc), core::Names::splatSlice(), zlhloc,
+                                     MK::Local(zloc, tempExpanded), MK::Int(zloc, left), MK::Int(zloc, right));
                 stats.emplace_back(MK::Assign(lhloc, move(lh), move(ary)));
             }
             i = -right;

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -710,6 +710,12 @@ void GlobalState::initEmpty() {
                  .untypedArg(Names::arg1())
                  .untypedArg(Names::arg2())
                  .buildWithResultUntyped();
+    // Synthesize <Magic>.<splatSlice>(arg0: T.untyped, arg1: Integer, arg2: Integer) => T.untyped
+    method = enterMethod(*this, Symbols::MagicSingleton(), Names::splatSlice())
+                 .untypedArg(Names::arg0())
+                 .untypedArg(Names::arg1())
+                 .untypedArg(Names::arg2())
+                 .buildWithResultUntyped();
     // Synthesize <Magic>.<call-with-splat>(args: *T.untyped) => T.untyped
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::callWithSplat())
                  .repeatedUntypedArg(Names::arg0())

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -21,7 +21,7 @@ namespace sorbet::core {
 using namespace std;
 
 const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 214;
-const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 51;
+const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 52;
 const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 20;
 const int Symbols::MAX_SYNTHETIC_TYPEPARAMETER_SYMBOLS = 6;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 106;

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -408,6 +408,7 @@ NameDef names[] = {
     {"toHashNoDup", "<to-hash-nodup>"},
     {"splat", "<splat>"},
     {"expandSplat", "<expand-splat>"},
+    {"splatSlice", "<splat-slice>"},
     {"suggestConstantType", "<suggest-constant-type>"},
     {"suggestFieldType", "<suggest-field-type>"},
     {"checkMatchArray", "<check-match-array>"},

--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -320,11 +320,11 @@ ast::ExpressionPtr Translator::desugarDString(core::LocOffsets loc, pm_node_list
 // ```rb
 // tmp = ::<Magic>.expandSplat(arr, 1, 0)
 // a = tmp[0]
-// b = tmp.to_ary
+// b = ::<Magic>.splatSlice(tmp, 1, 0)
 // ```
 //
-// While calling `to_ary` doesn't return the correct value if we were to execute this code,
-// it returns the correct type from a static point of view.
+// The splatSlice intrinsic extracts the correct slice of elements for the splat variable,
+// allowing for precise type inference of the splat portion.
 ast::ExpressionPtr Translator::desugarMlhs(core::LocOffsets loc, parser::Mlhs *lhs, ast::ExpressionPtr rhs) {
     ast::InsSeq::STATS_store stats;
 
@@ -347,14 +347,11 @@ ast::ExpressionPtr Translator::desugarMlhs(core::LocOffsets loc, parser::Mlhs *l
             int right = lhs->exprs.size() - left - 1;
 
             if (!ast::isa_tree<ast::EmptyTree>(lh)) {
-                if (right == 0) {
-                    right = 1;
-                }
                 auto lhloc = lh.loc();
                 auto zlhloc = lhloc.copyWithZeroLength();
-                // Calling `to_ary` is not faithful to the runtime behavior,
-                // but that it is faithful to the expected static type-checking behavior.
-                auto ary = MK::Send0(loc, MK::Local(loc, tempExpanded), core::Names::toAry(), zlhloc);
+                // Use splatSlice to extract the correct slice of elements for this splat variable
+                auto ary = MK::Send3(loc, MK::Magic(loc), core::Names::splatSlice(), zlhloc,
+                                     MK::Local(loc, tempExpanded), MK::Int(loc, left), MK::Int(loc, right));
                 stats.emplace_back(MK::Assign(lhloc, move(lh), move(ary)));
             }
             i = -right;

--- a/test/testdata/desugar/multi_assign.rb.desugar-tree.exp
+++ b/test/testdata/desugar/multi_assign.rb.desugar-tree.exp
@@ -36,13 +36,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           <assignTemp>$8 = array
           <assignTemp>$9 = ::<Magic>.<expand-splat>(<assignTemp>$8, 1, 0)
           a = <assignTemp>$9.[](0)
-          b = <assignTemp>$9.to_ary()
+          b = ::<Magic>.<splat-slice>(<assignTemp>$9, 1, 0)
           <assignTemp>$8
         end
         begin
           <assignTemp>$10 = array
           <assignTemp>$11 = ::<Magic>.<expand-splat>(<assignTemp>$10, 0, 1)
-          a = <assignTemp>$11.to_ary()
+          a = ::<Magic>.<splat-slice>(<assignTemp>$11, 0, 1)
           b = <assignTemp>$11.[](-1)
           <assignTemp>$10
         end
@@ -51,7 +51,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           <assignTemp>$13 = ::<Magic>.<expand-splat>(<assignTemp>$12, 2, 2)
           a = <assignTemp>$13.[](0)
           b = <assignTemp>$13.[](1)
-          c = <assignTemp>$13.to_ary()
+          c = ::<Magic>.<splat-slice>(<assignTemp>$13, 2, 2)
           d = <assignTemp>$13.[](-2)
           e = <assignTemp>$13.[](-1)
           <assignTemp>$12
@@ -73,13 +73,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           <assignTemp>$18 = ::<Magic>.<splat>(<emptyTree>::<C T>.unsafe(array))
           <assignTemp>$19 = ::<Magic>.<expand-splat>(<assignTemp>$18, 1, 0)
           a = <assignTemp>$19.[](0)
-          b = <assignTemp>$19.to_ary()
+          b = ::<Magic>.<splat-slice>(<assignTemp>$19, 1, 0)
           <assignTemp>$18
         end
         begin
           <assignTemp>$20 = ::<Magic>.<splat>(<emptyTree>::<C T>.unsafe(array))
           <assignTemp>$21 = ::<Magic>.<expand-splat>(<assignTemp>$20, 0, 1)
-          a = <assignTemp>$21.to_ary()
+          a = ::<Magic>.<splat-slice>(<assignTemp>$21, 0, 1)
           b = <assignTemp>$21.[](-1)
           <assignTemp>$20
         end

--- a/test/testdata/infer/splat_slice_typing.rb
+++ b/test/testdata/infer/splat_slice_typing.rb
@@ -1,0 +1,36 @@
+# typed: true
+# This test verifies that splat slice typing is precise for tuple literals.
+# Prior to splatSlice, splat variables would get imprecise types from to_ary.
+# With splatSlice, we can extract the exact tuple slice for the splat variable.
+
+# Basic splat at end - extracts remaining elements as tuple
+a, *b = [1, "hello", :world]
+T.assert_type!(a, Integer)
+T.reveal_type(b) # error: Revealed type: `[String("hello"), Symbol(:world)] (2-tuple)`
+
+# Splat at start - extracts leading elements as tuple
+*c, d = [1, "hello", :world]
+T.reveal_type(c) # error: Revealed type: `[Integer(1), String("hello")] (2-tuple)`
+T.assert_type!(d, Symbol)
+
+# Splat in middle - extracts middle elements as tuple
+e, *f, g = [1, 2, 3, 4, 5]
+T.assert_type!(e, Integer)
+T.reveal_type(f) # error: Revealed type: `[Integer(2), Integer(3), Integer(4)] (3-tuple)`
+T.assert_type!(g, Integer)
+
+# Mixed types with splat in middle
+h, *i, j = [1, "two", :three, 4.0]
+T.assert_type!(h, Integer)
+T.reveal_type(i) # error: Revealed type: `[String("two"), Symbol(:three)] (2-tuple)`
+T.assert_type!(j, Float)
+
+# Empty splat when tuple exactly matches non-splat count
+k, *l, m = [1, 2]
+T.assert_type!(k, Integer)
+T.reveal_type(l) # error: Revealed type: `[] (0-tuple)`
+T.assert_type!(m, Integer)
+
+# Splat grabs all elements when no surrounding elements
+*n = [1, 2, 3]
+T.reveal_type(n) # error: Revealed type: `[Integer(1), Integer(2), Integer(3)] (3-tuple)`

--- a/test/testdata/parser/misc.rb.desugar-tree.exp
+++ b/test/testdata/parser/misc.rb.desugar-tree.exp
@@ -187,7 +187,7 @@ rescue <emptyTree>::<C E> => x
   begin
     <assignTemp>$14 = ::<Magic>.<splat>(y)
     <assignTemp>$15 = ::<Magic>.<expand-splat>(<assignTemp>$14, 0, 0)
-    x = <assignTemp>$15.to_ary()
+    x = ::<Magic>.<splat-slice>(<assignTemp>$15, 0, 0)
     <assignTemp>$14
   end
 

--- a/test/testdata/rbs/assertions_massign.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_massign.rb.rewrite-tree.exp
@@ -3,7 +3,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <assignTemp>$2 = <cast:let>(<emptyTree>::<C ARGV>, <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>))
     <assignTemp>$3 = ::<Magic>.<expand-splat>(<assignTemp>$2, 1, 0)
     let1 = <assignTemp>$3.[](0)
-    let2 = <assignTemp>$3.to_ary()
+    let2 = ::<Magic>.<splat-slice>(<assignTemp>$3, 1, 0)
     <assignTemp>$2
   end
 
@@ -15,7 +15,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <assignTemp>$4 = <cast:let>(<emptyTree>::<C ARGV>, <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>))
     <assignTemp>$5 = ::<Magic>.<expand-splat>(<assignTemp>$4, 1, 0)
     let3 = <assignTemp>$5.[](0)
-    let4 = <assignTemp>$5.to_ary()
+    let4 = ::<Magic>.<splat-slice>(<assignTemp>$5, 1, 0)
     <assignTemp>$4
   end
 
@@ -27,7 +27,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <assignTemp>$6 = <cast:let>(<emptyTree>::<C ARGV>, <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>))
     <assignTemp>$7 = ::<Magic>.<expand-splat>(<assignTemp>$6, 1, 0)
     let5 = <assignTemp>$7.[](0)
-    let6 = <assignTemp>$7.to_ary()
+    let6 = ::<Magic>.<splat-slice>(<assignTemp>$7, 1, 0)
     <assignTemp>$6
   end
 
@@ -39,7 +39,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <assignTemp>$8 = <emptyTree>::<C ARGV>
     <assignTemp>$9 = ::<Magic>.<expand-splat>(<assignTemp>$8, 1, 0)
     let7 = <assignTemp>$9.[](0)
-    let8 = <assignTemp>$9.to_ary()
+    let8 = ::<Magic>.<splat-slice>(<assignTemp>$9, 1, 0)
     <assignTemp>$8
   end, <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>))
 


### PR DESCRIPTION
Previously, splat variables in multi-assignments like `a, *b, c = arr` would get imprecise types from calling `to_ary`, resulting in `T::Array[T.any(...)]` containing the union of all element types.

The new splatSlice intrinsic extracts the exact tuple slice for the splat variable, enabling precise type inference:

```
  a, *b = [1, "hello", :world]
  # Before: b :: T::Array[T.any(Integer, String, Symbol)]
  # After:  b :: [String, Symbol]
```

Implementation:
- Add Magic_splatSlice intrinsic in core/types/calls.cc
- Register <splat-slice> name in generate_names.cc
- Add method signature in GlobalState.cc
- Update desugaring in Desugar.cc, PrismDesugar.cc, Translator.cc to use splatSlice instead of to_ary
- Add test for precise splat slice typing


### Motivation
Extracted out of https://github.com/sorbet/sorbet/pull/9792

### Test plan
See included automated tests.
