### PR TITLE
Show stdlib RBI location in superclass redefinition errors

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -787,6 +787,7 @@ private:
                                 e.setHeader("Parent of class `{}` redefined from `{}` to `{}`", job.klass.show(ctx),
                                             job.klass.data(ctx)->superClass().show(ctx), resolvedClass.show(ctx));
                                 if (!fileIsPayload && klassDefinedInPayload) {
+                                    e.addErrorLine(job.klass.data(ctx)->loc(), "Originally defined here");
                                     e.addErrorNote(
                                         "Pass `{}` at the command line or in the `{}` file to silence this error.\n"
                                         "    Only use this to work around Ruby or gem upgrade incompatibilities.",


### PR DESCRIPTION
Error 5012 (RedefinitionOfParents) now includes a secondary error line pointing to the original class definition location, making it easier to understand where the conflict originates.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Before:
```
lib/tapioca.rb:7: Parent of class RDoc::Markup::BlankLine redefined from RDoc::Markup::Element to RDoc::Markup https://srb.help/5012
     7 |class RDoc::Markup::BlankLine < ::RDoc::Markup
                                        ^^^^^^^^^^^^^^
  Note:
    Pass --suppress-payload-superclass-redefinition-for=RDoc::Markup::BlankLine at the command line or in the sorbet/config file to silence this error.
    Only use this to work around Ruby or gem upgrade incompatibilities.
Errors: 1
```

After

```
lib/tapioca.rb:7: Parent of class RDoc::Markup::BlankLine redefined from RDoc::Markup::Element to RDoc::Markup https://srb.help/5012
     7 |class RDoc::Markup::BlankLine < ::RDoc::Markup
                                        ^^^^^^^^^^^^^^
    https://github.com/sorbet/sorbet/tree/ddf8d6ea25b234a2c80c37adbdc4792a1bb60f02/rbi/stdlib/rdoc.rbi#L4378: Originally defined here
    4378 |class RDoc::Markup::BlankLine < ::RDoc::Markup::Element
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  Note:
    Pass --suppress-payload-superclass-redefinition-for=RDoc::Markup::BlankLine at the command line or in the sorbet/config file to silence this error.
    Only use this to work around Ruby or gem upgrade incompatibilities.
Errors: 1
```

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
I think with this change it'll be clearer to the user that Sorbet ships with RBI files. In some cases they could see that the RBI is outdated and open a PR to update them.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I couldn't find any expectations for the message content.
