### PR TITLE
Fix `WEBrick::HTTPServer#mount_proc` RBI

### DIFF
--- a/rbi/stdlib/webrick.rbi
+++ b/rbi/stdlib/webrick.rbi
@@ -2072,12 +2072,13 @@ class WEBrick::HTTPServer < WEBrick::GenericServer
   # [`WEBrick::HTTPResponse`](https://docs.ruby-lang.org/en/2.7.0/WEBrick/HTTPResponse.html)
   sig do
     params(
-      dir: T.untyped,
-      proc: T.untyped,
+      dir: String,
+      proc: T.nilable(T.proc.params(request: WEBrick::HTTPRequest, response: WEBrick::HTTPResponse).void),
+      block: T.nilable(T.proc.params(request: WEBrick::HTTPRequest, response: WEBrick::HTTPResponse).void),
     )
-    .returns(T.untyped)
+    .void
   end
-  def mount_proc(dir, proc=T.unsafe(nil)); end
+  def mount_proc(dir, proc = T.unsafe(nil), &block); end
 
   # Processes requests on `sock`
   sig do


### PR DESCRIPTION
### Motivation

You can count `mount_proc` directly with a literal block.

Also added real types while I was at it.
