### PR TITLE
Fix invalid index in for

### DIFF
--- a/test/prism_regression/invalid/for_invalid_index.rb
+++ b/test/prism_regression/invalid/for_invalid_index.rb
@@ -1,0 +1,6 @@
+# typed: true
+# disable-parser-comparison: true
+
+for
+def foo
+end

--- a/test/prism_regression/invalid/for_invalid_index.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/invalid/for_invalid_index.rb.desugar-tree-raw.exp
@@ -1,0 +1,12 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    Literal{ value = nil }
+  ]
+}


### PR DESCRIPTION
Part of #9065.

This fixes a crash with the following:

```rb
for
def foo
end
```

Prism parses this as a `ForNode` where the `index` field is a `DefNode`. That's obviously invalid. The original parser returns a `Nil` for this cases (and probably others like it). I copied that behavior, checking if the node in the `index` field is a valid node type or not.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Part of ongoing Prism parser integration work.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
