### PR TITLE
Store the offsets for prelude_package

### DIFF
--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -743,7 +743,7 @@ PackageInfo::CanModifyResult PackageInfo::canModifySymbol(const core::GlobalStat
 
     // Modifying an unpackaged symbol is only allowed from prelude packages.
     if (!symPackage.exists()) {
-        if (this->isPreludePackage_) {
+        if (this->isPreludePackage()) {
             return CanModifyResult::CanModify;
         } else {
             return CanModifyResult::UnpackagedSymbol;

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -164,6 +164,9 @@ public:
 
         // Set to non-none loc when this package is marked `test!`
         core::LocOffsets testPackage;
+
+        // Set to non-none loc when this package is marked `prelude_package`
+        core::LocOffsets preludePackage;
     } locs;
 
     core::FileRef file;
@@ -181,8 +184,6 @@ public:
 
     // Whether `visible_to` directives should be ignored for test code
     bool visibleToTests_ = false;
-
-    bool isPreludePackage_ = false;
 
     // Whether or not this package has other packages underneath its namespace.
     //
@@ -279,7 +280,7 @@ public:
     // True when the package is marked with a `prelude_package` annotation. This requires that the package only import
     // other prelude packages and markes it as an implicit dependency of all non-prelude packages.
     bool isPreludePackage() const {
-        return this->isPreludePackage_;
+        return this->locs.preludePackage.exists();
     }
 
     // True if this package was marked as a `test!` package.
@@ -322,7 +323,7 @@ public:
     std::optional<core::AutocorrectSuggestion>
     aggregateMissingVisibleTo(const core::GlobalState &gs, std::vector<core::packages::MangledName> &visibleTos) const;
 };
-CheckSize(PackageInfo, 248, 8);
+CheckSize(PackageInfo, 256, 8);
 
 } // namespace sorbet::core::packages
 #endif

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -597,7 +597,7 @@ struct PackageSpecBodyWalk {
                 info.locs.exportAll = send.loc;
             }
         } else if (send.fun == core::Names::preludePackage() && !send.hasBlock() && !send.hasNonBlockArgs()) {
-            info.isPreludePackage_ = true;
+            info.locs.preludePackage = send.loc;
         } else if (send.fun == core::Names::visibleTo()) {
             if (send.numPosArgs() == 1) {
                 if (auto target = ast::cast_tree<ast::Literal>(send.getPosArg(0))) {


### PR DESCRIPTION
Instead of tracking if a package is a `prelude_package` using a boolean, store the non-empty loc of the send when it's present.

### Motivation
Consistency with how we track other boolean properties of packages.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Refactoring only.
