### PR TITLE
Fix RBIs for `private`/`protected`/`public` and `module_function`

### DIFF
--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -1292,13 +1292,11 @@ class Module < Object
   # Mod.one     #=> "This is one"
   # c.call_one  #=> "This is the new one"
   # ```
-  sig do
-    params(
-        arg0: T.any(Symbol, String),
-    )
-    .returns(T.self_type)
-  end
-  def module_function(*arg0); end
+  sig { returns(NilClass) }
+  sig { params(arg0: Symbol).returns(Symbol) }
+  sig { params(arg0: String).returns(String) }
+  sig { params(arg0: T.any(Symbol, String), rest: T.any(Symbol, String)).returns(T::Array[T.any(Symbol, String)]) }
+  def module_function(arg0=T.unsafe(nil), *rest); end
 
   # Returns the name of the module *mod*. Returns nil for anonymous modules.
   sig {returns(T.nilable(String))}
@@ -1373,13 +1371,11 @@ class Module < Object
   #
   # Note that to show a private method on
   # [`RDoc`](https://docs.ruby-lang.org/en/2.7.0/RDoc.html), use `:doc:`.
-  sig do
-    params(
-        arg0: T.any(Symbol, String),
-    )
-    .returns(T.self_type)
-  end
-  def private(*arg0); end
+  sig { returns(NilClass) }
+  sig { params(method_name: Symbol).returns(Symbol) }
+  sig { params(method_name: String).returns(String) }
+  sig { params(method_name: T.any(Symbol, String), rest: T.any(Symbol, String)).returns(T::Array[T.any(Symbol, String)]) }
+  def private(method_name=T.unsafe(nil), *rest); end
 
   # Makes existing class methods private. Often used to hide the default
   # constructor `new`.
@@ -1490,13 +1486,11 @@ class Module < Object
   # To show a private method on
   # [`RDoc`](https://docs.ruby-lang.org/en/2.7.0/RDoc.html), use `:doc:` instead
   # of this.
-  sig do
-    params(
-        arg0: T.any(Symbol, String),
-    )
-    .returns(T.self_type)
-  end
-  def protected(*arg0); end
+  sig { returns(NilClass) }
+  sig { params(method_name: Symbol).returns(Symbol) }
+  sig { params(method_name: String).returns(String) }
+  sig { params(method_name: T.any(Symbol, String), rest: T.any(Symbol, String)).returns(T::Array[T.any(Symbol, String)]) }
+  def protected(method_name=T.unsafe(nil), *rest); end
 
   # Returns a list of the protected instance methods defined in *mod*. If the
   # optional parameter is `false`, the methods of any ancestors are not
@@ -1550,13 +1544,11 @@ class Module < Object
   # Strings is also accepted. If a single argument is passed, it is returned. If
   # no argument is passed, nil is returned. If multiple arguments are passed,
   # the arguments are returned as an array.
-  sig do
-    params(
-        arg0: T.any(Symbol, String),
-    )
-    .returns(T.self_type)
-  end
-  def public(*arg0); end
+  sig { returns(NilClass) }
+  sig { params(method_name: Symbol).returns(Symbol) }
+  sig { params(method_name: String).returns(String) }
+  sig { params(method_name: T.any(Symbol, String), rest: T.any(Symbol, String)).returns(T::Array[T.any(Symbol, String)]) }
+  def public(method_name=T.unsafe(nil), *rest); end
 
   # Makes a list of existing class methods public.
   #

--- a/test/testdata/infer/self_type.rb.cfg-text.exp
+++ b/test/testdata/infer/self_type.rb.cfg-text.exp
@@ -523,9 +523,9 @@ bb23[firstDead=11](<block-pre-call-temp>$74: Sorbet::Private::Static::Void, <sel
     <cfgAlias>$89: T.class_of(T) = alias <C T>
     <statTemp>$84: T.class_of(B) = <self>: T.class_of(B).extend(<cfgAlias>$87: T.class_of(T::Sig))
     <statTemp>$94: Symbol(:takes_self_private) = :takes_self_private
-    <statTemp>$92: T.class_of(B) = <self>: T.class_of(B).private(<statTemp>$94: Symbol(:takes_self_private))
+    <statTemp>$92: Symbol = <self>: T.class_of(B).private(<statTemp>$94: Symbol(:takes_self_private))
     <statTemp>$98: Symbol(:takes_self_or_integer) = :takes_self_or_integer
-    <statTemp>$96: T.class_of(B) = <self>: T.class_of(B).private(<statTemp>$98: Symbol(:takes_self_or_integer))
+    <statTemp>$96: Symbol = <self>: T.class_of(B).private(<statTemp>$98: Symbol(:takes_self_or_integer))
     <returnMethodTemp>$2: Symbol(:==) = :==
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:==)
     <unconditional> -> bb1

--- a/test/testdata/namer/module_function.rb.cfg-text.exp
+++ b/test/testdata/namer/module_function.rb.cfg-text.exp
@@ -157,11 +157,11 @@ bb19[firstDead=13](<block-pre-call-temp>$57: Sorbet::Private::Static::Void, <sel
     <cfgAlias>$73: T.class_of(T) = alias <C T>
     <statTemp>$68: T.class_of(Funcs) = <self>: T.class_of(Funcs).extend(<cfgAlias>$71: T.class_of(T::Sig))
     <statTemp>$77: Symbol(:f) = :f
-    <statTemp>$75: T.class_of(Funcs) = <self>: T.class_of(Funcs).private(<statTemp>$77: Symbol(:f))
+    <statTemp>$75: Symbol = <self>: T.class_of(Funcs).private(<statTemp>$77: Symbol(:f))
     <statTemp>$81: Symbol(:g) = :g
-    <statTemp>$79: T.class_of(Funcs) = <self>: T.class_of(Funcs).private(<statTemp>$81: Symbol(:g))
+    <statTemp>$79: Symbol = <self>: T.class_of(Funcs).private(<statTemp>$81: Symbol(:g))
     <statTemp>$85: Symbol(:h) = :h
-    <statTemp>$83: T.class_of(Funcs) = <self>: T.class_of(Funcs).private(<statTemp>$85: Symbol(:h))
+    <statTemp>$83: Symbol = <self>: T.class_of(Funcs).private(<statTemp>$85: Symbol(:h))
     <returnMethodTemp>$2: Symbol(:h) = :h
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:h)
     <unconditional> -> bb1

--- a/test/testdata/rewriter/private_before_sig.rb
+++ b/test/testdata/rewriter/private_before_sig.rb
@@ -4,6 +4,6 @@ class A
   extend T::Sig
 
   private sig {void}
-  #       ^^^^^^^^^^ error: Expected `T.any(Symbol, String)` but found `NilClass` for argument `arg0`
+  #       ^^^^^^^^^^ error: Expected `Symbol` but found `NilClass` for argument `method_name`
   def foo; end
 end

--- a/test/testdata/rewriter/t_enum_snapshot.rb.cfg-text.exp
+++ b/test/testdata/rewriter/t_enum_snapshot.rb.cfg-text.exp
@@ -71,7 +71,7 @@ bb6[firstDead=-1](<self>: T.class_of(MyEnum), <block-pre-call-temp>$23: Sorbet::
 bb7[firstDead=5](<block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(MyEnum)):
     <statTemp>$21: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$23, enums>
     <self>: T.class_of(MyEnum) = <selfRestore>$24
-    <statTemp>$52: T.class_of(MyEnum) = <self>: T.class_of(MyEnum).public()
+    <statTemp>$52: NilClass = <self>: T.class_of(MyEnum).public()
     <returnMethodTemp>$2: Symbol(:serialize) = :serialize
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:serialize)
     <unconditional> -> bb1
@@ -271,7 +271,7 @@ bb6[firstDead=-1](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$23: Sor
 bb7[firstDead=5](<block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(EnumsDoEnum)):
     <statTemp>$21: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$23, enums>
     <self>: T.class_of(EnumsDoEnum) = <selfRestore>$24
-    <statTemp>$53: T.class_of(EnumsDoEnum) = <self>: T.class_of(EnumsDoEnum).public()
+    <statTemp>$53: NilClass = <self>: T.class_of(EnumsDoEnum).public()
     <returnMethodTemp>$2: Symbol(:serialize) = :serialize
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:serialize)
     <unconditional> -> bb1
@@ -461,7 +461,7 @@ bb7[firstDead=17](<block-pre-call-temp>$32: Sorbet::Private::Static::Void, <self
     keep_for_ide$57: T.untyped = <keep-alive> keep_for_ide$57
     <castTemp>$59: Integer(1) = 1
     <C StaticField4>$56: Integer = cast(<castTemp>$59: Integer(1), Integer);
-    <statTemp>$60: T.class_of(BadConsts) = <self>: T.class_of(BadConsts).public()
+    <statTemp>$60: NilClass = <self>: T.class_of(BadConsts).public()
     <returnMethodTemp>$2: Symbol(:serialize) = :serialize
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:serialize)
     <unconditional> -> bb1


### PR DESCRIPTION
### Motivation

These methods never returned `T.self_type` in the first place. I think this might have come from `Module#public_class_method`/`private_class_method`, which do actually `return self`.

The incorrect return type made it impossible to chain these with other programming modifiers.

### Test plan

Updated existing tests.
