### PR TITLE
Move abstract class instantiation check to definition_validator

### DIFF
--- a/core/errors/cfg.h
+++ b/core/errors/cfg.h
@@ -9,6 +9,6 @@ constexpr ErrorClass UndeclaredVariable{6002, StrictLevel::Strict};
 constexpr ErrorClass MalformedTAbsurd{6004, StrictLevel::True};
 constexpr ErrorClass MalformedTBind{6005, StrictLevel::False};
 constexpr ErrorClass UnknownTypeParameter{6006, StrictLevel::True};
-constexpr ErrorClass AbstractClassInstantiated{6007, StrictLevel::True};
+// constexpr ErrorClass AbstractClassInstantiated{6007, StrictLevel::True};
 } // namespace sorbet::core::errors::CFG
 #endif

--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -78,7 +78,7 @@ constexpr ErrorClass MultipleStatementsInSig{5069, StrictLevel::False};
 constexpr ErrorClass NilableUntyped{5070, StrictLevel::False};
 constexpr ErrorClass BindNonBlockParameter{5071, StrictLevel::False};
 constexpr ErrorClass TypeMemberScopeMismatch{5072, StrictLevel::False};
-// constexpr ErrorClass AbstractClassInstantiated{5073, StrictLevel::True};
+constexpr ErrorClass AbstractClassInstantiated{5073, StrictLevel::True};
 constexpr ErrorClass HasAttachedClassIncluded{5074, StrictLevel::False};
 constexpr ErrorClass TypeAliasToTypeMember{5075, StrictLevel::False};
 constexpr ErrorClass TNilableArity{5076, StrictLevel::False};

--- a/test/testdata/resolver/abstract_class_instantiation.rb
+++ b/test/testdata/resolver/abstract_class_instantiation.rb
@@ -1,0 +1,69 @@
+# typed: strict
+
+# This test verifies that attempting to instantiate an abstract class
+# produces error 5073 (Resolver::AbstractClassInstantiated) which was
+# moved from the CFG builder to the definition_validator.
+# The benefit is that this error is now caught earlier in the pipeline,
+# during definition validation rather than during CFG construction.
+
+class AbstractParent
+  extend T::Sig
+  extend T::Helpers
+  abstract!
+
+  sig {abstract.returns(String)}
+  def foo; end
+end
+
+class ConcreteChild < AbstractParent
+  sig {override.returns(String)}
+  def foo
+    "hello"
+  end
+end
+
+class Instantiator
+  extend T::Sig
+
+  sig {void}
+  def create_abstract
+    AbstractParent.new # error: Attempt to instantiate abstract class `AbstractParent`
+  end
+
+  sig {void}
+  def create_concrete
+    # This is fine - concrete class can be instantiated
+    ConcreteChild.new
+  end
+end
+
+# Test instantiation in various contexts
+AbstractParent.new # error: Attempt to instantiate abstract class `AbstractParent`
+
+x = AbstractParent.new # error: Attempt to instantiate abstract class `AbstractParent`
+
+# Test that defining custom .new on abstract class allows instantiation
+class AbstractWithCustomNew
+  extend T::Sig
+  extend T::Helpers
+  abstract!
+
+  sig {returns(AbstractWithCustomNew)}
+  def self.new
+    # Factory method that returns a concrete instance
+    ConcreteWithCustomNew.allocate
+  end
+
+  sig {abstract.returns(String)}
+  def bar; end
+end
+
+class ConcreteWithCustomNew < AbstractWithCustomNew
+  sig {override.returns(String)}
+  def bar
+    "custom"
+  end
+end
+
+# This is fine because AbstractWithCustomNew defines its own .new method
+AbstractWithCustomNew.new


### PR DESCRIPTION
This change moves the AbstractClassInstantiated error detection from the CFG builder (handleSpecialMethods) to the definition_validator. This provides the following benefits:

1. The check runs earlier in the pipeline (during definition validation rather than CFG construction)
2. Error code changes from 6007 (CFG) to 5073 (Resolver)
3. More consistent with other validation logic in definition_validator

The check detects attempts to instantiate abstract classes that don't define their own .new method, which would fail at runtime.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
Extracted from PR #9792

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
