### PR TITLE
 In `--gen-packages` mode, don't report a visibility error if we're adding a `visible_to` that will silence that error

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -1039,7 +1039,9 @@ void validateVisibility(core::Context ctx, const PackageInfo &absPkg, const Impo
     auto &otherPkg = ctx.state.packageDB().getPackageInfo(i.mangledName);
     ENFORCE(otherPkg.exists());
 
-    if (!otherPkg.isVisibleTo(ctx, absPkg, i.type)) {
+    // We should only report a visibility error if we're not going to add a visible_to to the package
+    // Otherwise the error is pointless since it'll go away after the new visible_to is added
+    if (!otherPkg.isVisibleTo(ctx, absPkg, i.type) && !ctx.state.packageDB().updateVisibilityFor(i.mangledName)) {
         if (auto e = ctx.beginError(i.loc, core::errors::Packager::ImportNotVisible)) {
             e.setHeader("Package `{}` includes explicit visibility modifiers and cannot be imported from `{}`",
                         otherPkg.show(ctx), absPkg.show(ctx));

--- a/test/cli/package-gen-packages/test.out
+++ b/test/cli/package-gen-packages/test.out
@@ -47,12 +47,6 @@ C/__package.rb:3: `C` is missing imports https://srb.help/3734
      8 |  import D
                   ^
 
-D/__package.rb:7: Package `B` includes explicit visibility modifiers and cannot be imported from `D` https://srb.help/3723
-     7 |  import B
-          ^^^^^^^^
-  Note:
-    Please consult with the owning team before adding a `visible_to` line to the package `B`
-
 D/__package.rb:3: `D` is missing exports https://srb.help/3734
      3 |class D < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
@@ -80,7 +74,7 @@ C/app.rb:9: Package `G` includes explicit visibility modifiers and cannot be imp
                    ^^^^^^^^^^^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
-Errors: 9
+Errors: 8
 # typed: strict
 
 class B < PackageSpec
@@ -147,12 +141,6 @@ C/__package.rb:3: `C` is missing imports https://srb.help/3734
      8 |  import D
                   ^
 
-D/__package.rb:7: Package `B` includes explicit visibility modifiers and cannot be imported from `D` https://srb.help/3723
-     7 |  import B
-          ^^^^^^^^
-  Note:
-    Please consult with the owning team before adding a `visible_to` line to the package `B`
-
 D/__package.rb:3: `D` is missing exports https://srb.help/3734
      3 |class D < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
@@ -193,7 +181,7 @@ C/app.rb:9: Package `G` includes explicit visibility modifiers and cannot be imp
                    ^^^^^^^^^^^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
-Errors: 8
+Errors: 7
 # typed: strict
 
 class B < PackageSpec


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Reduce noise. In this test, we're adding `visible_to D` to `B`'s `__package.rb`, so the `Package B includes explicit visibility modifiers and cannot be imported from D` error isn't useful, since it'll disappear after the `visible_to` is added.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
