### PR TITLE
Allow abstract method implementation as 'super if defined?(super) or raise ...'

### DIFF
--- a/test/testdata/rbs/signatures_defs.rb
+++ b/test/testdata/rbs/signatures_defs.rb
@@ -412,6 +412,18 @@ module Annotations
     class Error < StandardError; end
   end
 
+  class AbstractWithSuperFallback
+    # @abstract
+    #: -> Integer
+    def method_with_super_fallback
+      if defined?(super)
+        super
+      else
+        raise "Abstract method called"
+      end
+    end
+  end
+
   class Final
     extend T::Helpers
 

--- a/test/testdata/resolver/abstract_abstract.rb
+++ b/test/testdata/resolver/abstract_abstract.rb
@@ -21,3 +21,18 @@ class Child < Parent
   sig {abstract.returns(T.nilable(Integer))}
   def example2; end # error: Return type `T.nilable(Integer)` does not match return type of abstract method `Parent#example2`
 end
+
+module AbstractWithSuperFallback
+  extend T::Sig
+  extend T::Helpers
+  interface!
+
+  sig {abstract.returns(Integer)}
+  def with_super_fallback
+    if defined?(super)
+      super
+    else
+      raise "Abstract method called"
+    end
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

In the RBS syntax, the currently-accepted implementation is 

```ruby
# @abstract
def method
  raise "anything"
end
```

This prevents a subclass from implementing an interface satisfied by a superclass

```ruby
module Interface
  # @abstract
  #: -> Integer
  def a
    raise "Abstract method called"
  end
end

class Foo
  def a
    1
  end
end

class Bar < Foo
  include Interface
end

Bar.new.a  # => expected to return 1 (to call super, which finds Foo#a)
```

However, making the same class hierarchy with `sig {}` syntax is perfectly fine. 

To this end, I propose making the canonical implementation of `abstract` (at least for RBS) methods be:

```ruby
if defined?(super)
  super
else
  raise 'Abstract method called'
end
```
    
This works both in RBI where the method is fully erased and RBS where the method will transparently call super only if it's defined.

### Motivation

RBS should provide the same level of support for interface as RBI does.

### For Reviewers

I don't know how to write C++ and I'm unfamiliar with the Sorbet codebase 