### PR TITLE
Prism/case node locations [3/6]

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -1822,6 +1822,20 @@ ast::ExpressionPtr Translator::desugar(pm_node_t *node) {
             }
 
             auto elseClause = desugarNullable(up_cast(caseNode->else_clause));
+            // Capture the start of the line containing the `else` keyword (or `end` if no else clause).
+            // Whitequark extends empty when bodies to the start of the next line (column 1), not to the
+            // `else`/`end` keyword itself. We find the start of the line by scanning backwards for a newline.
+            core::LocOffsets clauseLoc;
+            if (caseNode->else_clause != nullptr) {
+                clauseLoc = translateLoc(caseNode->else_clause->base.location);
+            } else {
+                // No else clause - use the `end` keyword location as the fallback
+                clauseLoc = translateLoc(caseNode->end_keyword_loc);
+            }
+
+            auto detail = core::Loc::pos2Detail(ctx.file.data(ctx), clauseLoc.beginPos());
+            auto lineStart = core::Loc::detail2Pos(ctx.file.data(ctx), {detail.line, 1}).value();
+            core::LocOffsets nextClauseStartLoc = core::LocOffsets{lineStart, clauseLoc.endPos()};
 
             if (preserveConcreteSyntax) {
                 auto locZeroLen = location.copyWithZeroLength();
@@ -1859,7 +1873,9 @@ ast::ExpressionPtr Translator::desugar(pm_node_t *node) {
 
             core::NameRef tempName;
             core::LocOffsets predicateLoc;
-            bool hasPredicate = (predicate != nullptr);
+            // Check if the prism node has a predicate, not the desugared result,
+            // because desugarNullable returns EmptyTree (not nullptr) for null nodes.
+            bool hasPredicate = (caseNode->predicate != nullptr);
 
             if (hasPredicate) {
                 predicateLoc = predicate.loc();
@@ -1871,6 +1887,9 @@ ast::ExpressionPtr Translator::desugar(pm_node_t *node) {
             // The if/else ladder for the entire case statement, starting with the else clause as the final `else` when
             // building backwards
             ExpressionPtr resultExpr = move(elseClause);
+            // Track the location of the next clause (else, end, or when) for extending empty when bodies.
+            // Initially this is the else/end clause location; after each iteration it becomes the If location.
+            core::LocOffsets nextClauseLoc = nextClauseStartLoc;
 
             // Iterate over Prism when nodes in reverse to build the if/else ladder backwards
             for (auto it = prismWhenNodes.rbegin(); it != prismWhenNodes.rend(); ++it) {
@@ -1916,7 +1935,22 @@ ast::ExpressionPtr Translator::desugar(pm_node_t *node) {
                 }
 
                 auto then = desugarStatements(prismWhen->statements);
-                resultExpr = MK::If(whenLoc, move(patternsResult), move(then), move(resultExpr));
+                // Whitequark extends the when clause location to include the start of the next line,
+                // but ONLY when the when body is empty. Use the start of nextClauseLoc as the end.
+                auto ifLoc = whenLoc;
+                bool bodyIsEmpty = (then == nullptr || ast::isa_tree<ast::EmptyTree>(then));
+                if (bodyIsEmpty && nextClauseLoc.exists()) {
+                    ifLoc = core::LocOffsets{whenLoc.beginPos(), nextClauseLoc.beginPos()};
+                }
+                resultExpr = MK::If(ifLoc, move(patternsResult), move(then), move(resultExpr));
+                // Update nextClauseLoc to be the start of this when clause's LINE for the next iteration.
+                // This ensures empty when bodies extend to column 1, not to the indented clause start.
+                auto source = ctx.file.data(ctx).source();
+                uint32_t lineStart = whenLoc.beginPos();
+                while (lineStart > 0 && source[lineStart - 1] != '\n') {
+                    lineStart--;
+                }
+                nextClauseLoc = core::LocOffsets{lineStart, whenLoc.endPos()};
             }
 
             if (hasPredicate) {

--- a/test/BUILD
+++ b/test/BUILD
@@ -436,8 +436,6 @@ pipeline_tests(
             "testdata/infer/missing_method_name.rb",
             "testdata/infer/no_when_t_forwarder.rb",
             "testdata/infer/or_and_conditional_branch.rb",
-            "testdata/infer/singleton_case_exhaustiveness.rb",
-            "testdata/infer/singleton_enum_case.rb",
             "testdata/infer/t_class_any.rb",
             "testdata/infer/t_proc_metatype.rb",
             "testdata/lsp/code_actions/extract_variable_multiple/case.rb",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

- Part of #9065 
- Part 3 of 6 in stack. [Diff from Part 2](https://github.com/Shopify/sorbet/compare/prism/refactor-desugar-mlhs...prism/case-node-locations)

This change fixes the location tracking for empty when clause bodies in case statements to match Whitequark's behavior. When a when clause has an empty body, the location is now extended to the start of the next line (column 1) rather than just to the next keyword.

The Prism translator was not correctly handling location offsets for empty when clause bodies in case statements. Whitequark extends empty when bodies to the start of the next line, but the previous implementation was not replicating this behavior, leading to inconsistent location reporting between parsers.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Removed test exclusions.