### PR TITLE
Don't unfreeze for incremental fast path

### DIFF
--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -815,12 +815,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         handler.addObserved(*gs, "rbs-rewrite-tree", [&]() { return nodes->toString(*gs); });
 
         // Desugarer
-        ast::ExpressionPtr ast;
-        {
-            core::UnfreezeNameTable nameTableAccess(ctx); // enters original strings
-            ast = usePrismDesugar ? ast::prismDesugar::node2Tree(ctx, move(nodes))
-                                  : ast::desugar::node2Tree(ctx, move(nodes));
-        }
+        auto ast = usePrismDesugar ? ast::prismDesugar::node2Tree(ctx, move(nodes))
+                                   : ast::desugar::node2Tree(ctx, move(nodes));
 
         ast::ParsedFile file = testSerialize(*gs, ast::ParsedFile{move(ast), f.file});
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The file hasn't changed, so if there are names that need entered still,
it means that something weird is going on, as in: we didn't parse it
correctly the first time.

This unfreeze was added in error in the original changes to retrofit prism
parsing into the `pipeline_test_runner.cc` in #9131. Before that PR, it was
intentional that this phase of the test runner did not re-open the name table
for new additions.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

test-only change