### PR TITLE
Reap old-format `session-<hex>` cache directories

### DIFF
--- a/main/cache/cache.h
+++ b/main/cache/cache.h
@@ -52,6 +52,7 @@ class SessionCache {
 
 public:
     static const std::string_view SESSION_DIR_PREFIX;
+    static const std::string_view OLD_SESSION_DIR_PREFIX;
 
     // Removes the session cache.
     ~SessionCache() noexcept(false);


### PR DESCRIPTION
## Summary

- Extend `reapOldCaches()` to unconditionally remove pre-#9106 `session-<hex>` cache directories, which are never cleaned up by the existing PID-based reaping
- Add `OLD_SESSION_DIR_PREFIX` constant for the legacy `"session-"` prefix
- Add `ReapOldFormatSessionDirectories` test covering old-format removal alongside live new-format directory preservation

## Motivation

PR #9106 changed session cache naming from `session-<hex>` to `sorbet-session-<PID>`, and PR #9116 added reaping for the new format. But old `session-<hex>` dirs from before #9106 are never cleaned up — they don't match `sorbet-session-` and encode a UUID rather than a PID, so liveness checking is impossible.

Since no current Sorbet creates `session-<hex>` directories, they are definitionally orphaned and can be unconditionally removed.

## Test plan

- Added `ReapOldFormatSessionDirectories` test that creates fake `session-<hex>` dirs alongside a live `sorbet-session-<PID>` dir, calls `reapOldCaches()`, and asserts old-format dirs are removed while the live dir is preserved
- Existing `ReapOldCacheDirectories` test continues to pass
- `bazel test //test/lsp:cache_protocol_test_corpus` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)