### PR TITLE
Use constant name missing for invalid constant path

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -4356,7 +4356,7 @@ ast::ExpressionPtr Translator::translateConst(pm_node_t *anyNode) {
     // Constant name might be unset, e.g. `::`.
     if (node->name == PM_CONSTANT_ID_UNSET) {
         auto location = translateLoc(node->base.location);
-        return MK::UnresolvedConstant(location, MK::EmptyTree(), core::Names::empty());
+        return MK::UnresolvedConstant(location, MK::EmptyTree(), core::Names::Constants::ConstantNameMissing());
     }
 
     // It's important that in all branches `enterNameUTF8` is called, which `translateConstantName` does,

--- a/test/prism_regression/constants_invalid.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/constants_invalid.rb.desugar-tree-raw.exp
@@ -18,7 +18,7 @@ ClassDef{
           name = <U <blk>>
         } }]
       rhs = UnresolvedConstantLit{
-        cnst = <U >
+        cnst = <C <U <ConstantNameMissing>>>
         scope = EmptyTree
       }
     }

--- a/test/prism_regression/invalid/module_empty_constant_path.rb
+++ b/test/prism_regression/invalid/module_empty_constant_path.rb
@@ -1,0 +1,5 @@
+# typed: true
+# disable-parser-comparison: true
+
+module ::
+end

--- a/test/prism_regression/invalid/module_empty_constant_path.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/invalid/module_empty_constant_path.rb.desugar-tree-raw.exp
@@ -1,0 +1,23 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    ClassDef{
+      kind = module
+      name = UnresolvedConstantLit{
+        cnst = <C <U <ConstantNameMissing>>>
+        scope = EmptyTree
+      }
+      symbol = <C <U <todo sym>>>
+      ancestors = []
+      rhs = [
+        EmptyTree
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Part of #9065.

We previously fixed something similar [here](https://github.com/sorbet/sorbet/pull/9669), but apparently that wasn't enough/incorrect. For example:

```rb
module ::
end
```

Prism parses the `ConstantPathNode` as not having a name. The code will crash when the unresolved constant name is `core::Names::empty()`. This Pr fixes that by using `core::Names::Constants::ConstantNameMissing()` instead (which is arguably more appropriate anyway).

The desugar tree is different to the original parser, which throws away more of the tree. The easier fix for the Prism parse tree is to insert this `ConstantNameMissing` constant and retain the rest of the tree.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Part of ongoing Prism parser integration.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
