### PR TITLE
Log the file names for slow fast path runs

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -320,7 +320,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
 
     auto duration = timeit.setEndTime();
     std::string files;
-    if (duration.usec > 1000000) {
+    if (duration.usec > 1'000'000) {
         auto span = absl::MakeSpan(toTypecheck);
         const auto numFilesToShow = 10;
         files = fmt::format("{}", fmt::map_join(span.size() > numFilesToShow ? span.subspan(0, numFilesToShow) : span,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

For fast path runs that take more than 1s, add the first 10 files in the set of files being typechecked to the log line. This is omitted for runs that take less time, to reduce noise.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Make it easier to debug why certain fast path runs take so long.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Changes the usec threshold and ensured the file list was shown in the logs.

See included automated tests.
