### PR TITLE
Return the Import from importsPackage

### DIFF
--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -396,17 +396,17 @@ optional<core::AutocorrectSuggestion> PackageInfo::addVisibleTo(const core::Glob
     return {suggestion};
 }
 
-optional<ImportType> PackageInfo::importsPackage(MangledName mangledName) const {
+const Import *PackageInfo::importsPackage(MangledName mangledName) const {
     if (!mangledName.exists()) {
-        return nullopt;
+        return nullptr;
     }
 
     auto imp = absl::c_find_if(importedPackageNames, [mangledName](auto &i) { return i.mangledName == mangledName; });
     if (imp == importedPackageNames.end()) {
-        return nullopt;
+        return nullptr;
     }
 
-    return imp->type;
+    return &*imp;
 }
 
 // Is it a layering violation to import otherPkg from this package?

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -256,7 +256,7 @@ public:
     // The list of known direct sub-packages of this package.
     std::vector<MangledName> directSubPackages(const core::GlobalState &gs) const;
 
-    std::optional<ImportType> importsPackage(MangledName mangledName) const;
+    const Import *importsPackage(MangledName mangledName) const;
 
     // Is it a layering violation to import otherPkg from this package?
     bool causesLayeringViolation(const PackageDB &packageDB, const PackageInfo &otherPkg) const;

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -545,15 +545,14 @@ public:
         isExported = isExported || db.allowRelaxedPackagerChecksFor(this->package.mangledName());
         bool definesBehavior =
             !litSymbol.isClassOrModule() || litSymbol.asClassOrModuleRef().data(ctx)->flags.isBehaviorDefining;
-        auto currentImportType = this->package.importsPackage(otherPackage);
-        auto wasImported = currentImportType.has_value();
+        auto *import = this->package.importsPackage(otherPackage);
+        auto wasImported = import != nullptr;
 
         // Is this a test import (whether test helper or not) used in a production context?
-        auto testImportInProd = wasImported && currentImportType.value() != core::packages::ImportType::Normal &&
-                                this->fileType == FileType::ProdFile;
+        auto testImportInProd =
+            wasImported && import->type != core::packages::ImportType::Normal && this->fileType == FileType::ProdFile;
         // Is this a test import not intended for use in helpers?
-        auto testUnitImportInHelper = wasImported &&
-                                      currentImportType.value() == core::packages::ImportType::TestUnit &&
+        auto testUnitImportInHelper = wasImported && import->type == core::packages::ImportType::TestUnit &&
                                       this->fileType != FileType::TestUnitFile;
         bool importNeeded = !wasImported || testImportInProd || testUnitImportInHelper;
         referencedPackages[otherPackage] = {


### PR DESCRIPTION
Returning a pointer to the `Import` gives us access to the other data of the import, and we can use `nullptr` to indicate that the package wasn't imported. This is useful in my refactoring for test packages, as it gives access to additional metadata about the import.


### Motivation
Refactoring.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Pure refactoring change.
