### PR TITLE
Bump toolchain to pull in sorbet/bazel-toolchain#11

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -202,9 +202,9 @@ def register_sorbet_dependencies():
     # )
     http_archive(
         name = "toolchains_llvm",
-        url = "https://github.com/sorbet/bazel-toolchain/archive/84b8f4c73584dd8d174cbe8c942a774df8e0d731.tar.gz",
-        sha256 = "fb4e2de5b54793e561dccad3afa5748ab1c8f49f9c9d4cfdad9fbd4c4c5a51b6",
-        strip_prefix = "bazel-toolchain-84b8f4c73584dd8d174cbe8c942a774df8e0d731",
+        url = "https://github.com/sorbet/bazel-toolchain/archive/b9c2f11092c90377d4bfc64c406766573545af47.tar.gz",
+        sha256 = "723ebe8994d754acb3ef81a271ad645a0a3ee4a8680f0499b3c24f537b16cfcc",
+        strip_prefix = "bazel-toolchain-b9c2f11092c90377d4bfc64c406766573545af47",
     )
 
     http_archive(


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

<https://github.com/sorbet/bazel-toolchain/pull/11>

I had accidentally made the bump in Sorbet against a not-yet-merged PR
in the sorbet/bazel-toolchain repo, so it got accidentally reverted when
we made other bazel toolchain changes recently. See #9873.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a