### PR TITLE
Fix malformed sig parsed as multi-target

### DIFF
--- a/test/prism_regression/invalid/malformed_sig.rb
+++ b/test/prism_regression/invalid/malformed_sig.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# disable-parser-comparison: true
+
+sig,{params(x: Integer).void}
+def f(x)
+end

--- a/test/prism_regression/invalid/malformed_sig.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/invalid/malformed_sig.rb.desugar-tree-raw.exp
@@ -1,0 +1,25 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    EmptyTree
+
+    MethodDef{
+      flags = {}
+      name = <U f><<U <todo method>>>
+      params = [UnresolvedIdent{
+          kind = Local
+          name = <U x>
+        }, BlockParam{ expr = UnresolvedIdent{
+          kind = Local
+          name = <U <blk>>
+        } }]
+      rhs = EmptyTree
+    }
+  ]
+}


### PR DESCRIPTION
Part of #9065.

This fixes a crash when Prism parses a malformed sig as a multi target node:

```rb
sig,{params(x: Integer).void}
```

This is just an example that came out of the fuzzer, it's not specific to sigs, it's how Prism parses the comma in the malformed code:

```
@ MultiTargetNode (location: (1,0)-(1,29))
├── flags: newline
├── lefts: (length: 2)
│   ├── @ LocalVariableTargetNode (location: (1,0)-(1,3))
│   │   ├── flags: ∅
│   │   ├── name: :sig
│   │   └── depth: 0
│   └── @ HashNode (location: (1,4)-(1,29))
│       ├── flags: ∅
│       ├── opening_loc: (1,4)-(1,5) = "{"
│       ├── elements: (length: 1)
│       │   └── @ AssocNode (location: (1,5)-(1,28))
│       │       ├── flags: ∅
│       │       ├── key:
│       │       │   @ CallNode (location: (1,5)-(1,28))
│       │       │   ├── flags: ∅
│       │       │   ├── receiver:
│       │       │   │   @ CallNode (location: (1,5)-(1,23))
│       │       │   │   ├── flags: ignore_visibility
│       │       │   │   ├── receiver: ∅
│       │       │   │   ├── call_operator_loc: ∅
│       │       │   │   ├── name: :params
│       │       │   │   ├── message_loc: (1,5)-(1,11) = "params"
│       │       │   │   ├── opening_loc: (1,11)-(1,12) = "("
│       │       │   │   ├── arguments:
│       │       │   │   │   @ ArgumentsNode (location: (1,12)-(1,22))
│       │       │   │   │   ├── flags: contains_keywords
│       │       │   │   │   └── arguments: (length: 1)
│       │       │   │   │       └── @ KeywordHashNode (location: (1,12)-(1,22))
│       │       │   │   │           ├── flags: symbol_keys
│       │       │   │   │           └── elements: (length: 1)
│       │       │   │   │               └── @ AssocNode (location: (1,12)-(1,22))
│       │       │   │   │                   ├── flags: ∅
│       │       │   │   │                   ├── key:
│       │       │   │   │                   │   @ SymbolNode (location: (1,12)-(1,14))
│       │       │   │   │                   │   ├── flags: static_literal, forced_us_ascii_encoding
│       │       │   │   │                   │   ├── opening_loc: ∅
│       │       │   │   │                   │   ├── value_loc: (1,12)-(1,13) = "x"
│       │       │   │   │                   │   ├── closing_loc: (1,13)-(1,14) = ":"
│       │       │   │   │                   │   └── unescaped: "x"
│       │       │   │   │                   ├── value:
│       │       │   │   │                   │   @ ConstantReadNode (location: (1,15)-(1,22))
│       │       │   │   │                   │   ├── flags: ∅
│       │       │   │   │                   │   └── name: :Integer
│       │       │   │   │                   └── operator_loc: ∅
│       │       │   │   ├── closing_loc: (1,22)-(1,23) = ")"
│       │       │   │   └── block: ∅
│       │       │   ├── call_operator_loc: (1,23)-(1,24) = "."
│       │       │   ├── name: :void
│       │       │   ├── message_loc: (1,24)-(1,28) = "void"
│       │       │   ├── opening_loc: ∅
│       │       │   ├── arguments: ∅
│       │       │   ├── closing_loc: ∅
│       │       │   └── block: ∅
│       │       ├── value:
│       │       │   @ MissingNode (location: (1,28)-(1,28))
│       │       │   └── flags: ∅
│       │       └── operator_loc: (1,28)-(1,28) = ""
│       └── closing_loc: (1,28)-(1,29) = "}"
├── rest: ∅
├── rights: (length: 0)
├── lparen_loc: ∅
└── rparen_loc: ∅
```

Here, one of the `lefts` is a `HashNode` (the `{params…}` part), which is obviously not valid.

The fix I came up with, is to check each of the lefts and rights to ensure they are [valid nodes](https://github.com/ruby/prism/blob/849f726ccfcfdd8e8f60fa0d343b1b7694ee45f3/config.yml#L3723-L3732), and otherwise just return an empty tree. I'm not 100% sure this is the best approach, and it's different to how the original parser handles it.

Original desugar tree:

```
class <emptyTree><<C <root>>> < (::<todo sym>)
  def f<<todo method>>(x, &<blk>)
    <emptyTree>
  end
end
```

Prism desugar tree:

```
class <emptyTree><<C <root>>> < (::<todo sym>)
  <emptyTree>

  def f<<todo method>>(x, &<blk>)
    <emptyTree>
  end
end
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Part of ongoing work to support Prism parser in Sorbet.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
