### PR TITLE
Fix missing/invalid class/module names

### DIFF
--- a/parser/prism/Translator.h
+++ b/parser/prism/Translator.h
@@ -274,6 +274,9 @@ private:
     // Desugar a class, singleton class or module body.
     ast::ClassDef::RHS_store desugarClassOrModule(pm_node *prismBodyNode);
 
+    // Handle invalid or missing constant paths in class/module declarations.
+    ast::ExpressionPtr desugarClassOrModuleName(pm_node_t *constantPath, pm_location_t keywordLoc);
+
     void reportError(core::LocOffsets loc, const std::string &message) const;
 
     // Helper to determine whether to use super or untypedSuper based on context

--- a/test/prism_regression/class_missing_name.rb
+++ b/test/prism_regression/class_missing_name.rb
@@ -1,0 +1,17 @@
+# typed: false
+# disable-parser-comparison: true
+
+# Missing constant path
+class
+end
+
+# Invalid constant path without body
+class
+  def foo; end # Parsed as constant path
+end
+
+# Invalid constant path with body
+class
+  def foo; end # Parsed as constant path
+  def bar; end # Parsed as body
+end

--- a/test/prism_regression/class_missing_name.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/class_missing_name.rb.desugar-tree-raw.exp
@@ -1,0 +1,66 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    ClassDef{
+      kind = class
+      name = UnresolvedConstantLit{
+        cnst = <C <U <ConstantNameMissing>>>
+        scope = EmptyTree
+      }
+      symbol = <C <U <todo sym>>>
+      ancestors = [ConstantLit{
+          symbol = (class ::<todo sym>)
+          orig = nullptr
+        }]
+      rhs = [
+        EmptyTree
+      ]
+    }
+
+    ClassDef{
+      kind = class
+      name = UnresolvedConstantLit{
+        cnst = <C <U <ConstantNameMissing>>>
+        scope = EmptyTree
+      }
+      symbol = <C <U <todo sym>>>
+      ancestors = [ConstantLit{
+          symbol = (class ::<todo sym>)
+          orig = nullptr
+        }]
+      rhs = [
+        EmptyTree
+      ]
+    }
+
+    ClassDef{
+      kind = class
+      name = UnresolvedConstantLit{
+        cnst = <C <U <ConstantNameMissing>>>
+        scope = EmptyTree
+      }
+      symbol = <C <U <todo sym>>>
+      ancestors = [ConstantLit{
+          symbol = (class ::<todo sym>)
+          orig = nullptr
+        }]
+      rhs = [
+        MethodDef{
+          flags = {}
+          name = <U bar><<U <todo method>>>
+          params = [BlockParam{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = EmptyTree
+        }
+      ]
+    }
+  ]
+}

--- a/test/prism_regression/module_missing_name.rb
+++ b/test/prism_regression/module_missing_name.rb
@@ -1,0 +1,17 @@
+# typed: false
+# disable-parser-comparison: true
+
+# Missing constant path
+module
+end
+
+# Invalid constant path without body
+module
+  def foo; end # Parsed as constant path
+end
+
+# Invalid constant path with body
+module
+  def foo; end # Parsed as constant path
+  def bar; end # Parsed as body
+end

--- a/test/prism_regression/module_missing_name.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/module_missing_name.rb.desugar-tree-raw.exp
@@ -1,0 +1,62 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    ClassDef{
+      kind = module
+      name = UnresolvedConstantLit{
+        cnst = <C <U <ConstantNameMissing>>>
+        scope = EmptyTree
+      }
+      symbol = <C <U <todo sym>>>
+      ancestors = []
+      rhs = [
+        EmptyTree
+      ]
+    }
+
+    ConstantLit{
+      symbol = (static-field ::<ErrorNode>)
+      orig = nullptr
+    }
+
+    ClassDef{
+      kind = module
+      name = UnresolvedConstantLit{
+        cnst = <C <U <ConstantNameMissing>>>
+        scope = EmptyTree
+      }
+      symbol = <C <U <todo sym>>>
+      ancestors = []
+      rhs = [
+        EmptyTree
+      ]
+    }
+
+    ClassDef{
+      kind = module
+      name = UnresolvedConstantLit{
+        cnst = <C <U <ConstantNameMissing>>>
+        scope = EmptyTree
+      }
+      symbol = <C <U <todo sym>>>
+      ancestors = []
+      rhs = [
+        MethodDef{
+          flags = {}
+          name = <U bar><<U <todo method>>>
+          params = [BlockParam{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = EmptyTree
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Part of #9065.

This ensures running Sorbet with the Prism parser mode does not crash on missing or invalid class/model constant paths. See the regression tests for examples that were crashing without the fix.

The fix is to check `constant_path` exists and is one of the expected node types (`ConstantReadNode` or `ConstantPathNode`). If it doesn't exist or is an unexpected node type, we construct a "constant missing" constant  to use in its place.

For example:

```rb
module
end
```

In this case, `constant_path` is not set and the body is empty.

```rb
module
  def foo
  end
end
```

Here `constant_path` is a `DefNode` and the body is empty.

```rb
module
  def foo
  end

  def bar
  end
end
```

Here `constant_path` is a `DefNode` and the body contains the second `DefNode` inside a `StatementsNode`.

The behavior is different to the original parser, which throws away much more of the class/module. Here we're able to keep most of it and only throw away whatever node was incorrectly in the `constant_path` field.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Part of the error recovery work for supporting Prism in Sorbet.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
