### PR TITLE
Use resolved constant for missing nodes

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -2876,7 +2876,7 @@ ast::ExpressionPtr Translator::desugar(pm_node_t *node) {
             unreachable("Prism's parser never produces `PM_SCOPE_NODE` nodes.");
 
         case PM_MISSING_NODE: {
-            return MK::UnresolvedConstant(location, MK::EmptyTree(), core::Names::Constants::ErrorNode());
+            return MK::Constant(location, core::Symbols::ErrorNode());
         }
     }
 }

--- a/test/prism_regression/call_kw_nil_args.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_kw_nil_args.rb.desugar-tree-raw.exp
@@ -71,15 +71,15 @@ ClassDef{
         } }]
       rhs = InsSeq{
         stats = [
-          UnresolvedConstantLit{
-            cnst = <C <U <ErrorNode>>>
-            scope = EmptyTree
+          ConstantLit{
+            symbol = (static-field ::<ErrorNode>)
+            orig = nullptr
           }
           Literal{ value = 10 }
         ],
-        expr = UnresolvedConstantLit{
-          cnst = <C <U <ErrorNode>>>
-          scope = EmptyTree
+        expr = ConstantLit{
+          symbol = (static-field ::<ErrorNode>)
+          orig = nullptr
         }
       }
     }

--- a/test/prism_regression/error_recovery/assign.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/error_recovery/assign.rb.desugar-tree-raw.exp
@@ -22,9 +22,9 @@ ClassDef{
           kind = Local
           name = <U x>
         }
-        rhs = UnresolvedConstantLit{
-          cnst = <C <U <ErrorNode>>>
-          scope = EmptyTree
+        rhs = ConstantLit{
+          symbol = (static-field ::<ErrorNode>)
+          orig = nullptr
         }
       }
     }

--- a/test/prism_regression/invalid/missing_node.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/invalid/missing_node.rb.desugar-tree-raw.exp
@@ -14,9 +14,9 @@ ClassDef{
       block = nullptr
       pos_args = 1
       args = [
-        UnresolvedConstantLit{
-          cnst = <C <U <ErrorNode>>>
-          scope = EmptyTree
+        ConstantLit{
+          symbol = (static-field ::<ErrorNode>)
+          orig = nullptr
         }
       ]
     }

--- a/test/prism_regression/invalid/missing_node_in_statements.rb
+++ b/test/prism_regression/invalid/missing_node_in_statements.rb
@@ -1,0 +1,4 @@
+# typed: true
+# disable-parser-comparison: true
+
+foo: bar

--- a/test/prism_regression/invalid/missing_node_in_statements.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/invalid/missing_node_in_statements.rb.desugar-tree-raw.exp
@@ -1,0 +1,35 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    Send{
+      flags = {privateOk}
+      recv = Self
+      fun = <U foo>
+      block = nullptr
+      pos_args = 0
+      args = [
+      ]
+    }
+
+    ConstantLit{
+      symbol = (static-field ::<ErrorNode>)
+      orig = nullptr
+    }
+
+    Send{
+      flags = {privateOk}
+      recv = Self
+      fun = <U bar>
+      block = nullptr
+      pos_args = 0
+      args = [
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Part of #9065.

Using an unresolved constant for missing nodes causes issues later on in the pipeline. Instead, use a constant with the error node symbol, which is what we do for an error node in Desugar.cc. This commit also adds a test case for missing nodes in statements, which was crashing before due to this unresolved constant issue.

https://github.com/sorbet/sorbet/blob/0a871d2922d7f6a8cba6e3512b51e76d149b613a/ast/desugar/Desugar.cc#L2426

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Part of ongoing Prism parser integration.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.