### PR TITLE
Emit class symbol alias for ClassDef expressions in CFG

### DIFF
--- a/test/testdata/cfg/class_def_value.rb
+++ b/test/testdata/cfg/class_def_value.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+# Tests that ClassDef expressions produce values in the CFG.
+# The <static-init> method should return T.class_of(Foo), not NilClass.
+
+class A
+  X = class Foo
+  end
+end

--- a/test/testdata/cfg/class_def_value.rb.cfg-text.exp
+++ b/test/testdata/cfg/class_def_value.rb.cfg-text.exp
@@ -1,0 +1,47 @@
+method ::<Class:<root>>#<static-init> {
+
+bb0[firstDead=2]():
+    <self>: T.class_of(<root>) = cast(<self>: NilClass, T.class_of(<root>));
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
+    <unconditional> -> bb1
+
+# backedges
+# - bb0
+bb1[firstDead=-1]():
+    <unconditional> -> bb1
+
+}
+
+method ::<Class:A>#<static-init> {
+
+bb0[firstDead=7]():
+    <C X>$3: T.untyped = alias <C X>
+    <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
+    <cfgAlias>$5: T.class_of(<Magic>) = alias <C <Magic>>
+    <cfgAlias>$7: T.class_of(A::Foo) = alias <C Foo>
+    <C X>$3: T.class_of(A::Foo) = <cfgAlias>$5: T.class_of(<Magic>).<suggest-constant-type>(<cfgAlias>$7: T.class_of(A::Foo))
+    <returnMethodTemp>$2: T.class_of(A::Foo) = <C X>$3
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.class_of(A::Foo)
+    <unconditional> -> bb1
+
+# backedges
+# - bb0
+bb1[firstDead=-1]():
+    <unconditional> -> bb1
+
+}
+
+method ::A::<Class:Foo>#<static-init> {
+
+bb0[firstDead=2]():
+    <self>: T.class_of(A::Foo) = cast(<self>: NilClass, T.class_of(A::Foo));
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
+    <unconditional> -> bb1
+
+# backedges
+# - bb0
+bb1[firstDead=-1]():
+    <unconditional> -> bb1
+
+}
+

--- a/test/testdata/infer/class_def_expression_value.rb
+++ b/test/testdata/infer/class_def_expression_value.rb
@@ -1,0 +1,15 @@
+# typed: true
+
+# Test that class definition expressions produce correct type for the class symbol.
+# The CFG builder emits an Alias instruction for the class symbol in ClassDef expressions.
+
+class A
+  class Foo; end
+  class Bar; end
+  module Baz; end
+
+  # Direct access to class/module symbols produces correct types
+  T.reveal_type(Foo) # error: `T.class_of(A::Foo)`
+  T.reveal_type(Bar) # error: `T.class_of(A::Bar)`
+  T.reveal_type(Baz) # error: `T.class_of(A::Baz)`
+end


### PR DESCRIPTION
When a class definition is used as an expression (e.g., `X = class Foo; end`), the CFG should return the class symbol. This change ensures the class alias is properly emitted as the return value for ClassDef nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Motivation
Extracted out of https://github.com/sorbet/sorbet/pull/9792


### Test plan
See included automated tests.
