### PR TITLE
Log whether a given fast path run ran the incremental namer or was a preemption

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -331,8 +331,10 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
     } else {
         files = "...";
     }
-    config->logger->debug("Running fast path over num_files={} incrementalNamer={} duration={} files=[{}]",
-                          toTypecheck.size(), shouldRunIncrementalNamer, duration.usec, files);
+    auto isPreemption = gs->epochManager->getStatus().slowPathRunning;
+    config->logger->debug(
+        "Running fast path over num_files={} incrementalNamer={} preemption={} duration={} files=[{}]",
+        toTypecheck.size(), shouldRunIncrementalNamer, isPreemption, duration.usec, files);
 
     return toTypecheck;
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Make it easier to debug why certain fast path runs take so long.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Manual testing:
- Trigged a slow path run, and then after the status was "Typechecking in Background", made an edit that would take the fast path (but not cancel the slow path in combination), and checked that the log line showed `preemption=true`
- Made a change to a method signature and checked that the log line showed `incrementalNamer=true`