### PR TITLE
Add nil-returning overload for <=> on numeric types

### DIFF
--- a/rbi/core/float.rbi
+++ b/rbi/core/float.rbi
@@ -397,6 +397,7 @@ class Float < Numeric
     )
     .returns(Integer)
   end
+  sig { params(arg0: T.anything).returns(NilClass) }
   def <=>(arg0); end
 
   # Returns `true` only if `obj` has the same value as `float`. Contrast this

--- a/rbi/core/float.rbi
+++ b/rbi/core/float.rbi
@@ -397,7 +397,7 @@ class Float < Numeric
     )
     .returns(Integer)
   end
-  sig { params(arg0: T.anything).returns(NilClass) }
+  sig { params(arg0: T.anything).returns(T.nilable(Integer)) }
   def <=>(arg0); end
 
   # Returns `true` only if `obj` has the same value as `float`. Contrast this

--- a/rbi/core/integer.rbi
+++ b/rbi/core/integer.rbi
@@ -346,7 +346,7 @@ class Integer < Numeric
     )
     .returns(Integer)
   end
-  sig { params(arg0: T.anything).returns(NilClass) }
+  sig { params(arg0: T.anything).returns(T.nilable(Integer)) }
   def <=>(arg0); end
 
   # Returns `true` if `int` equals `other` numerically. Contrast this with

--- a/rbi/core/integer.rbi
+++ b/rbi/core/integer.rbi
@@ -346,6 +346,7 @@ class Integer < Numeric
     )
     .returns(Integer)
   end
+  sig { params(arg0: T.anything).returns(NilClass) }
   def <=>(arg0); end
 
   # Returns `true` if `int` equals `other` numerically. Contrast this with

--- a/rbi/core/numeric.rbi
+++ b/rbi/core/numeric.rbi
@@ -164,7 +164,7 @@ class Numeric < Object
     )
     .returns(Integer)
   end
-  sig { params(arg0: T.anything).returns(NilClass) }
+  sig { params(arg0: T.anything).returns(T.nilable(Integer)) }
   def <=>(arg0); end
 
   sig do

--- a/rbi/core/numeric.rbi
+++ b/rbi/core/numeric.rbi
@@ -164,6 +164,7 @@ class Numeric < Object
     )
     .returns(Integer)
   end
+  sig { params(arg0: T.anything).returns(NilClass) }
   def <=>(arg0); end
 
   sig do

--- a/rbi/core/rational.rbi
+++ b/rbi/core/rational.rbi
@@ -379,6 +379,7 @@ class Rational < Numeric
     )
     .returns(Integer)
   end
+  sig { params(arg0: T.anything).returns(NilClass) }
   def <=>(arg0); end
 
   # Returns `true` if `rat` equals `object` numerically.

--- a/rbi/core/rational.rbi
+++ b/rbi/core/rational.rbi
@@ -379,7 +379,7 @@ class Rational < Numeric
     )
     .returns(Integer)
   end
-  sig { params(arg0: T.anything).returns(NilClass) }
+  sig { params(arg0: T.anything).returns(T.nilable(Integer)) }
   def <=>(arg0); end
 
   # Returns `true` if `rat` equals `object` numerically.

--- a/rbi/stdlib/bigdecimal.rbi
+++ b/rbi/stdlib/bigdecimal.rbi
@@ -599,6 +599,7 @@ class BigDecimal < Numeric
     )
     .returns(Integer)
   end
+  sig { params(arg0: T.anything).returns(NilClass) }
   def <=>(arg0); end
 
   # Tests for value equality; returns true if the values are equal.

--- a/rbi/stdlib/bigdecimal.rbi
+++ b/rbi/stdlib/bigdecimal.rbi
@@ -599,7 +599,7 @@ class BigDecimal < Numeric
     )
     .returns(Integer)
   end
-  sig { params(arg0: T.anything).returns(NilClass) }
+  sig { params(arg0: T.anything).returns(T.nilable(Integer)) }
   def <=>(arg0); end
 
   # Tests for value equality; returns true if the values are equal.

--- a/test/testdata/rbi/bigdecimal.rb
+++ b/test/testdata/rbi/bigdecimal.rb
@@ -31,3 +31,10 @@ BigDecimal(2).fdiv(x)
 BigDecimal(2).modulo(x)
 BigDecimal(2).power(x)
 BigDecimal(2).quo(x)
+
+# <=> returns Integer for comparable types, NilClass for incomparable types
+T.reveal_type(BigDecimal('1.0') <=> 2) # error: type: `Integer`
+T.reveal_type(BigDecimal('1.0') <=> 2.0) # error: type: `Integer`
+T.reveal_type(BigDecimal('1.0') <=> Rational(1, 2)) # error: type: `Integer`
+T.reveal_type(BigDecimal('1.0') <=> BigDecimal('2.0')) # error: type: `Integer`
+T.reveal_type(BigDecimal('1.0') <=> 'incompatible') # error: type: `NilClass`

--- a/test/testdata/rbi/bigdecimal.rb
+++ b/test/testdata/rbi/bigdecimal.rb
@@ -32,9 +32,9 @@ BigDecimal(2).modulo(x)
 BigDecimal(2).power(x)
 BigDecimal(2).quo(x)
 
-# <=> returns Integer for comparable types, NilClass for incomparable types
+# <=> returns Integer for comparable types, T.nilable(Integer) for incomparable types
 T.reveal_type(BigDecimal('1.0') <=> 2) # error: type: `Integer`
 T.reveal_type(BigDecimal('1.0') <=> 2.0) # error: type: `Integer`
 T.reveal_type(BigDecimal('1.0') <=> Rational(1, 2)) # error: type: `Integer`
 T.reveal_type(BigDecimal('1.0') <=> BigDecimal('2.0')) # error: type: `Integer`
-T.reveal_type(BigDecimal('1.0') <=> 'incompatible') # error: type: `NilClass`
+T.reveal_type(BigDecimal('1.0') <=> 'incompatible') # error: type: `T.nilable(Integer)`

--- a/test/testdata/rbi/float.rb
+++ b/test/testdata/rbi/float.rb
@@ -3,9 +3,9 @@
   1.0.to_s(10)
 #          ^^ error: Too many arguments provided for method `Float#to_s`. Expected: `0`, got: `1`
 
-# <=> returns Integer for comparable types, NilClass for incomparable types
+# <=> returns Integer for comparable types, T.nilable(Integer) for incomparable types
 T.reveal_type(1.0 <=> 2) # error: type: `Integer`
 T.reveal_type(1.0 <=> 2.0) # error: type: `Integer`
 T.reveal_type(1.0 <=> Rational(1, 2)) # error: type: `Integer`
 T.reveal_type(1.0 <=> BigDecimal('1.0')) # error: type: `Integer`
-T.reveal_type(1.0 <=> 'incompatible') # error: type: `NilClass`
+T.reveal_type(1.0 <=> 'incompatible') # error: type: `T.nilable(Integer)`

--- a/test/testdata/rbi/float.rb
+++ b/test/testdata/rbi/float.rb
@@ -2,3 +2,10 @@
 
   1.0.to_s(10)
 #          ^^ error: Too many arguments provided for method `Float#to_s`. Expected: `0`, got: `1`
+
+# <=> returns Integer for comparable types, NilClass for incomparable types
+T.reveal_type(1.0 <=> 2) # error: type: `Integer`
+T.reveal_type(1.0 <=> 2.0) # error: type: `Integer`
+T.reveal_type(1.0 <=> Rational(1, 2)) # error: type: `Integer`
+T.reveal_type(1.0 <=> BigDecimal('1.0')) # error: type: `Integer`
+T.reveal_type(1.0 <=> 'incompatible') # error: type: `NilClass`

--- a/test/testdata/rbi/integer.rb
+++ b/test/testdata/rbi/integer.rb
@@ -5,9 +5,9 @@
 255[1..]
 255[..4]
 
-# <=> returns Integer for comparable types, NilClass for incomparable types
+# <=> returns Integer for comparable types, T.nilable(Integer) for incomparable types
 T.reveal_type(1 <=> 2) # error: type: `Integer`
 T.reveal_type(1 <=> 2.0) # error: type: `Integer`
 T.reveal_type(1 <=> Rational(1, 2)) # error: type: `Integer`
 T.reveal_type(1 <=> BigDecimal('1.0')) # error: type: `Integer`
-T.reveal_type(1 <=> 'incompatible') # error: type: `NilClass`
+T.reveal_type(1 <=> 'incompatible') # error: type: `T.nilable(Integer)`

--- a/test/testdata/rbi/integer.rb
+++ b/test/testdata/rbi/integer.rb
@@ -4,3 +4,10 @@
 255[1..4]
 255[1..]
 255[..4]
+
+# <=> returns Integer for comparable types, NilClass for incomparable types
+T.reveal_type(1 <=> 2) # error: type: `Integer`
+T.reveal_type(1 <=> 2.0) # error: type: `Integer`
+T.reveal_type(1 <=> Rational(1, 2)) # error: type: `Integer`
+T.reveal_type(1 <=> BigDecimal('1.0')) # error: type: `Integer`
+T.reveal_type(1 <=> 'incompatible') # error: type: `NilClass`

--- a/test/testdata/rbi/numeric.rb
+++ b/test/testdata/rbi/numeric.rb
@@ -4,9 +4,9 @@ class MyNumeric < Numeric
 end
 
 n = MyNumeric.new
-# <=> returns Integer for comparable types, NilClass for incomparable types
+# <=> returns Integer for comparable types, T.nilable(Integer) for incomparable types
 T.reveal_type(n <=> 2) # error: type: `Integer`
 T.reveal_type(n <=> 2.0) # error: type: `Integer`
 T.reveal_type(n <=> Rational(1, 2)) # error: type: `Integer`
 T.reveal_type(n <=> BigDecimal('1.0')) # error: type: `Integer`
-T.reveal_type(n <=> 'incompatible') # error: type: `NilClass`
+T.reveal_type(n <=> 'incompatible') # error: type: `T.nilable(Integer)`

--- a/test/testdata/rbi/numeric.rb
+++ b/test/testdata/rbi/numeric.rb
@@ -1,0 +1,12 @@
+# typed: true
+
+class MyNumeric < Numeric
+end
+
+n = MyNumeric.new
+# <=> returns Integer for comparable types, NilClass for incomparable types
+T.reveal_type(n <=> 2) # error: type: `Integer`
+T.reveal_type(n <=> 2.0) # error: type: `Integer`
+T.reveal_type(n <=> Rational(1, 2)) # error: type: `Integer`
+T.reveal_type(n <=> BigDecimal('1.0')) # error: type: `Integer`
+T.reveal_type(n <=> 'incompatible') # error: type: `NilClass`

--- a/test/testdata/rbi/rational.rb
+++ b/test/testdata/rbi/rational.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+# <=> returns Integer for comparable types, NilClass for incomparable types
+T.reveal_type(Rational(1, 2) <=> 2) # error: type: `Integer`
+T.reveal_type(Rational(1, 2) <=> 2.0) # error: type: `Integer`
+T.reveal_type(Rational(1, 2) <=> Rational(1, 3)) # error: type: `Integer`
+T.reveal_type(Rational(1, 2) <=> BigDecimal('1.0')) # error: type: `Integer`
+T.reveal_type(Rational(1, 2) <=> 'incompatible') # error: type: `NilClass`

--- a/test/testdata/rbi/rational.rb
+++ b/test/testdata/rbi/rational.rb
@@ -1,8 +1,8 @@
 # typed: true
 
-# <=> returns Integer for comparable types, NilClass for incomparable types
+# <=> returns Integer for comparable types, T.nilable(Integer) for incomparable types
 T.reveal_type(Rational(1, 2) <=> 2) # error: type: `Integer`
 T.reveal_type(Rational(1, 2) <=> 2.0) # error: type: `Integer`
 T.reveal_type(Rational(1, 2) <=> Rational(1, 3)) # error: type: `Integer`
 T.reveal_type(Rational(1, 2) <=> BigDecimal('1.0')) # error: type: `Integer`
-T.reveal_type(Rational(1, 2) <=> 'incompatible') # error: type: `NilClass`
+T.reveal_type(Rational(1, 2) <=> 'incompatible') # error: type: `T.nilable(Integer)`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Ruby's spaceship operator returns `nil` when comparing incompatible types (e.g., `1 <=> "hello"` returns nil). This adds an overload with `T.anything` parameter returning `NilClass` to Float, Integer, Numeric, Rational, and BigDecimal to properly type this behavior.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tests verify that the spaceship operator returns Integer for comparable numeric types and NilClass for incomparable types like String.
