### PR TITLE
Alternate design for `CommentAssociator` context stack

### DIFF
--- a/rbs/CommentsAssociator.h
+++ b/rbs/CommentsAssociator.h
@@ -36,8 +36,35 @@ private:
     std::map<int, CommentNode> commentByLine;
     std::map<parser::Node *, std::vector<CommentNode>> signaturesForNode;
     std::map<parser::Node *, std::vector<CommentNode>> assertionsForNode;
-    std::vector<std::pair<bool, core::LocOffsets>> contextAllowingTypeAlias;
     int lastLine;
+};
+
+
+class CommentsAssociatorImpl {
+    CommentsAssociator &storage;
+
+    // Context state
+    core::LocOffsets nodeLoc;
+    bool &typeAliasAllowed;
+
+    // First constructor
+    CommentsAssociatorImpl(CommentsAssociator &storage) : storage(storage), nodeLoc(core::LocOffsets::none()), typeAliasAllowed(true) {};
+
+    // Child constructor
+    CommentsAssociatorImpl(CommentsAssociator &storage, core::LocOffsets nodeLoc, bool &typeAliasAllowed) : storage(storage), nodeLoc(nodeLoc), typeAliasAllowed(typeAliasAllowed) {};
+
+    // Context management
+    CommentsAssociatorImpl enterContextThatAllowsTypeAlias(core::LocOffsets nodeLoc) {
+        return CommentsAssociatorImpl(storage, nodeLoc, true);
+    }
+
+    CommentsAssociatorImpl enterContextThatDisallowsTypeAlias(core::LocOffsets nodeLoc) {
+        return CommentsAssociatorImpl(storage, nodeLoc, false);
+    }
+
+    bool typeAliasAllowedInContext() {
+        this->typeAliasAllowed;
+    }
 
     void walkNode(parser::Node *node);
     void walkNodes(parser::NodeVec &nodes);
@@ -52,8 +79,7 @@ private:
     std::optional<uint32_t> locateTargetLine(parser::Node *node);
 
     int maybeInsertStandalonePlaceholders(parser::NodeVec &nodes, int index, int lastLine, int currentLine);
-    bool typeAliasAllowedInContext();
-};
+}
 
 } // namespace sorbet::rbs
 #endif // SORBET_RBS_COMMENTS_ASSOCIATOR_H


### PR DESCRIPTION
### Motivation

Rather than managing our own `std::vector<std::pair<bool, core::LocOffsets>>`, we can use the runtime stack, similar to how the Prism translator works.

One "gotcha" is that this `CommentsAssociator` has several `std::vector`/`std::map` that it holds by-value (that would be the same across the recursion, anyway). So we'd have one object that holds that state, and another smaller one that's pushed/popped onto the runtime stack, which just contains the contextual state as it changes

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
