### PR TITLE
Make members_ private in ClassOrModule

### DIFF
--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -679,8 +679,10 @@ public:
     NameRef name; // todo: move out? it should not matter but it's important for name resolution
     TypePtr resultType;
 
+private:
     UnorderedMap<NameRef, SymbolRef> members_;
 
+public:
     UnorderedMap<NameRef, SymbolRef> &members() {
         return members_;
     };


### PR DESCRIPTION
Make the `members_` map private in `ClassOrModule`, to ensure that we're consistent about the way it's accessed.

### Motivation
Consistency.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Refactor only.
