### PR TITLE
[Exploration] Implement `abstract` method in `T::Helpers`

### DIFF
--- a/gems/sorbet-runtime/lib/types/helpers.rb
+++ b/gems/sorbet-runtime/lib/types/helpers.rb
@@ -21,6 +21,11 @@ module T::Helpers
     Private::Abstract::Declare.declare_abstract(self, type: :abstract)
   end
 
+  def abstract(method_name)
+    Private::Methods.declare_abstract(self, method_name)
+    method_name
+  end
+
   def interface!
     Private::Abstract::Declare.declare_abstract(self, type: :interface)
   end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -310,12 +310,28 @@ module T::Private::Methods
     method_sig
   end
 
+  @pending_abstract = false # FIXME: Move this to `T::Private::DeclState.current`
+
   # Executes the `sig` block, and converts the resulting Declaration
   # to a Signature.
   def self.run_sig(hook_mod, method_name, original_method, declaration_block)
     current_declaration =
       begin
-        run_builder(declaration_block)
+        decl = run_builder(declaration_block)
+
+        if decl && @pending_abstract
+          @pending_abstract = false
+          case decl.mode
+          when Modes.standard
+            decl.mode = Modes.abstract
+          when Modes.abstract
+            raise DeclBuilder::BuilderError.new(".abstract cannot be repeated in a single signature")
+          else
+            raise DeclBuilder::BuilderError.new("`.abstract` cannot be combined with `.override` or `.overridable`.")
+          end
+        end
+
+        decl
       rescue DeclBuilder::BuilderError => e
         T::Configuration.sig_builder_error_handler(e, declaration_block.loc)
         nil
@@ -402,12 +418,12 @@ module T::Private::Methods
 
   def self.declare_abstract(mod, method_name)
     key = method_owner_and_name_to_key(mod, method_name)
-    sig = signature_for_key(key)
-
-    sig.make_abstract!
-
-    # Unwrap the method, so it will be rewrapped with an abstract wrapper.
-    unwrap_method(mod, sig, sig.method)
+    @pending_abstract = true
+    begin
+      signature_for_key(key)
+    ensure
+      @pending_abstract = false
+    end
   end
 
   def self.unwrap_method(mod, signature, original_method)

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -400,6 +400,16 @@ module T::Private::Methods
     @signatures_by_method[key]
   end
 
+  def self.declare_abstract(mod, method_name)
+    key = method_owner_and_name_to_key(mod, method_name)
+    sig = signature_for_key(key)
+
+    sig.make_abstract!
+
+    # Unwrap the method, so it will be rewrapped with an abstract wrapper.
+    unwrap_method(mod, sig, sig.method)
+  end
+
   def self.unwrap_method(mod, signature, original_method)
     maybe_wrapped_method = CallValidation.wrap_method_if_needed(mod, signature, original_method)
     @signatures_by_method[method_to_key(maybe_wrapped_method)] = signature

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -157,6 +157,20 @@ class T::Private::Methods::Signature
   attr_writer :method_name
   protected :method_name=
 
+  # Adapted from T::Private::Methods::DeclBuilder#abstract
+  def make_abstract!
+    case mode
+    when T::Private::Methods::Modes.standard
+      @mode = T::Private::Methods::Modes.abstract
+    when T::Private::Methods::Modes.abstract
+      raise T::Private::Methods::DeclBuilder::BuilderError.new(".abstract cannot be repeated in a single signature")
+    else
+      raise T::Private::Methods::DeclBuilder::BuilderError.new("`.abstract` cannot be combined with `.override` or `.overridable`.")
+    end
+
+    nil
+  end
+
   def as_alias(alias_name)
     new_sig = clone
     new_sig.method_name = alias_name

--- a/gems/sorbet-runtime/test/types/abstract_validation.rb
+++ b/gems/sorbet-runtime/test/types/abstract_validation.rb
@@ -18,6 +18,12 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
     def bar; end
 
     sig { returns(Object) }
+    abstract def foo_kw; end
+
+    sig { returns(Object) }
+    abstract def bar_kw; end
+
+    sig { returns(Object) }
     def concrete_standard; end
 
     def concrete_no_signature; end
@@ -33,6 +39,9 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
 
     sig { abstract.returns(Object) }
     def bar; end
+
+    sig { returns(Object) }
+    abstract def bar_kw; end
   end
 
   it "raises an error when defining an abstract class method on a module" do
@@ -61,6 +70,8 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
 
       def foo; end
       def bar; end
+      def foo_kw; end
+      def bar_kw; end
     end
 
     klass = Class.new do
@@ -68,6 +79,8 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
     end
     klass.new.foo
     klass.new.bar
+    klass.new.foo_kw
+    klass.new.bar_kw
   end
 
   it "succeeds when overriding an abstract method with a sig via a mixin" do
@@ -80,6 +93,12 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
 
       sig { returns(Object) }
       def bar; end
+
+      sig { returns(Object) }
+      def foo_kw; end
+
+      sig { returns(Object) }
+      def bar_kw; end
     end
 
     mod = Module.new do
@@ -93,6 +112,8 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
     end
     klass.new.foo
     klass.new.bar
+    klass.new.foo_kw
+    klass.new.bar_kw
   end
 
   it "raises an error when calling an abstract method" do
@@ -116,6 +137,12 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
 
       sig { override.returns(Object) }
       def bar; end
+
+      sig { override.returns(Object) }
+      def foo_kw; end
+
+      sig { override.returns(Object) }
+      def bar_kw; end
     end
 
     klass = Class.new do
@@ -123,6 +150,8 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
     end
     klass.new.foo
     klass.new.bar
+    klass.new.foo_kw
+    klass.new.bar_kw
   end
 
   it "fails if a concrete module doesn't implement abstract methods" do
@@ -138,6 +167,8 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
     assert_includes(err.message, "Missing implementation for abstract instance method(s) in #{mod}")
     assert_includes(err.message, "`foo` declared in #{AbstractMixin}")
     assert_includes(err.message, "`bar` declared in #{AbstractMixin}")
+    assert_includes(err.message, "`foo_kw` declared in #{AbstractMixin}")
+    assert_includes(err.message, "`bar_kw` declared in #{AbstractMixin}")
   end
 
   describe "class methods" do
@@ -152,6 +183,12 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
 
         sig { override.returns(Object) }
         def self.bar; end
+
+        sig { override.returns(Object) }
+        def self.foo_kw; end
+
+        sig { override.returns(Object) }
+        def self.bar_kw; end
       end
 
       T::Private::Abstract::Validate.validate_subclass(mod)
@@ -170,6 +207,8 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
       assert_includes(err.message, "Missing implementation for abstract class method(s) in #{mod.singleton_class}")
       assert_includes(err.message, "`foo` declared in #{AbstractMixin}")
       assert_includes(err.message, "`bar` declared in #{AbstractMixin}")
+      assert_includes(err.message, "`foo_kw` declared in #{AbstractMixin}")
+      assert_includes(err.message, "`bar_kw` declared in #{AbstractMixin}")
     end
   end
 
@@ -183,6 +222,14 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
         def bar
           :bar
         end
+
+        def foo_kw
+          :foo_kw
+        end
+
+        def bar_kw
+          :bar_kw
+        end
       end
 
       klass = Class.new(parent) do
@@ -191,12 +238,16 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
 
       assert_equal(:foo, klass.new.foo)
       assert_equal(:bar, klass.new.bar)
+      assert_equal(:foo_kw, klass.new.foo_kw)
+      assert_equal(:bar_kw, klass.new.bar_kw)
     end
 
     it "succeeds when the method comes from a mixin" do
       mixin = Module.new do
         def foo; end
         def bar; end
+        def foo_kw; end
+        def bar_kw; end
       end
 
       mod = Module.new do
@@ -278,6 +329,8 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
         extend T::Helpers
         abstract!
         def foo; end
+        def foo_kw; end
+        def bar_kw; end
         include AbstractMixin
       end
 
@@ -312,9 +365,13 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
 
         sig { override.returns(Object) }
         def bar; end
+
+        sig { override.returns(Object) }
+        def bar_kw; end
       end
       klass.foo
       klass.new.bar
+      klass.new.bar_kw
     end
 
     it "fails if a class method is unimplemented" do
@@ -323,6 +380,9 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
         extend T::Helpers
         sig { override.returns(Object) }
         def bar; end
+
+        sig { override.returns(Object) }
+        def bar_kw; end
       end
 
       err = assert_raises(RuntimeError) do
@@ -353,6 +413,7 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
         "Missing implementation for abstract instance method(s) in #{klass}"
       )
       assert_includes(err.message, "`bar` declared in #{AbstractClass}")
+      assert_includes(err.message, "`bar_kw` declared in #{AbstractClass}")
     end
 
     it "fails when instantiating the class" do
@@ -377,8 +438,14 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
         def bar
           "baz"
         end
+
+        sig { override.returns(Object) }
+        def bar_kw
+          "baz_kw"
+        end
       end
       assert_equal("baz", klass.new.bar)
+      assert_equal("baz_kw", klass.new.bar_kw)
     end
 
     it 'succeeds with abstract methods from parents' do

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -604,6 +604,18 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     T::Private::Abstract::Validate.validate_abstract_module(klass)
   end
 
+  it 'allows private abstract methods (keyword style)' do
+    klass = Class.new do
+      extend T::Sig
+      extend T::Helpers
+      abstract!
+
+      sig { void }
+      abstract private def foo_kw; end
+    end
+    T::Private::Abstract::Validate.validate_abstract_module(klass)
+  end
+
   it 'allows abstract classes to return instances of other types' do
     mod = Module.new do
       def new(type: self)

--- a/gems/sorbet-runtime/test/types/method_modes.rb
+++ b/gems/sorbet-runtime/test/types/method_modes.rb
@@ -9,6 +9,9 @@ class Opus::Types::Test::MethodModesTest < Critic::Unit::UnitTest
 
     sig { abstract.returns(Object) }
     def foo; end
+
+    sig { returns(Object) }
+    abstract def foo_kw; end
   end
 
   describe "with a super method" do
@@ -83,6 +86,8 @@ class Opus::Types::Test::MethodModesTest < Critic::Unit::UnitTest
         extend T::Helpers
         sig { override.overridable.returns(Object) }
         def foo; end
+        sig { override.overridable.returns(Object) }
+        def foo_kw; end
       end
 
       mod = Module.new do
@@ -91,6 +96,8 @@ class Opus::Types::Test::MethodModesTest < Critic::Unit::UnitTest
         extend T::Helpers
         sig { override.returns(Object) }
         def foo; end
+        sig { override.returns(Object) }
+        def foo_kw; end
       end
 
       klass = Class.new do
@@ -155,6 +162,8 @@ class Opus::Types::Test::MethodModesTest < Critic::Unit::UnitTest
         include AbstractMixin
         sig { returns(Object) }
         def foo; end
+        sig { returns(Object) }
+        def foo_kw; end
       end
 
       err = assert_raises(RuntimeError) do

--- a/gems/sorbet-runtime/test/types/props/_props.rb
+++ b/gems/sorbet-runtime/test/types/props/_props.rb
@@ -478,11 +478,15 @@ class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest
 
         sig { abstract.returns(Integer) }
         private def foo; end
+
+        sig { returns(Integer) }
+        abstract private def foo_kw; end
       end
 
       class B < T::Struct
         include A
         const :foo, Integer, override: true
+        const :foo_kw, Integer, override: true
       end
     end
   end
@@ -498,7 +502,11 @@ class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest
         sig { abstract.returns(Integer) }
         private def foo; end
 
+        sig { returns(Integer) }
+        abstract private def foo_kw; end
+
         const :foo, Integer, override: true
+        const :foo_kw, Integer, override: true
       end
     end
 

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1224,6 +1224,7 @@ module Opus::Types::Test
       interface!
 
       sig { abstract.returns(T.untyped) }; def hello; end
+      sig { returns(T.untyped) }; abstract def hello_kw; end
     end
 
     module TestInterface2
@@ -1232,6 +1233,7 @@ module Opus::Types::Test
       interface!
 
       sig { abstract.returns(T.untyped) }; def goodbye; end
+      sig { returns(T.untyped) }; abstract def goodbye_kw; end
     end
 
     class InterfaceImplementor1
@@ -1241,6 +1243,10 @@ module Opus::Types::Test
         'hello'
       end
 
+      def hello_kw
+        'hello_kw'
+      end
+
     end
 
     class InterfaceImplementor2
@@ -1248,6 +1254,10 @@ module Opus::Types::Test
 
       def goodbye
         'goodbye'
+      end
+
+      def goodbye_kw
+        'goodbye_kw'
       end
 
     end

--- a/gems/sorbet-runtime/test/types/validate_override_shape.rb
+++ b/gems/sorbet-runtime/test/types/validate_override_shape.rb
@@ -11,6 +11,9 @@ module Opus::Types::Test
 
       sig { abstract.returns(Integer) }
       def foo; end
+
+      sig { returns(Integer) }
+      abstract def foo_kw; end
     end
 
     class Base
@@ -25,8 +28,14 @@ module Opus::Types::Test
 
     class AbstractBase
       extend T::Sig
+      extend T::Helpers
+      abstract!
+
       sig { abstract.void }
       def initialize; end
+
+      sig { void }
+      abstract def initialize_kw; end
     end
 
     it "succeeds if the override matches the shape" do
@@ -58,8 +67,14 @@ module Opus::Types::Test
         def foo
           0
         end
+
+        sig { override.returns(Integer) }
+        def foo_kw
+          1
+        end
       end
       assert_equal(0, another.new.foo)
+      assert_equal(1, another.new.foo_kw)
     end
 
     it "succeeds if the override has additional optional args and kwargs" do
@@ -220,6 +235,9 @@ module Opus::Types::Test
         extend T::Sig
         sig { override.void }
         def initialize; super; end
+
+        sig { override.void }
+        def initialize_kw; end
 
         def foo
           0

--- a/gems/sorbet-runtime/test/types/validate_override_shape.rb
+++ b/gems/sorbet-runtime/test/types/validate_override_shape.rb
@@ -59,6 +59,9 @@ module Opus::Types::Test
 
         sig { abstract.returns(Integer) }
         def foo; end
+
+        sig { returns(Integer) }
+        abstract def foo_kw; end
       end
       another = Class.new(klass) do
         extend T::Sig

--- a/gems/sorbet-runtime/test/types/visibility.rb
+++ b/gems/sorbet-runtime/test/types/visibility.rb
@@ -8,11 +8,15 @@ class Opus::Types::Test::VisibilityTest < Critic::Unit::UnitTest
       abstract!
       sig { abstract.returns(Integer) }
       def foo; end
+      sig { returns(Integer) }
+      abstract def foo_kw; end
     end
     child = Class.new(parent) do
       extend T::Sig, T::Helpers
       sig { override.returns(Integer) }
       def foo; 0; end
+      sig { override.returns(Integer) }
+      def foo_kw; 0; end
     end
 
     T::Private::Abstract::Validate.validate_subclass(child)
@@ -24,11 +28,15 @@ class Opus::Types::Test::VisibilityTest < Critic::Unit::UnitTest
       abstract!
       sig { abstract.returns(Integer) }
       private def foo; end
+      sig { returns(Integer) }
+      private abstract def foo_kw; end
     end
     child = Class.new(parent) do
       extend T::Sig, T::Helpers
       sig { override.returns(Integer) }
       private def foo; 0; end
+      sig { override.returns(Integer) }
+      private def foo_kw; 0; end
     end
 
     T::Private::Abstract::Validate.validate_subclass(child)
@@ -40,11 +48,15 @@ class Opus::Types::Test::VisibilityTest < Critic::Unit::UnitTest
       abstract!
       sig { abstract.returns(Integer) }
       private def foo; end
+      sig { returns(Integer) }
+      private abstract def foo_kw; end
     end
     child = Class.new(parent) do
       extend T::Sig, T::Helpers
       sig { override.returns(Integer) }
       def foo; 0; end
+      sig { override.returns(Integer) }
+      def foo_kw; 0; end
     end
 
     T::Private::Abstract::Validate.validate_subclass(child)
@@ -56,11 +68,15 @@ class Opus::Types::Test::VisibilityTest < Critic::Unit::UnitTest
       abstract!
       sig { abstract.returns(Integer) }
       protected def foo; end
+      sig { returns(Integer) }
+      protected abstract def foo_kw; end
     end
     child = Class.new(parent) do
       extend T::Sig, T::Helpers
       sig { override.returns(Integer) }
       def foo; 0; end
+      sig { override.returns(Integer) }
+      def foo_kw; 0; end
     end
 
     T::Private::Abstract::Validate.validate_subclass(child)
@@ -72,11 +88,15 @@ class Opus::Types::Test::VisibilityTest < Critic::Unit::UnitTest
       abstract!
       sig { abstract.returns(Integer) }
       def foo; end
+      sig { returns(Integer) }
+      abstract def foo_kw; end
     end
     child = Class.new(parent) do
       extend T::Sig, T::Helpers
       sig { override.returns(Integer) }
       private def foo; 0; end
+      sig { override.returns(Integer) }
+      private def foo_kw; 0; end
     end
 
     err = assert_raises(RuntimeError) do
@@ -92,11 +112,15 @@ class Opus::Types::Test::VisibilityTest < Critic::Unit::UnitTest
       abstract!
       sig { abstract.returns(Integer) }
       def foo; end
+      sig { returns(Integer) }
+      abstract def foo_kw; end
     end
     child = Class.new(parent) do
       extend T::Sig, T::Helpers
       sig { override.returns(Integer) }
       protected def foo; 0; end
+      sig { override.returns(Integer) }
+      protected def foo_kw; 0; end
     end
 
     err = assert_raises(RuntimeError) do
@@ -112,11 +136,15 @@ class Opus::Types::Test::VisibilityTest < Critic::Unit::UnitTest
       abstract!
       sig { abstract.returns(Integer) }
       protected def foo; end
+      sig { returns(Integer) }
+      protected abstract def foo_kw; end
     end
     child = Class.new(parent) do
       extend T::Sig, T::Helpers
       sig { override.returns(Integer) }
       private def foo; 0; end
+      sig { override.returns(Integer) }
+      private def foo_kw; 0; end
     end
 
     err = assert_raises(RuntimeError) do
@@ -132,11 +160,15 @@ class Opus::Types::Test::VisibilityTest < Critic::Unit::UnitTest
       abstract!
       sig { abstract.returns(Integer) }
       def foo; end
+      sig { returns(Integer) }
+      abstract def foo_kw; end
     end
     child = Class.new(parent) do
       extend T::Sig, T::Helpers
       sig { override(allow_incompatible: :visibility).returns(Integer) }
       private def foo; 0; end
+      sig { override(allow_incompatible: :visibility).returns(Integer) }
+      private def foo_kw; 0; end
     end
 
     T::Private::Abstract::Validate.validate_subclass(child)
@@ -148,11 +180,15 @@ class Opus::Types::Test::VisibilityTest < Critic::Unit::UnitTest
       abstract!
       sig { abstract.returns(Integer) }
       def foo; end
+      sig { returns(Integer) }
+      abstract def foo_kw; end
     end
     child = Class.new(parent) do
       extend T::Sig, T::Helpers
       sig { override(allow_incompatible: true).returns(Integer) }
       private def foo; 0; end
+      sig { override(allow_incompatible: true).returns(Integer) }
+      private def foo_kw; 0; end
     end
 
     T::Private::Abstract::Validate.validate_subclass(child)

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -406,6 +406,14 @@ public:
                     addMethodModifiers(ctx, original.fun, original.posArgs());
                 }
                 break;
+            case core::Names::abstract().rawId():
+                if (ownerIsMethod) {
+                    break;
+                }
+                if (original.hasPosArgs()) {
+                    addMethodModifiers(ctx, original.fun, original.posArgs());
+                }
+                break;
             case core::Names::privateConstant().rawId(): {
                 if (ownerIsMethod) {
                     break;
@@ -515,6 +523,18 @@ public:
             return sym->asSymbol();
         } else if (auto def = ast::cast_tree<ast::RuntimeMethodDefinition>(expr)) {
             return def->name;
+        } else if (auto send = ast::cast_tree<ast::Send>(expr)) {
+            // Handles combinations of modifiers like
+            // - `private abstract def foo` (`private(abstract(def foo; end))`)
+            // - `abstract private def foo` (`abstract(private(def foo; end))`)
+            if (send->numPosArgs() == 1) {
+                auto fun = send->fun;
+                if (fun == core::Names::abstract() || fun == core::Names::private_() ||
+                    fun == core::Names::protected_() || fun == core::Names::public_()) {
+                    return unwrapLiteralToMethodName(ctx, send->getPosArg(0));
+                }
+            }
+            return core::NameRef::noName();
         } else {
             ENFORCE(!ast::isa_tree<ast::MethodDef>(expr), "methods inside sends should be gone");
             return core::NameRef::noName();
@@ -1155,6 +1175,9 @@ private:
                 case core::Names::public_().rawId():
                 case core::Names::publicClassMethod().rawId():
                     method.data(ctx)->setMethodPublic();
+                    break;
+                case core::Names::abstract().rawId():
+                    method.data(ctx)->flags.isAbstract = true;
                     break;
                 default:
                     break;

--- a/parser/prism/Parser.cc
+++ b/parser/prism/Parser.cc
@@ -142,7 +142,7 @@ bool Parser::isSafeNavigationCall(pm_node_t *node) const {
     return PM_NODE_TYPE_P(node, PM_CALL_NODE) && PM_NODE_FLAG_P(node, PM_CALL_NODE_FLAGS_SAFE_NAVIGATION);
 }
 
-bool Parser::isVisibilityCall(pm_node_t *node) const {
+bool Parser::isMethodDefModifierCall(pm_node_t *node) const {
     if (!PM_NODE_TYPE_P(node, PM_CALL_NODE)) {
         return false;
     }

--- a/parser/prism/Parser.cc
+++ b/parser/prism/Parser.cc
@@ -169,7 +169,8 @@ bool Parser::isMethodDefModifierCall(pm_node_t *node) const {
     auto methodName = resolveConstant(call->name);
     return methodName == "private"sv || methodName == "protected"sv || methodName == "public"sv ||
            methodName == "private_class_method"sv || methodName == "public_class_method"sv ||
-           methodName == "package_private"sv || methodName == "package_private_class_method"sv;
+           methodName == "package_private"sv || methodName == "package_private_class_method"sv ||
+           methodName == "abstract"sv;
 }
 
 bool Parser::isAttrAccessorCall(pm_node_t *node) const {

--- a/parser/prism/Parser.h
+++ b/parser/prism/Parser.h
@@ -81,7 +81,7 @@ public:
     bool isT(pm_node_t *node) const;
     bool isSetterCall(pm_node_t *node) const;
     bool isSafeNavigationCall(pm_node_t *node) const;
-    bool isVisibilityCall(pm_node_t *node) const;
+    bool isMethodDefModifierCall(pm_node_t *node) const;
     bool isAttrAccessorCall(pm_node_t *node) const;
 
     void destroyNode(pm_node_t *node);

--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -1292,13 +1292,11 @@ class Module < Object
   # Mod.one     #=> "This is one"
   # c.call_one  #=> "This is the new one"
   # ```
-  sig do
-    params(
-        arg0: T.any(Symbol, String),
-    )
-    .returns(T.self_type)
-  end
-  def module_function(*arg0); end
+  sig { returns(NilClass) }
+  sig { params(arg0: Symbol).returns(Symbol) }
+  sig { params(arg0: String).returns(String) }
+  sig { params(arg0: T.any(Symbol, String), rest: T.any(Symbol, String)).returns(T::Array[T.any(Symbol, String)]) }
+  def module_function(arg0=T.unsafe(nil), *rest); end
 
   # Returns the name of the module *mod*. Returns nil for anonymous modules.
   sig {returns(T.nilable(String))}
@@ -1373,13 +1371,11 @@ class Module < Object
   #
   # Note that to show a private method on
   # [`RDoc`](https://docs.ruby-lang.org/en/2.7.0/RDoc.html), use `:doc:`.
-  sig do
-    params(
-        arg0: T.any(Symbol, String),
-    )
-    .returns(T.self_type)
-  end
-  def private(*arg0); end
+  sig { returns(NilClass) }
+  sig { params(method_name: Symbol).returns(Symbol) }
+  sig { params(method_name: String).returns(String) }
+  sig { params(method_name: T.any(Symbol, String), rest: T.any(Symbol, String)).returns(T::Array[T.any(Symbol, String)]) }
+  def private(method_name=T.unsafe(nil), *rest); end
 
   # Makes existing class methods private. Often used to hide the default
   # constructor `new`.
@@ -1490,13 +1486,11 @@ class Module < Object
   # To show a private method on
   # [`RDoc`](https://docs.ruby-lang.org/en/2.7.0/RDoc.html), use `:doc:` instead
   # of this.
-  sig do
-    params(
-        arg0: T.any(Symbol, String),
-    )
-    .returns(T.self_type)
-  end
-  def protected(*arg0); end
+  sig { returns(NilClass) }
+  sig { params(method_name: Symbol).returns(Symbol) }
+  sig { params(method_name: String).returns(String) }
+  sig { params(method_name: T.any(Symbol, String), rest: T.any(Symbol, String)).returns(T::Array[T.any(Symbol, String)]) }
+  def protected(method_name=T.unsafe(nil), *rest); end
 
   # Returns a list of the protected instance methods defined in *mod*. If the
   # optional parameter is `false`, the methods of any ancestors are not
@@ -1550,13 +1544,11 @@ class Module < Object
   # Strings is also accepted. If a single argument is passed, it is returned. If
   # no argument is passed, nil is returned. If multiple arguments are passed,
   # the arguments are returned as an array.
-  sig do
-    params(
-        arg0: T.any(Symbol, String),
-    )
-    .returns(T.self_type)
-  end
-  def public(*arg0); end
+  sig { returns(NilClass) }
+  sig { params(method_name: Symbol).returns(Symbol) }
+  sig { params(method_name: String).returns(String) }
+  sig { params(method_name: T.any(Symbol, String), rest: T.any(Symbol, String)).returns(T::Array[T.any(Symbol, String)]) }
+  def public(method_name=T.unsafe(nil), *rest); end
 
   # Makes a list of existing class methods public.
   #

--- a/rbs/prism/CommentsAssociatorPrism.cc
+++ b/rbs/prism/CommentsAssociatorPrism.cc
@@ -662,7 +662,7 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
         case PM_CALL_NODE: {
             auto *call = down_cast<pm_call_node_t>(node);
 
-            if (parser.isVisibilityCall(node)) {
+            if (parser.isMethodDefModifierCall(node)) {
                 // This is a visibility modifier wrapping a method definition: `private def foo; end`
                 associateSignatureCommentsToNode(node);
                 associateAssertionCommentsToNode(node);

--- a/rbs/prism/SigsRewriterPrism.cc
+++ b/rbs/prism/SigsRewriterPrism.cc
@@ -32,7 +32,7 @@ bool canHaveSignature(pm_node_t *node, const parser::Prism::Parser &parser) {
             // (singleton methods have a receiver field set)
             return true;
         case PM_CALL_NODE: {
-            return parser.isAttrAccessorCall(node) || parser.isVisibilityCall(node);
+            return parser.isAttrAccessorCall(node) || parser.isMethodDefModifierCall(node);
         }
         default:
             return false;
@@ -346,7 +346,7 @@ unique_ptr<vector<pm_node_t *>> SigsRewriterPrism::signaturesForNode(pm_node_t *
             }
         } else if (PM_NODE_TYPE_P(node, PM_CALL_NODE)) {
             auto *call = down_cast<pm_call_node_t>(node);
-            if (parser.isVisibilityCall(node)) {
+            if (parser.isMethodDefModifierCall(node)) {
                 // For visibility modifiers, translate the signature for the inner method definition
                 auto sig = signatureTranslator.translateMethodSignature(call->arguments->arguments.nodes[0],
                                                                         declaration, comments.annotations);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3710,7 +3710,7 @@ private:
                     (send.fun == core::Names::public_() || send.fun == core::Names::private_() ||
                      send.fun == core::Names::privateClassMethod() || send.fun == core::Names::protected_() ||
                      send.fun == core::Names::packagePrivateClassMethod() ||
-                     send.fun == core::Names::packagePrivate())) {
+                     send.fun == core::Names::packagePrivate() || send.fun == core::Names::abstract())) {
                     processStatement(ctx, send.getPosArg(0), lastSigs);
                     return;
                 }

--- a/test/testdata/infer/self_type.rb.cfg-text.exp
+++ b/test/testdata/infer/self_type.rb.cfg-text.exp
@@ -523,9 +523,9 @@ bb23[firstDead=11](<block-pre-call-temp>$74: Sorbet::Private::Static::Void, <sel
     <cfgAlias>$89: T.class_of(T) = alias <C T>
     <statTemp>$84: T.class_of(B) = <self>: T.class_of(B).extend(<cfgAlias>$87: T.class_of(T::Sig))
     <statTemp>$94: Symbol(:takes_self_private) = :takes_self_private
-    <statTemp>$92: T.class_of(B) = <self>: T.class_of(B).private(<statTemp>$94: Symbol(:takes_self_private))
+    <statTemp>$92: Symbol = <self>: T.class_of(B).private(<statTemp>$94: Symbol(:takes_self_private))
     <statTemp>$98: Symbol(:takes_self_or_integer) = :takes_self_or_integer
-    <statTemp>$96: T.class_of(B) = <self>: T.class_of(B).private(<statTemp>$98: Symbol(:takes_self_or_integer))
+    <statTemp>$96: Symbol = <self>: T.class_of(B).private(<statTemp>$98: Symbol(:takes_self_or_integer))
     <returnMethodTemp>$2: Symbol(:==) = :==
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:==)
     <unconditional> -> bb1

--- a/test/testdata/namer/module_function.rb.cfg-text.exp
+++ b/test/testdata/namer/module_function.rb.cfg-text.exp
@@ -157,11 +157,11 @@ bb19[firstDead=13](<block-pre-call-temp>$57: Sorbet::Private::Static::Void, <sel
     <cfgAlias>$73: T.class_of(T) = alias <C T>
     <statTemp>$68: T.class_of(Funcs) = <self>: T.class_of(Funcs).extend(<cfgAlias>$71: T.class_of(T::Sig))
     <statTemp>$77: Symbol(:f) = :f
-    <statTemp>$75: T.class_of(Funcs) = <self>: T.class_of(Funcs).private(<statTemp>$77: Symbol(:f))
+    <statTemp>$75: Symbol = <self>: T.class_of(Funcs).private(<statTemp>$77: Symbol(:f))
     <statTemp>$81: Symbol(:g) = :g
-    <statTemp>$79: T.class_of(Funcs) = <self>: T.class_of(Funcs).private(<statTemp>$81: Symbol(:g))
+    <statTemp>$79: Symbol = <self>: T.class_of(Funcs).private(<statTemp>$81: Symbol(:g))
     <statTemp>$85: Symbol(:h) = :h
-    <statTemp>$83: T.class_of(Funcs) = <self>: T.class_of(Funcs).private(<statTemp>$85: Symbol(:h))
+    <statTemp>$83: Symbol = <self>: T.class_of(Funcs).private(<statTemp>$85: Symbol(:h))
     <returnMethodTemp>$2: Symbol(:h) = :h
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:h)
     <unconditional> -> bb1

--- a/test/testdata/resolver/abstract_keyword.rb
+++ b/test/testdata/resolver/abstract_keyword.rb
@@ -1,0 +1,35 @@
+# typed: true
+
+module T::Helpers
+  # Not implemented in sorbet-runtime yet, so lets add our own no-op shim here for now.
+  def abstract(method_name) = method_name
+end
+
+module AbstractKeywordInInterface
+  extend T::Helpers
+  interface!
+
+  abstract def foo; end
+  abstract def bar(x, y); end
+
+  public abstract def pub1; end
+  protected abstract def prot1; end # error: cannot be protected
+  private abstract def priv1; end
+  
+  abstract public def pub2; end
+  abstract protected def prot2; end # error: cannot be protected
+  abstract private def priv2; end
+end
+
+class AbstractKeywordInClass
+  extend T::Helpers
+  abstract!
+
+  public abstract def pub1; end
+  protected abstract def prot1; end
+  private abstract def priv1; end
+
+  abstract public def pub2; end
+  abstract protected def prot2; end
+  abstract private def priv2; end
+end

--- a/test/testdata/resolver/abstract_keyword.rb.symbol-table.exp
+++ b/test/testdata/resolver/abstract_keyword.rb.symbol-table.exp
@@ -1,0 +1,50 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/resolver/abstract_keyword.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=??? end=???}
+  class ::AbstractKeywordInClass < ::Object () @ test/testdata/resolver/abstract_keyword.rb:24
+    method ::AbstractKeywordInClass#priv1 : private|abstract (<blk>) @ test/testdata/resolver/abstract_keyword.rb:30
+      argument <blk><block> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=??? end=???}
+    method ::AbstractKeywordInClass#priv2 : private|abstract (<blk>) @ test/testdata/resolver/abstract_keyword.rb:34
+      argument <blk><block> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=??? end=???}
+    method ::AbstractKeywordInClass#prot1 : protected|abstract (<blk>) @ test/testdata/resolver/abstract_keyword.rb:29
+      argument <blk><block> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=??? end=???}
+    method ::AbstractKeywordInClass#prot2 : protected|abstract (<blk>) @ test/testdata/resolver/abstract_keyword.rb:33
+      argument <blk><block> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=??? end=???}
+    method ::AbstractKeywordInClass#pub1 : abstract (<blk>) @ test/testdata/resolver/abstract_keyword.rb:28
+      argument <blk><block> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=??? end=???}
+    method ::AbstractKeywordInClass#pub2 : abstract (<blk>) @ test/testdata/resolver/abstract_keyword.rb:32
+      argument <blk><block> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=??? end=???}
+  class ::<Class:AbstractKeywordInClass>[<AttachedClass>] < ::<Class:Object> (Helpers) @ test/testdata/resolver/abstract_keyword.rb:24
+    type-member(+) ::<Class:AbstractKeywordInClass>::<AttachedClass> -> T.attached_class (of AbstractKeywordInClass) @ test/testdata/resolver/abstract_keyword.rb:24
+    method ::<Class:AbstractKeywordInClass>#<static-init> (<blk>) @ test/testdata/resolver/abstract_keyword.rb:24
+      argument <blk><block> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=??? end=???}
+  module ::AbstractKeywordInInterface < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/resolver/abstract_keyword.rb:8
+    method ::AbstractKeywordInInterface#bar : abstract (x, y, <blk>) @ test/testdata/resolver/abstract_keyword.rb:13
+      argument x<> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=13:20 end=13:21}
+      argument y<> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=13:23 end=13:24}
+      argument <blk><block> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=??? end=???}
+    method ::AbstractKeywordInInterface#foo : abstract (<blk>) @ test/testdata/resolver/abstract_keyword.rb:12
+      argument <blk><block> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=??? end=???}
+    method ::AbstractKeywordInInterface#priv1 : private|abstract (<blk>) @ test/testdata/resolver/abstract_keyword.rb:17
+      argument <blk><block> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=??? end=???}
+    method ::AbstractKeywordInInterface#priv2 : private|abstract (<blk>) @ test/testdata/resolver/abstract_keyword.rb:21
+      argument <blk><block> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=??? end=???}
+    method ::AbstractKeywordInInterface#prot1 : protected|abstract (<blk>) @ test/testdata/resolver/abstract_keyword.rb:16
+      argument <blk><block> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=??? end=???}
+    method ::AbstractKeywordInInterface#prot2 : protected|abstract (<blk>) @ test/testdata/resolver/abstract_keyword.rb:20
+      argument <blk><block> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=??? end=???}
+    method ::AbstractKeywordInInterface#pub1 : abstract (<blk>) @ test/testdata/resolver/abstract_keyword.rb:15
+      argument <blk><block> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=??? end=???}
+    method ::AbstractKeywordInInterface#pub2 : abstract (<blk>) @ test/testdata/resolver/abstract_keyword.rb:19
+      argument <blk><block> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=??? end=???}
+  class ::<Class:AbstractKeywordInInterface>[<AttachedClass>] < ::Module (Helpers) @ test/testdata/resolver/abstract_keyword.rb:8
+    type-member(+) ::<Class:AbstractKeywordInInterface>::<AttachedClass> -> T.attached_class (of AbstractKeywordInInterface) @ test/testdata/resolver/abstract_keyword.rb:8
+    method ::<Class:AbstractKeywordInInterface>#<static-init> (<blk>) @ test/testdata/resolver/abstract_keyword.rb:8
+      argument <blk><block> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=??? end=???}
+  module ::T < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#LCENSORED
+    module ::T::Helpers < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ (test/testdata/resolver/abstract_keyword.rb:3, https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#LCENSORED)
+      method ::T::Helpers#abstract (method_name, <blk>) @ test/testdata/resolver/abstract_keyword.rb:5
+        argument method_name<> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=5:16 end=5:27}
+        argument <blk><block> @ Loc {file=test/testdata/resolver/abstract_keyword.rb start=??? end=???}
+

--- a/test/testdata/rewriter/private_before_sig.rb
+++ b/test/testdata/rewriter/private_before_sig.rb
@@ -4,6 +4,6 @@ class A
   extend T::Sig
 
   private sig {void}
-  #       ^^^^^^^^^^ error: Expected `T.any(Symbol, String)` but found `NilClass` for argument `arg0`
+  #       ^^^^^^^^^^ error: Expected `Symbol` but found `NilClass` for argument `method_name`
   def foo; end
 end

--- a/test/testdata/rewriter/t_enum_snapshot.rb.cfg-text.exp
+++ b/test/testdata/rewriter/t_enum_snapshot.rb.cfg-text.exp
@@ -71,7 +71,7 @@ bb6[firstDead=-1](<self>: T.class_of(MyEnum), <block-pre-call-temp>$23: Sorbet::
 bb7[firstDead=5](<block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(MyEnum)):
     <statTemp>$21: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$23, enums>
     <self>: T.class_of(MyEnum) = <selfRestore>$24
-    <statTemp>$52: T.class_of(MyEnum) = <self>: T.class_of(MyEnum).public()
+    <statTemp>$52: NilClass = <self>: T.class_of(MyEnum).public()
     <returnMethodTemp>$2: Symbol(:serialize) = :serialize
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:serialize)
     <unconditional> -> bb1
@@ -271,7 +271,7 @@ bb6[firstDead=-1](<self>: T.class_of(EnumsDoEnum), <block-pre-call-temp>$23: Sor
 bb7[firstDead=5](<block-pre-call-temp>$23: Sorbet::Private::Static::Void, <selfRestore>$24: T.class_of(EnumsDoEnum)):
     <statTemp>$21: Sorbet::Private::Static::Void = Solve<<block-pre-call-temp>$23, enums>
     <self>: T.class_of(EnumsDoEnum) = <selfRestore>$24
-    <statTemp>$53: T.class_of(EnumsDoEnum) = <self>: T.class_of(EnumsDoEnum).public()
+    <statTemp>$53: NilClass = <self>: T.class_of(EnumsDoEnum).public()
     <returnMethodTemp>$2: Symbol(:serialize) = :serialize
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:serialize)
     <unconditional> -> bb1
@@ -461,7 +461,7 @@ bb7[firstDead=17](<block-pre-call-temp>$32: Sorbet::Private::Static::Void, <self
     keep_for_ide$57: T.untyped = <keep-alive> keep_for_ide$57
     <castTemp>$59: Integer(1) = 1
     <C StaticField4>$56: Integer = cast(<castTemp>$59: Integer(1), Integer);
-    <statTemp>$60: T.class_of(BadConsts) = <self>: T.class_of(BadConsts).public()
+    <statTemp>$60: NilClass = <self>: T.class_of(BadConsts).public()
     <returnMethodTemp>$2: Symbol(:serialize) = :serialize
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:serialize)
     <unconditional> -> bb1


### PR DESCRIPTION
### Motivation

Runtime counterpart to #9963

### Known issues

#### Complicates sig lifetime and validation

Signatures could no longer be validated at the end of the call to `sig`, or in the method added hooks, because the signature can be modified after-the-fact by `abstract`. Order of events:

1. `sig` call
2. `method_added` hook
3. `abstract` call

#### Intermediate abstract fails

Fails for this case:

```ruby
class AbstractParent
  abstract!
  
  sig { void }
  abstract def foo; end
end

class AbstractChild < Parent
  # This sig fails validation, because it doesn't have `abstract.` or `override.`
  sig { void }
  abstract def foo; end
end

class ConcreteChild < AbstractParent
end
```

Problem: `signature_for_key` lazily runs the sig block, which calls `run_sig` → `build_sig` →
  `SignatureValidation.validate`, all with `mode = standard`. The `make_abstract!` call comes too late, after that validation has already rejected it.

<details><summary><h5>Potential Solution</h5></summary>

The `sig` block hasn't run yet when `declare_abstract` is called. We just need to inject abstract mode between `run_builder` (which parses the `sig` block) and `build_sig` (which does the validation).

We can change `declare_abstract` set a pending flag that `run_sig` consumes to override the declaration's mode before validation:

```ruby
  # In run_sig, after run_builder but before build_sig:
  def self.run_sig(hook_mod, method_name, original_method, declaration_block)
    current_declaration = run_builder(declaration_block)

    if @pending_abstract # FIXME: store this in `T::Private::DeclState.current`
      @pending_abstract = false
      case current_declaration.mode
      when Modes.standard
        current_declaration.mode = Modes.abstract
      when Modes.abstract
        raise DeclBuilder::BuilderError.new(".abstract cannot be repeated in a single signature")
      else
        raise DeclBuilder::BuilderError.new("`.abstract` cannot be combined with `.override` or `.overridable`.")
      end
    end

    signature = build_sig(hook_mod, method_name, original_method, current_declaration)
    unwrap_method(signature.method.owner, signature, original_method)
    signature
  end

  # declare_abstract becomes much simpler:
  def self.declare_abstract(mod, method_name)
    key = method_owner_and_name_to_key(mod, method_name)
    @pending_abstract = true
    begin
      signature_for_key(key)
    ensure
      @pending_abstract = false
    end
  end
```

</details>

#### `abstract self.foo; end`

Haven't tried it. Probably broken.

#### `abstract` with no `sig`

Haven't tried it. Probably broken.

### Test plan