### PR TITLE
prework: Massage pipeline_test_runner.cc

### DIFF
--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -702,8 +702,6 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     handler.addObserved(*gs, "symbol-table", [&]() { return gs->toString(); });
     handler.addObserved(*gs, "symbol-table-raw", [&]() { return gs->showRaw(); });
 
-    handler.checkExpectations();
-
     if (!test.minimizeRBI.empty()) {
         auto gsForMinimize = emptyGs->deepCopyGlobalState();
         auto opts = realmain::options::Options{};
@@ -720,6 +718,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         handler.addObserved(
             *gs, "minimized-rbi", [&]() { return printerConfig.flushToString(); }, addNewline);
     }
+
+    handler.checkExpectations();
 
     // Check warnings and errors
     {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Working towards shuffling around the pipeline test runner in service of making
it run package directed.

These changes should be no-ops, and I want to land them on their own

Review by commit.


- **no-op: index later, to match realmain** (62102e0dcc)


- **Sink the minimizeRBI logic further down** (a9fef66392)

  Its new location is better for the soon-to-be state where resolving and
  inference are interleaved.

- **Delete these assertions** (649d81c95a)

  I have literally never seen these fire, and I find it hard to believe
  that anyone on our team would ever review a change that made it possible
  for these to fire.

  Given that we're going to be interleaving mutable and immutable phases
  in package-directed mode, these assertions won't be possible to preserve
  in their current form.

  Given that they're not useful and preserving their behavior in the face
  of future changes would be annoying, let's just drop them.

- **Compute symbol-table.exp after everything** (15ef64ea2a)


- **fixup: minimizeRBI needs to be before checkExpectations** (ff8016558b)




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I verified that if I edited a `minimized-rbi.exp` file and a `symbol-table.exp`
file, that running the corresponding PosTest locally resulted in a test failure.