### PR TITLE
Push updateSymbolTableOffsets() into pipeline

### DIFF
--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -675,10 +675,6 @@ int realmain(int argc, char *argv[]) {
                     }
                 }
             }
-
-            // Update offsets for the next stratum. We do this at the end of the loop to ensure that the first
-            // iteration of the loop includes all of the payload symbols.
-            gs->updateSymbolTableOffsets();
         }
 
         if (opts.genPackages) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -4119,6 +4119,20 @@ ast::ParsedFilesOrCancelled Resolver::run(core::GlobalState &gs, vector<ast::Par
         return ast::ParsedFilesOrCancelled::cancel(move(trees), workers);
     }
 
+    // TODO(jez) Ideally, we would be able to mark the symbol table frozen and call updateSymbolTableOffsets() here.
+    //
+    // `symbolTableFrozen` is only checked when entering/deleting symbols (not any other mutable
+    // symbol table operations.) updateSymbolTableOffsets makes GlobalState remember the new count
+    // of all symbol kinds. Since we're not going to call `finalizeAncestors`/`finalizeSymbols`
+    // again for this strata, we need it to be the case that we don't introduce new symbols which
+    // would need to be finalized.
+    //
+    // That is not true today: both `ResolveTypeMembersAndFieldsWalk::run` and `resolveSigs` enter
+    // symbols (method overloads, type parameters, and method aliases at time of writing). Today it
+    // just so happens that those symbol kinds are not the symbols that we care about in
+    // `finalizeAncestors` / `finalizeSymbols`. But it would be ideal to be able to ENFORCE (via
+    // gs.freezeSymbolTable()) that no errant symbols are entered via those (and future) phases.
+
     auto rtmafResult = ResolveTypeMembersAndFieldsWalk::run(gs, std::move(trees), workers, computeAllSymbols);
     if (epochManager.wasTypecheckingCanceled()) {
         return ast::ParsedFilesOrCancelled::cancel(move(rtmafResult.trees), workers);
@@ -4127,6 +4141,9 @@ ast::ParsedFilesOrCancelled Resolver::run(core::GlobalState &gs, vector<ast::Par
     auto result = resolveSigs(gs, std::move(rtmafResult.trees), workers);
     ResolveTypeMembersAndFieldsWalk::resolvePendingCastItems(gs, rtmafResult.todoResolveCastItems);
     sanityCheck(gs, result);
+
+    // Update offsets for the next stratum.
+    gs.updateSymbolTableOffsets();
 
     return result;
 }


### PR DESCRIPTION
Ideally, realmain just schedules parts of the pipeline. Clients should
ideally just be able to do

    pipeline::index
    pipeline::resolve
    pipeline::typecheck

and have recreated everything from realmain. Of course, we've strayed
from that over time, but any logic that is not captured in one of those
calls then needs to be duplicately maintained (e.g., in LSPTypechecker,
pipeline_test_runner, etc.)

Pushing this updateSymbolTableOffsets makes for one less thing clients
have to care about cargo culting correctly.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Makes it easier to implement package-directed pipeline_test_runner.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests