### PR TITLE
Simplify printUntypedBlames getPackageInfo call

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1779,7 +1779,7 @@ void printUntypedBlames(const core::GlobalState &gs, const UnorderedMap<long, lo
             if (!pkg.exists()) {
                 writer.String("<none>");
             } else {
-                writer.String(gs.packageDB().getPackageInfo(pkg).show(gs));
+                writer.String(pkg.owner.show(gs));
             }
 
         } else {


### PR DESCRIPTION
We don't have to go get the whole PackageInfo just to get the package's
name anymore.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.