### PR TITLE
Add rubyRegionId tracking to CFG for exception handling

### DIFF
--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -39,6 +39,15 @@ BasicBlock *CFG::freshBlock(int outerLoops) {
     return r.get();
 }
 
+BasicBlock *CFG::freshBlockWithRegion(int outerLoops, int rubyRegionId) {
+    int id = this->maxBasicBlockId++;
+    auto &r = this->basicBlocks.emplace_back(make_unique<BasicBlock>());
+    r->id = id;
+    r->outerLoops = outerLoops;
+    r->rubyRegionId = rubyRegionId;
+    return r.get();
+}
+
 void CFG::enterLocalInternal(core::LocalVariable variable, LocalRef &ref) {
     ENFORCE_NO_TIMER(!this->localVariablesFrozen);
     int id = this->localVariables.size();
@@ -374,6 +383,9 @@ string BasicBlock::toTextualString(const core::GlobalState &gs, const CFG &cfg) 
 
     if (this->outerLoops > 0) {
         fmt::format_to(std::back_inserter(buf), "    # outerLoops: {}\n", this->outerLoops);
+    }
+    if (this->rubyRegionId > 0) {
+        fmt::format_to(std::back_inserter(buf), "    # rubyRegionId: {}\n", this->rubyRegionId);
     }
     for (const Binding &exp : this->exprs) {
         fmt::format_to(std::back_inserter(buf), "    {} = {}\n", exp.bind.toString(gs, cfg),

--- a/cfg/CFG.h
+++ b/cfg/CFG.h
@@ -65,6 +65,7 @@ public:
     };
     Flags flags;
     int outerLoops = 0;
+    int rubyRegionId = 0;
     int firstDeadInstructionIdx = -1;
     std::vector<Binding> exprs;
     BlockExit bexit;
@@ -110,6 +111,7 @@ public:
     };
 
     friend class CFGBuilder;
+    friend class CFGContext;
     friend class LocalRef;
     friend class UnfreezeCFGLocalVariables;
     /**
@@ -118,6 +120,7 @@ public:
      */
     core::MethodRef symbol;
     int maxBasicBlockId = 0;
+    int maxRubyRegionId = 0;
 
     /**
      * Get the number of unique local variables in the CFG. Used to size vectors that contain an entry per LocalRef.
@@ -168,11 +171,6 @@ public:
     // static constexpr int MIN_LOOP_GLOBAL = -2;
     static constexpr int MIN_LOOP_LET = -3;
 
-    // special ruby region id offsets for exception handling
-    static constexpr int HANDLERS_REGION_OFFSET = 1;
-    static constexpr int ENSURE_REGION_OFFSET = 2;
-    static constexpr int ELSE_REGION_OFFSET = 3;
-
     void sanityCheck(core::Context ctx);
 
     class ReadsAndWrites {
@@ -193,6 +191,7 @@ public:
 private:
     CFG();
     BasicBlock *freshBlock(int outerLoops);
+    BasicBlock *freshBlockWithRegion(int outerLoops, int rubyRegionId);
     void enterLocalInternal(core::LocalVariable variable, LocalRef &ref);
     std::vector<int> minLoops;
     std::vector<int> maxLoopWrite;

--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -54,6 +54,7 @@ public:
     LocalRef target;
     LocalRef blockBreakTarget;
     int loops;
+    int rubyRegionId;
     bool isInsideRubyBlock;
     bool isInsideLambda;
     bool breakIsJump;
@@ -69,10 +70,15 @@ public:
     CFGContext withTarget(LocalRef target);
     CFGContext withBlockBreakTarget(LocalRef blockBreakTarget);
     CFGContext withLoopBreakTarget(LocalRef blockBreakTarget);
-    CFGContext withLoopScope(BasicBlock *nextScope, BasicBlock *breakScope, bool insideRubyBlock = false);
+    CFGContext withLoopScope(BasicBlock *nextScope, BasicBlock *breakScope, bool insideRubyBlock = false,
+                             int rubyRegionId = 0);
     CFGContext withSendAndBlockLink(std::shared_ptr<core::SendAndBlockLink> &link);
 
     LocalRef newTemporary(core::NameRef name);
+
+    // Creates a fresh block, using the current rubyRegionId if inside a Ruby block
+    // loopOffset can be used to increase the loop depth (e.g., for loop headers/bodies)
+    BasicBlock *freshBlock(int loopOffset = 0);
 
 private:
     friend std::unique_ptr<CFG> CFGBuilder::buildFor(core::Context ctx, const ast::MethodDef &md);
@@ -80,9 +86,10 @@ private:
     CFGContext(core::Context ctx, CFG &inWhat, LocalRef target, int loops, BasicBlock *nextScope,
                BasicBlock *breakScope, BasicBlock *rescueScope, UnorderedMap<core::SymbolRef, LocalRef> &aliases,
                UnorderedMap<core::NameRef, LocalRef> &discoveredUndeclaredFields, uint32_t &temporaryCounter)
-        : ctx(ctx), inWhat(inWhat), target(target), loops(loops), isInsideRubyBlock(false), isInsideLambda(false),
-          breakIsJump(false), nextScope(nextScope), breakScope(breakScope), rescueScope(rescueScope), aliases(aliases),
-          discoveredUndeclaredFields(discoveredUndeclaredFields), temporaryCounter(temporaryCounter){};
+        : ctx(ctx), inWhat(inWhat), target(target), loops(loops), rubyRegionId(0), isInsideRubyBlock(false),
+          isInsideLambda(false), breakIsJump(false), nextScope(nextScope), breakScope(breakScope),
+          rescueScope(rescueScope), aliases(aliases), discoveredUndeclaredFields(discoveredUndeclaredFields),
+          temporaryCounter(temporaryCounter){};
 };
 } // namespace sorbet::cfg
 #endif // SORBET_BUILDER_H

--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -53,11 +53,15 @@ void CFGBuilder::simplify(core::Context ctx, CFG &cfg) {
                 // 1. Are not to the dead block
                 // 2. Are not a back edge to the parent
                 // 3. Do not differ in their outerLoops values
+                // 4. Do not differ in their rubyRegionId values
                 //
                 // The third condition is important to avoid situations where we might duplicate a loop header.
                 // Duplicating a loop header will potentially invalidate the cached `forwardsTopoSort` traversal, and
                 // throw off inference by causing values to look nilable after loops that don't use them.
-                if (thenb != cfg.deadBlock() && thenb != bb && thenb->outerLoops == bb->outerLoops) {
+                //
+                // The fourth condition preserves region information critical for exception handling.
+                if (thenb != cfg.deadBlock() && thenb != bb && thenb->outerLoops == bb->outerLoops &&
+                    thenb->rubyRegionId == bb->rubyRegionId) {
                     // If this is the only block that jumps to `thenb`, we can squish it into `bb` and disconnect it
                     // from the graph.
                     if (thenb->backEdges.size() == 1) {

--- a/test/testdata/cfg/array.rb.cfg-text.exp
+++ b/test/testdata/cfg/array.rb.cfg-text.exp
@@ -30,6 +30,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(TestArray), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(TestArray)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -45,6 +46,7 @@ bb3[firstDead=-1](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfR
 # - bb2
 bb5[firstDead=4](<self>: T.class_of(TestArray), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(TestArray)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$10: T.class_of(Integer) = alias <C Integer>
     <blockReturnTemp>$7: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$10: T.class_of(Integer))
@@ -56,6 +58,7 @@ bb5[firstDead=4](<self>: T.class_of(TestArray), <block-pre-call-temp>$5: Sorbet:
 # - bb9
 bb6[firstDead=-1](<self>: T.class_of(TestArray), <block-pre-call-temp>$14: Sorbet::Private::Static::Void, <selfRestore>$15: T.class_of(TestArray)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
@@ -74,6 +77,7 @@ bb7[firstDead=7](<block-pre-call-temp>$14: Sorbet::Private::Static::Void, <selfR
 # - bb6
 bb9[firstDead=4](<self>: T.class_of(TestArray), <block-pre-call-temp>$14: Sorbet::Private::Static::Void, <selfRestore>$15: T.class_of(TestArray)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$19: T.class_of(String) = alias <C String>
     <blockReturnTemp>$16: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$19: T.class_of(String))

--- a/test/testdata/cfg/block_in_deadcode.rb.cfg-text.exp
+++ b/test/testdata/cfg/block_in_deadcode.rb.cfg-text.exp
@@ -32,6 +32,7 @@ bb1[firstDead=-1](<self>):
 # - bb0
 bb2[firstDead=-1](<self>: Object, <block-pre-call-temp>$4: Sorbet::Private::Static::Void):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -46,6 +47,7 @@ bb3[firstDead=3](<self>: Object, <block-pre-call-temp>$4: Sorbet::Private::Stati
 # - bb2
 bb5[firstDead=2](<self>: Object):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: Object = loadSelf(outer)
     <statTemp>$7: T.noreturn = return <returnTemp>$8: NilClass
     <unconditional> -> bb1

--- a/test/testdata/cfg/blocks.rb.cfg-text.exp
+++ b/test/testdata/cfg/blocks.rb.cfg-text.exp
@@ -48,6 +48,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: BlockTest, <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: BlockTest):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -61,6 +62,7 @@ bb3[firstDead=2](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=6](<self>: BlockTest, <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: BlockTest):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: BlockTest = loadSelf(foo)
     <blk>$9: T.untyped = load_yield_params(foo)
     x$1: T.untyped = yield_load_arg(0, <blk>$9: T.untyped)

--- a/test/testdata/cfg/break.rb.cfg-text.exp
+++ b/test/testdata/cfg/break.rb.cfg-text.exp
@@ -16,6 +16,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(<root>)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -36,6 +37,7 @@ bb3[firstDead=-1](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfR
 # - bb2
 bb5[firstDead=13](<self>: T.class_of(<root>), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(<root>)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$10: Symbol(:blk) = :blk
     <cfgAlias>$15: T.class_of(T) = alias <C T>
@@ -56,6 +58,7 @@ bb5[firstDead=13](<self>: T.class_of(<root>), <block-pre-call-temp>$5: Sorbet::P
 # - bb11
 bb6[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$38: Sorbet::Private::Static::Void, <selfRestore>$39: T.class_of(<root>)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
@@ -79,6 +82,7 @@ bb8[firstDead=-1](a: T.any(String, Integer), <selfRestore>$39: T.class_of(<root>
 # - bb6
 bb9[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$38: Sorbet::Private::Static::Void, <selfRestore>$39: T.class_of(<root>)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <self>: T.class_of(<root>) = loadSelf(bar)
     <blk>$40: [Integer] = load_yield_params(bar)
     x$2: Integer = yield_load_arg(0, <blk>$40: [Integer])
@@ -90,6 +94,7 @@ bb9[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$38: Sorbet::
 # - bb9
 bb10[firstDead=-1](<selfRestore>$39: T.class_of(<root>)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <returnTemp>$46: Integer(10) = 10
     <block-break-assign>$47: Integer(10) = <returnTemp>$46
     <magic>$48: T.class_of(<Magic>) = alias <C <Magic>>
@@ -101,6 +106,7 @@ bb10[firstDead=-1](<selfRestore>$39: T.class_of(<root>)):
 # - bb9
 bb11[firstDead=2](<self>: T.class_of(<root>), <block-pre-call-temp>$38: Sorbet::Private::Static::Void, <selfRestore>$39: T.class_of(<root>)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <blockReturnTemp>$41: String("test") = "test"
     <blockReturnTemp>$50: T.noreturn = blockreturn<bar> <blockReturnTemp>$41: String("test")
     <unconditional> -> bb6
@@ -110,6 +116,7 @@ bb11[firstDead=2](<self>: T.class_of(<root>), <block-pre-call-temp>$38: Sorbet::
 # - bb17
 bb12[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(<root>)):
     # outerLoops: 1
+    # rubyRegionId: 3
     <block-call> -> (NilClass ? bb15 : bb13)
 
 # backedges
@@ -130,6 +137,7 @@ bb14[firstDead=-1](b: T.nilable(String), <selfRestore>$58: T.class_of(<root>)):
 # - bb12
 bb15[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(<root>)):
     # outerLoops: 1
+    # rubyRegionId: 3
     <self>: T.class_of(<root>) = loadSelf(bar)
     <blk>$59: [Integer] = load_yield_params(bar)
     x$3: Integer = yield_load_arg(0, <blk>$59: [Integer])
@@ -141,6 +149,7 @@ bb15[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$57: Sorbet:
 # - bb15
 bb16[firstDead=-1](<selfRestore>$58: T.class_of(<root>)):
     # outerLoops: 1
+    # rubyRegionId: 3
     <block-break-assign>$66: NilClass = <returnTemp>$65
     <magic>$67: T.class_of(<Magic>) = alias <C <Magic>>
     <block-break>$68: T.untyped = <magic>$67: T.class_of(<Magic>).<block-break>(<returnTemp>$65: NilClass)
@@ -151,6 +160,7 @@ bb16[firstDead=-1](<selfRestore>$58: T.class_of(<root>)):
 # - bb15
 bb17[firstDead=2](<self>: T.class_of(<root>), <block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(<root>)):
     # outerLoops: 1
+    # rubyRegionId: 3
     <blockReturnTemp>$60: String("test") = "test"
     <blockReturnTemp>$69: T.noreturn = blockreturn<bar> <blockReturnTemp>$60: String("test")
     <unconditional> -> bb12
@@ -223,6 +233,7 @@ bb1[firstDead=-1]():
 # - bb0
 bb2[firstDead=-1](<self>: Object, <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: Object):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -244,6 +255,7 @@ bb4[firstDead=3](target: T.any(T::Array[T.noreturn], Integer), <selfRestore>$9: 
 # - bb2
 bb5[firstDead=-1](<self>: Object, <selfRestore>$9: Object):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: Object = loadSelf(map)
     <blk>$10: [Integer] = load_yield_params(map)
     x$1: Integer = yield_load_arg(0, <blk>$10: [Integer])

--- a/test/testdata/cfg/dealias_with_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/dealias_with_return.rb.cfg-text.exp
@@ -22,8 +22,7 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb4
-# - bb7
-# - bb8
+# - bb6
 # - bb9
 bb1[firstDead=-1]():
     <exceptionValue>$4 = <get-current-exception>
@@ -32,6 +31,7 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 bb3[firstDead=-1](<exceptionValue>$4: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
@@ -39,27 +39,35 @@ bb3[firstDead=-1](<exceptionValue>$4: Exception):
 # backedges
 # - bb0
 bb4[firstDead=2]():
+    # rubyRegionId: 1
     <returnTemp>$5: Integer(1) = 1
     <statTemp>$3: T.noreturn = return <returnTemp>$5: Integer(1)
     <unconditional> -> bb1
 
 # backedges
+# - bb7
+# - bb8
+bb6[firstDead=-1](a: T.nilable(Integer), <gotoDeadTemp>$10: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$10 -> (T.nilable(TrueClass) ? bb1 : bb9)
+
+# backedges
 # - bb3
 bb7[firstDead=-1](<exceptionValue>$4: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$6: T.untyped = <keep-alive> <exceptionValue>$4
     a: Integer(2) = 2
-    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1]():
     <gotoDeadTemp>$10: TrueClass = true
-    <gotoDeadTemp>$10 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
-# - bb7
-# - bb8
+# - bb6
 bb9[firstDead=3](a: Integer(2)):
     <statTemp>$13: Integer(3) = 3
     <returnMethodTemp>$2: Integer = a: Integer(2).+(<statTemp>$13: Integer(3))

--- a/test/testdata/cfg/default_args_cases.rb.cfg-text.exp
+++ b/test/testdata/cfg/default_args_cases.rb.cfg-text.exp
@@ -30,6 +30,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(Test)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -45,6 +46,7 @@ bb3[firstDead=-1](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfR
 # - bb2
 bb5[firstDead=20](<self>: T.class_of(Test), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(Test)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$10: Symbol(:a) = :a
     <cfgAlias>$12: T.class_of(Integer) = alias <C Integer>
@@ -72,6 +74,7 @@ bb5[firstDead=20](<self>: T.class_of(Test), <block-pre-call-temp>$5: Sorbet::Pri
 # - bb9
 bb6[firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$36: Sorbet::Private::Static::Void, <selfRestore>$37: T.class_of(Test)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
@@ -87,6 +90,7 @@ bb7[firstDead=-1](<block-pre-call-temp>$36: Sorbet::Private::Static::Void, <self
 # - bb6
 bb9[firstDead=12](<self>: T.class_of(Test), <block-pre-call-temp>$36: Sorbet::Private::Static::Void, <selfRestore>$37: T.class_of(Test)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$41: Symbol(:x) = :x
     <cfgAlias>$43: T.class_of(Integer) = alias <C Integer>
@@ -106,6 +110,7 @@ bb9[firstDead=12](<self>: T.class_of(Test), <block-pre-call-temp>$36: Sorbet::Pr
 # - bb13
 bb10[firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$55: Sorbet::Private::Static::Void, <selfRestore>$56: T.class_of(Test)):
     # outerLoops: 1
+    # rubyRegionId: 3
     <block-call> -> (NilClass ? bb13 : bb11)
 
 # backedges
@@ -121,6 +126,7 @@ bb11[firstDead=-1](<block-pre-call-temp>$55: Sorbet::Private::Static::Void, <sel
 # - bb10
 bb13[firstDead=12](<self>: T.class_of(Test), <block-pre-call-temp>$55: Sorbet::Private::Static::Void, <selfRestore>$56: T.class_of(Test)):
     # outerLoops: 1
+    # rubyRegionId: 3
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$60: Symbol(:x) = :x
     <cfgAlias>$62: T.class_of(Integer) = alias <C Integer>
@@ -140,6 +146,7 @@ bb13[firstDead=12](<self>: T.class_of(Test), <block-pre-call-temp>$55: Sorbet::P
 # - bb17
 bb14[firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$74: Sorbet::Private::Static::Void, <selfRestore>$75: T.class_of(Test)):
     # outerLoops: 1
+    # rubyRegionId: 4
     <block-call> -> (NilClass ? bb17 : bb15)
 
 # backedges
@@ -155,6 +162,7 @@ bb15[firstDead=-1](<block-pre-call-temp>$74: Sorbet::Private::Static::Void, <sel
 # - bb14
 bb17[firstDead=6](<self>: T.class_of(Test), <block-pre-call-temp>$74: Sorbet::Private::Static::Void, <selfRestore>$75: T.class_of(Test)):
     # outerLoops: 1
+    # rubyRegionId: 4
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$80: T.class_of(T) = alias <C T>
     <cfgAlias>$82: T.class_of(Integer) = alias <C Integer>
@@ -168,6 +176,7 @@ bb17[firstDead=6](<self>: T.class_of(Test), <block-pre-call-temp>$74: Sorbet::Pr
 # - bb21
 bb18[firstDead=-1](<self>: T.class_of(Test), <block-pre-call-temp>$86: Sorbet::Private::Static::Void, <selfRestore>$87: T.class_of(Test)):
     # outerLoops: 1
+    # rubyRegionId: 5
     <block-call> -> (NilClass ? bb21 : bb19)
 
 # backedges
@@ -186,6 +195,7 @@ bb19[firstDead=7](<block-pre-call-temp>$86: Sorbet::Private::Static::Void, <self
 # - bb18
 bb21[firstDead=6](<self>: T.class_of(Test), <block-pre-call-temp>$86: Sorbet::Private::Static::Void, <selfRestore>$87: T.class_of(Test)):
     # outerLoops: 1
+    # rubyRegionId: 5
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$91: Symbol(:x) = :x
     <cfgAlias>$93: T.class_of(Integer) = alias <C Integer>

--- a/test/testdata/cfg/next.rb.cfg-text.exp
+++ b/test/testdata/cfg/next.rb.cfg-text.exp
@@ -36,6 +36,7 @@ bb1[firstDead=-1](<self>):
 # - bb5
 bb2[firstDead=-1](<self>: Object, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -50,6 +51,7 @@ bb3[firstDead=3](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=6](<self>: Object, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: Object):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: Object = loadSelf(map)
     <blk>$8: [Integer] = load_yield_params(map)
     x$1: Integer = yield_load_arg(0, <blk>$8: [Integer])

--- a/test/testdata/cfg/reassign_dead_block_bug.rb.cfg-text.exp
+++ b/test/testdata/cfg/reassign_dead_block_bug.rb.cfg-text.exp
@@ -17,6 +17,7 @@ bb1[firstDead=-1]():
 # - bb0
 bb2[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$4: Sorbet::Private::Static::Void):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -31,6 +32,7 @@ bb3[firstDead=3](<self>: T.class_of(<root>), <block-pre-call-temp>$4: Sorbet::Pr
 # - bb2
 bb5[firstDead=4](<self>: T.class_of(<root>)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T.class_of(<root>) = loadSelf(times)
     x$1: Integer(1) = 1
     <returnTemp>$9: Integer(1) = 1

--- a/test/testdata/cfg/rescue.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue.rb.cfg-text.exp
@@ -31,6 +31,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$11: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$12: T::Boolean = <cfgAlias>$11: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$12 -> (T::Boolean ? bb7 : bb8)
@@ -38,6 +39,7 @@ bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionVal
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: Object):
+    # rubyRegionId: 1
     <returnMethodTemp>$2: T.untyped = <self>: Object.a()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
@@ -45,6 +47,7 @@ bb4[firstDead=-1](<self>: Object):
 # backedges
 # - bb4
 bb5[firstDead=-1](<self>: Object, <exceptionValue>$3: NilClass):
+    # rubyRegionId: 4
     <returnMethodTemp>$2: T.untyped = <self>: Object.c()
     <unconditional> -> bb6
 
@@ -53,6 +56,7 @@ bb5[firstDead=-1](<self>: Object, <exceptionValue>$3: NilClass):
 # - bb7
 # - bb8
 bb6[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$14: T.nilable(TrueClass)):
+    # rubyRegionId: 3
     <cfgAlias>$7: T.class_of(T) = alias <C T>
     <rescueTemp>$2: T.untyped = <cfgAlias>$7: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
     <throwAwayTemp>$15: T.untyped = <self>: Object.d()
@@ -61,6 +65,7 @@ bb6[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <exceptionVal
 # backedges
 # - bb3
 bb7[firstDead=-1](<self>: Object, <exceptionValue>$3: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$9: T.untyped = <keep-alive> <exceptionValue>$3
     <returnMethodTemp>$2: T.untyped = <self>: Object.b()

--- a/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_complex.rb.cfg-text.exp
@@ -30,6 +30,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(TestRescue), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(TestRescue)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -45,6 +46,7 @@ bb3[firstDead=-1](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfR
 # - bb2
 bb5[firstDead=9](<self>: T.class_of(TestRescue), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(TestRescue)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$11: T.class_of(T::Array) = alias <C Array>
     <cfgAlias>$13: T.class_of(T) = alias <C T>
@@ -61,6 +63,7 @@ bb5[firstDead=9](<self>: T.class_of(TestRescue), <block-pre-call-temp>$5: Sorbet
 # - bb9
 bb6[firstDead=-1](<self>: T.class_of(TestRescue), <block-pre-call-temp>$22: Sorbet::Private::Static::Void, <selfRestore>$23: T.class_of(TestRescue)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
@@ -79,6 +82,7 @@ bb7[firstDead=7](<block-pre-call-temp>$22: Sorbet::Private::Static::Void, <selfR
 # - bb6
 bb9[firstDead=11](<self>: T.class_of(TestRescue), <block-pre-call-temp>$22: Sorbet::Private::Static::Void, <selfRestore>$23: T.class_of(TestRescue)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$30: T.class_of(T) = alias <C T>
     <cfgAlias>$32: T.class_of(TypeError) = alias <C TypeError>
@@ -253,9 +257,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb9
-# - bb10
 # - bb11
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -264,6 +265,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$7: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$8 -> (T::Boolean ? bb7 : bb8)
@@ -271,22 +273,28 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: TestRescue):
+    # rubyRegionId: 1
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$15: NilClass):
-    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb11)
+# - bb7
+# - bb9
+# - bb10
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$15: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$15 -> (T.nilable(TrueClass) ? bb1 : bb11)
 
 # backedges
 # - bb3
 bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()
-    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb11)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
@@ -298,22 +306,20 @@ bb8[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 # backedges
 # - bb8
 bb9[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$10: T.untyped = <keep-alive> <exceptionValue>$3
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
-    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb11)
+    <unconditional> -> bb6
 
 # backedges
 # - bb8
 bb10[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$15: TrueClass = true
-    <gotoDeadTemp>$15 -> (TrueClass ? bb1 : bb11)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb9
-# - bb10
 bb11[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -329,8 +335,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb9
 # - bb10
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -339,6 +343,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$7: T.untyped = alias <C T.untyped>
     <isaCheckTemp>$8: T.untyped = <cfgAlias>$7: T.untyped.===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$8 -> (T.untyped ? bb7 : bb8)
@@ -346,24 +351,29 @@ bb3[firstDead=-1](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: TestRescue):
+    # rubyRegionId: 1
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: NilClass):
-    <gotoDeadTemp>$12 -> (NilClass ? bb1 : bb10)
+# - bb7
+# - bb9
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3
 # - bb8
 bb7[firstDead=-1](<exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     baz: Exception = <exceptionValue>$3
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
     <returnMethodTemp>$2: Exception = baz
-    <gotoDeadTemp>$12 -> (NilClass ? bb1 : bb10)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
@@ -376,12 +386,10 @@ bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception
 # - bb8
 bb9[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$12: TrueClass = true
-    <gotoDeadTemp>$12 -> (TrueClass ? bb1 : bb10)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb9
 bb10[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -397,8 +405,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb9
 # - bb10
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -407,6 +413,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<exceptionValue>$4: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$8: T.class_of(LoadError) = alias <C LoadError>
     <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(LoadError).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
@@ -414,23 +421,28 @@ bb3[firstDead=-1](<exceptionValue>$4: Exception):
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: TestRescue):
+    # rubyRegionId: 1
     <statTemp>$3: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](baz: NilClass, <gotoDeadTemp>$13: NilClass):
-    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb10)
+# - bb7
+# - bb9
+bb6[firstDead=-1](baz: T.nilable(T.any(LoadError, SocketError)), <gotoDeadTemp>$13: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb10)
 
 # backedges
 # - bb3
 # - bb8
 bb7[firstDead=-1](<exceptionValue>$4: T.any(LoadError, SocketError)):
+    # rubyRegionId: 2
     baz: T.any(LoadError, SocketError) = <exceptionValue>$4
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$6: T.untyped = <keep-alive> <exceptionValue>$4
-    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb10)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
@@ -443,12 +455,10 @@ bb8[firstDead=-1](<exceptionValue>$4: Exception):
 # - bb8
 bb9[firstDead=-1]():
     <gotoDeadTemp>$13: TrueClass = true
-    <gotoDeadTemp>$13 -> (TrueClass ? bb1 : bb10)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb9
 bb10[firstDead=3](baz: T.nilable(T.any(LoadError, SocketError))):
     <cfgAlias>$16: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: T.nilable(T.any(LoadError, SocketError)) = <cfgAlias>$16: T.class_of(T).reveal_type(baz: T.nilable(T.any(LoadError, SocketError)))
@@ -474,8 +484,6 @@ bb0[firstDead=-1]():
 # backedges
 # - bb3
 # - bb10
-# - bb11
-# - bb12
 bb1[firstDead=-1]():
     <unconditional> -> bb1
 
@@ -484,6 +492,7 @@ bb1[firstDead=-1]():
 # - bb13
 bb2[firstDead=-1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: NilClass, <gotoDeadTemp>$21: NilClass):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -497,6 +506,7 @@ bb3[firstDead=1](<block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfR
 # - bb2
 bb5[firstDead=-1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: NilClass, <gotoDeadTemp>$21: NilClass):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: TestRescue = loadSelf(loop)
     ex: NilClass = nil
     <exceptionValue>$15: T.nilable(Exception) = <get-current-exception>
@@ -507,6 +517,7 @@ bb5[firstDead=-1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-c
 # - bb8
 bb7[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <exceptionValue>$15: Exception, <gotoDeadTemp>$21: NilClass):
     # outerLoops: 1
+    # rubyRegionId: 3
     <cfgAlias>$19: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$20: T::Boolean = <cfgAlias>$19: T.class_of(StandardError).===(<exceptionValue>$15: Exception)
     <isaCheckTemp>$20 -> (T::Boolean ? bb11 : bb12)
@@ -515,38 +526,43 @@ bb7[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: So
 # - bb5
 bb8[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <gotoDeadTemp>$21: NilClass):
     # outerLoops: 1
+    # rubyRegionId: 2
     <blockReturnTemp>$13: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$15: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$15 -> (T.nilable(Exception) ? bb7 : bb10)
 
 # backedges
 # - bb8
-bb10[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$21: NilClass):
+# - bb11
+# - bb12
+bb10[firstDead=-1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$21: T.nilable(TrueClass)):
     # outerLoops: 1
-    <gotoDeadTemp>$21 -> (NilClass ? bb1 : bb13)
+    # rubyRegionId: 4
+    <gotoDeadTemp>$21 -> (T.nilable(TrueClass) ? bb1 : bb13)
 
 # backedges
 # - bb7
 bb11[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <exceptionValue>$15: StandardError, <gotoDeadTemp>$21: NilClass):
     # outerLoops: 1
+    # rubyRegionId: 3
     ex: StandardError = <exceptionValue>$15
     <exceptionValue>$15: NilClass = nil
     <keepForCfgTemp>$17: T.untyped = <keep-alive> <exceptionValue>$15
-    <gotoDeadTemp>$21 -> (NilClass ? bb1 : bb13)
+    <unconditional> -> bb10
 
 # backedges
 # - bb7
 bb12[firstDead=-1](<self>: TestRescue, ex: NilClass, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped):
     # outerLoops: 1
+    # rubyRegionId: 1
     <gotoDeadTemp>$21: TrueClass = true
-    <gotoDeadTemp>$21 -> (TrueClass ? bb1 : bb13)
+    <unconditional> -> bb10
 
 # backedges
 # - bb10
-# - bb11
-# - bb12
 bb13[firstDead=1](<self>: TestRescue, ex: T.nilable(StandardError), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: TestRescue, <blockReturnTemp>$13: T.untyped, <gotoDeadTemp>$21: NilClass):
     # outerLoops: 1
+    # rubyRegionId: 1
     <blockReturnTemp>$23: T.noreturn = blockreturn<loop> <blockReturnTemp>$13: T.untyped
     <unconditional> -> bb2
 
@@ -561,8 +577,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -571,6 +585,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$8: T.class_of(<Magic>) = alias <C <Magic>>
     <statTemp>$9: T.untyped = <self>: TestRescue.untyped_exceptions()
     <exceptionClassTemp>$6: T.untyped = <cfgAlias>$8: T.class_of(<Magic>).<splat>(<statTemp>$9: T.untyped)
@@ -580,35 +595,38 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: TestRescue):
+    # rubyRegionId: 1
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$15: NilClass):
-    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb9)
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$15: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$15 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb7[firstDead=-1](<exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     e: Exception = <exceptionValue>$3
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
     <cfgAlias>$13: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: Exception = <cfgAlias>$13: T.class_of(T).reveal_type(e: Exception)
-    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$15: TrueClass = true
-    <gotoDeadTemp>$15 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -624,8 +642,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -634,6 +650,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$8: T.class_of(<Magic>) = alias <C <Magic>>
     <statTemp>$9: T::Array[T.class_of(Exception)] = <self>: TestRescue.typed_exceptions()
     <exceptionClassTemp>$6: T::Array[T.class_of(Exception)] = <cfgAlias>$8: T.class_of(<Magic>).<splat>(<statTemp>$9: T::Array[T.class_of(Exception)])
@@ -643,35 +660,38 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: TestRescue):
+    # rubyRegionId: 1
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$15: NilClass):
-    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb9)
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$15: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$15 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb7[firstDead=-1](<exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     e: Exception = <exceptionValue>$3
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
     <cfgAlias>$13: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: Exception = <cfgAlias>$13: T.class_of(T).reveal_type(e: Exception)
-    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$15: TrueClass = true
-    <gotoDeadTemp>$15 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -687,8 +707,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -697,6 +715,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$8: T.class_of(<Magic>) = alias <C <Magic>>
     <statTemp>$9: [T.class_of(TypeError), T.class_of(ArgumentError)] = <self>: TestRescue.tuple_exceptions()
     <exceptionClassTemp>$6: [T.class_of(TypeError), T.class_of(ArgumentError)] = <cfgAlias>$8: T.class_of(<Magic>).<splat>(<statTemp>$9: [T.class_of(TypeError), T.class_of(ArgumentError)])
@@ -706,35 +725,38 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: TestRescue):
+    # rubyRegionId: 1
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$15: NilClass):
-    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb9)
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$15: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$15 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb7[firstDead=-1](<exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     e: Exception = <exceptionValue>$3
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
     <cfgAlias>$13: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: Exception = <cfgAlias>$13: T.class_of(T).reveal_type(e: Exception)
-    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$15: TrueClass = true
-    <gotoDeadTemp>$15 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -758,6 +780,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$10: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$11: T::Boolean = <cfgAlias>$10: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$11 -> (T::Boolean ? bb7 : bb8)
@@ -765,6 +788,7 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: TestRescue):
+    # rubyRegionId: 1
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
@@ -774,6 +798,7 @@ bb4[firstDead=-1](<self>: TestRescue):
 # - bb7
 # - bb8
 bb6[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$13: T.nilable(TrueClass)):
+    # rubyRegionId: 3
     <cfgAlias>$6: T.class_of(T) = alias <C T>
     <rescueTemp>$2: T.untyped = <cfgAlias>$6: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
     <throwAwayTemp>$14: T.untyped = <self>: TestRescue.bar()
@@ -782,6 +807,7 @@ bb6[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 # backedges
 # - bb3
 bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$8: T.untyped = <keep-alive> <exceptionValue>$3
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()
@@ -810,8 +836,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -820,6 +844,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$6: T.class_of(LoadError) = alias <C LoadError>
     <isaCheckTemp>$7: T::Boolean = <cfgAlias>$6: T.class_of(LoadError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$7 -> (T::Boolean ? bb7 : bb8)
@@ -827,31 +852,34 @@ bb3[firstDead=-1](<exceptionValue>$3: Exception):
 # backedges
 # - bb0
 bb4[firstDead=-1]():
+    # rubyRegionId: 1
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<gotoDeadTemp>$8: NilClass):
-    <gotoDeadTemp>$8 -> (NilClass ? bb1 : bb9)
+# - bb7
+# - bb8
+bb6[firstDead=-1](<gotoDeadTemp>$8: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$8 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb7[firstDead=-1](<exceptionValue>$3: LoadError):
+    # rubyRegionId: 2
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$4: T.untyped = <keep-alive> <exceptionValue>$3
-    <gotoDeadTemp>$8 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1]():
     <gotoDeadTemp>$8: TrueClass = true
-    <gotoDeadTemp>$8 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 bb9[firstDead=1]():
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1
@@ -867,8 +895,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -877,6 +903,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <exceptionValue>$5: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$5: Exception)
     <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
@@ -884,33 +911,36 @@ bb3[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <exceptionValue>$
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: TestRescue):
+    # rubyRegionId: 1
     <statTemp>$4: T.untyped = <self>: TestRescue.bar()
     <exceptionValue>$5: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <gotoDeadTemp>$11: NilClass):
-    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
+# - bb7
+# - bb8
+bb6[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped, <gotoDeadTemp>$11: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$5: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$5: NilClass = nil
     <keepForCfgTemp>$7: T.untyped = <keep-alive> <exceptionValue>$5
     <statTemp>$4: NilClass = nil
-    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<self>: TestRescue, <statTemp>$4: T.untyped):
     <gotoDeadTemp>$11: TrueClass = true
-    <gotoDeadTemp>$11 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 bb9[firstDead=2](<self>: TestRescue, <statTemp>$4: T.untyped):
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.take_arg(<statTemp>$4: T.untyped)
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
@@ -927,8 +957,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -937,6 +965,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$7: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$8 -> (T::Boolean ? bb7 : bb8)
@@ -944,33 +973,36 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: TestRescue):
+    # rubyRegionId: 1
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$10: NilClass):
-    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$10: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$10 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
-    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$10: TrueClass = true
-    <gotoDeadTemp>$10 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -986,8 +1018,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -996,6 +1026,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <exceptionClassTemp>$6: T.untyped = <self>: TestRescue.foo()
     <isaCheckTemp>$8: T.untyped = <exceptionClassTemp>$6: T.untyped.===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$8 -> (T.untyped ? bb7 : bb8)
@@ -1003,33 +1034,36 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: TestRescue):
+    # rubyRegionId: 1
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$10: NilClass):
-    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$10: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$10 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
-    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$10: TrueClass = true
-    <gotoDeadTemp>$10 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -1053,6 +1087,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$11: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$12: T::Boolean = <cfgAlias>$11: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$12 -> (T::Boolean ? bb7 : bb8)
@@ -1060,6 +1095,7 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: TestRescue):
+    # rubyRegionId: 1
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
@@ -1067,6 +1103,7 @@ bb4[firstDead=-1](<self>: TestRescue):
 # backedges
 # - bb4
 bb5[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: NilClass):
+    # rubyRegionId: 4
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.foo()
     <unconditional> -> bb6
 
@@ -1075,6 +1112,7 @@ bb5[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: NilClass):
 # - bb7
 # - bb8
 bb6[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$14: T.nilable(TrueClass)):
+    # rubyRegionId: 3
     <cfgAlias>$7: T.class_of(T) = alias <C T>
     <rescueTemp>$2: T.untyped = <cfgAlias>$7: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
     <throwAwayTemp>$15: T.untyped = <self>: TestRescue.bar()
@@ -1083,6 +1121,7 @@ bb6[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 # backedges
 # - bb3
 bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$9: T.untyped = <keep-alive> <exceptionValue>$3
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.baz()
@@ -1111,8 +1150,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -1121,6 +1158,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$7: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$8 -> (T::Boolean ? bb7 : bb8)
@@ -1128,33 +1166,36 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: TestRescue):
+    # rubyRegionId: 1
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$10: NilClass):
-    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$10: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$10 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.foo()
-    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$10: TrueClass = true
-    <gotoDeadTemp>$10 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -1170,8 +1211,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -1180,6 +1219,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$7: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$8 -> (T::Boolean ? bb7 : bb8)
@@ -1187,33 +1227,36 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: TestRescue):
+    # rubyRegionId: 1
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$10: NilClass):
-    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$10: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$10 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
-    <gotoDeadTemp>$10 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$10: TrueClass = true
-    <gotoDeadTemp>$10 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -1230,8 +1273,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -1240,6 +1281,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception, @ex$10: T.nilable(StandardError)):
+    # rubyRegionId: 2
     <cfgAlias>$7: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$8 -> (T::Boolean ? bb7 : bb8)
@@ -1247,35 +1289,38 @@ bb3[firstDead=-1](<self>: TestRescue, <returnMethodTemp>$2: T.untyped, <exceptio
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: TestRescue, @ex$10: T.nilable(StandardError)):
+    # rubyRegionId: 1
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: NilClass):
-    <gotoDeadTemp>$12 -> (NilClass ? bb1 : bb9)
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb7[firstDead=-1](<self>: TestRescue, <exceptionValue>$3: StandardError, @ex$10: T.nilable(StandardError)):
+    # rubyRegionId: 2
     <rescueTemp>$2: StandardError = <exceptionValue>$3
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
     @ex$10: StandardError = <rescueTemp>$2
     <returnMethodTemp>$2: T.untyped = <self>: TestRescue.bar()
-    <gotoDeadTemp>$12 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.untyped):
     <gotoDeadTemp>$12: TrueClass = true
-    <gotoDeadTemp>$12 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: T.untyped):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
@@ -1292,8 +1337,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -1302,6 +1345,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <statTemp>$4: T.untyped, <exceptionValue>$5: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$5: Exception)
     <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
@@ -1309,33 +1353,36 @@ bb3[firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <statTemp>$4: T.un
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass):
+    # rubyRegionId: 1
     <statTemp>$4: T.untyped = <self>: TestRescue.meth()
     <exceptionValue>$5: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$5 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped, <gotoDeadTemp>$12: NilClass):
-    <gotoDeadTemp>$12 -> (NilClass ? bb1 : bb9)
+# - bb7
+# - bb8
+bb6[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped, <gotoDeadTemp>$12: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$12 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb7[firstDead=-1](<self>: TestRescue, <statTemp>$3: NilClass, <exceptionValue>$5: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$5: NilClass = nil
     <keepForCfgTemp>$7: T.untyped = <keep-alive> <exceptionValue>$5
     <statTemp>$4: T.untyped = <self>: TestRescue.bar()
-    <gotoDeadTemp>$12 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
     <gotoDeadTemp>$12: TrueClass = true
-    <gotoDeadTemp>$12 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 bb9[firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: T.untyped):
     foo: T.untyped = <statTemp>$3: NilClass.+(<statTemp>$4: T.untyped)
     <returnMethodTemp>$2: T.untyped = foo
@@ -1353,8 +1400,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -1363,6 +1408,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](foo: NilClass, <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$9: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$10: T::Boolean = <cfgAlias>$9: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$10 -> (T::Boolean ? bb7 : bb8)
@@ -1370,6 +1416,7 @@ bb3[firstDead=-1](foo: NilClass, <exceptionValue>$3: Exception):
 # backedges
 # - bb0
 bb4[firstDead=2](<self>: TestRescue):
+    # rubyRegionId: 1
     <statTemp>$5: T.untyped = <self>: TestRescue.bar()
     foo: T.noreturn = <self>: TestRescue.raise(<statTemp>$5: T.untyped)
     <exceptionValue>$3 = <get-current-exception>
@@ -1377,27 +1424,29 @@ bb4[firstDead=2](<self>: TestRescue):
 
 # backedges
 # - bb4
-bb6[firstDead=0](foo: NilClass, <gotoDeadTemp>$11: NilClass):
-    <gotoDeadTemp>$11 -> (<nullptr> ? bb1 : bb9)
+# - bb7
+# - bb8
+bb6[firstDead=-1](foo: NilClass, <gotoDeadTemp>$11: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$11 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb7[firstDead=-1](<exceptionValue>$3: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$7: T.untyped = <keep-alive> <exceptionValue>$3
     foo: NilClass = nil
-    <gotoDeadTemp>$11 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1](foo: NilClass):
     <gotoDeadTemp>$11: TrueClass = true
-    <gotoDeadTemp>$11 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 bb9[firstDead=2](foo: NilClass):
     <returnMethodTemp>$2: NilClass = foo
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
@@ -1415,8 +1464,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -1425,6 +1472,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <exceptionValue>$5: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$11: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$12: T::Boolean = <cfgAlias>$11: T.class_of(StandardError).===(<exceptionValue>$5: Exception)
     <isaCheckTemp>$12 -> (T::Boolean ? bb7 : bb8)
@@ -1432,6 +1480,7 @@ bb3[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <exceptionValu
 # backedges
 # - bb0
 bb4[firstDead=2](<self>: TestRescue, <statTemp>$3: NilClass):
+    # rubyRegionId: 1
     <statTemp>$7: T.untyped = <self>: TestRescue.bar()
     <statTemp>$4: T.noreturn = <self>: TestRescue.raise(<statTemp>$7: T.untyped)
     <exceptionValue>$5 = <get-current-exception>
@@ -1439,27 +1488,29 @@ bb4[firstDead=2](<self>: TestRescue, <statTemp>$3: NilClass):
 
 # backedges
 # - bb4
-bb6[firstDead=0](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <gotoDeadTemp>$13: NilClass):
-    <gotoDeadTemp>$13 -> (<nullptr> ? bb1 : bb9)
+# - bb7
+# - bb8
+bb6[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass, <gotoDeadTemp>$13: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb7[firstDead=-1](<statTemp>$3: NilClass, <exceptionValue>$5: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$5: NilClass = nil
     <keepForCfgTemp>$9: T.untyped = <keep-alive> <exceptionValue>$5
     <statTemp>$4: NilClass = nil
-    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
     <gotoDeadTemp>$13: TrueClass = true
-    <gotoDeadTemp>$13 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 bb9[firstDead=3](<statTemp>$3: NilClass, <statTemp>$4: NilClass):
     foo: T.untyped = <statTemp>$3: NilClass.+(<statTemp>$4: NilClass)
     <returnMethodTemp>$2: T.untyped = foo
@@ -1480,8 +1531,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -1490,6 +1539,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <exceptionValue>$13: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$19: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$20: T::Boolean = <cfgAlias>$19: T.class_of(StandardError).===(<exceptionValue>$13: Exception)
     <isaCheckTemp>$20 -> (T::Boolean ? bb7 : bb8)
@@ -1497,6 +1547,7 @@ bb3[firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <s
 # backedges
 # - bb0
 bb4[firstDead=2](<self>: TestRescue, []$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped):
+    # rubyRegionId: 1
     <statTemp>$15: T.untyped = <self>: TestRescue.bar()
     <statTemp>$12: T.noreturn = <self>: TestRescue.raise(<statTemp>$15: T.untyped)
     <exceptionValue>$13 = <get-current-exception>
@@ -1504,27 +1555,29 @@ bb4[firstDead=2](<self>: TestRescue, []$3: T.untyped, []$4: Integer(0), <statTem
 
 # backedges
 # - bb4
-bb6[firstDead=0]([]$3: NilClass, []$4: NilClass, <statTemp>$9: NilClass, <statTemp>$12: NilClass, <gotoDeadTemp>$21: NilClass):
-    <gotoDeadTemp>$21 -> (<nullptr> ? bb1 : bb9)
+# - bb7
+# - bb8
+bb6[firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass, <gotoDeadTemp>$21: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$21 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb7[firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <exceptionValue>$13: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$13: NilClass = nil
     <keepForCfgTemp>$17: T.untyped = <keep-alive> <exceptionValue>$13
     <statTemp>$12: NilClass = nil
-    <gotoDeadTemp>$21 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass):
     <gotoDeadTemp>$21: TrueClass = true
-    <gotoDeadTemp>$21 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 bb9[firstDead=3]([]$3: T.untyped, []$4: Integer(0), <statTemp>$9: T.untyped, <statTemp>$12: NilClass):
     <statTemp>$8: T.untyped = <statTemp>$9: T.untyped.+(<statTemp>$12: NilClass)
     <returnMethodTemp>$2: T.untyped = []$3: T.untyped.[]=([]$4: Integer(0), <statTemp>$8: T.untyped)

--- a/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
@@ -21,10 +21,7 @@ bb0[firstDead=-1]():
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb4)
 
 # backedges
-# - bb6
-# - bb7
-# - bb10
-# - bb11
+# - bb9
 # - bb12
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -33,6 +30,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$7: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$8 -> (T::Boolean ? bb10 : bb11)
@@ -40,6 +38,7 @@ bb3[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: 
 # backedges
 # - bb0
 bb4[firstDead=-1]():
+    # rubyRegionId: 1
     <returnMethodTemp>$2: Integer(1) = 1
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb5)
@@ -47,6 +46,7 @@ bb4[firstDead=-1]():
 # backedges
 # - bb4
 bb5[firstDead=-1]():
+    # rubyRegionId: 4
     <ifTemp>$4: Integer(2) = 2
     <ifTemp>$4 -> (Integer(2) ? bb6 : bb7)
 
@@ -54,32 +54,39 @@ bb5[firstDead=-1]():
 # - bb5
 bb6[firstDead=-1]():
     <returnMethodTemp>$2: Integer(3) = 3
-    <gotoDeadTemp>$9 -> (NilClass ? bb1 : bb12)
+    <unconditional> -> bb9
 
 # backedges
 # - bb5
 bb7[firstDead=0]():
     <returnMethodTemp>$2 = nil
-    <gotoDeadTemp>$9 -> (<nullptr> ? bb1 : bb12)
-
-# backedges
-# - bb3
-bb10[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: StandardError):
-    <exceptionValue>$3: NilClass = nil
-    <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
-    <gotoDeadTemp>$9 -> (NilClass ? bb1 : bb12)
-
-# backedges
-# - bb3
-bb11[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer)):
-    <gotoDeadTemp>$9: TrueClass = true
-    <gotoDeadTemp>$9 -> (TrueClass ? bb1 : bb12)
+    <unconditional> -> bb9
 
 # backedges
 # - bb6
 # - bb7
 # - bb10
 # - bb11
+bb9[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$9: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$9 -> (T.nilable(TrueClass) ? bb1 : bb12)
+
+# backedges
+# - bb3
+bb10[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: StandardError):
+    # rubyRegionId: 2
+    <exceptionValue>$3: NilClass = nil
+    <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
+    <unconditional> -> bb9
+
+# backedges
+# - bb3
+bb11[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer)):
+    <gotoDeadTemp>$9: TrueClass = true
+    <unconditional> -> bb9
+
+# backedges
+# - bb9
 bb12[firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)
     <unconditional> -> bb1

--- a/test/testdata/cfg/rescue_expression.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_expression.rb.cfg-text.exp
@@ -23,8 +23,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -33,6 +31,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$12: T.class_of(MyException) = alias <C MyException>
     <statTemp>$10: MyException = <cfgAlias>$12: T.class_of(MyException).new()
     <exceptionClassTemp>$9: T.class_of(MyException) = <statTemp>$10: MyException.class()
@@ -42,6 +41,7 @@ bb3[firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: Exception)
 # backedges
 # - bb0
 bb4[firstDead=3](<self>: Object):
+    # rubyRegionId: 1
     <cfgAlias>$7: T.class_of(MyException) = alias <C MyException>
     <statTemp>$5: MyException = <cfgAlias>$7: T.class_of(MyException).new()
     <returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$5: MyException)
@@ -50,27 +50,29 @@ bb4[firstDead=3](<self>: Object):
 
 # backedges
 # - bb4
-bb6[firstDead=0](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$14: NilClass):
-    <gotoDeadTemp>$14 -> (<nullptr> ? bb1 : bb9)
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <gotoDeadTemp>$14: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$14 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb7[firstDead=-1](<exceptionValue>$3: MyException):
+    # rubyRegionId: 2
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$8: T.untyped = <keep-alive> <exceptionValue>$3
     <returnMethodTemp>$2: Integer(3) = 3
-    <gotoDeadTemp>$14 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$14: TrueClass = true
-    <gotoDeadTemp>$14 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: Integer(3)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)
     <unconditional> -> bb1

--- a/test/testdata/cfg/rescue_two_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_two_return.rb.cfg-text.exp
@@ -22,8 +22,8 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb4
+# - bb6
 # - bb7
-# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <exceptionValue>$4 = <get-current-exception>
@@ -32,6 +32,7 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 bb3[firstDead=-1](<self>: Object, <exceptionValue>$4: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$8: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$9: T::Boolean = <cfgAlias>$8: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$9 -> (T::Boolean ? bb7 : bb8)
@@ -39,13 +40,21 @@ bb3[firstDead=-1](<self>: Object, <exceptionValue>$4: Exception):
 # backedges
 # - bb0
 bb4[firstDead=2]():
+    # rubyRegionId: 1
     <returnTemp>$5: Integer(1) = 1
     <statTemp>$3: T.noreturn = return <returnTemp>$5: Integer(1)
     <unconditional> -> bb1
 
 # backedges
+# - bb8
+bb6[firstDead=-1](<self>: Object, <gotoDeadTemp>$11: TrueClass):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$11 -> (TrueClass ? bb1 : bb9)
+
+# backedges
 # - bb3
 bb7[firstDead=4](<exceptionValue>$4: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$6: T.untyped = <keep-alive> <exceptionValue>$4
     <returnTemp>$10: Integer(2) = 2
@@ -56,10 +65,10 @@ bb7[firstDead=4](<exceptionValue>$4: StandardError):
 # - bb3
 bb8[firstDead=-1](<self>: Object):
     <gotoDeadTemp>$11: TrueClass = true
-    <gotoDeadTemp>$11 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
-# - bb8
+# - bb6
 bb9[firstDead=0](<self>: Object):
     <returnMethodTemp>$2 = <self>.deadcode()
     <finalReturn> = return <returnMethodTemp>$2

--- a/test/testdata/cfg/rescue_var_expression.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_var_expression.rb.cfg-text.exp
@@ -23,8 +23,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -33,6 +31,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$8: T.class_of(Exception) = alias <C Exception>
     <isaCheckTemp>$9: TrueClass = <cfgAlias>$8: T.class_of(Exception).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$9 -> (TrueClass ? bb7 : bb8)
@@ -40,6 +39,7 @@ bb3[firstDead=-1](<returnMethodTemp>$2: NilClass, <exceptionValue>$3: Exception)
 # backedges
 # - bb0
 bb4[firstDead=2](<self>: Object):
+    # rubyRegionId: 1
     <statTemp>$5: String("boop") = "boop"
     <returnMethodTemp>$2: T.noreturn = <self>: Object.raise(<statTemp>$5: String("boop"))
     <exceptionValue>$3 = <get-current-exception>
@@ -47,12 +47,16 @@ bb4[firstDead=2](<self>: Object):
 
 # backedges
 # - bb4
-bb6[firstDead=0](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$15: NilClass):
-    <gotoDeadTemp>$15 -> (<nullptr> ? bb1 : bb9)
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: Integer(3), <gotoDeadTemp>$15: NilClass):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb7[firstDead=-1](<exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <rescueTemp>$2: Exception = <exceptionValue>$3
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$6: T.untyped = <keep-alive> <exceptionValue>$3
@@ -60,18 +64,16 @@ bb7[firstDead=-1](<exceptionValue>$3: Exception):
     <statTemp>$11: MyClass = <cfgAlias>$13: T.class_of(MyClass).new()
     <statTemp>$10: Exception = <statTemp>$11: MyClass.foo=(<rescueTemp>$2: Exception)
     <returnMethodTemp>$2: Integer(3) = 3
-    <gotoDeadTemp>$15 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=0](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$15 = true
-    <gotoDeadTemp>$15 -> (<nullptr> ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: Integer(3)):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Integer(3)
     <unconditional> -> bb1

--- a/test/testdata/cfg/rescue_with_return.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_with_return.rb.cfg-text.exp
@@ -22,8 +22,7 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb4
-# - bb7
-# - bb8
+# - bb6
 # - bb9
 bb1[firstDead=-1]():
     <exceptionValue>$3 = <get-current-exception>
@@ -32,6 +31,7 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 bb3[firstDead=-1](<exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$7: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$8 -> (T::Boolean ? bb7 : bb8)
@@ -39,26 +39,34 @@ bb3[firstDead=-1](<exceptionValue>$3: Exception):
 # backedges
 # - bb0
 bb4[firstDead=2]():
+    # rubyRegionId: 1
     <returnTemp>$4: Integer(1) = 1
     <returnMethodTemp>$2: T.noreturn = return <returnTemp>$4: Integer(1)
     <unconditional> -> bb1
 
 # backedges
+# - bb7
+# - bb8
+bb6[firstDead=-1](<gotoDeadTemp>$9: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$9 -> (T.nilable(TrueClass) ? bb1 : bb9)
+
+# backedges
 # - bb3
 bb7[firstDead=-1](<exceptionValue>$3: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
-    <gotoDeadTemp>$9 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1]():
     <gotoDeadTemp>$9: TrueClass = true
-    <gotoDeadTemp>$9 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
-# - bb7
-# - bb8
+# - bb6
 bb9[firstDead=1]():
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1

--- a/test/testdata/cfg/retry.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry.rb.cfg-text.exp
@@ -22,7 +22,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb9
-# - bb11
 # - bb12
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -38,6 +37,7 @@ bb2[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0
 # - bb2
 # - bb7
 bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$15: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$16: T::Boolean = <cfgAlias>$15: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$16 -> (T::Boolean ? bb10 : bb11)
@@ -45,6 +45,7 @@ bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0
 # backedges
 # - bb2
 bb4[firstDead=-1](<self>: Object, try: Integer(0)):
+    # rubyRegionId: 1
     <statTemp>$7: Integer(3) = 3
     <ifTemp>$5: T::Boolean = try: Integer(0).<(<statTemp>$7: Integer(3))
     <ifTemp>$5 -> (T::Boolean ? bb5 : bb6)
@@ -74,12 +75,15 @@ bb7[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0
 
 # backedges
 # - bb7
-bb9[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$23: NilClass):
-    <gotoDeadTemp>$23 -> (NilClass ? bb1 : bb12)
+# - bb11
+bb9[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$23: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$23 -> (T.nilable(TrueClass) ? bb1 : bb12)
 
 # backedges
 # - bb3
 bb10[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$13: T.untyped = <keep-alive> <exceptionValue>$4
     <statTemp>$19: String("rescue") = "rescue"
@@ -92,11 +96,10 @@ bb10[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(
 # - bb3
 bb11[firstDead=-1](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$23: TrueClass = true
-    <gotoDeadTemp>$23 -> (TrueClass ? bb1 : bb12)
+    <unconditional> -> bb9
 
 # backedges
 # - bb9
-# - bb11
 bb12[firstDead=1](<returnMethodTemp>$2: NilClass):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1

--- a/test/testdata/cfg/retry_multiple.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry_multiple.rb.cfg-text.exp
@@ -22,7 +22,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb12
-# - bb16
 # - bb17
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -39,6 +38,7 @@ bb2[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0
 # - bb2
 # - bb10
 bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$27: T.class_of(A) = alias <C A>
     <isaCheckTemp>$28: T::Boolean = <cfgAlias>$27: T.class_of(A).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$28 -> (T::Boolean ? bb13 : bb14)
@@ -46,6 +46,7 @@ bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0
 # backedges
 # - bb2
 bb4[firstDead=-1](<self>: Object, try: Integer(0)):
+    # rubyRegionId: 1
     <statTemp>$7: Integer(3) = 3
     <ifTemp>$5: T::Boolean = try: Integer(0).<(<statTemp>$7: Integer(3))
     <ifTemp>$5 -> (T::Boolean ? bb5 : bb6)
@@ -95,12 +96,15 @@ bb10[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(
 
 # backedges
 # - bb10
-bb12[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$45: NilClass):
-    <gotoDeadTemp>$45 -> (NilClass ? bb1 : bb17)
+# - bb16
+bb12[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$45: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$45 -> (T.nilable(TrueClass) ? bb1 : bb17)
 
 # backedges
 # - bb3
 bb13[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: A):
+    # rubyRegionId: 2
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$25: T.untyped = <keep-alive> <exceptionValue>$4
     <statTemp>$31: String("rescue A ") = "rescue A "
@@ -119,6 +123,7 @@ bb14[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(
 # backedges
 # - bb14
 bb15[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: B):
+    # rubyRegionId: 2
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$35: T.untyped = <keep-alive> <exceptionValue>$4
     <statTemp>$41: String("rescue B ") = "rescue B "
@@ -131,11 +136,10 @@ bb15[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(
 # - bb14
 bb16[firstDead=-1](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$45: TrueClass = true
-    <gotoDeadTemp>$45 -> (TrueClass ? bb1 : bb17)
+    <unconditional> -> bb12
 
 # backedges
 # - bb12
-# - bb16
 bb17[firstDead=1](<returnMethodTemp>$2: NilClass):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1

--- a/test/testdata/cfg/retry_nested.rb.cfg-text.exp
+++ b/test/testdata/cfg/retry_nested.rb.cfg-text.exp
@@ -22,9 +22,7 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb15
-# - bb17
 # - bb20
-# - bb22
 # - bb23
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -40,6 +38,7 @@ bb2[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0
 # - bb2
 # - bb18
 bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: Exception, <gotoDeadTemp>$39: NilClass):
+    # rubyRegionId: 2
     <cfgAlias>$43: T.class_of(B) = alias <C B>
     <isaCheckTemp>$44: T::Boolean = <cfgAlias>$43: T.class_of(B).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$44 -> (T::Boolean ? bb21 : bb22)
@@ -47,6 +46,7 @@ bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0
 # backedges
 # - bb2
 bb4[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$39: NilClass):
+    # rubyRegionId: 1
     <statTemp>$7: String("top") = "top"
     <statTemp>$5: NilClass = <self>: Object.puts(<statTemp>$7: String("top"))
     <unconditional> -> bb5
@@ -62,6 +62,7 @@ bb5[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0
 # - bb5
 # - bb13
 bb6[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$8: Exception, <gotoDeadTemp>$39: NilClass):
+    # rubyRegionId: 6
     <cfgAlias>$31: T.class_of(A) = alias <C A>
     <isaCheckTemp>$32: T::Boolean = <cfgAlias>$31: T.class_of(A).===(<exceptionValue>$8: Exception)
     <isaCheckTemp>$32 -> (T::Boolean ? bb16 : bb17)
@@ -69,6 +70,7 @@ bb6[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0
 # backedges
 # - bb5
 bb7[firstDead=-1](<self>: Object, try: Integer(0), <gotoDeadTemp>$39: NilClass):
+    # rubyRegionId: 5
     <statTemp>$11: Integer(3) = 3
     <ifTemp>$9: T::Boolean = try: Integer(0).<(<statTemp>$11: Integer(3))
     <ifTemp>$9 -> (T::Boolean ? bb8 : bb9)
@@ -118,12 +120,15 @@ bb13[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(
 
 # backedges
 # - bb13
-bb15[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$39: NilClass):
-    <gotoDeadTemp>$39 -> (NilClass ? bb1 : bb18)
+# - bb17
+bb15[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$39: T.nilable(TrueClass)):
+    # rubyRegionId: 7
+    <gotoDeadTemp>$39 -> (T.nilable(TrueClass) ? bb1 : bb18)
 
 # backedges
 # - bb6
 bb16[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$8: A, <gotoDeadTemp>$39: NilClass):
+    # rubyRegionId: 6
     <exceptionValue>$8: NilClass = nil
     <keepForCfgTemp>$29: T.untyped = <keep-alive> <exceptionValue>$8
     <statTemp>$35: String("rescue A") = "rescue A"
@@ -136,23 +141,25 @@ bb16[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(
 # - bb6
 bb17[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0)):
     <gotoDeadTemp>$39: TrueClass = true
-    <gotoDeadTemp>$39 -> (TrueClass ? bb1 : bb18)
+    <unconditional> -> bb15
 
 # backedges
 # - bb15
-# - bb17
 bb18[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <gotoDeadTemp>$39: NilClass):
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb20)
 
 # backedges
 # - bb18
-bb20[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$51: NilClass):
-    <gotoDeadTemp>$51 -> (NilClass ? bb1 : bb23)
+# - bb22
+bb20[firstDead=-1](<returnMethodTemp>$2: NilClass, <gotoDeadTemp>$51: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$51 -> (T.nilable(TrueClass) ? bb1 : bb23)
 
 # backedges
 # - bb3
 bb21[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(0), <exceptionValue>$4: B, <gotoDeadTemp>$39: NilClass):
+    # rubyRegionId: 2
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$41: T.untyped = <keep-alive> <exceptionValue>$4
     <statTemp>$47: String("rescue B ") = "rescue B "
@@ -165,11 +172,10 @@ bb21[firstDead=-1](<self>: Object, <returnMethodTemp>$2: NilClass, try: Integer(
 # - bb3
 bb22[firstDead=-1](<returnMethodTemp>$2: NilClass):
     <gotoDeadTemp>$51: TrueClass = true
-    <gotoDeadTemp>$51 -> (TrueClass ? bb1 : bb23)
+    <unconditional> -> bb20
 
 # backedges
 # - bb20
-# - bb22
 bb23[firstDead=1](<returnMethodTemp>$2: NilClass):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: NilClass
     <unconditional> -> bb1

--- a/test/testdata/cfg/textoutput.rb.cfg-text.exp
+++ b/test/testdata/cfg/textoutput.rb.cfg-text.exp
@@ -15,6 +15,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$19: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$20: T::Boolean = <cfgAlias>$19: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$20 -> (T::Boolean ? bb7 : bb8)
@@ -22,6 +23,7 @@ bb3[firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: T.class_of(<root>)):
+    # rubyRegionId: 1
     <cfgAlias>$6: T.class_of(A) = alias <C A>
     <statTemp>$4: A = <cfgAlias>$6: T.class_of(A).new()
     <hashTemp>$9: Symbol(:z) = :z
@@ -40,6 +42,7 @@ bb4[firstDead=-1](<self>: T.class_of(<root>)):
 # - bb7
 # - bb8
 bb6[firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$23: T.nilable(TrueClass)):
+    # rubyRegionId: 3
     <cfgAlias>$15: T.class_of(T) = alias <C T>
     e: T.untyped = <cfgAlias>$15: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
     <statTemp>$26: String("done") = "done"
@@ -49,6 +52,7 @@ bb6[firstDead=-1](<self>: T.class_of(<root>), <returnMethodTemp>$2: T.untyped, <
 # backedges
 # - bb3
 bb7[firstDead=-1](<self>: T.class_of(<root>), <exceptionValue>$3: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$17: T.untyped = <keep-alive> <exceptionValue>$3
     <statTemp>$22: String("whoops") = "whoops"
@@ -104,6 +108,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: A, y: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: A):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -117,6 +122,7 @@ bb3[firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=5](<self>: A, y: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: A):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: A = loadSelf(map)
     <blk>$6: T.untyped = load_yield_params(map)
     e$1: T.untyped = yield_load_arg(0, <blk>$6: T.untyped)

--- a/test/testdata/cfg/uaf1.rb.cfg-text.exp
+++ b/test/testdata/cfg/uaf1.rb.cfg-text.exp
@@ -39,8 +39,6 @@ bb0[firstDead=-1]():
 # backedges
 # - bb3
 # - bb10
-# - bb11
-# - bb12
 bb1[firstDead=-1]():
     <unconditional> -> bb1
 
@@ -49,6 +47,7 @@ bb1[firstDead=-1]():
 # - bb13
 bb2[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: NilClass, <gotoDeadTemp>$13: NilClass):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -62,6 +61,7 @@ bb3[firstDead=2](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: NilClass, <gotoDeadTemp>$13: NilClass):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: A = loadSelf(map)
     <exceptionValue>$8: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$8 -> (T.nilable(Exception) ? bb7 : bb8)
@@ -71,6 +71,7 @@ bb5[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::V
 # - bb8
 bb7[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer), <exceptionValue>$8: Exception, <gotoDeadTemp>$13: NilClass):
     # outerLoops: 1
+    # rubyRegionId: 3
     <cfgAlias>$11: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$12: T::Boolean = <cfgAlias>$11: T.class_of(StandardError).===(<exceptionValue>$8: Exception)
     <isaCheckTemp>$12 -> (T::Boolean ? bb11 : bb12)
@@ -79,38 +80,43 @@ bb7[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::V
 # - bb5
 bb8[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <gotoDeadTemp>$13: NilClass):
     # outerLoops: 1
+    # rubyRegionId: 2
     <blockReturnTemp>$7: Integer(1) = 1
     <exceptionValue>$8: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$8 -> (T.nilable(Exception) ? bb7 : bb10)
 
 # backedges
 # - bb8
-bb10[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: Integer(1), <gotoDeadTemp>$13: NilClass):
+# - bb11
+# - bb12
+bb10[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer), <gotoDeadTemp>$13: T.nilable(TrueClass)):
     # outerLoops: 1
-    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb13)
+    # rubyRegionId: 4
+    <gotoDeadTemp>$13 -> (T.nilable(TrueClass) ? bb1 : bb13)
 
 # backedges
 # - bb7
 bb11[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <exceptionValue>$8: StandardError, <gotoDeadTemp>$13: NilClass):
     # outerLoops: 1
+    # rubyRegionId: 3
     <exceptionValue>$8: NilClass = nil
     <keepForCfgTemp>$9: T.untyped = <keep-alive> <exceptionValue>$8
     <blockReturnTemp>$7: Integer(2) = 2
-    <gotoDeadTemp>$13 -> (NilClass ? bb1 : bb13)
+    <unconditional> -> bb10
 
 # backedges
 # - bb7
 bb12[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <gotoDeadTemp>$13: TrueClass = true
-    <gotoDeadTemp>$13 -> (TrueClass ? bb1 : bb13)
+    <unconditional> -> bb10
 
 # backedges
 # - bb10
-# - bb11
-# - bb12
 bb13[firstDead=1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: Integer, <gotoDeadTemp>$13: NilClass):
     # outerLoops: 1
+    # rubyRegionId: 1
     <blockReturnTemp>$15: T.noreturn = blockreturn<map> <blockReturnTemp>$7: Integer
     <unconditional> -> bb2
 

--- a/test/testdata/desugar/ensure_without_rescue.rb.cfg-text.exp
+++ b/test/testdata/desugar/ensure_without_rescue.rb.cfg-text.exp
@@ -30,12 +30,14 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped):
+    # rubyRegionId: 2
     <gotoDeadTemp>$5: TrueClass = true
     <unconditional> -> bb6
 
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: Object):
+    # rubyRegionId: 1
     <returnMethodTemp>$2: T.untyped = <self>: Object.a()
     <exceptionValue>$3: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$3 -> (T.nilable(Exception) ? bb3 : bb6)
@@ -44,6 +46,7 @@ bb4[firstDead=-1](<self>: Object):
 # - bb3
 # - bb4
 bb6[firstDead=-1](<self>: Object, <returnMethodTemp>$2: T.untyped, <gotoDeadTemp>$5: T.nilable(TrueClass)):
+    # rubyRegionId: 3
     <throwAwayTemp>$6: T.untyped = <self>: Object.b()
     <gotoDeadTemp>$5 -> (T.nilable(TrueClass) ? bb1 : bb7)
 

--- a/test/testdata/desugar/for.rb.cfg-text.exp
+++ b/test/testdata/desugar/for.rb.cfg-text.exp
@@ -146,6 +146,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -162,6 +163,7 @@ bb3[firstDead=-1](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfR
 # - bb2
 bb5[firstDead=6](<self>: T.class_of(Main), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T.class_of(Main) = loadSelf(each)
     <blk>$8: T.untyped = load_yield_params(each)
     a$1: T.untyped = yield_load_arg(0, <blk>$8: T.untyped)
@@ -175,6 +177,7 @@ bb5[firstDead=6](<self>: T.class_of(Main), <block-pre-call-temp>$6: Sorbet::Priv
 # - bb9
 bb6[firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$17: Sorbet::Private::Static::Void, <selfRestore>$18: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
+    # rubyRegionId: 2
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
@@ -191,6 +194,7 @@ bb7[firstDead=-1](<block-pre-call-temp>$17: Sorbet::Private::Static::Void, <self
 # - bb6
 bb9[firstDead=14](<self>: T.class_of(Main), <block-pre-call-temp>$17: Sorbet::Private::Static::Void, <selfRestore>$18: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
+    # rubyRegionId: 2
     <self>: T.class_of(Main) = loadSelf(each)
     <blk>$19: T.untyped = load_yield_params(each)
     forTemp$2: T.untyped = yield_load_arg(0, <blk>$19: T.untyped)
@@ -212,6 +216,7 @@ bb9[firstDead=14](<self>: T.class_of(Main), <block-pre-call-temp>$17: Sorbet::Pr
 # - bb13
 bb10[firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
+    # rubyRegionId: 3
     <block-call> -> (NilClass ? bb13 : bb11)
 
 # backedges
@@ -228,6 +233,7 @@ bb11[firstDead=-1](<block-pre-call-temp>$42: Sorbet::Private::Static::Void, <sel
 # - bb10
 bb13[firstDead=9](<self>: T.class_of(Main), <block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
+    # rubyRegionId: 3
     <self>: T.class_of(Main) = loadSelf(each)
     <blk>$44: T.untyped = load_yield_params(each)
     a$3: T.untyped = yield_load_arg(0, <blk>$44: T.untyped)
@@ -244,6 +250,7 @@ bb13[firstDead=9](<self>: T.class_of(Main), <block-pre-call-temp>$42: Sorbet::Pr
 # - bb17
 bb14[firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
+    # rubyRegionId: 4
     <block-call> -> (NilClass ? bb17 : bb15)
 
 # backedges
@@ -262,6 +269,7 @@ bb15[firstDead=-1](<block-pre-call-temp>$57: Sorbet::Private::Static::Void, <sel
 # - bb14
 bb17[firstDead=18](<self>: T.class_of(Main), <block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
+    # rubyRegionId: 4
     <self>: T.class_of(Main) = loadSelf(each)
     <blk>$59: T.untyped = load_yield_params(each)
     forTemp$4: T.untyped = yield_load_arg(0, <blk>$59: T.untyped)
@@ -287,6 +295,7 @@ bb17[firstDead=18](<self>: T.class_of(Main), <block-pre-call-temp>$57: Sorbet::P
 # - bb21
 bb18[firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$92: Sorbet::Private::Static::Void, <selfRestore>$93: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
+    # rubyRegionId: 5
     <block-call> -> (NilClass ? bb21 : bb19)
 
 # backedges
@@ -303,6 +312,7 @@ bb19[firstDead=-1](<block-pre-call-temp>$92: Sorbet::Private::Static::Void, <sel
 # - bb18
 bb21[firstDead=40](<self>: T.class_of(Main), <block-pre-call-temp>$92: Sorbet::Private::Static::Void, <selfRestore>$93: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped):
     # outerLoops: 1
+    # rubyRegionId: 5
     <self>: T.class_of(Main) = loadSelf(each)
     <cfgAlias>$99: T.class_of(<Magic>) = alias <C <Magic>>
     <statTemp>$101: Integer(5) = 5
@@ -350,6 +360,7 @@ bb21[firstDead=40](<self>: T.class_of(Main), <block-pre-call-temp>$92: Sorbet::P
 # - bb25
 bb22[firstDead=-1](<self>: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped, <block-pre-call-temp>$160: Sorbet::Private::Static::Void, <selfRestore>$161: T.class_of(Main)):
     # outerLoops: 1
+    # rubyRegionId: 6
     <block-call> -> (NilClass ? bb25 : bb23)
 
 # backedges
@@ -363,6 +374,7 @@ bb23[firstDead=2](<block-pre-call-temp>$160: Sorbet::Private::Static::Void, <sel
 # - bb22
 bb25[firstDead=44](<self>: T.class_of(Main), @a$104: T.untyped, @@b$114: T.untyped, $c$124: T.untyped, <block-pre-call-temp>$160: Sorbet::Private::Static::Void, <selfRestore>$161: T.class_of(Main)):
     # outerLoops: 1
+    # rubyRegionId: 6
     <self>: T.class_of(Main) = loadSelf(each)
     <blk>$162: T.untyped = load_yield_params(each)
     forTemp$6: T.untyped = yield_load_arg(0, <blk>$162: T.untyped)

--- a/test/testdata/infer/blocks2.rb.cfg-text.exp
+++ b/test/testdata/infer/blocks2.rb.cfg-text.exp
@@ -62,6 +62,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: Foo, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Foo):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -75,6 +76,7 @@ bb3[firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=5](<self>: Foo, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Foo):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: Foo = loadSelf(bar)
     <blk>$6: T.untyped = load_yield_params(bar)
     r$1: T.untyped = yield_load_arg(0, <blk>$6: T.untyped)

--- a/test/testdata/infer/bound_proc.rb.cfg-text.exp
+++ b/test/testdata/infer/bound_proc.rb.cfg-text.exp
@@ -17,6 +17,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(<root>)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -33,6 +34,7 @@ bb3[firstDead=5](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=10](<self>: T.class_of(<root>), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(<root>)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T.class_of(<root>) = loadSelf(class_helper)
     <cfgAlias>$11: T.class_of(B) = alias <C B>
     keep_for_ide$10: T.class_of(B) = <cfgAlias>$11
@@ -143,6 +145,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(Readable), <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(Readable)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -156,6 +159,7 @@ bb3[firstDead=2](<block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=4](<self>: T.class_of(Readable), <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(Readable)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T.class_of(Readable) = loadSelf(included)
     <statTemp>$12: Symbol(:do_this) = :do_this
     <blockReturnTemp>$10: T.untyped = <self>: T.class_of(Readable).before_create(<statTemp>$12: Symbol(:do_this))
@@ -184,6 +188,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(Writable), <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(Writable)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -197,6 +202,7 @@ bb3[firstDead=2](<block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=15](<self>: T.class_of(Writable), <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(Writable)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T.class_of(Writable) = loadSelf(included)
     <cfgAlias>$14: T.class_of(T) = alias <C T>
     <cfgAlias>$17: T.class_of(T) = alias <C T>
@@ -236,6 +242,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(Shareable), <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(Shareable)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -249,6 +256,7 @@ bb3[firstDead=2](<block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=10](<self>: T.class_of(Shareable), <block-pre-call-temp>$8: Sorbet::Private::Static::Void, <selfRestore>$9: T.class_of(Shareable)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T.class_of(Shareable) = loadSelf(included)
     <cfgAlias>$14: T.class_of(T) = alias <C T>
     <cfgAlias>$16: T.class_of(Article) = alias <C Article>
@@ -289,6 +297,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(Post), <statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -304,6 +313,7 @@ bb3[firstDead=4](<statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_cal
 # - bb2
 bb5[firstDead=3](<self>: T.class_of(Post), <statTemp>$12: T.class_of(Post), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Post)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T.class_of(Post) = loadSelf(lambda)
     <blockReturnTemp>$20: T.untyped = <self>: T.class_of(Post).should_run_callback?()
     <blockReturnTemp>$22: T.noreturn = blockreturn<lambda> <blockReturnTemp>$20: T.untyped
@@ -397,6 +407,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(Article), <statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -412,6 +423,7 @@ bb3[firstDead=4](<statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_
 # - bb2
 bb5[firstDead=8](<self>: T.class_of(Article), <statTemp>$12: T.class_of(Article), <statTemp>$13: Symbol(:run_callback), <hashTemp>$14: Symbol(:if), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Article)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T.class_of(Article) = loadSelf(lambda)
     <cfgAlias>$23: T.class_of(Article) = alias <C Article>
     keep_for_ide$22: T.class_of(Article) = <cfgAlias>$23
@@ -472,6 +484,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -489,6 +502,7 @@ bb3[firstDead=6](<block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=10](<self>: T.class_of(A), <block-pre-call-temp>$7: Sorbet::Private::Static::Void, <selfRestore>$8: T.class_of(A)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T.class_of(A) = loadSelf(lambda)
     <cfgAlias>$12: T.class_of(A) = alias <C A>
     keep_for_ide$11: T.class_of(A) = <cfgAlias>$12
@@ -535,6 +549,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(B)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -553,6 +568,7 @@ bb3[firstDead=7](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=8](<self>: T.class_of(B), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(B)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$10: Symbol(:blk) = :blk
     <cfgAlias>$14: T.class_of(T) = alias <C T>
@@ -731,8 +747,6 @@ bb0[firstDead=-1]():
 # backedges
 # - bb3
 # - bb10
-# - bb11
-# - bb12
 bb1[firstDead=-1]():
     <unconditional> -> bb1
 
@@ -741,6 +755,7 @@ bb1[firstDead=-1]():
 # - bb13
 bb2[firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: NilClass, <castTemp>$13: NilClass, <gotoDeadTemp>$24: NilClass):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -755,6 +770,7 @@ bb3[firstDead=3](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: NilClass, <castTemp>$13: NilClass, <gotoDeadTemp>$24: NilClass):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T.class_of(Rescues) = loadSelf(takes_block)
     <exceptionValue>$9: T.nilable(Exception) = <get-current-exception>
     <self>: Integer = cast(<castTemp>$13: NilClass, Integer);
@@ -765,6 +781,7 @@ bb5[firstDead=-1](<self>: T.class_of(Rescues), <block-pre-call-temp>$6: Sorbet::
 # - bb8
 bb7[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: T.nilable(Integer), <exceptionValue>$9: Exception, <castTemp>$13: T.nilable(Integer), <gotoDeadTemp>$24: NilClass):
     # outerLoops: 1
+    # rubyRegionId: 3
     <cfgAlias>$19: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$20: T::Boolean = <cfgAlias>$19: T.class_of(StandardError).===(<exceptionValue>$9: Exception)
     <isaCheckTemp>$20 -> (T::Boolean ? bb11 : bb12)
@@ -773,6 +790,7 @@ bb7[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Sta
 # - bb5
 bb8[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <gotoDeadTemp>$24: NilClass):
     # outerLoops: 1
+    # rubyRegionId: 2
     <cfgAlias>$12: T.class_of(Integer) = alias <C Integer>
     keep_for_ide$11: T.class_of(Integer) = <cfgAlias>$12
     keep_for_ide$11: T.untyped = <keep-alive> keep_for_ide$11
@@ -785,33 +803,37 @@ bb8[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Sta
 
 # backedges
 # - bb8
-bb10[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: Integer, <castTemp>$13: Integer, <gotoDeadTemp>$24: NilClass):
+# - bb11
+# - bb12
+bb10[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: T.nilable(Integer), <castTemp>$13: T.nilable(Integer), <gotoDeadTemp>$24: T.nilable(TrueClass)):
     # outerLoops: 1
-    <gotoDeadTemp>$24 -> (NilClass ? bb1 : bb13)
+    # rubyRegionId: 4
+    <gotoDeadTemp>$24 -> (T.nilable(TrueClass) ? bb1 : bb13)
 
 # backedges
 # - bb7
 bb11[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <exceptionValue>$9: StandardError, <castTemp>$13: T.nilable(Integer), <gotoDeadTemp>$24: NilClass):
     # outerLoops: 1
+    # rubyRegionId: 3
     <exceptionValue>$9: NilClass = nil
     <keepForCfgTemp>$17: T.untyped = <keep-alive> <exceptionValue>$9
     <cfgAlias>$22: T.class_of(T) = alias <C T>
     <blockReturnTemp>$8: Integer = <cfgAlias>$22: T.class_of(T).reveal_type(<self>: Integer)
-    <gotoDeadTemp>$24 -> (NilClass ? bb1 : bb13)
+    <unconditional> -> bb10
 
 # backedges
 # - bb7
 bb12[firstDead=-1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: T.nilable(Integer), <castTemp>$13: T.nilable(Integer)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <gotoDeadTemp>$24: TrueClass = true
-    <gotoDeadTemp>$24 -> (TrueClass ? bb1 : bb13)
+    <unconditional> -> bb10
 
 # backedges
 # - bb10
-# - bb11
-# - bb12
 bb13[firstDead=1](<self>: Integer, <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Rescues), <blockReturnTemp>$8: Integer, <castTemp>$13: T.nilable(Integer), <gotoDeadTemp>$24: NilClass):
     # outerLoops: 1
+    # rubyRegionId: 1
     <blockReturnTemp>$26: T.noreturn = blockreturn<takes_block> <blockReturnTemp>$8: Integer
     <unconditional> -> bb2
 
@@ -849,6 +871,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$16: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$17: T::Boolean = <cfgAlias>$16: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$17 -> (T::Boolean ? bb7 : bb8)
@@ -856,6 +879,7 @@ bb3[firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exce
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: String):
+    # rubyRegionId: 1
     <cfgAlias>$6: T.class_of(String) = alias <C String>
     keep_for_ide$5: T.class_of(String) = <cfgAlias>$6
     keep_for_ide$5: T.untyped = <keep-alive> keep_for_ide$5
@@ -871,6 +895,7 @@ bb4[firstDead=-1](<self>: String):
 # - bb7
 # - bb8
 bb6[firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$21: T.nilable(TrueClass)):
+    # rubyRegionId: 3
     <cfgAlias>$12: T.class_of(T) = alias <C T>
     <rescueTemp>$2: T.untyped = <cfgAlias>$12: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
     <cfgAlias>$24: T.class_of(T) = alias <C T>
@@ -880,6 +905,7 @@ bb6[firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exce
 # backedges
 # - bb3
 bb7[firstDead=-1](<self>: String, <exceptionValue>$3: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$14: T.untyped = <keep-alive> <exceptionValue>$3
     <cfgAlias>$19: T.class_of(T) = alias <C T>
@@ -920,6 +946,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: T.any(Float, String), <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$3: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$16: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$17: T::Boolean = <cfgAlias>$16: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$17 -> (T::Boolean ? bb7 : bb8)
@@ -927,6 +954,7 @@ bb3[firstDead=-1](<self>: T.any(Float, String), <returnMethodTemp>$2: T.nilable(
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: Float):
+    # rubyRegionId: 1
     <cfgAlias>$6: T.class_of(String) = alias <C String>
     keep_for_ide$5: T.class_of(String) = <cfgAlias>$6
     keep_for_ide$5: T.untyped = <keep-alive> keep_for_ide$5
@@ -942,6 +970,7 @@ bb4[firstDead=-1](<self>: Float):
 # - bb7
 # - bb8
 bb6[firstDead=-1](<self>: T.any(Float, String, Integer), <returnMethodTemp>$2: T.nilable(T.any(String, Integer)), <exceptionValue>$3: T.nilable(Exception), <gotoDeadTemp>$25: T.nilable(TrueClass)):
+    # rubyRegionId: 3
     <cfgAlias>$12: T.class_of(T) = alias <C T>
     <rescueTemp>$2: T.untyped = <cfgAlias>$12: T.class_of(T).unsafe(<exceptionValue>$3: T.nilable(Exception))
     <cfgAlias>$29: T.class_of(Float) = alias <C Float>
@@ -956,6 +985,7 @@ bb6[firstDead=-1](<self>: T.any(Float, String, Integer), <returnMethodTemp>$2: T
 # backedges
 # - bb3
 bb7[firstDead=-1](<self>: T.any(Float, String), <exceptionValue>$3: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$14: T.untyped = <keep-alive> <exceptionValue>$3
     <cfgAlias>$20: T.class_of(Integer) = alias <C Integer>
@@ -993,8 +1023,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 # - bb9
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -1003,6 +1031,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exceptionValue>$7: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$17: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$18: T::Boolean = <cfgAlias>$17: T.class_of(StandardError).===(<exceptionValue>$7: Exception)
     <isaCheckTemp>$18 -> (T::Boolean ? bb7 : bb8)
@@ -1010,6 +1039,7 @@ bb3[firstDead=-1](<self>: String, <returnMethodTemp>$2: T.nilable(String), <exce
 # backedges
 # - bb0
 bb4[firstDead=-1](<self>: String):
+    # rubyRegionId: 1
     <cfgAlias>$10: T.class_of(String) = alias <C String>
     keep_for_ide$9: T.class_of(String) = <cfgAlias>$10
     keep_for_ide$9: T.untyped = <keep-alive> keep_for_ide$9
@@ -1022,28 +1052,30 @@ bb4[firstDead=-1](<self>: String):
 
 # backedges
 # - bb4
-bb6[firstDead=-1](<returnMethodTemp>$2: String, <gotoDeadTemp>$22: NilClass):
-    <gotoDeadTemp>$22 -> (NilClass ? bb1 : bb9)
+# - bb7
+# - bb8
+bb6[firstDead=-1](<returnMethodTemp>$2: T.nilable(String), <gotoDeadTemp>$22: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$22 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb7[firstDead=-1](<self>: String, <exceptionValue>$7: StandardError):
+    # rubyRegionId: 2
     <exceptionValue>$7: NilClass = nil
     <keepForCfgTemp>$15: T.untyped = <keep-alive> <exceptionValue>$7
     <cfgAlias>$20: T.class_of(T) = alias <C T>
     <returnMethodTemp>$2: String = <cfgAlias>$20: T.class_of(T).reveal_type(<self>: String)
-    <gotoDeadTemp>$22 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1](<returnMethodTemp>$2: T.nilable(String)):
     <gotoDeadTemp>$22: TrueClass = true
-    <gotoDeadTemp>$22 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 bb9[firstDead=1](<returnMethodTemp>$2: String):
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: String
     <unconditional> -> bb1

--- a/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
@@ -38,8 +38,6 @@ bb0[firstDead=-1]():
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 # - bb24
 bb1[firstDead=-1]():
     <unconditional> -> bb1
@@ -48,6 +46,7 @@ bb1[firstDead=-1]():
 # - bb0
 # - bb4
 bb3[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <exceptionValue>$4: Exception):
+    # rubyRegionId: 2
     <cfgAlias>$7: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(StandardError).===(<exceptionValue>$4: Exception)
     <isaCheckTemp>$8 -> (T::Boolean ? bb7 : bb8)
@@ -55,33 +54,36 @@ bb3[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <exceptionValue>$4: 
 # backedges
 # - bb0
 bb4[firstDead=-1](final_attempt: T.untyped, foo: T.untyped):
+    # rubyRegionId: 1
     <exceptionValue>$4: T.nilable(Exception) = <get-current-exception>
     <exceptionValue>$4 -> (T.nilable(Exception) ? bb3 : bb6)
 
 # backedges
 # - bb4
-bb6[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: NilClass, <gotoDeadTemp>$9: NilClass):
-    <gotoDeadTemp>$9 -> (NilClass ? bb1 : bb9)
+# - bb7
+# - bb8
+bb6[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: T.nilable(StandardError), <gotoDeadTemp>$9: T.nilable(TrueClass)):
+    # rubyRegionId: 3
+    <gotoDeadTemp>$9 -> (T.nilable(TrueClass) ? bb1 : bb9)
 
 # backedges
 # - bb3
 bb7[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, <exceptionValue>$4: StandardError):
+    # rubyRegionId: 2
     e: StandardError = <exceptionValue>$4
     <exceptionValue>$4: NilClass = nil
     <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$4
     err: StandardError = e
-    <gotoDeadTemp>$9 -> (NilClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb3
 bb8[firstDead=-1](final_attempt: T.untyped, foo: T.untyped):
     <gotoDeadTemp>$9: TrueClass = true
-    <gotoDeadTemp>$9 -> (TrueClass ? bb1 : bb9)
+    <unconditional> -> bb6
 
 # backedges
 # - bb6
-# - bb7
-# - bb8
 bb9[firstDead=-1](final_attempt: T.untyped, foo: T.untyped, err: T.nilable(StandardError)):
     is_successful: T::Boolean = err: T.nilable(StandardError).nil?()
     is_successful -> (T::Boolean ? bb10 : bb11)

--- a/test/testdata/infer/control_flow/normalize_params.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/normalize_params.rb.cfg-text.exp
@@ -74,6 +74,7 @@ bb5[firstDead=-1](v: T.untyped):
 # - bb9
 bb6[firstDead=-1](<self>: Test, <block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: Test):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
@@ -86,6 +87,7 @@ bb7[firstDead=-1](<block-pre-call-temp>$16: Sorbet::Private::Static::Void, <self
 # - bb6
 bb9[firstDead=5](<self>: Test, <block-pre-call-temp>$16: Sorbet::Private::Static::Void, <selfRestore>$17: Test):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: Test = loadSelf(map)
     <blk>$18: [T.untyped] = load_yield_params(map)
     e$1: T.untyped = yield_load_arg(0, <blk>$18: [T.untyped])

--- a/test/testdata/infer/control_flow/simple.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/simple.rb.cfg-text.exp
@@ -30,6 +30,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(ControlFlow)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -45,6 +46,7 @@ bb3[firstDead=-1](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfR
 # - bb2
 bb5[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(ControlFlow)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$10: Symbol(:a) = :a
     <cfgAlias>$13: T.class_of(T) = alias <C T>
@@ -62,6 +64,7 @@ bb5[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$5: Sorb
 # - bb9
 bb6[firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(ControlFlow)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
@@ -77,6 +80,7 @@ bb7[firstDead=-1](<block-pre-call-temp>$23: Sorbet::Private::Static::Void, <self
 # - bb6
 bb9[firstDead=7](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(ControlFlow)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$28: Symbol(:a) = :a
     <cfgAlias>$30: T.class_of(Integer) = alias <C Integer>
@@ -91,6 +95,7 @@ bb9[firstDead=7](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$23: Sorb
 # - bb13
 bb10[firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$36: Sorbet::Private::Static::Void, <selfRestore>$37: T.class_of(ControlFlow)):
     # outerLoops: 1
+    # rubyRegionId: 3
     <block-call> -> (NilClass ? bb13 : bb11)
 
 # backedges
@@ -106,6 +111,7 @@ bb11[firstDead=-1](<block-pre-call-temp>$36: Sorbet::Private::Static::Void, <sel
 # - bb10
 bb13[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$36: Sorbet::Private::Static::Void, <selfRestore>$37: T.class_of(ControlFlow)):
     # outerLoops: 1
+    # rubyRegionId: 3
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$41: Symbol(:a) = :a
     <cfgAlias>$44: T.class_of(T) = alias <C T>
@@ -123,6 +129,7 @@ bb13[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$36: So
 # - bb17
 bb14[firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$54: Sorbet::Private::Static::Void, <selfRestore>$55: T.class_of(ControlFlow)):
     # outerLoops: 1
+    # rubyRegionId: 4
     <block-call> -> (NilClass ? bb17 : bb15)
 
 # backedges
@@ -138,6 +145,7 @@ bb15[firstDead=-1](<block-pre-call-temp>$54: Sorbet::Private::Static::Void, <sel
 # - bb14
 bb17[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$54: Sorbet::Private::Static::Void, <selfRestore>$55: T.class_of(ControlFlow)):
     # outerLoops: 1
+    # rubyRegionId: 4
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$59: Symbol(:a) = :a
     <cfgAlias>$62: T.class_of(T) = alias <C T>
@@ -155,6 +163,7 @@ bb17[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$54: So
 # - bb21
 bb18[firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$72: Sorbet::Private::Static::Void, <selfRestore>$73: T.class_of(ControlFlow)):
     # outerLoops: 1
+    # rubyRegionId: 5
     <block-call> -> (NilClass ? bb21 : bb19)
 
 # backedges
@@ -170,6 +179,7 @@ bb19[firstDead=-1](<block-pre-call-temp>$72: Sorbet::Private::Static::Void, <sel
 # - bb18
 bb21[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$72: Sorbet::Private::Static::Void, <selfRestore>$73: T.class_of(ControlFlow)):
     # outerLoops: 1
+    # rubyRegionId: 5
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$77: Symbol(:a) = :a
     <cfgAlias>$80: T.class_of(T) = alias <C T>
@@ -187,6 +197,7 @@ bb21[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$72: So
 # - bb25
 bb22[firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$90: Sorbet::Private::Static::Void, <selfRestore>$91: T.class_of(ControlFlow)):
     # outerLoops: 1
+    # rubyRegionId: 6
     <block-call> -> (NilClass ? bb25 : bb23)
 
 # backedges
@@ -202,6 +213,7 @@ bb23[firstDead=-1](<block-pre-call-temp>$90: Sorbet::Private::Static::Void, <sel
 # - bb22
 bb25[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$90: Sorbet::Private::Static::Void, <selfRestore>$91: T.class_of(ControlFlow)):
     # outerLoops: 1
+    # rubyRegionId: 6
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$95: Symbol(:a) = :a
     <cfgAlias>$98: T.class_of(T) = alias <C T>
@@ -219,6 +231,7 @@ bb25[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$90: So
 # - bb29
 bb26[firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$108: Sorbet::Private::Static::Void, <selfRestore>$109: T.class_of(ControlFlow)):
     # outerLoops: 1
+    # rubyRegionId: 7
     <block-call> -> (NilClass ? bb29 : bb27)
 
 # backedges
@@ -234,6 +247,7 @@ bb27[firstDead=-1](<block-pre-call-temp>$108: Sorbet::Private::Static::Void, <se
 # - bb26
 bb29[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$108: Sorbet::Private::Static::Void, <selfRestore>$109: T.class_of(ControlFlow)):
     # outerLoops: 1
+    # rubyRegionId: 7
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$113: Symbol(:a) = :a
     <cfgAlias>$116: T.class_of(T) = alias <C T>
@@ -251,6 +265,7 @@ bb29[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$108: S
 # - bb33
 bb30[firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$126: Sorbet::Private::Static::Void, <selfRestore>$127: T.class_of(ControlFlow)):
     # outerLoops: 1
+    # rubyRegionId: 8
     <block-call> -> (NilClass ? bb33 : bb31)
 
 # backedges
@@ -266,6 +281,7 @@ bb31[firstDead=-1](<block-pre-call-temp>$126: Sorbet::Private::Static::Void, <se
 # - bb30
 bb33[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$126: Sorbet::Private::Static::Void, <selfRestore>$127: T.class_of(ControlFlow)):
     # outerLoops: 1
+    # rubyRegionId: 8
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$131: Symbol(:a) = :a
     <cfgAlias>$134: T.class_of(T) = alias <C T>
@@ -283,6 +299,7 @@ bb33[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$126: S
 # - bb37
 bb34[firstDead=-1](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$144: Sorbet::Private::Static::Void, <selfRestore>$145: T.class_of(ControlFlow)):
     # outerLoops: 1
+    # rubyRegionId: 9
     <block-call> -> (NilClass ? bb37 : bb35)
 
 # backedges
@@ -301,6 +318,7 @@ bb35[firstDead=7](<block-pre-call-temp>$144: Sorbet::Private::Static::Void, <sel
 # - bb34
 bb37[firstDead=10](<self>: T.class_of(ControlFlow), <block-pre-call-temp>$144: Sorbet::Private::Static::Void, <selfRestore>$145: T.class_of(ControlFlow)):
     # outerLoops: 1
+    # rubyRegionId: 9
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$149: Symbol(:a) = :a
     <cfgAlias>$152: T.class_of(T) = alias <C T>

--- a/test/testdata/infer/isa_generic.rb.cfg-text.exp
+++ b/test/testdata/infer/isa_generic.rb.cfg-text.exp
@@ -16,6 +16,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(<root>)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -31,6 +32,7 @@ bb3[firstDead=-1](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfR
 # - bb2
 bb5[firstDead=9](<self>: T.class_of(<root>), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(<root>)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$10: Symbol(:x) = :x
     <cfgAlias>$13: T.class_of(T) = alias <C T>
@@ -47,6 +49,7 @@ bb5[firstDead=9](<self>: T.class_of(<root>), <block-pre-call-temp>$5: Sorbet::Pr
 # - bb9
 bb6[firstDead=-1](<self>: T.class_of(<root>), <block-pre-call-temp>$21: Sorbet::Private::Static::Void, <selfRestore>$22: T.class_of(<root>)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
@@ -65,6 +68,7 @@ bb7[firstDead=7](<block-pre-call-temp>$21: Sorbet::Private::Static::Void, <selfR
 # - bb6
 bb9[firstDead=9](<self>: T.class_of(<root>), <block-pre-call-temp>$21: Sorbet::Private::Static::Void, <selfRestore>$22: T.class_of(<root>)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$26: Symbol(:x) = :x
     <cfgAlias>$29: T.class_of(T) = alias <C T>
@@ -249,6 +253,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(Concrete), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Concrete)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -263,6 +268,7 @@ bb3[firstDead=3](<block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfR
 # - bb2
 bb5[firstDead=6](<self>: T.class_of(Concrete), <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Concrete)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T.class_of(Concrete) = loadSelf(type_template)
     <hashTemp>$15: Symbol(:fixed) = :fixed
     <cfgAlias>$17: T.class_of(String) = alias <C String>

--- a/test/testdata/infer/rebind.rb.cfg-text.exp
+++ b/test/testdata/infer/rebind.rb.cfg-text.exp
@@ -59,6 +59,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(B)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -77,6 +78,7 @@ bb3[firstDead=7](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=10](<self>: T.class_of(B), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(B)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$10: Symbol(:blk) = :blk
     <cfgAlias>$15: T.class_of(T) = alias <C T>
@@ -123,6 +125,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(A)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -141,6 +144,7 @@ bb3[firstDead=7](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=10](<self>: T.class_of(A), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(A)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$10: Symbol(:blk) = :blk
     <cfgAlias>$15: T.class_of(T) = alias <C T>
@@ -219,6 +223,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: Use, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Use):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -232,6 +237,7 @@ bb3[firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=3](<self>: Use, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Use):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: Use = loadSelf(only_on_Use)
     <blockReturnTemp>$6: Integer(1) = 1
     <blockReturnTemp>$7: T.noreturn = blockreturn<only_on_Use> <blockReturnTemp>$6: Integer(1)
@@ -258,6 +264,7 @@ bb1[firstDead=-1]():
 # - bb7
 bb2[firstDead=-1](<self>: Use, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -271,6 +278,7 @@ bb3[firstDead=2](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=-1](<self>: Use, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: B = loadSelf(mySig)
     <statTemp>$8: T.untyped = <self>: B.only_on_Use()
     <statTemp>$10: T.untyped = <self>: B.mySig()
@@ -283,12 +291,14 @@ bb5[firstDead=-1](<self>: Use, <block-pre-call-temp>$5: Sorbet::Private::Static:
 # - bb9
 bb6[firstDead=-1](<self>: B, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use, <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: B):
     # outerLoops: 2
+    # rubyRegionId: 2
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
 # - bb6
 bb7[firstDead=3](<self>: B, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use, <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: B):
     # outerLoops: 1
+    # rubyRegionId: 1
     <blockReturnTemp>$7: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$13, only_on_B>
     <self>: B = <selfRestore>$14
     <blockReturnTemp>$20: T.noreturn = blockreturn<mySig> <blockReturnTemp>$7: Sorbet::Private::Static::Void
@@ -298,6 +308,7 @@ bb7[firstDead=3](<self>: B, <block-pre-call-temp>$5: Sorbet::Private::Static::Vo
 # - bb6
 bb9[firstDead=4](<self>: B, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Use, <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: B):
     # outerLoops: 2
+    # rubyRegionId: 2
     <self>: C = loadSelf(only_on_B)
     <statTemp>$16: T.untyped = <self>: C.only_on_B()
     <blockReturnTemp>$15: T.untyped = <self>: C.only_on_C()

--- a/test/testdata/infer/self_type.rb.cfg-text.exp
+++ b/test/testdata/infer/self_type.rb.cfg-text.exp
@@ -131,6 +131,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(Parent), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(Parent)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -149,6 +150,7 @@ bb3[firstDead=7](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=5](<self>: T.class_of(Parent), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(Parent)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$11: T.class_of(T) = alias <C T>
     <statTemp>$9: Runtime object representing type: T.untyped = <cfgAlias>$11: T.class_of(T).self_type()
@@ -206,6 +208,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(Generic), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(Generic)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -225,6 +228,7 @@ bb3[firstDead=8](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=7](<self>: T.class_of(Generic), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(Generic)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$11: T.class_of(Generic) = alias <C Generic>
     <cfgAlias>$14: T.class_of(T) = alias <C T>
@@ -287,6 +291,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(Array), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(Array)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -305,6 +310,7 @@ bb3[firstDead=7](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=5](<self>: T.class_of(Array), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(Array)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$11: T.class_of(T) = alias <C T>
     <statTemp>$9: Runtime object representing type: T.untyped = <cfgAlias>$11: T.class_of(T).self_type()
@@ -361,6 +367,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(B)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -376,6 +383,7 @@ bb3[firstDead=-1](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfR
 # - bb2
 bb5[firstDead=5](<self>: T.class_of(B), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(B)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$11: T.class_of(T) = alias <C T>
     <statTemp>$9: Runtime object representing type: T.untyped = <cfgAlias>$11: T.class_of(T).self_type()
@@ -388,6 +396,7 @@ bb5[firstDead=5](<self>: T.class_of(B), <block-pre-call-temp>$5: Sorbet::Private
 # - bb9
 bb6[firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$15: Sorbet::Private::Static::Void, <selfRestore>$16: T.class_of(B)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
@@ -403,6 +412,7 @@ bb7[firstDead=-1](<block-pre-call-temp>$15: Sorbet::Private::Static::Void, <self
 # - bb6
 bb9[firstDead=7](<self>: T.class_of(B), <block-pre-call-temp>$15: Sorbet::Private::Static::Void, <selfRestore>$16: T.class_of(B)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$20: Symbol(:x) = :x
     <cfgAlias>$23: T.class_of(T) = alias <C T>
@@ -417,6 +427,7 @@ bb9[firstDead=7](<self>: T.class_of(B), <block-pre-call-temp>$15: Sorbet::Privat
 # - bb13
 bb10[firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(B)):
     # outerLoops: 1
+    # rubyRegionId: 3
     <block-call> -> (NilClass ? bb13 : bb11)
 
 # backedges
@@ -432,6 +443,7 @@ bb11[firstDead=-1](<block-pre-call-temp>$27: Sorbet::Private::Static::Void, <sel
 # - bb10
 bb13[firstDead=7](<self>: T.class_of(B), <block-pre-call-temp>$27: Sorbet::Private::Static::Void, <selfRestore>$28: T.class_of(B)):
     # outerLoops: 1
+    # rubyRegionId: 3
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$32: Symbol(:x) = :x
     <cfgAlias>$35: T.class_of(T) = alias <C T>
@@ -446,6 +458,7 @@ bb13[firstDead=7](<self>: T.class_of(B), <block-pre-call-temp>$27: Sorbet::Priva
 # - bb17
 bb14[firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$39: Sorbet::Private::Static::Void, <selfRestore>$40: T.class_of(B)):
     # outerLoops: 1
+    # rubyRegionId: 4
     <block-call> -> (NilClass ? bb17 : bb15)
 
 # backedges
@@ -461,6 +474,7 @@ bb15[firstDead=-1](<block-pre-call-temp>$39: Sorbet::Private::Static::Void, <sel
 # - bb14
 bb17[firstDead=12](<self>: T.class_of(B), <block-pre-call-temp>$39: Sorbet::Private::Static::Void, <selfRestore>$40: T.class_of(B)):
     # outerLoops: 1
+    # rubyRegionId: 4
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$44: Symbol(:blk) = :blk
     <cfgAlias>$49: T.class_of(T) = alias <C T>
@@ -480,6 +494,7 @@ bb17[firstDead=12](<self>: T.class_of(B), <block-pre-call-temp>$39: Sorbet::Priv
 # - bb21
 bb18[firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(B)):
     # outerLoops: 1
+    # rubyRegionId: 5
     <block-call> -> (NilClass ? bb21 : bb19)
 
 # backedges
@@ -495,6 +510,7 @@ bb19[firstDead=-1](<block-pre-call-temp>$57: Sorbet::Private::Static::Void, <sel
 # - bb18
 bb21[firstDead=10](<self>: T.class_of(B), <block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(B)):
     # outerLoops: 1
+    # rubyRegionId: 5
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$62: Symbol(:x) = :x
     <cfgAlias>$65: T.class_of(T) = alias <C T>
@@ -512,6 +528,7 @@ bb21[firstDead=10](<self>: T.class_of(B), <block-pre-call-temp>$57: Sorbet::Priv
 # - bb25
 bb22[firstDead=-1](<self>: T.class_of(B), <block-pre-call-temp>$74: Sorbet::Private::Static::Void, <selfRestore>$75: T.class_of(B)):
     # outerLoops: 1
+    # rubyRegionId: 6
     <block-call> -> (NilClass ? bb25 : bb23)
 
 # backedges
@@ -534,6 +551,7 @@ bb23[firstDead=11](<block-pre-call-temp>$74: Sorbet::Private::Static::Void, <sel
 # - bb22
 bb25[firstDead=7](<self>: T.class_of(B), <block-pre-call-temp>$74: Sorbet::Private::Static::Void, <selfRestore>$75: T.class_of(B)):
     # outerLoops: 1
+    # rubyRegionId: 6
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$79: Symbol(:other) = :other
     <cfgAlias>$82: T.class_of(T) = alias <C T>

--- a/test/testdata/infer/transitive.rb.cfg-text.exp
+++ b/test/testdata/infer/transitive.rb.cfg-text.exp
@@ -30,6 +30,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(A)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -48,6 +49,7 @@ bb3[firstDead=7](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=4](<self>: T.class_of(A), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(A)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$10: T.class_of(Integer) = alias <C Integer>
     <blockReturnTemp>$7: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$10: T.class_of(Integer))
@@ -88,6 +90,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(Bar), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(Bar)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -106,6 +109,7 @@ bb3[firstDead=7](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=7](<self>: T.class_of(Bar), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(Bar)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$10: Symbol(:arg) = :arg
     <cfgAlias>$12: T.class_of(Integer) = alias <C Integer>

--- a/test/testdata/infer/zsuper.rb.cfg-text.exp
+++ b/test/testdata/infer/zsuper.rb.cfg-text.exp
@@ -77,6 +77,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: Bar, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -90,6 +91,7 @@ bb3[firstDead=2](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=5](<self>: Bar, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Bar):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: Bar = loadSelf(<super>)
     <blk>$7: T.untyped = load_yield_params(<super>)
     a$1: T.untyped = yield_load_arg(0, <blk>$7: T.untyped)

--- a/test/testdata/namer/module_function.rb.cfg-text.exp
+++ b/test/testdata/namer/module_function.rb.cfg-text.exp
@@ -30,6 +30,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(Funcs)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -45,6 +46,7 @@ bb3[firstDead=-1](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfR
 # - bb2
 bb5[firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(Funcs)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$10: Symbol(:x) = :x
     <cfgAlias>$12: T.class_of(Integer) = alias <C Integer>
@@ -59,6 +61,7 @@ bb5[firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$5: Sorbet::Pri
 # - bb9
 bb6[firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Funcs)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
@@ -74,6 +77,7 @@ bb7[firstDead=-1](<block-pre-call-temp>$18: Sorbet::Private::Static::Void, <self
 # - bb6
 bb9[firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$18: Sorbet::Private::Static::Void, <selfRestore>$19: T.class_of(Funcs)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$23: Symbol(:s) = :s
     <cfgAlias>$25: T.class_of(Symbol) = alias <C Symbol>
@@ -88,6 +92,7 @@ bb9[firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$18: Sorbet::Pr
 # - bb13
 bb10[firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$31: Sorbet::Private::Static::Void, <selfRestore>$32: T.class_of(Funcs)):
     # outerLoops: 1
+    # rubyRegionId: 3
     <block-call> -> (NilClass ? bb13 : bb11)
 
 # backedges
@@ -103,6 +108,7 @@ bb11[firstDead=-1](<block-pre-call-temp>$31: Sorbet::Private::Static::Void, <sel
 # - bb10
 bb13[firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$31: Sorbet::Private::Static::Void, <selfRestore>$32: T.class_of(Funcs)):
     # outerLoops: 1
+    # rubyRegionId: 3
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$36: Symbol(:s) = :s
     <cfgAlias>$38: T.class_of(Symbol) = alias <C Symbol>
@@ -117,6 +123,7 @@ bb13[firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$31: Sorbet::P
 # - bb17
 bb14[firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$44: Sorbet::Private::Static::Void, <selfRestore>$45: T.class_of(Funcs)):
     # outerLoops: 1
+    # rubyRegionId: 4
     <block-call> -> (NilClass ? bb17 : bb15)
 
 # backedges
@@ -132,6 +139,7 @@ bb15[firstDead=-1](<block-pre-call-temp>$44: Sorbet::Private::Static::Void, <sel
 # - bb14
 bb17[firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$44: Sorbet::Private::Static::Void, <selfRestore>$45: T.class_of(Funcs)):
     # outerLoops: 1
+    # rubyRegionId: 4
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$49: Symbol(:s) = :s
     <cfgAlias>$51: T.class_of(String) = alias <C String>
@@ -146,6 +154,7 @@ bb17[firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$44: Sorbet::P
 # - bb21
 bb18[firstDead=-1](<self>: T.class_of(Funcs), <block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(Funcs)):
     # outerLoops: 1
+    # rubyRegionId: 5
     <block-call> -> (NilClass ? bb21 : bb19)
 
 # backedges
@@ -170,6 +179,7 @@ bb19[firstDead=13](<block-pre-call-temp>$57: Sorbet::Private::Static::Void, <sel
 # - bb18
 bb21[firstDead=7](<self>: T.class_of(Funcs), <block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(Funcs)):
     # outerLoops: 1
+    # rubyRegionId: 5
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <hashTemp>$62: Symbol(:s) = :s
     <cfgAlias>$64: T.class_of(String) = alias <C String>

--- a/test/testdata/namer/yield.rb.cfg-text.exp
+++ b/test/testdata/namer/yield.rb.cfg-text.exp
@@ -103,6 +103,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: Main, <blk>: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Main):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -116,6 +117,7 @@ bb3[firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=5](<self>: Main, <blk>: T.untyped, <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: Main):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: Main = loadSelf(yielder)
     <blk>$6: T.untyped = load_yield_params(yielder)
     i$1: T.untyped = yield_load_arg(0, <blk>$6: T.untyped)
@@ -143,6 +145,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: Main, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -169,6 +172,7 @@ bb3[firstDead=15](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfR
 # - bb2
 bb5[firstDead=6](<self>: Main, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: Main):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: Main = loadSelf(lambda)
     <blk>$7: [T.untyped] = load_yield_params(lambda)
     x$1: T.untyped = yield_load_arg(0, <blk>$7: [T.untyped])

--- a/test/testdata/rewriter/class_new_strict.rb.cfg-text.exp
+++ b/test/testdata/rewriter/class_new_strict.rb.cfg-text.exp
@@ -30,6 +30,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(A)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -48,6 +49,7 @@ bb3[firstDead=7](<block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=3](<self>: T.class_of(A), <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: T.class_of(A)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <blockReturnTemp>$7: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.void()
     <blockReturnTemp>$9: T.noreturn = blockreturn<sig> <blockReturnTemp>$7: T::Private::Methods::DeclBuilder
@@ -74,6 +76,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(A)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -91,6 +94,7 @@ bb3[firstDead=-1](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfR
 # - bb2
 bb5[firstDead=8](<self>: T.class_of(A), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(A)):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T.class_of(A) = loadSelf(new)
     <cfgAlias>$12: T.class_of(T::Class) = alias <C Class>
     <cfgAlias>$14: T.class_of(Object) = alias <C Object>
@@ -106,6 +110,7 @@ bb5[firstDead=8](<self>: T.class_of(A), <block-pre-call-temp>$6: Sorbet::Private
 # - bb9
 bb6[firstDead=-1](<self>: T.class_of(A), <block-pre-call-temp>$21: Sorbet::Private::Static::Void, <selfRestore>$22: T.class_of(A)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
@@ -120,6 +125,7 @@ bb7[firstDead=3](<block-pre-call-temp>$21: Sorbet::Private::Static::Void, <selfR
 # - bb6
 bb9[firstDead=8](<self>: T.class_of(A), <block-pre-call-temp>$21: Sorbet::Private::Static::Void, <selfRestore>$22: T.class_of(A)):
     # outerLoops: 1
+    # rubyRegionId: 2
     <self>: T.class_of(A) = loadSelf(new)
     <cfgAlias>$27: T.class_of(T) = alias <C T>
     <cfgAlias>$29: T.class_of(A) = alias <C A>

--- a/test/testdata/rewriter/t_enum_snapshot.rb.cfg-text.exp
+++ b/test/testdata/rewriter/t_enum_snapshot.rb.cfg-text.exp
@@ -34,6 +34,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(MyEnum), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(MyEnum), <C X>$28: MyEnum::X, <C Y>$36: MyEnum::Y, <C Z>$45: MyEnum::Z):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -53,6 +54,7 @@ bb3[firstDead=-1](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfR
 # - bb2
 bb5[firstDead=4](<self>: T.class_of(MyEnum), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(MyEnum), <C X>$28: MyEnum::X, <C Y>$36: MyEnum::Y, <C Z>$45: MyEnum::Z):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$11: T.class_of(String) = alias <C String>
     <blockReturnTemp>$8: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$11: T.class_of(String))
@@ -64,6 +66,7 @@ bb5[firstDead=4](<self>: T.class_of(MyEnum), <block-pre-call-temp>$6: Sorbet::Pr
 # - bb9
 bb6[firstDead=-1](<self>: T.class_of(MyEnum), <block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(MyEnum), <C X>$28: MyEnum::X, <C Y>$36: MyEnum::Y, <C Z>$45: MyEnum::Z):
     # outerLoops: 1
+    # rubyRegionId: 2
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
@@ -80,6 +83,7 @@ bb7[firstDead=5](<block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfR
 # - bb6
 bb9[firstDead=22](<self>: T.class_of(MyEnum), <block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(MyEnum), <C X>$28: MyEnum::X, <C Y>$36: MyEnum::Y, <C Z>$45: MyEnum::Z):
     # outerLoops: 1
+    # rubyRegionId: 2
     <self>: T.class_of(MyEnum) = loadSelf(enums)
     <cfgAlias>$30: T.class_of(MyEnum::X) = alias <C X$1>
     keep_for_ide$29: T.class_of(MyEnum::X) = <cfgAlias>$30
@@ -185,6 +189,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(NotAnEnum), <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: T.class_of(NotAnEnum), <C X>$8: T.untyped, <C Y>$13: T.untyped):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -198,6 +203,7 @@ bb3[firstDead=2](<block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRe
 # - bb2
 bb5[firstDead=10](<self>: T.class_of(NotAnEnum), <block-pre-call-temp>$4: Sorbet::Private::Static::Void, <selfRestore>$5: T.class_of(NotAnEnum), <C X>$8: T.untyped, <C Y>$13: T.untyped):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T.class_of(NotAnEnum) = loadSelf(enums)
     <cfgAlias>$10: T.class_of(<Magic>) = alias <C <Magic>>
     <statTemp>$11: T.attached_class (of NotAnEnum) = <self>: T.class_of(NotAnEnum).new()
@@ -234,6 +240,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(EnumsDoEnum), <C X>$28: EnumsDoEnum::X, <C Y>$36: EnumsDoEnum::Y, <C Z>$45: EnumsDoEnum::Z):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -253,6 +260,7 @@ bb3[firstDead=-1](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfR
 # - bb2
 bb5[firstDead=4](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(EnumsDoEnum), <C X>$28: EnumsDoEnum::X, <C Y>$36: EnumsDoEnum::Y, <C Z>$45: EnumsDoEnum::Z):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$11: T.class_of(String) = alias <C String>
     <blockReturnTemp>$8: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$11: T.class_of(String))
@@ -264,6 +272,7 @@ bb5[firstDead=4](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$6: Sorbe
 # - bb9
 bb6[firstDead=-1](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(EnumsDoEnum), <C X>$28: EnumsDoEnum::X, <C Y>$36: EnumsDoEnum::Y, <C Z>$45: EnumsDoEnum::Z):
     # outerLoops: 1
+    # rubyRegionId: 2
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
@@ -280,6 +289,7 @@ bb7[firstDead=5](<block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfR
 # - bb6
 bb9[firstDead=22](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(EnumsDoEnum), <C X>$28: EnumsDoEnum::X, <C Y>$36: EnumsDoEnum::Y, <C Z>$45: EnumsDoEnum::Z):
     # outerLoops: 1
+    # rubyRegionId: 2
     <self>: T.class_of(EnumsDoEnum) = loadSelf(enums)
     <cfgAlias>$30: T.class_of(EnumsDoEnum::X) = alias <C X$1>
     keep_for_ide$29: T.class_of(EnumsDoEnum::X) = <cfgAlias>$30
@@ -405,6 +415,7 @@ bb1[firstDead=-1]():
 # - bb5
 bb2[firstDead=-1](<self>: T.class_of(BadConsts), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(BadConsts), <C Before>$22: BadConsts::Before, <C StaticField1>$29: Integer, <C Inside>$37: BadConsts::Inside, <C StaticField2>$44: Integer, <C After>$47: BadConsts::After, <C StaticField3>$54: Integer, <C StaticField4>$56: Integer):
     # outerLoops: 1
+    # rubyRegionId: 1
     <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
@@ -431,6 +442,7 @@ bb3[firstDead=-1](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfR
 # - bb2
 bb5[firstDead=4](<self>: T.class_of(BadConsts), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(BadConsts), <C Before>$22: BadConsts::Before, <C StaticField1>$29: Integer, <C Inside>$37: BadConsts::Inside, <C StaticField2>$44: Integer, <C After>$47: BadConsts::After, <C StaticField3>$54: Integer, <C StaticField4>$56: Integer):
     # outerLoops: 1
+    # rubyRegionId: 1
     <self>: T::Private::Methods::DeclBuilder = loadSelf(sig)
     <cfgAlias>$11: T.class_of(String) = alias <C String>
     <blockReturnTemp>$8: T::Private::Methods::DeclBuilder = <self>: T::Private::Methods::DeclBuilder.returns(<cfgAlias>$11: T.class_of(String))
@@ -442,6 +454,7 @@ bb5[firstDead=4](<self>: T.class_of(BadConsts), <block-pre-call-temp>$6: Sorbet:
 # - bb9
 bb6[firstDead=-1](<self>: T.class_of(BadConsts), <block-pre-call-temp>$32: Sorbet::Private::Static::Void, <selfRestore>$33: T.class_of(BadConsts), <C Inside>$37: BadConsts::Inside, <C StaticField2>$44: Integer, <C After>$47: BadConsts::After, <C StaticField3>$54: Integer, <C StaticField4>$56: Integer):
     # outerLoops: 1
+    # rubyRegionId: 2
     <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
@@ -470,6 +483,7 @@ bb7[firstDead=17](<block-pre-call-temp>$32: Sorbet::Private::Static::Void, <self
 # - bb6
 bb9[firstDead=10](<self>: T.class_of(BadConsts), <block-pre-call-temp>$32: Sorbet::Private::Static::Void, <selfRestore>$33: T.class_of(BadConsts), <C Inside>$37: BadConsts::Inside, <C StaticField2>$44: Integer, <C After>$47: BadConsts::After, <C StaticField3>$54: Integer, <C StaticField4>$56: Integer):
     # outerLoops: 1
+    # rubyRegionId: 2
     <self>: T.class_of(BadConsts) = loadSelf(enums)
     <cfgAlias>$39: T.class_of(BadConsts::Inside) = alias <C Inside$1>
     keep_for_ide$38: T.class_of(BadConsts::Inside) = <cfgAlias>$39


### PR DESCRIPTION
Track Ruby exception handling region IDs in the CFG to enable proper code generation for rescue/ensure blocks. Each basic block now stores its rubyRegionId, which identifies which exception handling region it belongs to.

Changes:
- Add rubyRegionId field to BasicBlock
- Track region IDs through CFGContext during CFG construction
- Assign region IDs when creating blocks for exception handling
- Update cfg-text output to display rubyRegionId for debugging
- Update test expectations with new rubyRegionId output

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Extracted out of https://github.com/sorbet/sorbet/pull/9792


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
