### PR TITLE
Handle implicit begin node

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -4516,6 +4516,13 @@ ast::ClassDef::RHS_store Translator::desugarClassOrModule(pm_node *prismBodyNode
         return result;
     }
 
+    if (PM_NODE_TYPE_P(prismBodyNode, PM_BEGIN_NODE)) {
+        auto beginNode = down_cast<pm_begin_node>(prismBodyNode);
+        ast::ClassDef::RHS_store result;
+        result.emplace_back(desugarBegin(beginNode));
+        return result;
+    }
+
     ENFORCE(PM_NODE_TYPE_P(prismBodyNode, PM_STATEMENTS_NODE));
 
     auto body = desugar(prismBodyNode);

--- a/test/prism_regression/begin_in_module.rb
+++ b/test/prism_regression/begin_in_module.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+module Foo
+  1
+rescue
+  2
+end

--- a/test/prism_regression/begin_in_module.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/begin_in_module.rb.desugar-tree-raw.exp
@@ -1,0 +1,38 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    ClassDef{
+      kind = module
+      name = UnresolvedConstantLit{
+        cnst = <C <U Foo>>
+        scope = EmptyTree
+      }
+      symbol = <C <U <todo sym>>>
+      ancestors = []
+      rhs = [
+        Rescue{
+          body = Literal{ value = 1 }
+          rescueCases = [
+            RescueCase{
+              exceptions = [
+              ]
+              var = UnresolvedIdent{
+                kind = Local
+                name = <D <U <rescueTemp>> $2>
+              }
+              body = Literal{ value = 2 }
+            }
+          ]
+          else = EmptyTree
+          ensure = EmptyTree
+        }
+      ]
+    }
+  ]
+}

--- a/test/prism_regression/begin_in_module.rb.parse-tree.exp
+++ b/test/prism_regression/begin_in_module.rb.parse-tree.exp
@@ -1,0 +1,21 @@
+Module {
+  name = Const {
+    scope = NULL
+    name = <C <U Foo>>
+  }
+  body = Rescue {
+    body = Integer {
+      val = "1"
+    }
+    rescue = [
+      Resbody {
+        exception = NULL
+        var = NULL
+        body = Integer {
+          val = "2"
+        }
+      }
+    ]
+    else_ = NULL
+  }
+}


### PR DESCRIPTION
Part of #9065.

This commit ensures we handle the implicit begin node that can be the `body` field in `ModuleNode` and `ClassNode`:

```rb
module Foo
  1
rescue
  2
end
```

```
@ ModuleNode (location: (1,0)-(5,3))
├── flags: newline
├── locals: []
├── module_keyword_loc: (1,0)-(1,6) = "module"
├── constant_path:
│   @ ConstantReadNode (location: (1,7)-(1,10))
│   ├── flags: ∅
│   └── name: :Foo
├── body:
│   @ BeginNode (location: (1,0)-(5,3))
│   ├── flags: ∅
│   ├── begin_keyword_loc: ∅
│   ├── statements:
│   │   @ StatementsNode (location: (2,2)-(2,3))
│   │   ├── flags: ∅
│   │   └── body: (length: 1)
│   │       └── @ IntegerNode (location: (2,2)-(2,3))
│   │           ├── flags: newline, static_literal, decimal
│   │           └── value: 1
│   ├── rescue_clause:
│   │   @ RescueNode (location: (3,0)-(4,3))
│   │   ├── flags: ∅
│   │   ├── keyword_loc: (3,0)-(3,6) = "rescue"
│   │   ├── exceptions: (length: 0)
│   │   ├── operator_loc: ∅
│   │   ├── reference: ∅
│   │   ├── then_keyword_loc: ∅
│   │   ├── statements:
│   │   │   @ StatementsNode (location: (4,2)-(4,3))
│   │   │   ├── flags: ∅
│   │   │   └── body: (length: 1)
│   │   │       └── @ IntegerNode (location: (4,2)-(4,3))
│   │   │           ├── flags: newline, static_literal, decimal
│   │   │           └── value: 2
│   │   └── subsequent: ∅
│   ├── else_clause: ∅
│   ├── ensure_clause: ∅
│   └── end_keyword_loc: (5,0)-(5,3) = "end"
├── end_keyword_loc: (5,0)-(5,3) = "end"
└── name: :Foo
```

Previously we were only handling `StatementsNode`.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Part of ongoing work to support Prism parser mode.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
