### PR TITLE
RDoc 7.0.3 class inheritance changes

### DIFF
--- a/rbi/stdlib/rdoc.rbi
+++ b/rbi/stdlib/rdoc.rbi
@@ -4375,7 +4375,7 @@ class RDoc::Markup::Attributes
 end
 
 # An empty line. This class is a singleton.
-class RDoc::Markup::BlankLine
+class RDoc::Markup::BlankLine < ::RDoc::Markup::Element
   # Calls accept\_blank\_line on `visitor`
   def accept(visitor); end
 
@@ -4390,6 +4390,13 @@ end
 class RDoc::Markup::BlockQuote < ::RDoc::Markup::Raw
   # Calls accept\_block\_quote on `visitor`
   def accept(visitor); end
+end
+
+# Base class defining the interface for all markup elements found in documentation
+class RDoc::Markup::Element
+  def accept(visitor); end
+
+  def pretty_print(q); end
 end
 
 # A [`Document`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Markup/Document.html)
@@ -4572,7 +4579,7 @@ class RDoc::Markup::Formatter::InlineTag < ::Struct
 end
 
 # A hard-break in the middle of a paragraph.
-class RDoc::Markup::HardBreak
+class RDoc::Markup::HardBreak < ::RDoc::Markup::Element
   def ==(other); end
 
   # Calls accept\_hard\_break on `visitor`
@@ -4585,7 +4592,7 @@ class RDoc::Markup::HardBreak
   def self.new; end
 end
 
-class RDoc::Markup::Heading < ::Struct
+class RDoc::Markup::Heading < ::RDoc::Markup::Element
   Elem = type_member(:out)
 
   def accept(visitor); end


### PR DESCRIPTION
See https://github.com/ruby/rdoc/compare/v7.0.2...v7.0.3

### Motivation
Fix these errors:
```
sorbet/rbi/gems/rdoc@7.0.3.rbi:5345: Parent of class RDoc::Markup::BlankLine redefined from Object to RDoc::Markup::Element https://srb.help/5012
    5345 |class RDoc::Markup::BlankLine < ::RDoc::Markup::Element
                                          ^^^^^^^^^^^^^^^^^^^^^^^
  Note:
    Pass --suppress-payload-superclass-redefinition-for=RDoc::Markup::BlankLine at the command line or in the sorbet/config file to silence this error.
    Only use this to work around Ruby or gem upgrade incompatibilities.

sorbet/rbi/gems/rdoc@7.0.3.rbi:5687: Parent of class RDoc::Markup::HardBreak redefined from Object to RDoc::Markup::Element https://srb.help/5012
    5687 |class RDoc::Markup::HardBreak < ::RDoc::Markup::Element
                                          ^^^^^^^^^^^^^^^^^^^^^^^
  Note:
    Pass --suppress-payload-superclass-redefinition-for=RDoc::Markup::HardBreak at the command line or in the sorbet/config file to silence this error.
    Only use this to work around Ruby or gem upgrade incompatibilities.

sorbet/rbi/gems/rdoc@7.0.3.rbi:5720: Parent of class RDoc::Markup::Heading redefined from Struct to RDoc::Markup::Element https://srb.help/5012
    5720 |class RDoc::Markup::Heading < ::RDoc::Markup::Element
                                        ^^^^^^^^^^^^^^^^^^^^^^^
  Note:
    Pass --suppress-payload-superclass-redefinition-for=RDoc::Markup::Heading at the command line or in the sorbet/config file to silence this error.
    Only use this to work around Ruby or gem upgrade incompatibilities.
Errors: 3
```