### PR TITLE
Disable threading in the sigil-rbi test

### DIFF
--- a/test/cli/sigil-rbi/test.out
+++ b/test/cli/sigil-rbi/test.out
@@ -1,7 +1,3 @@
-test/cli/sigil-rbi/no_type.rbi:3: To use `sig`, this file must declare an explicit `# typed:` sigil (found: none). If you're not sure which one to use, start with `# typed: false` https://srb.help/5038
-     3 |sig {returns(Integer)}
-        ^^^^^^^^^^^^^^^^^^^^^^
-
 test/cli/sigil-rbi/multiple_definition.rbi:4: The method `m` does not have a `sig` https://srb.help/7017
      4 |    def m; end
             ^^^^^
@@ -9,4 +5,8 @@ test/cli/sigil-rbi/multiple_definition.rbi:4: The method `m` does not have a `si
 test/cli/sigil-rbi/multiple_definition.rbi:5: The method `m` does not have a `sig` https://srb.help/7017
      5 |    def m; end
             ^^^^^
+
+test/cli/sigil-rbi/no_type.rbi:3: To use `sig`, this file must declare an explicit `# typed:` sigil (found: none). If you're not sure which one to use, start with `# typed: false` https://srb.help/5038
+     3 |sig {returns(Integer)}
+        ^^^^^^^^^^^^^^^^^^^^^^
 Errors: 3

--- a/test/cli/sigil-rbi/test.sh
+++ b/test/cli/sigil-rbi/test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 main/sorbet --silence-dev-message \
+    --max-threads=0 \
     test/cli/sigil-rbi/no_type.rbi \
     test/cli/sigil-rbi/typed.rbi \
     test/cli/sigil-rbi/strict.rbi \


### PR DESCRIPTION
This test flaked for me, because the error order changed. Let's disable threading so that it's output is stable.

### Motivation
Avoiding flaky tests.

### Test plan
See included automated tests.
