### PR TITLE
Narrow parameter types of Time math methods

### DIFF
--- a/rbi/core/time.rbi
+++ b/rbi/core/time.rbi
@@ -336,7 +336,7 @@ class Time < Object
   # ```
   sig do
     params(
-        arg0: BasicObject,
+        arg0: Numeric,
     )
     .returns(Time)
   end
@@ -361,7 +361,7 @@ class Time < Object
   end
   sig do
     params(
-        arg0: BasicObject,
+        arg0: Numeric,
     )
     .returns(Time)
   end


### PR DESCRIPTION
### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
One cannot add or subtract arbitrary objects from time 🙅 

See https://docs.ruby-lang.org/en/3.4/Time.html#method-i-2B
