### PR TITLE
Use setter for enum props in typed initialize

### DIFF
--- a/test/testdata/rewriter/t_struct/enum_prop.rb
+++ b/test/testdata/rewriter/t_struct/enum_prop.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# typed: true
+
+class A < T::Struct
+  prop :foo, T.nilable(String), enum: ['foo', 'bar']
+end
+
+a1 = A.new(foo: 'bar')
+p a1.foo
+a1.foo = 'foo'
+p a1.foo
+begin
+  a1.foo = 'nope'
+  p a1.foo
+rescue
+  p :ok
+end

--- a/test/testdata/rewriter/t_struct/enum_prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/t_struct/enum_prop.rb.rewrite-tree.exp
@@ -1,0 +1,53 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C A><<C <todo sym>>> < (<emptyTree>::<C T>::<C Struct>)
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:foo, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>)).void()
+    end
+
+    def initialize<<todo method>>(foo: = nil, &<blk>)
+      begin
+        <self>.foo=(foo)
+        nil
+      end
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
+    end
+
+    def foo<<todo method>>(&<blk>)
+      @foo
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:arg0, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>)).returns(<emptyTree>::<C T>.nilable(<emptyTree>::<C String>))
+    end
+
+    def foo=<<todo method>>(arg0, &<blk>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    <runtime method definition of initialize>
+
+    <self>.prop(:foo, <emptyTree>::<C T>.nilable(<emptyTree>::<C String>), :enum, ["foo", "bar"])
+
+    <runtime method definition of foo>
+
+    <runtime method definition of foo=>
+  end
+
+  a1 = <emptyTree>::<C A>.new(:foo, "bar")
+
+  <self>.p(a1.foo())
+
+  a1.foo=("foo")
+
+  <self>.p(a1.foo())
+
+  begin
+    a1.foo=("nope")
+    <self>.p(a1.foo())
+  end
+rescue => <rescueTemp>$2
+  <self>.p(:ok)
+end


### PR DESCRIPTION
For T::Struct props with enum validation, use the setter method in the typed initialize instead of direct instance variable assignment. This preserves both type checking and would do runtime enum validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Extracted out of https://github.com/sorbet/sorbet/pull/9792


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
