### PR TITLE
Change `Net::IMAP::CommandData` parent class to `::Data`

### DIFF
--- a/rbi/stdlib/net.rbi
+++ b/rbi/stdlib/net.rbi
@@ -4366,7 +4366,7 @@ class Net::IMAP::DataLite < Data
   def init_with(coder); end
 end
 
-class Net::IMAP::CommandData < Net::IMAP::DataLite
+class Net::IMAP::CommandData < ::Data
   def initialize(data); end
 
   def data; end


### PR DESCRIPTION
### Motivation

As of `net-imap` version 0.6.0, [the `DataLite` class has been deleted](https://github.com/ruby/net-imap/compare/v0.5.12...v0.6.0#diff-44fb0e7c33fd0a93588ace2bad1763a97f9252f04d19621ec96a67918cafc654L6). This means the alias of `Data` to `DataLite` no longer exists, and thus the parent of `CommandData` is simply `::Data`.

This should resolve type checking issues between Tapioca's generated RBI for more recent versions of the `net-imap` gem and the RBIs provided by Sorbet.
