### PR TITLE
Fix crash in `.case` completion

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -394,6 +394,7 @@ pipeline_tests(
             "testdata/lsp/completion/missing_const_name.rb",
             "testdata/lsp/completion/self_receiver.rb",
             "testdata/lsp/completion/enum_case.rb",
+            "testdata/lsp/completion/enum_case_crash.rb",
             "testdata/lsp/duplicate_kwarg.rb",
             "testdata/namer/fuzz_repeated_kwarg.rb",
             "testdata/deviations/keyword_method_names.rb",

--- a/test/testdata/lsp/completion/enum_case_crash.rb
+++ b/test/testdata/lsp/completion/enum_case_crash.rb
@@ -1,0 +1,13 @@
+# typed: true
+
+class MyEnum < T::Enum
+  enums do
+    X = new
+    Y = new
+  end
+end
+
+def example
+  MyEnum::X.
+  #         ^ completion: serialize, ...
+end # error: unexpected token "end"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Given `MyEnum::X.`, the singleton will not be the `T.class_of(MyEnum)` but rather
`T.class_of(MyEnum::X)`, which will not have a `sealed_subclasses` method on it.

If we don't have a `sealed_subclasses` method directly on our singleton class, then it
doesn't make sense to show a `.case` completion.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.