### PR TITLE
Improve CI command formatting

### DIFF
--- a/tools/scripts/format_build_files.sh
+++ b/tools/scripts/format_build_files.sh
@@ -13,17 +13,17 @@ if [ "$1" == "-t" ]; then
     "--noshow_progress"
   )
   if ! bazel run "${bazel_args[@]}" //test/lint/buildifier:lint &> /dev/null; then
-    echo "Some bazel files need to be formatted!"
-    echo "\`\`\`"
-    bazel run "${bazel_args[@]}" //test/lint/buildifier:diff 2> /dev/null || true
-    echo "\`\`\`"
-    echo -e "Run \`./tools/scripts/format_build_files.sh\` to format them."
+    echo "Some bazel files need to be formatted! Please run:"
+    echo
+    echo '```sh'
+    echo "./tools/scripts/format_build_files.sh"
+    echo '```'
     echo
     echo "To set up your editor to format on save, run:"
     echo
-    echo "\`\`\`"
+    echo '```sh'
     echo "bazel build @com_github_bazelbuild_buildtools//buildifier:buildifier"
-    echo "\`\`\`"
+    echo '```'
     echo
     echo "then copy the resulting binary out of bazel-bin/ onto your PATH, and configure your editor to run this executable on save."
     echo

--- a/tools/scripts/format_cxx.sh
+++ b/tools/scripts/format_cxx.sh
@@ -75,12 +75,24 @@ if [ "$mode" = "fix" ]; then
         echo '### END SYNCBACK ###'
     fi
 else
-    echo "Some c++ files need to be formatted!"
-    for src in "${misformatted[@]}"; do
-        echo "* $src"
-    done
+    echo "Some c++ files need to be formatted! Please run:"
     echo ""
-    echo "Run \`./tools/scripts/format_cxx.sh\` to format them"
+    echo '```sh'
+    if [ "${#misformatted[@]}" -eq 1 ]; then
+        # Single file - put everything on one line
+        echo "./tools/scripts/format_cxx.sh ${misformatted[0]}"
+    else
+        # Multiple files - use multi-line format
+        echo "./tools/scripts/format_cxx.sh \\"
+        for i in "${!misformatted[@]}"; do
+            if [ "$i" -eq $((${#misformatted[@]} - 1)) ]; then
+                echo "  ${misformatted[$i]}"
+            else
+                echo "  ${misformatted[$i]} \\"
+            fi
+        done
+    fi
+    echo '```'
 fi
 
 


### PR DESCRIPTION
### Motivation

* Move the `--config=dbg --test_output=errors` to the top
    * Less likely to accidentally chop it off and start a release build
    * Easier to go back to edit the test case list without having to jump over these
* One-line these if there's only a single file/testcase

### Test plan

Testing in ~production~ CI:

<img width="623" height="357" alt="image" src="https://github.com/user-attachments/assets/bbc8fb71-21e0-4c7f-855f-8a3b06948f90" />

[Example failed build with the new messages](https://buildkite.com/sorbet/sorbet/builds/40499#019c06c0-8eec-4e98-b25d-155b5cc52131)