### PR TITLE
Hide internal magic constants from `sorbet/showSymbol`

### DIFF
--- a/main/lsp/requests/sorbet_show_symbol.cc
+++ b/main/lsp/requests/sorbet_show_symbol.cc
@@ -45,6 +45,10 @@ unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerDeleg
         // Using symbolBeforeDealias instead of symbol here lets us show the name of the actual
         // constant under the user's cursor, not what it aliases to.
         sym = c->symbolBeforeDealias;
+        if (sym == core::Symbols::StubModule() || sym == core::Symbols::StubSuperClass() ||
+            sym == core::Symbols::StubMixin() || sym == core::Symbols::ErrorNode()) {
+            sym = core::Symbols::noClassOrModule();
+        }
     } else if (auto d = resp->isMethodDef()) {
         sym = d->symbol;
     } else if (auto f = resp->isField()) {

--- a/test/BUILD
+++ b/test/BUILD
@@ -453,6 +453,7 @@ pipeline_tests(
             "testdata/lsp/completion/untyped_receiver.rb",
             "testdata/lsp/hover_methods_inside_block.rb",
             "testdata/lsp/when_eqeqeq.rb",
+            "testdata/lsp/show_symbol.rb",
             "testdata/namer/duplicate_field_error.rb",
             "testdata/parser/bad_argument_crash.rb",
             "testdata/parser/chained_sends_lots.rb",

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -2472,6 +2472,13 @@ void ShowSymbolAssertion::check(const UnorderedMap<string, shared_ptr<core::File
                                       errorPrefix, prettyPrintRangeComment(sourceLine, *range, toString()),
                                       prettyPrintRangeComment(sourceLine, *range,
                                                               fmt::format("show-symbol: {}", showSymbolContents))));
+    } else if (holds_alternative<unique_ptr<SymbolInformation>>(showSymbolResponse) &&
+               get<unique_ptr<SymbolInformation>>(showSymbolResponse)->location == nullptr) {
+        auto sourceLine = getSourceLine(sourceFileContents, filename, range->start->line);
+        ADD_FAIL_CHECK_AT(filename.c_str(), range->start->line + 1,
+                          fmt::format("{}This `show-symbol` has `nullptr` for `location`:\n{}", errorPrefix,
+                                      prettyPrintRangeComment(sourceLine, *range,
+                                                              fmt::format("show-symbol: {}", showSymbolContents))));
     }
 }
 

--- a/test/testdata/lsp/show_symbol.rb
+++ b/test/testdata/lsp/show_symbol.rb
@@ -55,3 +55,13 @@ module Outer
     end
   end
 end
+
+Hello # error: Unable to resolve constant `Hello`
+# ^ show-symbol: null
+Hello:: # error: Unable to resolve constant `Hello`
+#    ^^ error: expected constant name following "::"
+#     ^ show-symbol: null
+module A
+  Goodbye =
+  #        ^ show-symbol: null
+end # error: unexpected token "end"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This prevents a crash in attempting to serialize a `nullptr` for the
`location` of a `SymbolInformation`. It also makes the user experience
better, because previously we would attempt to copy something like
`Sorbet::Static::Private::<StubModule>` onto your clipboard.

The lsp_test_runner test doesn't _quite_ exercise this crash, because we
never actually call `toJSONValue`, but I've tested in VS Code directly
and made sure that we don't crash anymore. I've also updated the test
harness to check that `location` is not `nullptr` directly, which was
the proximal cause of the crash.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.