### PR TITLE
Improve docs about T.bind in RBS

### DIFF
--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -1063,29 +1063,50 @@ T.absurd(x)
 
 ### `T.bind`
 
-[`T.bind`](type-assertions.md#tbind) can be expressed using RBS comments with the special `self as` construct:
+[`T.bind`](type-assertions.md#tbind) can be expressed using RBS comments with the special `self as` construct.
+
+For example, let's imagine a gem dependency provides a configuration DSL:
 
 ```ruby
-class Foo
-  def foo; end
+module SomeGem
+  def self.configure(&block)
+    config = SomeGem::Configuration.new
+    config.instance_eval(&block)
+  end
 end
+```
 
-def bar
-  #: self as Foo
+In your own annotated code, Sorbet needs your help to understand who is `self` within such configure block:
 
-  foo
+```ruby
+SomeGem.configure do
+  #: self as SomeGem::Configuration
+  ...
 end
 ```
 
 This is equivalent to:
 
 ```ruby
-def bar
-  T.bind(self, Foo)
-
-  foo
+SomeGem.configure do
+  T.bind(self, SomeGem::Configuration)
+  ...
 end
 ```
+
+On the other hand, if the original API was already annotated this way:
+
+```ruby
+module SomeGem
+  #: { () [self: SomeGem::Configuration] -> void } -> void
+  def self.configure(&block)
+    config = SomeGem::Configuration.new
+    config.instance_eval(&block)
+  end
+end
+```
+
+the manual `self as` in client code would be unnecessary.
 
 [Class instance type]: https://github.com/ruby/rbs/blob/master/docs/syntax.md#class-instance-type
 [Class singleton type]: https://github.com/ruby/rbs/blob/master/docs/syntax.md#class-singleton-type


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This patch improves the docs about `T.bind` in inline RBS comments by providing more realistic examples (in my view).

As an extra ball, it documents support in block annotations (I am assuming that is officially supported, let's remove if it is not).

### Motivation

When I read the existing examples about `#: self as`, its use cases were not very clear to me. Why would you need to cast `self` at the top of a regular method?

It was not until I needed it that I understood what it is for. Please, note that I did not have previous Sorbet experience using the Ruby API.