### PR TITLE
Name the genPackages argument in LSPIndexer.cc

### DIFF
--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -275,6 +275,7 @@ void LSPIndexer::transferInitializeState(InitializedTask &task) {
     // Copying the global state here means that we snapshot before any files have been loaded. That means that the
     // indexer and typechecker's file tables will almost immediately diverge, but that's not an issue as we don't share
     // `core::FileRef` values between the two.
+    auto disableGenPackages = false;
     auto typecheckerGS = std::exchange(
         this->gs, this->gs->copyForLSPTypechecker(
                       this->config->opts.cacheSensitiveOptions.sorbetPackages,
@@ -283,7 +284,7 @@ void LSPIndexer::transferInitializeState(InitializedTask &task) {
                       this->config->opts.extraPackageFilesDirectorySlashPrefixes,
                       this->config->opts.packageSkipRBIExportEnforcementDirs,
                       this->config->opts.allowRelaxedPackagerChecksFor, this->config->opts.updateVisibilityFor,
-                      this->config->opts.packagerLayers, this->config->opts.sorbetPackagesHint, false));
+                      this->config->opts.packagerLayers, this->config->opts.sorbetPackagesHint, disableGenPackages));
 
     task.setGlobalState(std::move(typecheckerGS));
     task.setKeyValueStore(std::move(this->kvstore));


### PR DESCRIPTION
Name the `genPackages` argument in the call to `copyForLSPTypechecker` in `LSPTypechecker.cc`.

### Motivation
Clarity.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Pure refactor.
