### PR TITLE
Add sig for IO#wait_readable

### DIFF
--- a/rbi/core/io.rbi
+++ b/rbi/core/io.rbi
@@ -3544,7 +3544,7 @@ class IO < Object
   # times out. Returns a truthy value immediately when buffered data is available.
   #
   # You must require 'io/wait' to use this method.
-  sig { params(timeout: T.any(Float, Integer, Rational, NilClass)).returns(T.any(IO, T::Boolean, NilClass)) }
+  sig { params(timeout: T.nilable(T.any(Float, Integer, Rational))).returns(T.nilable(T.any(IO, T::Boolean))) }
   def wait_readable(timeout = nil); end
 
   # Writes the given string to *ios* using the write(2) system call after


### PR DESCRIPTION
Return types derived from Ruby 4.0 [source](https://github.com/ruby/ruby/blob/e4dd078a2734f1f3b7169feb4da8c68587effc6e/io.c#L9811-L9825) (io.c):
- `true`: returned when rb_io_read_pending() is true (buffered data available)
- `self` (IO): returned from io_wait_event when the IO becomes readable
- `nil`: returned on timeout (!RB_TEST(result))
- `false`: edge case from io_wait_event when result is truthy but event doesn't match

Timeout parameter accepts Float, Integer, Rational, or nil (wait indefinitely).
