### PR TITLE
Rename skipTypeMemberNames → shapeHash

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -2326,7 +2326,7 @@ ClassOrModuleRef SymbolRef::enclosingClass(const GlobalState &gs) const {
     return result;
 }
 
-uint32_t ClassOrModule::hash(const GlobalState &gs, bool skipTypeMemberNames) const {
+uint32_t ClassOrModule::hash(const GlobalState &gs, bool shapeHash) const {
     uint32_t result = _hash(name.shortName(gs));
 
     // Bit of a hack to ensure that the isBehaviorDefining flag is not serialized.
@@ -2375,7 +2375,7 @@ uint32_t ClassOrModule::hash(const GlobalState &gs, bool skipTypeMemberNames) co
                 }
             }
 
-            if (skipTypeMemberNames && e.second.isTypeMember()) {
+            if (shapeHash && e.second.isTypeMember()) {
                 // skipTypeMemberNames is currently the difference between `hash` and `classOrModuleShapeHash`
                 // (It felt wasteful to dupe this whole method.) Type member names have to be in the
                 // full hash so that a change to a type member name causes the right downstream

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -430,10 +430,10 @@ public:
     void addLoc(const core::GlobalState &gs, core::Loc loc);
     void removeLocsForFile(core::FileRef file);
 
-    uint32_t hash(const GlobalState &gs, bool includeTypeMemberNames) const;
+    uint32_t hash(const GlobalState &gs, bool shapeHash) const;
     uint32_t classOrModuleShapeHash(const GlobalState &gs) const {
-        auto skipTypeMemberNames = true;
-        return hash(gs, skipTypeMemberNames);
+        auto shapeHash = true;
+        return hash(gs, shapeHash);
     }
 
     std::vector<TypePtr> selfTypeArgs(const GlobalState &gs) const;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Note that the name was actually wrong for `ClassOrModule::hash` in the
header file, it was "skip" when the meaning of it was "include".

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests