### PR TITLE
Add `--remote_download_outputs=all` to `--config=dbg`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -71,6 +71,10 @@ build --cxxopt=-Wno-unqualified-std-cast-call --host_cxxopt=-Wno-unqualified-std
 build:dbg --copt=-O0
 build:dbg --compilation_mode=dbg
 build:dbg --config=debugsymbols
+# As of Bazel 7, cached files are not put into the `bazel-bin/` folder unless they're toplevel targets.
+# We want to force files to be downloaded because otherwise clangd won't find them (and possibly lldb, though I haven't checked)
+# TODO(jez) Do newer compile commands generators suffer from this problem? The one we use is archived
+build:dbg --remote_download_outputs=all
 
 build:rubydbg --copt=-DRUBY_DEBUG --copt=-DVM_CHECK_MODE=1 --copt=-DTRANSIENT_HEAP_CHECK_MODE --copt=-DRGENGC_CHECK_MODE --copt=-DENC_DEBUG
 

--- a/tools/scripts/build_compilation_db.sh
+++ b/tools/scripts/build_compilation_db.sh
@@ -4,6 +4,19 @@ set -e
 
 cd "$(dirname "$0")/../.."
 
+#   NOTE on `--config=dbg` and `--remote_download_outputs=all`
+#
+# We assume that you'll be iterating locally with `--config=dbg` builds.
+# If you choose to use something else, be sure to:
+#
+# - edit this script and then (re-)generat the compile_commands.json file
+# - pass `--remote_download_outputs=all` when building
+#
+# (The `--config=dbg` configuration already passes that flag.) Without this
+# flag, intermediate generated outputs will not be placed in the `bazel-bin/`
+# folder if they have been cached, which means that clangd won't find them.
+#
+# TODO(jez) Do other compile commands generators work better here?
 ./bazel build //tools:compdb --config=dbg "$@"
 
 if command -v jq &> /dev/null; then


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This makes clangd work again.

We recently upgraded to Bazel 7 (see 0e3ed53dfd3caac88496ebca1ce714623e65e952).
In that release, they flipped the default of
`--remote_download_outputs`, which broke our `clangd` integration
depending on whether certain intermediate outputs were computed from
scratch or downloaded from the cache.

See <https://blog.bazel.build/2023/12/11/bazel-7-release.html#build-without-the-bytes-bwob>


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested locally by firing up `clangd`