### PR TITLE
Fix missing constant name in assignment

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1247,8 +1247,12 @@ ast::ExpressionPtr Translator::desugarAssignment(pm_node_t *untypedNode) {
             // Substitute a fake local variable assignment so parsing can continue
             lhs = MK::Local(nameLoc, core::Names::dynamicConstAssign());
         } else {
-            auto name = translateConstantName(node->name);
-            auto constantName = ctx.state.enterNameConstant(name);
+            core::NameRef constantName;
+            if (node->name == PM_CONSTANT_ID_UNSET) {
+                constantName = core::Names::Constants::ConstantNameMissing();
+            } else {
+                constantName = ctx.state.enterNameConstant(translateConstantName(node->name));
+            }
             lhs = MK::UnresolvedConstant(nameLoc, MK::EmptyTree(), constantName);
         }
     } else if constexpr (is_same_v<PrismAssignmentNode, pm_constant_path_write_node>) {
@@ -1268,8 +1272,12 @@ ast::ExpressionPtr Translator::desugarAssignment(pm_node_t *untypedNode) {
             } else {
                 scope = desugar(target->parent);
             }
-            auto name = translateConstantName(target->name);
-            auto constantName = ctx.state.enterNameConstant(name);
+            core::NameRef constantName;
+            if (target->name == PM_CONSTANT_ID_UNSET) {
+                constantName = core::Names::Constants::ConstantNameMissing();
+            } else {
+                constantName = ctx.state.enterNameConstant(translateConstantName(target->name));
+            }
             lhs = MK::UnresolvedConstant(pathLoc, move(scope), constantName);
         }
     } else {

--- a/test/prism_regression/invalid/constant_path_write_missing_name.rb
+++ b/test/prism_regression/invalid/constant_path_write_missing_name.rb
@@ -1,0 +1,4 @@
+# typed: true
+# disable-parser-comparison: true
+
+X:: = 1

--- a/test/prism_regression/invalid/constant_path_write_missing_name.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/invalid/constant_path_write_missing_name.rb.desugar-tree-raw.exp
@@ -1,0 +1,21 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    Assign{
+      lhs = UnresolvedConstantLit{
+        cnst = <C <U <ConstantNameMissing>>>
+        scope = UnresolvedConstantLit{
+          cnst = <C <U X>>
+          scope = EmptyTree
+        }
+      }
+      rhs = Literal{ value = 1 }
+    }
+  ]
+}


### PR DESCRIPTION
Part of #9065.

This PR fixes a crash when a constant assignment has a missing name:

```
X:: = 1
```

In this case Prism will parse this as a constant assignment where the constant path node is missing a name.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Part of ongoing Prism parser integration.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
