### PR TITLE
Fix segfault in CommentsAssociator

### DIFF
--- a/test/testdata/rbs/empty_if_else_module.rb
+++ b/test/testdata/rbs/empty_if_else_module.rb
@@ -30,3 +30,35 @@ module EmptyElseInModule
   else
   end
 end
+
+module EmptyRescueBodyInModule
+  #: type c = Float
+
+  # Empty begin body before rescue - rescue->body is nullptr
+  # This crashes when walkBody is called with node=nullptr (multi-line case)
+  begin
+  rescue StandardError
+    STDERR.puts "rescued"
+  end
+end
+
+# `unless` is desugared to `if` with swapped branches, so these test the same code path
+module EmptyUnlessInModule
+  #: type d = Symbol
+
+  # Empty unless body (becomes empty else in the If node)
+  unless ARGV.empty?
+    STDERR.puts "not empty"
+  else
+  end
+end
+
+module EmptyUnlessElseInModule
+  #: type e = Array
+
+  # Empty else in unless (becomes empty then in the If node)
+  unless ARGV.any?
+  else
+    STDERR.puts "any"
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
- Fixes segfault introduced in https://github.com/sorbet/sorbet/pull/9159
- Segfault happens when RBS is enabled, RBS comment is present, and empty if/unless/else branches are present within the top level of a class or module

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- Added test which triggers segfault without fix to prevent future regression