### PR TITLE
Check dynamic const multi-assignment

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1786,14 +1786,16 @@ ast::ExpressionPtr Translator::desugar(pm_node_t *node) {
         }
         case PM_CONSTANT_PATH_TARGET_NODE: { // Target of an indirect write to a constant path
             // ... like `A::TARGET1, A::TARGET2 = 1, 2`, `rescue => A::TARGET`, etc.
-            return translateConst<pm_constant_path_target_node>(node);
+            constexpr bool checkForDynamicConstAssign = true;
+            return translateConst<pm_constant_path_target_node, checkForDynamicConstAssign>(node);
         }
         case PM_CONSTANT_PATH_WRITE_NODE: { // Regular assignment to a constant path, e.g. `A::B = 1`
             return desugarAssignment<pm_constant_path_write_node>(node);
         }
         case PM_CONSTANT_TARGET_NODE: { // Target of an indirect write to a constant
             // ... like `TARGET1, TARGET2 = 1, 2`, `rescue => TARGET`, etc.
-            return translateConst<pm_constant_target_node>(node);
+            constexpr bool checkForDynamicConstAssign = true;
+            return translateConst<pm_constant_target_node, checkForDynamicConstAssign>(node);
         }
         case PM_CONSTANT_AND_WRITE_NODE: { // And-assignment to a constant, e.g. `C &&= false`
             return desugarConstantOpAssign<pm_constant_and_write_node, OpAssignKind::And>(node);
@@ -4371,7 +4373,9 @@ ast::ExpressionPtr Translator::translateConst(pm_node_t *anyNode) {
                           is_same_v<PrismLhsNode, pm_constant_and_write_node> ||
                           is_same_v<PrismLhsNode, pm_constant_or_write_node>) {
                 location = translateLoc(node->name_loc);
-            } else if constexpr (is_same_v<PrismLhsNode, pm_constant_path_node>) {
+            } else if constexpr (is_same_v<PrismLhsNode, pm_constant_path_node> ||
+                                 is_same_v<PrismLhsNode, pm_constant_path_target_node> ||
+                                 is_same_v<PrismLhsNode, pm_constant_target_node>) {
                 location = translateLoc(node->base.location);
             } else {
                 static_assert(always_false_v<PrismLhsNode>, "Unexpected case");

--- a/test/prism_regression/assign_to_constant.rb
+++ b/test/prism_regression/assign_to_constant.rb
@@ -108,8 +108,7 @@ def method1
   DynamicConstantLazyAndAssign &&= 13
   DynamicConstantLazyOrAssgin  ||= 14
 
-  # Sorbet doesn't do the dynamic constant workaround for multi-target assignments
-  # DynamicConstantTarget1, DynamicConstantTarget2 = 35, 36
+  DynamicConstantTarget1, DynamicConstantTarget2 = 15, 16
 end
 
 def method2
@@ -136,8 +135,7 @@ def method2
   ConstantPath::DynamicConstantLazyAndAssign &&= 13
   ConstantPath::DynamicConstantLazyOrAssgin  ||= 14
 
-  # Sorbet doesn't do the dynamic constant workaround for multi-target assignments
-  # ConstantPath::DynamicConstantTarget1, ConstantPath::DynamicConstantTarget2 = 35, 36
+  ConstantPath::DynamicConstantTarget1, ConstantPath::DynamicConstantTarget2 = 15, 16
 end
 
 
@@ -165,6 +163,5 @@ def method3
   ::FullyQualified::ConstantPath::DynamicConstantLazyAndAssign &&= 13
   ::FullyQualified::ConstantPath::DynamicConstantLazyOrAssgin  ||= 14
 
-  # Sorbet doesn't do the dynamic constant workaround for multi-target assignments
-  # ::FullyQualified::ConstantPath::DynamicConstantTarget1, ::FullyQualified::ConstantPath::DynamicConstantTarget2 = 35, 36
+  ::FullyQualified::ConstantPath::DynamicConstantTarget1, ::FullyQualified::ConstantPath::DynamicConstantTarget2 = 15, 16
 end

--- a/test/prism_regression/assign_to_constant.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/assign_to_constant.rb.desugar-tree-raw.exp
@@ -636,22 +636,104 @@ ClassDef{
               name = <U <dynamic-const-assign>>
             }
           }
-        ],
-        expr = If{
-          cond = UnresolvedIdent{
-            kind = Local
-            name = <U <dynamic-const-assign>>
-          }
-          thenp = UnresolvedIdent{
-            kind = Local
-            name = <U <dynamic-const-assign>>
-          }
-          elsep = Assign{
-            lhs = UnresolvedIdent{
+          If{
+            cond = UnresolvedIdent{
               kind = Local
               name = <U <dynamic-const-assign>>
             }
-            rhs = Literal{ value = 14 }
+            thenp = UnresolvedIdent{
+              kind = Local
+              name = <U <dynamic-const-assign>>
+            }
+            elsep = Assign{
+              lhs = UnresolvedIdent{
+                kind = Local
+                name = <U <dynamic-const-assign>>
+              }
+              rhs = Literal{ value = 14 }
+            }
+          }
+        ],
+        expr = InsSeq{
+          stats = [
+            Assign{
+              lhs = UnresolvedIdent{
+                kind = Local
+                name = <D <U <assignTemp>> $2>
+              }
+              rhs = Array{
+                elems = [
+                  Literal{ value = 15 }
+                  Literal{ value = 16 }
+                ]
+              }
+            }
+            Assign{
+              lhs = UnresolvedIdent{
+                kind = Local
+                name = <D <U <assignTemp>> $3>
+              }
+              rhs = Send{
+                flags = {}
+                recv = ConstantLit{
+                  symbol = (class ::<Magic>)
+                  orig = nullptr
+                }
+                fun = <U <expand-splat>>
+                block = nullptr
+                pos_args = 3
+                args = [
+                  UnresolvedIdent{
+                    kind = Local
+                    name = <D <U <assignTemp>> $2>
+                  }
+                  Literal{ value = 2 }
+                  Literal{ value = 0 }
+                ]
+              }
+            }
+            Assign{
+              lhs = UnresolvedIdent{
+                kind = Local
+                name = <U <dynamic-const-assign>>
+              }
+              rhs = Send{
+                flags = {}
+                recv = UnresolvedIdent{
+                  kind = Local
+                  name = <D <U <assignTemp>> $3>
+                }
+                fun = <U []>
+                block = nullptr
+                pos_args = 1
+                args = [
+                  Literal{ value = 0 }
+                ]
+              }
+            }
+            Assign{
+              lhs = UnresolvedIdent{
+                kind = Local
+                name = <U <dynamic-const-assign>>
+              }
+              rhs = Send{
+                flags = {}
+                recv = UnresolvedIdent{
+                  kind = Local
+                  name = <D <U <assignTemp>> $3>
+                }
+                fun = <U []>
+                block = nullptr
+                pos_args = 1
+                args = [
+                  Literal{ value = 1 }
+                ]
+              }
+            }
+          ],
+          expr = UnresolvedIdent{
+            kind = Local
+            name = <D <U <assignTemp>> $2>
           }
         }
       }
@@ -685,8 +767,90 @@ ClassDef{
           EmptyTree
           EmptyTree
           EmptyTree
+          EmptyTree
         ],
-        expr = EmptyTree
+        expr = InsSeq{
+          stats = [
+            Assign{
+              lhs = UnresolvedIdent{
+                kind = Local
+                name = <D <U <assignTemp>> $2>
+              }
+              rhs = Array{
+                elems = [
+                  Literal{ value = 15 }
+                  Literal{ value = 16 }
+                ]
+              }
+            }
+            Assign{
+              lhs = UnresolvedIdent{
+                kind = Local
+                name = <D <U <assignTemp>> $3>
+              }
+              rhs = Send{
+                flags = {}
+                recv = ConstantLit{
+                  symbol = (class ::<Magic>)
+                  orig = nullptr
+                }
+                fun = <U <expand-splat>>
+                block = nullptr
+                pos_args = 3
+                args = [
+                  UnresolvedIdent{
+                    kind = Local
+                    name = <D <U <assignTemp>> $2>
+                  }
+                  Literal{ value = 2 }
+                  Literal{ value = 0 }
+                ]
+              }
+            }
+            Assign{
+              lhs = UnresolvedIdent{
+                kind = Local
+                name = <U <dynamic-const-assign>>
+              }
+              rhs = Send{
+                flags = {}
+                recv = UnresolvedIdent{
+                  kind = Local
+                  name = <D <U <assignTemp>> $3>
+                }
+                fun = <U []>
+                block = nullptr
+                pos_args = 1
+                args = [
+                  Literal{ value = 0 }
+                ]
+              }
+            }
+            Assign{
+              lhs = UnresolvedIdent{
+                kind = Local
+                name = <U <dynamic-const-assign>>
+              }
+              rhs = Send{
+                flags = {}
+                recv = UnresolvedIdent{
+                  kind = Local
+                  name = <D <U <assignTemp>> $3>
+                }
+                fun = <U []>
+                block = nullptr
+                pos_args = 1
+                args = [
+                  Literal{ value = 1 }
+                ]
+              }
+            }
+          ],
+          expr = UnresolvedIdent{
+            kind = Local
+            name = <D <U <assignTemp>> $2>
+          }
+        }
       }
     }
 
@@ -718,8 +882,90 @@ ClassDef{
           EmptyTree
           EmptyTree
           EmptyTree
+          EmptyTree
         ],
-        expr = EmptyTree
+        expr = InsSeq{
+          stats = [
+            Assign{
+              lhs = UnresolvedIdent{
+                kind = Local
+                name = <D <U <assignTemp>> $2>
+              }
+              rhs = Array{
+                elems = [
+                  Literal{ value = 15 }
+                  Literal{ value = 16 }
+                ]
+              }
+            }
+            Assign{
+              lhs = UnresolvedIdent{
+                kind = Local
+                name = <D <U <assignTemp>> $3>
+              }
+              rhs = Send{
+                flags = {}
+                recv = ConstantLit{
+                  symbol = (class ::<Magic>)
+                  orig = nullptr
+                }
+                fun = <U <expand-splat>>
+                block = nullptr
+                pos_args = 3
+                args = [
+                  UnresolvedIdent{
+                    kind = Local
+                    name = <D <U <assignTemp>> $2>
+                  }
+                  Literal{ value = 2 }
+                  Literal{ value = 0 }
+                ]
+              }
+            }
+            Assign{
+              lhs = UnresolvedIdent{
+                kind = Local
+                name = <U <dynamic-const-assign>>
+              }
+              rhs = Send{
+                flags = {}
+                recv = UnresolvedIdent{
+                  kind = Local
+                  name = <D <U <assignTemp>> $3>
+                }
+                fun = <U []>
+                block = nullptr
+                pos_args = 1
+                args = [
+                  Literal{ value = 0 }
+                ]
+              }
+            }
+            Assign{
+              lhs = UnresolvedIdent{
+                kind = Local
+                name = <U <dynamic-const-assign>>
+              }
+              rhs = Send{
+                flags = {}
+                recv = UnresolvedIdent{
+                  kind = Local
+                  name = <D <U <assignTemp>> $3>
+                }
+                fun = <U []>
+                block = nullptr
+                pos_args = 1
+                args = [
+                  Literal{ value = 1 }
+                ]
+              }
+            }
+          ],
+          expr = UnresolvedIdent{
+            kind = Local
+            name = <D <U <assignTemp>> $2>
+          }
+        }
       }
     }
   ]


### PR DESCRIPTION
Part of #9065.

This PR enables the dynamic assignment check for multi targets. The comments in the regression test said `Sorbet doesn't do the dynamic constant workaround for multi-target assignments`—that may have been the case when the original translator was added, but doesn't appear to be so now.

The following code was crashing:

```rb
def foo
  A, B = 1, 2
end
```

Enabling the dynamic assignment check for the multi target results in this being desugared in the same way as the original parser, and therefore no longer crashes:

Prism:

```
class <emptyTree><<C <root>>> < (::<todo sym>)
  def foo<<todo method>>(&<blk>)
    begin
      <assignTemp>$2 = [1, 2]
      <assignTemp>$3 = ::<Magic>.<expand-splat>(<assignTemp>$2, 2, 0)
      <dynamic-const-assign> = <assignTemp>$3.[](0)
      <dynamic-const-assign> = <assignTemp>$3.[](1)
      <assignTemp>$2
    end
  end
end
```

Original:

```
class <emptyTree><<C <root>>> < (::<todo sym>)
  def foo<<todo method>>(&<blk>)
    begin
      <assignTemp>$2 = [1, 2]
      <assignTemp>$3 = ::<Magic>.<expand-splat>(<assignTemp>$2, 2, 0)
      <dynamic-const-assign> = <assignTemp>$3.[](0)
      <dynamic-const-assign> = <assignTemp>$3.[](1)
      <assignTemp>$2
    end
  end
end
```

The error messages are also identical:

```
test.rb:2: dynamic constant assignment https://srb.help/2001
     2 |  A, B = 1, 2
          ^

test.rb:2: dynamic constant assignment https://srb.help/2001
     2 |  A, B = 1, 2
             ^
Errors: 2
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Part of supporting Prism parser.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
