### PR TITLE
Add experimental typed return/args for `delegate`

### DIFF
--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -670,6 +670,10 @@ public:
         // attempt to support RSpec.
         bool rspecRewriterEnabled = false;
 
+        // Whether to infer return types for methods synthesized by ActiveSupport `delegate`.
+        // Guarded behind an experimental flag, because it can surface new type errors.
+        bool delegateReturnTypesEnabled = false;
+
         // So we can know whether we're running in autogen mode.
         // Right now this is only used to turn certain Rewriter passes on or off.
         // Think very hard before looking at this value in namer / resolver!

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -746,6 +746,9 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options(section)("enable-experimental-rbs-comments",
                                  "Enable experimental support for RBS signatures and assertions as inline comments");
 
+    options.add_options(section)("enable-experimental-delegate-return-types",
+                                 "Enable experimental inference of return types for ActiveSupport `delegate`");
+
     options.add_options(section)(
         "enable-experimental-rspec",
         "Enables experimental support for RSpec. "
@@ -1004,6 +1007,8 @@ void readOptions(Options &opts,
         }
 
         opts.cacheSensitiveOptions.requiresAncestorEnabled = raw["enable-experimental-requires-ancestor"].as<bool>();
+        opts.cacheSensitiveOptions.delegateReturnTypesEnabled =
+            raw["enable-experimental-delegate-return-types"].as<bool>();
         opts.cacheSensitiveOptions.rspecRewriterEnabled = raw["enable-experimental-rspec"].as<bool>();
 
         bool enableAllLSPFeatures = raw["enable-all-experimental-lsp-features"].as<bool>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -202,6 +202,9 @@ struct Options {
 
         bool rspecRewriterEnabled : 1;
 
+        // Experimental feature: infer return types for ActiveSupport `delegate`
+        bool delegateReturnTypesEnabled : 1;
+
         bool runningUnderAutogen : 1;
 
         bool sorbetPackages : 1;
@@ -211,20 +214,21 @@ struct Options {
         bool usePrismParser : 1;
 
         // HELLO! adding/removing MUST also change this number!!
-        constexpr static uint8_t NUMBER_OF_FLAGS = 8;
+        constexpr static uint8_t NUMBER_OF_FLAGS = 9;
 
         // In C++20 we can replace this with bit field initializers
         CacheSensitiveOptions()
             : noStdlib(false), typedSuper(true), rbsEnabled(false), requiresAncestorEnabled(false),
-              rspecRewriterEnabled(false), runningUnderAutogen(false), sorbetPackages(false), usePrismParser(false) {}
+              rspecRewriterEnabled(false), delegateReturnTypesEnabled(false), runningUnderAutogen(false),
+              sorbetPackages(false), usePrismParser(false) {}
 
-        constexpr static uint8_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
+        constexpr static uint16_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
 
-        uint8_t serialize() const {
-            static_assert(sizeof(CacheSensitiveOptions) == sizeof(uint8_t));
+        uint16_t serialize() const {
+            static_assert(sizeof(CacheSensitiveOptions) == sizeof(uint16_t));
             static_assert(sizeof(CacheSensitiveOptions) == sizeof(VALID_BITS_MASK));
             // Can replace this with std::bit_cast in C++20
-            auto rawBits = *reinterpret_cast<const uint8_t *>(this);
+            auto rawBits = *reinterpret_cast<const uint16_t *>(this);
             static_assert(sizeof(CacheSensitiveOptions) == sizeof(rawBits));
             // Mask the valid bits since uninitialized bits can be any value.
             return rawBits & VALID_BITS_MASK;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -61,6 +61,7 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
     gs.cacheSensitiveOptions.rbsEnabled = opts.cacheSensitiveOptions.rbsEnabled;
     gs.cacheSensitiveOptions.requiresAncestorEnabled = opts.cacheSensitiveOptions.requiresAncestorEnabled;
     gs.cacheSensitiveOptions.rspecRewriterEnabled = opts.cacheSensitiveOptions.rspecRewriterEnabled;
+    gs.cacheSensitiveOptions.delegateReturnTypesEnabled = opts.cacheSensitiveOptions.delegateReturnTypesEnabled;
     gs.cacheSensitiveOptions.typedSuper = opts.cacheSensitiveOptions.typedSuper;
 
     if (opts.silenceErrors) {

--- a/rewriter/Delegate.cc
+++ b/rewriter/Delegate.cc
@@ -39,6 +39,10 @@ vector<ast::ExpressionPtr> Delegate::run(core::MutableContext ctx, const ast::Se
         return empty;
     }
 
+    // Backwards compatibility: by default, Sorbet rewrites `delegate` into stubs returning `T.untyped`.
+    // We only emit extra metadata for return type inference behind an experimental flag.
+    const bool delegateReturnTypesEnabled = ctx.state.cacheSensitiveOptions.delegateReturnTypesEnabled;
+
     if (!send->hasPosArgs()) {
         // there has to be at least one positional argument
         return empty;
@@ -51,15 +55,27 @@ vector<ast::ExpressionPtr> Delegate::run(core::MutableContext ctx, const ast::Se
     }
 
     ast::ExpressionPtr const *prefixNode = nullptr;
+    bool allowNil = false;
     core::NameRef toName;
     {
         optional<core::NameRef> to;
+        const auto allowNilName = ctx.state.enterNameUTF8("allow_nil");
         for (auto [key, val] : options->kviter()) {
             if (literalSymbolEqual(ctx, key, core::Names::to())) {
                 to = stringOrSymbolNameRef(ctx, val);
             }
             if (literalSymbolEqual(ctx, key, core::Names::prefix())) {
                 prefixNode = &val;
+            }
+            if (literalSymbolEqual(ctx, key, allowNilName)) {
+                // ActiveSupport accepts allow_nil: true/false. We only model literal booleans.
+                if (auto lit = ast::cast_tree<ast::Literal>(val)) {
+                    if (lit->isTrue(ctx)) {
+                        allowNil = true;
+                    } else if (lit->isFalse(ctx)) {
+                        allowNil = false;
+                    }
+                }
             }
         }
 
@@ -89,6 +105,7 @@ vector<ast::ExpressionPtr> Delegate::run(core::MutableContext ctx, const ast::Se
         if (!lit || !lit->isSymbol()) {
             return empty;
         }
+        const core::NameRef delegatedMethodName = lit->asSymbol();
         core::NameRef methodName;
         if (prefixNode) {
             if (useToAsPrefix && (beforeUnderscore.empty() || beforeUnderscore[0] == '@')) {
@@ -96,9 +113,9 @@ vector<ast::ExpressionPtr> Delegate::run(core::MutableContext ctx, const ast::Se
                 return empty;
             }
             methodName =
-                ctx.state.enterNameUTF8(fmt::format("{}_{}", beforeUnderscore, lit->asSymbol().shortName(ctx)));
+                ctx.state.enterNameUTF8(fmt::format("{}_{}", beforeUnderscore, delegatedMethodName.shortName(ctx)));
         } else {
-            methodName = lit->asSymbol();
+            methodName = delegatedMethodName;
         }
         // sig {params(arg0: T.untyped, blk: Proc).returns(T.untyped)}
         auto sigArgs = ast::MK::SendArgs(ast::MK::Symbol(loc, core::Names::arg0()), ast::MK::Untyped(loc),
@@ -112,7 +129,19 @@ vector<ast::ExpressionPtr> Delegate::run(core::MutableContext ctx, const ast::Se
         params.emplace_back(ast::MK::RestParam(loc, ast::MK::Local(loc, core::Names::arg0())));
         params.emplace_back(ast::make_expression<ast::BlockParam>(loc, ast::MK::Local(loc, core::Names::blkArg())));
 
-        methodStubs.push_back(ast::MK::SyntheticMethod(loc, loc, methodName, std::move(params), ast::MK::EmptyTree()));
+        ast::ExpressionPtr rhs;
+        if (delegateReturnTypesEnabled) {
+            // Marker body consumed by a resolver post-pass (only when the flag is enabled).
+            // The call target is untyped, so this marker never produces type errors itself.
+            auto markerFun = ctx.state.enterNameUTF8("__sorbet_delegate_stub__");
+            auto markerArgs = ast::MK::SendArgs(ast::MK::Symbol(loc, toName), ast::MK::Symbol(loc, delegatedMethodName),
+                                                allowNil ? ast::MK::True(loc) : ast::MK::False(loc));
+            rhs = ast::MK::Send(loc, ast::MK::UntypedNil(loc), markerFun, loc, 3, std::move(markerArgs));
+        } else {
+            rhs = ast::MK::EmptyTree();
+        }
+
+        methodStubs.push_back(ast::MK::SyntheticMethod(loc, loc, methodName, std::move(params), std::move(rhs)));
     }
 
     return methodStubs;

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -270,6 +270,7 @@ const UnorderedMap<
         {"enable-packager", BooleanPropertyAssertion::make},
         {"enable-experimental-rbs-comments", BooleanPropertyAssertion::make},
         {"enable-experimental-requires-ancestor", BooleanPropertyAssertion::make},
+        {"enable-experimental-delegate-return-types", BooleanPropertyAssertion::make},
         {"enable-experimental-rspec", BooleanPropertyAssertion::make},
         {"experimental-ruby3-keyword-args", BooleanPropertyAssertion::make},
         {"typed-super", BooleanPropertyAssertion::make},
@@ -701,6 +702,8 @@ realmain::options::Options RangeAssertion::parseOptions(vector<shared_ptr<RangeA
         BooleanPropertyAssertion::getValue("enable-experimental-rbs-comments", assertions).value_or(false);
     opts.cacheSensitiveOptions.requiresAncestorEnabled =
         BooleanPropertyAssertion::getValue("enable-experimental-requires-ancestor", assertions).value_or(false);
+    opts.cacheSensitiveOptions.delegateReturnTypesEnabled =
+        BooleanPropertyAssertion::getValue("enable-experimental-delegate-return-types", assertions).value_or(false);
     opts.cacheSensitiveOptions.rspecRewriterEnabled =
         BooleanPropertyAssertion::getValue("enable-experimental-rspec", assertions).value_or(false);
     opts.ruby3KeywordArgs =

--- a/test/testdata/resolver/delegate_param_types.rb
+++ b/test/testdata/resolver/delegate_param_types.rb
@@ -1,0 +1,60 @@
+# typed: true
+# enable-experimental-delegate-return-types: true
+# disable-stress-incremental: true
+
+class DelegateParamTypesTarget
+  extend T::Sig
+
+  sig { params(x: Integer, y: String).returns(Float) }
+  def pos(x, y)
+    0.0
+  end
+
+  sig { params(a: Integer, b: String).returns(String) }
+  def kw(a:, b:)
+    b * a
+  end
+
+  sig { params(x: Integer, blk: T.proc.params(s: String).returns(Integer)).returns(Integer) }
+  def takes_block(x, &blk)
+    blk.call(x.to_s)
+  end
+end
+
+class DelegateParamTypesDelegator
+  extend T::Sig
+
+  delegate :pos, to: :target
+  delegate :kw, to: :target
+  delegate :takes_block, to: :target
+  delegate :size, to: :@str
+  delegate :length, to: :@nilable_str, allow_nil: true
+
+  sig { returns(DelegateParamTypesTarget) }
+  def target
+    T.unsafe(nil)
+  end
+
+  sig { void }
+  def initialize
+    @str = T.let("a string", String)
+    @nilable_str = T.let(nil, T.nilable(String))
+  end
+end
+
+d = DelegateParamTypesDelegator.new
+
+T.assert_type!(d.pos(1, "x"), Float)
+d.pos("nope", "x") # error: Expected `Integer` but found `String("nope")` for argument `x`
+d.pos(1, 2) # error: Expected `String` but found `Integer(2)` for argument `y`
+
+T.assert_type!(d.kw(a: 2, b: "hi"), String)
+d.kw(a: "nope", b: "hi") # error: Expected `Integer` but found `String("nope")` for argument `a`
+d.kw(a: 2, b: 10) # error: Expected `String` but found `Integer(10)` for argument `b`
+
+T.assert_type!(d.takes_block(5) {|s| s.size }, Integer)
+d.takes_block("nope") {|s| s.size } # error: Expected `Integer` but found `String("nope")` for argument `x`
+d.takes_block(5) {|s| s } # error: Expected `Integer` but found `String` for block result type
+
+T.assert_type!(d.size, Integer)
+T.reveal_type(d.length) # error: `T.untyped`

--- a/test/testdata/resolver/delegate_return_type.rb
+++ b/test/testdata/resolver/delegate_return_type.rb
@@ -1,0 +1,26 @@
+# typed: true
+# enable-experimental-delegate-return-types: true
+# disable-stress-incremental: true
+
+class DelegateReturnTypeFoo
+  extend T::Sig
+
+  sig { returns(String) }
+  def delegated_method
+    T.unsafe(nil)
+  end
+end
+
+class DelegateReturnTypeBar
+  extend T::Sig
+
+  delegate :delegated_method, to: :foo
+
+  sig { returns(DelegateReturnTypeFoo) }
+  def foo
+    T.unsafe(nil)
+  end
+end
+
+T.assert_type!(DelegateReturnTypeBar.new.delegated_method, String)
+

--- a/test/testdata/rewriter/rails/delegate_return_types_experimental.rb
+++ b/test/testdata/rewriter/rails/delegate_return_types_experimental.rb
@@ -1,0 +1,24 @@
+# typed: true
+# enable-experimental-delegate-return-types: true
+# disable-stress-incremental: true
+
+class DelegateReturnTypesExperimental
+  extend T::Sig
+
+  delegate :delegated_method, to: :foo
+
+  sig { returns(DelegateReturnTypeFoo) }
+  def foo
+    T.unsafe(nil)
+  end
+end
+
+class DelegateReturnTypeFoo
+  extend T::Sig
+
+  sig { returns(String) }
+  def delegated_method
+    T.unsafe(nil)
+  end
+end
+

--- a/test/testdata/rewriter/rails/delegate_return_types_experimental.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rails/delegate_return_types_experimental.rb.rewrite-tree.exp
@@ -1,0 +1,39 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C DelegateReturnTypesExperimental><<C <todo sym>>> < (::<todo sym>)
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:arg0, ::T.untyped(), :<blk>, ::T.nilable(::Proc)).returns(::T.untyped())
+    end
+
+    def delegated_method<<todo method>>(*arg0, &<blk>)
+      ::T.unsafe(nil).__sorbet_delegate_stub__(:foo, :delegated_method, false)
+    end
+
+    <self>.sig() do ||
+      <self>.returns(<emptyTree>::<C DelegateReturnTypeFoo>)
+    end
+
+    def foo<<todo method>>(&<blk>)
+      <emptyTree>::<C T>.unsafe(nil)
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    <runtime method definition of delegated_method>
+
+    <runtime method definition of foo>
+  end
+
+  class <emptyTree>::<C DelegateReturnTypeFoo><<C <todo sym>>> < (::<todo sym>)
+    <self>.sig() do ||
+      <self>.returns(<emptyTree>::<C String>)
+    end
+
+    def delegated_method<<todo method>>(&<blk>)
+      <emptyTree>::<C T>.unsafe(nil)
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+    <runtime method definition of delegated_method>
+  end
+end

--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -150,6 +150,11 @@ for this_src in "${rb_src[@]}" DUMMY; do
       needs_experimental_rbs=true
     fi
 
+    needs_delegate_return_types=false
+    if grep -q '^# enable-experimental-delegate-return-types: true' "${srcs[@]}"; then
+      needs_delegate_return_types=true
+    fi
+
     if grep -q '^# typed-super: false' "${srcs[@]}"; then
       needs_typed_super_false=true
     else
@@ -214,10 +219,13 @@ for this_src in "${rb_src[@]}" DUMMY; do
       if $needs_rspec; then
         args+=("--enable-experimental-rspec")
       else
-        args=()
+        args+=()
       fi
       if $needs_experimental_rbs; then
         args+=("--enable-experimental-rbs-comments")
+      fi
+      if $needs_delegate_return_types; then
+        args+=("--enable-experimental-delegate-return-types")
       fi
       if $needs_typed_super_false; then
         args+=("--typed-super=false")


### PR DESCRIPTION
### Motivation

#### Problem

Sorbet currently types all methods synthesized by `ActiveSupport`'s `delegate` as returning `T.untyped` with `T.untyped` parameters. This means callers of delegated methods get no type checking, even when the delegate target has a full `sig`.

For example:

```ruby
class Printer
  extend T::Sig

  sig { params(text: String).returns(Integer) }
  def print_length(text)
    text.length
  end
end

class Document
  extend T::Sig

  delegate :print_length, to: :printer

  sig { returns(Printer) }
  def printer
    @printer
  end
end

doc = Document.new
T.reveal_type(doc.print_length("hello")) # T.untyped (no type information)
doc.print_length(123)                     # no error reported
```

The return type is lost and argument types are not checked, despite the target method `Printer#print_length` having a complete signature. This is tracked in https://github.com/sorbet/sorbet/issues/4794.

#### Solution

This PR adds a new flag `--enable-experimental-delegate-return-types` that enables inference of return types and parameter types for methods synthesized by `delegate`. The change is backwards compatible, so behavior is unchanged unless the flag is explicitly passed.

With the flag enabled, the example above becomes:

```ruby
T.reveal_type(doc.print_length("hello")) # Integer
doc.print_length(123)                     # error: Expected `String` but found `Integer(123)` for argument `text`
```

#### What gets propagated

When the flag is enabled and the delegate target has a `sig`, Sorbet propagates:

- **Return type** from the target method onto the synthesized delegate method
- **Parameter types**, including positional, keyword, optional, rest, and block parameters

Delegation to both methods (`to: :method_name`) and instance variables (`to: :@ivar`) is supported. Delegates using `allow_nil: true` are not yet handled and will continue to produce `T.untyped` signatures. It does not handle the `prefix:` either, although supporting that would be straightforward.

#### How to enable

Pass the flag on the command line:

```
srb tc --enable-experimental-delegate-return-types
```

#### How it works

The implementation is split across two phases:

1. **Rewriter** (`rewriter/Delegate.cc`): When the flag is enabled, the rewriter emits a marker expression in the synthesized method body (`__sorbet_delegate_stub__`) that encodes the `to:` target name, the delegated method name, and whether `allow_nil` is set. When the flag is disabled, behavior is identical to before (empty method body).

2. **Resolver** (`resolver/resolver.cc`): A post-pass after signature resolution detects the marker, resolves the receiver type from the `to:` target (method return type or field type), looks up the delegated method on that class, and copies its parameter types and return type onto the synthesized method's symbol.

The approach is conservative: if any resolution step fails (target method has no `sig`, receiver type is too complex, delegated method not found), the synthesized method silently retains its default `T.untyped` signature.


### Test plan

- `test/testdata/resolver/delegate_return_type.rb` -- verifies return type propagation from a delegated method
- `test/testdata/resolver/delegate_param_types.rb` -- verifies argument type checking for positional, keyword, and block parameters, as well as delegation to an instance variable (`to: :@str`)
- `test/testdata/rewriter/rails/delegate_return_types_experimental.rb` -- rewrite-tree snapshot test confirming the marker is emitted when the flag is enabled
- All existing delegate tests continue to pass with no changes (flag is off by default)
