### PR TITLE
Preserve constant resolution in RSpec.describe with class arg

### DIFF
--- a/test/testdata/rewriter/rspec_describe.rb
+++ b/test/testdata/rewriter/rspec_describe.rb
@@ -66,6 +66,7 @@ class UserClass
 end
 
 RSpec.describe UserClass do
+#              ^^^^^^^^^ hover: T.class_of(UserClass)
   let(:name) { "Bob" }
 
   it "has a name" do
@@ -75,6 +76,7 @@ end
 
 # Test RSpec.describe with a class and metadata
 RSpec.describe UserClass, :needs_macos do
+#              ^^^^^^^^^ hover: T.class_of(UserClass)
   let(:value) { 100 }
 
   it "has a value" do

--- a/test/testdata/rewriter/rspec_describe.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_describe.rb.rewrite-tree.exp
@@ -78,28 +78,34 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C UserClass><<C <todo sym>>> < (::<todo sym>)
   end
 
-  class <emptyTree>::<C <describe 'UserClass'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
-    def name<<todo method>>(&<blk>)
-      "Bob"
-    end
+  begin
+    <emptyTree>::<C UserClass>
+    class <emptyTree>::<C <describe 'UserClass'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      def name<<todo method>>(&<blk>)
+        "Bob"
+      end
 
-    def <it 'has a name'><<todo method>>(&<blk>)
-      <self>.name()
-    end
+      def <it 'has a name'><<todo method>>(&<blk>)
+        <self>.name()
+      end
 
-    <runtime method definition of name>
+      <runtime method definition of name>
+    end
   end
 
-  class <emptyTree>::<C <describe 'UserClass'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
-    def value<<todo method>>(&<blk>)
-      100
-    end
+  begin
+    <emptyTree>::<C UserClass>
+    class <emptyTree>::<C <describe 'UserClass'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      def value<<todo method>>(&<blk>)
+        100
+      end
 
-    def <it 'has a value'><<todo method>>(&<blk>)
-      <self>.value()
-    end
+      def <it 'has a value'><<todo method>>(&<blk>)
+        <self>.value()
+      end
 
-    <runtime method definition of value>
+      <runtime method definition of value>
+    end
   end
 
   class <emptyTree>::<C <describe 'user_symbol'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)


### PR DESCRIPTION
When `RSpec.describe MyClass do` is rewritten, the synthetic class
`<describe 'MyClass'>` was using `MyClass`'s source location, causing
hover/go-to-def on `MyClass` to resolve to the synthetic class instead
of the real constant.

Fix by using a zero-length loc for the synthetic class name and
preserving the original constant reference in the tree via InsSeq,
matching the existing pattern used for `it` blocks.

Co-Authored-By: Claude <noreply@anthropic.com>
Committed-By-Agent: claude

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
