### PR TITLE
Combine initial lock and await

### DIFF
--- a/main/lsp/LSPLoop.cc
+++ b/main/lsp/LSPLoop.cc
@@ -269,9 +269,8 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> inp
         while (true) {
             unique_ptr<LSPTask> task;
             {
-                absl::MutexLock lck(taskQueue->getMutex());
                 Timer timeit(logger, "idle");
-                taskQueue->getMutex()->Await(absl::Condition(taskQueue.get(), &TaskQueue::ready));
+                absl::MutexLock lck(taskQueue->getMutex(), absl::Condition(taskQueue.get(), &TaskQueue::ready));
                 ENFORCE(!taskQueue->isPaused());
                 if (taskQueue->isTerminated()) {
                     if (taskQueue->getErrorCode() != 0) {

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -395,12 +395,12 @@ unique_ptr<Joinable> LSPPreprocessor::runPreprocessor(MessageQueueState &message
         while (true) {
             unique_ptr<LSPMessage> msg;
             {
-                absl::MutexLock lck(&messageQueueMutex);
-                messageQueueMutex.Await(absl::Condition(
-                    +[](MessageQueueState *messageQueue) -> bool {
-                        return messageQueue->terminate || !messageQueue->pendingRequests.empty();
-                    },
-                    &messageQueue));
+                absl::MutexLock lck(&messageQueueMutex, absl::Condition(
+                                                            +[](MessageQueueState *messageQueue) -> bool {
+                                                                return messageQueue->terminate ||
+                                                                       !messageQueue->pendingRequests.empty();
+                                                            },
+                                                            &messageQueue));
                 // Only terminate once incoming queue is drained.
                 if (messageQueue.terminate && messageQueue.pendingRequests.empty()) {
                     config->logger->debug("Preprocessor terminating");


### PR DESCRIPTION
The `absl::MutexLock` constructor can take a second argument of an `absl::Condition`, which we can use to combine the few places where we take the lock and then immediately call `Await`.

### Motivation
Less locking, by awaiting immediately instead.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Refactoring only, no behavioral changes.
