### PR TITLE
Prism/misc location alignment [5/6]

### DIFF
--- a/parser/prism/Translator.cc
+++ b/parser/prism/Translator.cc
@@ -335,10 +335,17 @@ void Translator::flattenKwargs(pm_keyword_hash_node *kwargsHashNode, Container &
         if (PM_NODE_TYPE_P(assoc->key, PM_SYMBOL_NODE)) {
             auto *symbolNode = down_cast<pm_symbol_node>(assoc->key);
 
-            // If opening_loc is null, the symbol has a trailing colon - drop it from the location
+            // If opening_loc is null, the symbol has a trailing colon syntax (e.g., `k5:` not `:k5 =>`)
             if (symbolNode->opening_loc.start == nullptr) {
-                auto symbolLoc = translateLoc(symbolNode->base.location.start, symbolNode->base.location.end - 1);
                 auto [symbolContent, _] = translateSymbol(symbolNode);
+
+                // For shorthand kwargs like `foo(k5:)` where the value is implicit, keep the colon in the location
+                // to match Whitequark behavior. For regular kwargs like `foo(k5: v)`, drop the colon.
+                bool isImplicitValue = PM_NODE_TYPE_P(assoc->value, PM_IMPLICIT_NODE);
+                auto symbolLoc = isImplicitValue
+                                     ? translateLoc(symbolNode->base.location)
+                                     : translateLoc(symbolNode->base.location.start, symbolNode->base.location.end - 1);
+
                 destination.emplace_back(MK::Symbol(symbolLoc, symbolContent));
                 destination.emplace_back(desugar(assoc->value));
                 continue;
@@ -4080,7 +4087,8 @@ ast::ExpressionPtr Translator::desugarMethodCall(ast::ExpressionPtr receiver, co
         sendLoc = sendWithBlockLoc;
     }
 
-    auto sendLoc0 = sendLoc.copyWithZeroLength();
+    // Zero-length location at START of full expression (matches Whitequark's locZeroLen)
+    auto sendLoc0 = sendWithBlockLoc.copyWithZeroLength();
 
     if (methodName == core::Names::squareBrackets() || methodName == core::Names::squareBracketsEq()) {
         // Empty funLoc implies that errors should use the callLoc
@@ -4844,7 +4852,9 @@ ast::ExpressionPtr Translator::desugarStatements(pm_statements_node *stmtsNode, 
         auto prismStatements = absl::MakeSpan(stmtsNode->body.nodes, stmtsNode->body.size);
 
         // Cover the locations spanned from the first to the last statements.
-        beginNodeLoc = translateLoc(prismStatements.front()->location.start, prismStatements.back()->location.end);
+        // This can be different from the `stmtsNode->base.location`,
+        // because of the special case (handled by `startLoc()` and `endLoc()`).
+        beginNodeLoc = translateLoc(startLoc(prismStatements.front()), endLoc(prismStatements.back()));
     }
 
     auto statements = nodeListToStore<ast::InsSeq::STATS_store>(stmtsNode->body);

--- a/test/BUILD
+++ b/test/BUILD
@@ -432,7 +432,6 @@ pipeline_tests(
             "testdata/infer/generics/option.rb",
             "testdata/infer/heredoc_loc.rb",
             "testdata/infer/isa_bug.rb",
-            "testdata/infer/kwsplat_nil.rb",
             "testdata/infer/missing_method_name.rb",
             "testdata/infer/no_when_t_forwarder.rb",
             "testdata/infer/or_and_conditional_branch.rb",
@@ -627,7 +626,6 @@ pipeline_tests(
 
             # Prism desugared tree doesn't match legacy desugared tree (desugar differences)
             "prism_regression/assign_to_index.rb",
-            "prism_regression/call_implicit_kw_args.rb",
             "prism_regression/literal_hash.rb",
             "prism_regression/multi_target.rb",
             "prism_regression/call_block_param.rb",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

- Part of #9065 
- Depends on https://github.com/sorbet/sorbet/pull/9945

This change improves location handling in the Prism parser translator to better match Whitequark parser in the construction of desugar trees behavior in three specific areas:

Keyword argument symbols: For shorthand kwargs like foo(k5:) where the value is implicit, the colon is now included in the symbol location. For regular kwargs like foo(k5: v), the colon is still excluded from the location.

Method call expressions: Zero-length locations now consistently point to the start of the full expression (including any block) rather than just the method call portion.

Statement blocks: Location calculation now uses helper functions startLoc() and endLoc() to handle special cases when determining the span from first to last statement.

The Prism parser translator needs to generate desugared node locations that match the existing Whitequark parser behavior to maintain compatibility and consistency across the codebase.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Removed test exlcusions.