### PR TITLE
"Attempt to" → "Attempting to"

### DIFF
--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -353,7 +353,7 @@ BasicBlock *CFGBuilder::handleSpecialMethods(CFGContext cctx, BasicBlock *curren
             if (method_new.data(cctx.ctx)->owner == core::Symbols::Class()) {
                 if (auto e = cctx.ctx.beginError(s.loc, core::errors::CFG::AbstractClassInstantiated)) {
                     auto symbolName = id->symbol().show(cctx.ctx);
-                    e.setHeader("Attempt to instantiate abstract class `{}`", symbolName);
+                    e.setHeader("Attempting to instantiate abstract class `{}`", symbolName);
                     e.addErrorLine(id->symbol().loc(cctx.ctx), "`{}` defined here", symbolName);
                 }
             }

--- a/test/testdata/resolver/abstract_initialization.rb
+++ b/test/testdata/resolver/abstract_initialization.rb
@@ -9,7 +9,7 @@ class Abstract
   def foo; end
 end
 
-Abstract.new # error: Attempt to instantiate abstract class `Abstract`
+Abstract.new # error: Attempting to instantiate abstract class `Abstract`
 
 class SubclassOfAbstract < Abstract
   def foo; end

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -3049,7 +3049,7 @@ class Abstract
   def foo; end
 end
 
-Abstract.new # error: Attempt to instantiate abstract class `Abstract`
+Abstract.new # error: Attempting to instantiate abstract class `Abstract`
 ```
 
 To fix this error, there are some options:


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I haven't collected data on this, and this is guidance I've never
given as feedback on a pull request before, but I feel like most of our
error messages use an `-ing` or `-ed` to start the error message
("Malformed ...", "Unsupported ...", "Reassigning ...", etc.)

In any case, "Attempt to" in an error message almost sounds like to fix
the error you need to attempt the thing mentioned, not that the error
arises from you having already attempted to.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.