### PR TITLE
Fix missing predicate in case match

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1600,6 +1600,10 @@ ast::ExpressionPtr Translator::desugar(pm_node_t *node) {
             }
 
             // Wrap in an InsSeq with the predicate assignment (if there is a predicate)
+            if (caseMatchNode->predicate == nullptr) {
+                return resultExpr;
+            }
+
             auto predicate = desugar(caseMatchNode->predicate);
             auto tempName = nextUniqueDesugarName(core::Names::assignTemp());
             auto assignExpr = MK::Assign(predicate.loc(), tempName, move(predicate));

--- a/test/prism_regression/invalid/case_match_missing_predicate.rb
+++ b/test/prism_regression/invalid/case_match_missing_predicate.rb
@@ -1,0 +1,6 @@
+# typed: true
+# disable-parser-comparison: true
+
+case
+in x
+end

--- a/test/prism_regression/invalid/case_match_missing_predicate.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/invalid/case_match_missing_predicate.rb.desugar-tree-raw.exp
@@ -1,0 +1,75 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    If{
+      cond = Send{
+        flags = {rewriterSynthesized}
+        recv = Send{
+          flags = {}
+          recv = ConstantLit{
+            symbol = (module ::T)
+            orig = nullptr
+          }
+          fun = <U unsafe>
+          block = nullptr
+          pos_args = 1
+          args = [
+            ConstantLit{
+              symbol = (module ::Kernel)
+              orig = nullptr
+            }
+          ]
+        }
+        fun = <U raise>
+        block = nullptr
+        pos_args = 1
+        args = [
+          Literal{ value = "Sorbet rewriter pass partially unimplemented" }
+        ]
+      }
+      thenp = InsSeq{
+        stats = [
+          Assign{
+            lhs = UnresolvedIdent{
+              kind = Local
+              name = <U x>
+            }
+            rhs = Send{
+              flags = {rewriterSynthesized}
+              recv = Send{
+                flags = {}
+                recv = ConstantLit{
+                  symbol = (module ::T)
+                  orig = nullptr
+                }
+                fun = <U unsafe>
+                block = nullptr
+                pos_args = 1
+                args = [
+                  ConstantLit{
+                    symbol = (module ::Kernel)
+                    orig = nullptr
+                  }
+                ]
+              }
+              fun = <U raise>
+              block = nullptr
+              pos_args = 1
+              args = [
+                Literal{ value = "Sorbet rewriter pass partially unimplemented" }
+              ]
+            }
+          }
+        ],
+        expr = EmptyTree
+      }
+      elsep = EmptyTree
+    }
+  ]
+}


### PR DESCRIPTION
Part of #9065.

This PR fixes a crash when using Sorbet with Prism on the following code:

```ruby
case
in x
end
```

This is invalid because a predicate is necessary for matching on. The original parser desugars this like so:

```
class <emptyTree><<C <root>>> < (::<todo sym>)
  if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
    begin
      x = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
    end
  else
    <emptyTree>
  end
end
```

In the Prism translator we can check if the predicate desugars as an empty tree and return the expression early:

```
class <emptyTree><<C <root>>> < (::<todo sym>)
  if ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
    begin
      x = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
      <emptyTree>
    end
  else
    <emptyTree>
  end
end
```

This is slightly different, we end up with `<emptyTree>` in place of `::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")`, but it seems to me a fine way to handle this. We could try to return a `RaiseUnimplemented` node here to match the original parser, but that seems wrong in the context—this is invalid code, not an unimplemented feature.

However, the error message for Prism is somewhat better:

```
test/prism_regression/invalid/case_match_missing_predicate.rb:4: expected a predicate for a case matching statement https://srb.help/2001
     4 |case
        ^^^^
Errors: 1
```

Compared with this for the original parser:

```
test/prism_regression/invalid/case_match_missing_predicate.rb:4: unexpected token "case" https://srb.help/2001
     4 |case
        ^^^^

test/prism_regression/invalid/case_match_missing_predicate.rb:6: unexpected token "end" https://srb.help/2001
     6 |end
        ^^^
Errors: 2
```


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Part of work to support Prism parser.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
