### PR TITLE
Add a test case for running `--gen-packages` with `--package-directed`

### DIFF
--- a/test/cli/package-gen-packages/A/constants.rb
+++ b/test/cli/package-gen-packages/A/constants.rb
@@ -2,4 +2,5 @@
 
 module A
   CONSTANT_FROM_A = "Hello from Package A"
+  puts G::ANOTHER_CONSTANT_FROM_G
 end

--- a/test/cli/package-gen-packages/G/__package.rb
+++ b/test/cli/package-gen-packages/G/__package.rb
@@ -4,6 +4,8 @@ class G < PackageSpec
   strict_dependencies 'dag'
   layer 'util'
 
+  import B
+
   export G::CONSTANT_FROM_G
 
   visible_to A

--- a/test/cli/package-gen-packages/G/constants.rb
+++ b/test/cli/package-gen-packages/G/constants.rb
@@ -2,4 +2,5 @@
 
 module G
   CONSTANT_FROM_G = "Hello from Package G"
+  ANOTHER_CONSTANT_FROM_G = "Hello from Package G"
 end

--- a/test/cli/package-gen-packages/test.out
+++ b/test/cli/package-gen-packages/test.out
@@ -1,6 +1,22 @@
 --gen-packages can only be can only be used in --sorbet-packages mode
 --gen-packages can not be used when --lsp is also enabled
 ------- Non package directed -------
+A/__package.rb:3: `A` is missing imports https://srb.help/3734
+     3 |class A < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    A/__package.rb:5: Inserted `import G`
+     5 |  layer 'app'
+                     ^
+
+G/__package.rb:3: `G` is missing exports https://srb.help/3734
+     3 |class G < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    G/__package.rb:8: Inserted `export G::ANOTHER_CONSTANT_FROM_G`
+     8 |
+        ^
+
 B/__package.rb:3: `B` is missing `visible_to`s https://srb.help/3734
      3 |class B < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
@@ -64,7 +80,7 @@ C/app.rb:9: Package `G` includes explicit visibility modifiers and cannot be imp
                    ^^^^^^^^^^^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
-Errors: 7
+Errors: 9
 # typed: strict
 
 class B < PackageSpec
@@ -147,6 +163,19 @@ D/__package.rb:3: `D` is missing exports https://srb.help/3734
      7 |  import B
                   ^
 
+A/constants.rb:5: Unable to resolve constant `G` https://srb.help/5002
+     5 |  puts G::ANOTHER_CONSTANT_FROM_G
+               ^
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#L16: `T` defined here
+    16 |module T
+        ^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/gc.rbi#L12: `GC` defined here
+    12 |module GC
+        ^^^^^^^^^
+    A/constants.rb:3: `A` defined here
+     3 |module A
+        ^^^^^^^^
+
 C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
      8 |      puts F::CONSTANT_FROM_F
                    ^^^^^^^^^^^^^^^^^^
@@ -164,7 +193,7 @@ C/app.rb:9: Package `G` includes explicit visibility modifiers and cannot be imp
                    ^^^^^^^^^^^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
-Errors: 7
+Errors: 8
 # typed: strict
 
 class B < PackageSpec

--- a/test/cli/package-gen-packages/test.sh
+++ b/test/cli/package-gen-packages/test.sh
@@ -17,7 +17,7 @@ cd "$tmp" || exit 1
 
 echo "------- Non package directed -------"
 
-"$cwd/main/sorbet" --max-threads=0 --silence-dev-message --sorbet-packages --gen-packages --packager-layers=util,app  --gen-packages-update-visibility-for=B -a . 2>&1
+"$cwd/main/sorbet" --did-you-mean=false --max-threads=0 --silence-dev-message --sorbet-packages --gen-packages --packager-layers=util,app  --gen-packages-update-visibility-for=B -a . 2>&1
 
 cat B/__package.rb
 
@@ -37,7 +37,7 @@ cd "$tmp" || exit 1
 
 echo "------- Package directed -------"
 
-"$cwd/main/sorbet" --max-threads=0 --silence-dev-message --sorbet-packages --experimental-package-directed --gen-packages --packager-layers=util,app  --gen-packages-update-visibility-for=B -a . 2>&1
+"$cwd/main/sorbet" --max-threads=0 --did-you-mean=false --silence-dev-message --sorbet-packages --experimental-package-directed --gen-packages --packager-layers=util,app  --gen-packages-update-visibility-for=B -a . 2>&1
 
 cat B/__package.rb
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Review commit-by-commit.

The first commit simply adds another invocation of the `--gen-packages` mode with `--package-directed` on. As the diff shows, the output is identical.

The second commit adds a case where the behaviour with `--package-directed` and without it differ.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Add tests for the intersection of the 2 so that we can eventually run `--gen-packages` with `--package-directed` enabled.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
