### PR TITLE
Skip unsetting test scope in test packages

### DIFF
--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -191,10 +191,11 @@ class PropagateVisibility final {
         auto nonTestScope = getScopeForPackage(gs, parts, core::Symbols::root());
         auto testNamespace = core::Symbols::root().data(gs)->findMember(gs, core::packages::PackageDB::TEST_NAMESPACE);
         core::ClassOrModuleRef testScope;
-        if (testNamespace.exists() && testNamespace.isClassOrModule()) {
+        if (!gs.packageDB().testPackages() && testNamespace.exists() && testNamespace.isClassOrModule()) {
             testScope = getScopeForPackage(gs, parts, testNamespace.asClassOrModuleRef());
         }
 
+        // TODO(trevor): we can remove the returned test scope after switching to test packages.
         return {nonTestScope, testScope};
     }
 


### PR DESCRIPTION
Skip unsetting the export flag on the `Test` namespace that would be associated with a package, if `--experimental-test-packages` is enabled.

### Motivation
Test packages.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
