### PR TITLE
Extract `desugarMethodCall()` helper

### DIFF
--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -120,6 +120,11 @@ private:
 
     ast::ExpressionPtr desugarSymbolProc(pm_symbol_node *symbol);
 
+    ast::ExpressionPtr desugarMethodCall(ast::ExpressionPtr receiver, core::NameRef methodName,
+                                         core::LocOffsets methodNameLoc, pm_arguments_node *argumentsNode,
+                                         pm_location_t closingLoc, DesugaredBlockArgument block,
+                                         core::LocOffsets location, bool isPrivateOk);
+
     template <typename StoreType>
     StoreType desugarArguments(pm_arguments_node *node, pm_node *blockArgumentNode = nullptr);
 


### PR DESCRIPTION
### Motivation

Part of #9065, also requested by @elliottt in in https://github.com/sorbet/sorbet/pull/9780#discussion_r2723243685

Cleans up and extracts the method-handling logic out of the `PM_CALL_NODE` case body, and into a helper method that can be used in the desugaring logic of other node types.

This was done in small incremental commits which are all green, so that's probably the easiest way to review it.

### Test plan

Passes existing desugar tests