### PR TITLE
`--gen-packages` strict mode: no-op `__package.rb` writer

### DIFF
--- a/core/AutocorrectSuggestion.h
+++ b/core/AutocorrectSuggestion.h
@@ -18,8 +18,10 @@ struct AutocorrectSuggestion {
 
     bool isDidYouMean;
 
-    AutocorrectSuggestion(std::string title, std::vector<Edit> edits, bool isDidYouMean = false)
-        : title(title), edits(edits), isDidYouMean(isDidYouMean) {}
+    bool hideEdit;
+
+    AutocorrectSuggestion(std::string title, std::vector<Edit> edits, bool isDidYouMean = false, bool hideEdit = false)
+        : title(title), edits(edits), isDidYouMean(isDidYouMean), hideEdit(hideEdit) {}
 
     // Reads all the files to be edited, and then accumulates all the edits that need to be applied
     // to those files into a resulting string with all edits applied. Does not write those back out

--- a/core/Error.cc
+++ b/core/Error.cc
@@ -232,21 +232,23 @@ void ErrorBuilder::addAutocorrect(AutocorrectSuggestion &&autocorrect) {
     }
 
     vector<ErrorLine> messages;
-    for (auto &edit : autocorrect.edits) {
-        auto isInsert = edit.replacement == "";
-        uint32_t n = edit.loc.length();
-        if (gs.autocorrect) {
-            auto line = isInsert ? ErrorLine::from(edit.loc, "Deleted")
-                                 : ErrorLine::from(edit.loc, "{} `{}`", n == 0 ? "Inserted" : "Replaced with",
-                                                   prettyPrintEditReplacement(edit.replacement));
+    if (!autocorrect.hideEdit) {
+        for (auto &edit : autocorrect.edits) {
+            auto isInsert = edit.replacement == "";
+            uint32_t n = edit.loc.length();
+            if (gs.autocorrect) {
+                auto line = isInsert ? ErrorLine::from(edit.loc, "Deleted")
+                                     : ErrorLine::from(edit.loc, "{} `{}`", n == 0 ? "Inserted" : "Replaced with",
+                                                       prettyPrintEditReplacement(edit.replacement));
 
-            messages.emplace_back(std::move(line));
-        } else {
-            auto line = isInsert ? ErrorLine::from(edit.loc, "Delete")
-                                 : ErrorLine::from(edit.loc, "{} `{}`", n == 0 ? "Insert" : "Replace with",
-                                                   prettyPrintEditReplacement(edit.replacement));
+                messages.emplace_back(std::move(line));
+            } else {
+                auto line = isInsert ? ErrorLine::from(edit.loc, "Delete")
+                                     : ErrorLine::from(edit.loc, "{} `{}`", n == 0 ? "Insert" : "Replace with",
+                                                       prettyPrintEditReplacement(edit.replacement));
 
-            messages.emplace_back(std::move(line));
+                messages.emplace_back(std::move(line));
+            }
         }
     }
     auto errorSection = ErrorSection{sectionTitle, std::move(messages)};

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2073,8 +2073,9 @@ unique_ptr<GlobalState> GlobalState::copyForIndexThread(
     const vector<string> &extraPackageFilesDirectorySlashDeprecatedPrefixes,
     const vector<string> &extraPackageFilesDirectorySlashPrefixes,
     const vector<string> &packageSkipRBIExportEnforcementDirs, const vector<string> &allowRelaxedPackagerChecksFor,
-    const vector<string> &updateVisibilityFor, const vector<string> &packagerLayers, string errorHint, bool genPackages,
-    bool allowRelaxingTestVisibility, bool packageAttributedErrors, bool testPackages) const {
+    const vector<string> &updateVisibilityFor, const vector<string> &packagerLayers, string errorHint,
+    packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility, bool packageAttributedErrors,
+    bool testPackages) const {
     ENFORCE(fileTableFrozen);
     auto result = make_unique<GlobalState>(this->errorQueue, this->epochManager);
 
@@ -2096,7 +2097,7 @@ unique_ptr<GlobalState> GlobalState::copyForIndexThread(
                                    extraPackageFilesDirectorySlashDeprecatedPrefixes,
                                    extraPackageFilesDirectorySlashPrefixes, packageSkipRBIExportEnforcementDirs,
                                    allowRelaxedPackagerChecksFor, updateVisibilityFor, packagerLayers, errorHint,
-                                   genPackages, allowRelaxingTestVisibility, packageAttributedErrors, testPackages);
+                                   genPackagesMode, allowRelaxingTestVisibility, packageAttributedErrors, testPackages);
     }
 
     return result;
@@ -2107,8 +2108,8 @@ unique_ptr<GlobalState> GlobalState::copyForLSPTypechecker(
     const vector<string> &extraPackageFilesDirectorySlashDeprecatedPrefixes,
     const vector<string> &extraPackageFilesDirectorySlashPrefixes,
     const vector<string> &packageSkipRBIExportEnforcementDirs, const vector<string> &allowRelaxedPackagerChecksFor,
-    const vector<string> &updateVisibilityFor, const vector<string> &packagerLayers, string errorHint, bool genPackages,
-    bool allowRelaxingTestVisibility, bool testPackages) const {
+    const vector<string> &updateVisibilityFor, const vector<string> &packagerLayers, string errorHint,
+    packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility, bool testPackages) const {
     auto result = make_unique<GlobalState>(this->errorQueue, this->epochManager);
 
     result->initEmpty();
@@ -2129,18 +2130,20 @@ unique_ptr<GlobalState> GlobalState::copyForLSPTypechecker(
                                    extraPackageFilesDirectorySlashDeprecatedPrefixes,
                                    extraPackageFilesDirectorySlashPrefixes, packageSkipRBIExportEnforcementDirs,
                                    allowRelaxedPackagerChecksFor, updateVisibilityFor, packagerLayers, errorHint,
-                                   genPackages, allowRelaxingTestVisibility, packageAttributedErrors, testPackages);
+                                   genPackagesMode, allowRelaxingTestVisibility, packageAttributedErrors, testPackages);
     }
 
     return result;
 }
-unique_ptr<GlobalState> GlobalState::copyForSlowPath(
-    const vector<string> &extraPackageFilesDirectoryUnderscorePrefixes,
-    const vector<string> &extraPackageFilesDirectorySlashDeprecatedPrefixes,
-    const vector<string> &extraPackageFilesDirectorySlashPrefixes,
-    const vector<string> &packageSkipRBIExportEnforcementDirs, const vector<string> &allowRelaxedPackagerChecksFor,
-    const vector<string> &updateVisibilityFor, const vector<string> &packagerLayers, string errorHint, bool genPackages,
-    bool allowRelaxingTestVisibility, bool packageAttributedErrors, bool testPackages) const {
+unique_ptr<GlobalState>
+GlobalState::copyForSlowPath(const vector<string> &extraPackageFilesDirectoryUnderscorePrefixes,
+                             const vector<string> &extraPackageFilesDirectorySlashDeprecatedPrefixes,
+                             const vector<string> &extraPackageFilesDirectorySlashPrefixes,
+                             const vector<string> &packageSkipRBIExportEnforcementDirs,
+                             const vector<string> &allowRelaxedPackagerChecksFor,
+                             const vector<string> &updateVisibilityFor, const vector<string> &packagerLayers,
+                             string errorHint, packages::GenPackagesMode genPackagesMode,
+                             bool allowRelaxingTestVisibility, bool packageAttributedErrors, bool testPackages) const {
     auto result = make_unique<GlobalState>(this->errorQueue, this->epochManager);
 
     // We omit a call to `initEmpty` here, as the only intended use of this function is to have its symbol table
@@ -2174,7 +2177,7 @@ unique_ptr<GlobalState> GlobalState::copyForSlowPath(
                                    extraPackageFilesDirectorySlashDeprecatedPrefixes,
                                    extraPackageFilesDirectorySlashPrefixes, packageSkipRBIExportEnforcementDirs,
                                    allowRelaxedPackagerChecksFor, updateVisibilityFor, packagerLayers, errorHint,
-                                   genPackages, allowRelaxingTestVisibility, packageAttributedErrors, testPackages);
+                                   genPackagesMode, allowRelaxingTestVisibility, packageAttributedErrors, testPackages);
     }
 
     return result;
@@ -2326,12 +2329,13 @@ void GlobalState::setPackagerOptions(const vector<string> &extraPackageFilesDire
                                      const vector<string> &packageSkipRBIExportEnforcementDirs,
                                      const vector<string> &allowRelaxedPackagerChecksFor,
                                      const vector<string> &updateVisibilityFor, const vector<string> &packagerLayers,
-                                     string errorHint, bool genPackages, bool allowRelaxingTestVisibility,
-                                     bool packageAttributedErrors, bool testPackages) {
+                                     string errorHint, packages::GenPackagesMode genPackagesMode,
+                                     bool allowRelaxingTestVisibility, bool packageAttributedErrors,
+                                     bool testPackages) {
     ENFORCE_NO_TIMER(!packageDB_.frozen);
 
     packageDB_.enabled_ = true;
-    packageDB_.genPackages_ = genPackages;
+    packageDB_.genPackagesMode_ = genPackagesMode;
     packageDB_.allowRelaxingTestVisibility_ = allowRelaxingTestVisibility;
     packageDB_.packageAttributedErrors_ = packageAttributedErrors;
     packageDB_.testPackages_ = testPackages;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -437,8 +437,9 @@ public:
                             const std::vector<std::string> &packageSkipRBIExportEnforcementDirs,
                             const std::vector<std::string> &skipImportVisibilityCheckFor,
                             const std::vector<std::string> &updateVisibilityFor,
-                            const std::vector<std::string> &packagerLayers, std::string errorHint, bool genPackages,
-                            bool allowRelaxingTestVisibility, bool packageAttributedErrors, bool testPackages);
+                            const std::vector<std::string> &packagerLayers, std::string errorHint,
+                            packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility,
+                            bool packageAttributedErrors, bool testPackages);
     packages::UnfreezePackages unfreezePackages();
 
     NameRef nextMangledName(ClassOrModuleRef owner, NameRef origName);
@@ -550,16 +551,15 @@ public:
     // have no overlap.
     // NOTE: this very intentionally will not copy the symbol or name tables. The symbol tables aren't used or populated
     // during indexing, and the name tables will only be written to.
-    std::unique_ptr<GlobalState>
-    copyForIndexThread(const bool packagerEnabled,
-                       const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
-                       const std::vector<std::string> &extraPackageFilesDirectorySlashDeprecatedPrefixes,
-                       const std::vector<std::string> &extraPackageFilesDirectorySlashPrefixes,
-                       const std::vector<std::string> &packageSkipRBIExportEnforcementDirs,
-                       const std::vector<std::string> &allowRelaxedPackagerChecksFor,
-                       const std::vector<std::string> &updateVisibilityFor,
-                       const std::vector<std::string> &packagerLayers, std::string errorHint, bool genPackages,
-                       bool allowRelaxingTestVisibility, bool packageAttributedErrors, bool testPackages) const;
+    std::unique_ptr<GlobalState> copyForIndexThread(
+        const bool packagerEnabled, const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
+        const std::vector<std::string> &extraPackageFilesDirectorySlashDeprecatedPrefixes,
+        const std::vector<std::string> &extraPackageFilesDirectorySlashPrefixes,
+        const std::vector<std::string> &packageSkipRBIExportEnforcementDirs,
+        const std::vector<std::string> &allowRelaxedPackagerChecksFor,
+        const std::vector<std::string> &updateVisibilityFor, const std::vector<std::string> &packagerLayers,
+        std::string errorHint, packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility,
+        bool packageAttributedErrors, bool testPackages) const;
 
     // Minimally copy the global state, including the file table, to initialize the LSPTypechecker.
     // NOTE: this very intentionally will not copy the symbol or name tables. The symbol tables aren't used or populated
@@ -571,7 +571,8 @@ public:
         const std::vector<std::string> &packageSkipRBIExportEnforcementDirs,
         const std::vector<std::string> &allowRelaxedPackagerChecksFor,
         const std::vector<std::string> &updateVisibilityFor, const std::vector<std::string> &packagerLayers,
-        std::string errorHint, bool genPackages, bool allowRelaxingTestVisibility, bool testPackages) const;
+        std::string errorHint, packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility,
+        bool testPackages) const;
 
     // Copy the name table, file table and other parts of GlobalState that are required to start the slow path.
     // NOTE: this very intentionally will not copy the symbol table, and the expectation is that the symbol table will
@@ -583,7 +584,7 @@ public:
                     const std::vector<std::string> &packageSkipRBIExportEnforcementDirs,
                     const std::vector<std::string> &allowRelaxedPackagerChecksFor,
                     const std::vector<std::string> &updateVisibilityFor, const std::vector<std::string> &packagerLayers,
-                    std::string errorHint, bool genPackages, bool allowRelaxingTestVisibility,
+                    std::string errorHint, packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility,
                     bool packageAttributedErrors, bool testPackages) const;
 
     // Contains a path prefix that should be stripped from all printed paths.
@@ -617,7 +618,7 @@ public:
     // find all references. For example, if a file references A::B::C::D, then only A::B::C::D will be in set returned,
     // and not A, A::B, A::B::C.
     const UnorderedSet<core::SymbolRef> &getSymbolsReferencedByFile(core::FileRef fref) const {
-        ENFORCE(packageDB().genPackages());
+        ENFORCE(packageDB().genPackagesMode() != packages::GenPackagesMode::Disabled);
         ENFORCE(symbolsReferencedByFile.size() == this->files->size(),
                 "mismatch in files.size ({}) and symbolsReferencedByFile.size(): ({})", files->size(),
                 symbolsReferencedByFile.size());

--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -211,7 +211,7 @@ PackageDB PackageDB::deepCopy() const {
 
     // --- options ---
     result.enabled_ = this->enabled_;
-    result.genPackages_ = this->genPackages_;
+    result.genPackagesMode_ = this->genPackagesMode_;
     result.allowRelaxingTestVisibility_ = this->allowRelaxingTestVisibility_;
     result.extraPackageFilesDirectoryUnderscorePrefixes_ = this->extraPackageFilesDirectoryUnderscorePrefixes_;
     result.extraPackageFilesDirectorySlashDeprecatedPrefixes_ =

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -13,6 +13,12 @@ namespace sorbet::core::packages {
 
 class PackageDB;
 
+enum class GenPackagesMode : uint8_t {
+    Disabled,
+    Normal,
+    Strict,
+};
+
 class UnfreezePackages final {
 public:
     PackageDB &db;
@@ -63,9 +69,8 @@ public:
         return this->enabled_;
     }
 
-    // Whether the --gen-packages mode is active.
-    bool genPackages() const {
-        return this->genPackages_;
+    GenPackagesMode genPackagesMode() const {
+        return this->genPackagesMode_;
     }
 
     // Whether --gen-packages-allow-relaxing-test-visibility is active.
@@ -118,7 +123,7 @@ public:
 
 private:
     bool enabled_ = false;
-    bool genPackages_ = false;
+    GenPackagesMode genPackagesMode_ = GenPackagesMode::Disabled;
     bool allowRelaxingTestVisibility_ = false;
     bool packageAttributedErrors_ = false;
     bool testPackages_ = false;

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -744,6 +744,7 @@ std::string PackageInfo::renderPackageRbContents(const core::GlobalState &gs) co
     //
     // NOTE: This information (the categories and how they are sorted) is duplicated with orderByStrictness.
     static const UnorderedMap<StrictDependenciesLevel, vector<pair<StrictDependenciesLevel, string>>> headerMap = {
+        {StrictDependenciesLevel::None, {}},
         {StrictDependenciesLevel::False,
          {{StrictDependenciesLevel::False, "  # strict_dependencies 'false':\n"},
           {StrictDependenciesLevel::Layered, "  # strict_dependencies 'layered' or more strict:\n"}}},
@@ -764,7 +765,11 @@ std::string PackageInfo::renderPackageRbContents(const core::GlobalState &gs) co
     // TODO(neil): sort the imports
     bool layeringViolationsHeaderShown = false;
     bool testImportNewLineAdded = false;
-    uint8_t headerIndex = 0;
+
+    ENFORCE(headerMap.find(strictDependenciesLevel) != headerMap.end(),
+            "should not happen, was a new StrictDependenciesLevel added?");
+    auto &headers = headerMap.find(strictDependenciesLevel)->second;
+    auto headersIt = headers.begin();
     for (auto &import : importedPackageNames) {
         auto impPackageName = import.mangledName.owner.show(gs);
         auto &impPkgInfo = gs.packageDB().getPackageInfo(import.mangledName);
@@ -778,20 +783,11 @@ std::string PackageInfo::renderPackageRbContents(const core::GlobalState &gs) co
                 layeringViolationsHeaderShown = true;
             }
 
-            if (!causesLayeringViolation(gs.packageDB(), impPkgInfo) &&
-                strictDependenciesLevel != StrictDependenciesLevel::None) {
-                auto it = headerMap.find(strictDependenciesLevel);
-                if (it == headerMap.end()) {
-                    // This is already inside a `if (strictDependenciesLevel != StrictDependenciesLevel::None), so this
-                    // can only happen if a StrictDependenciesLevel is added.
-                    ENFORCE(false, "should not happen, was a new StrictDependenciesLevel added?");
-                }
-                auto &headers = it->second;
+            if (!causesLayeringViolation(gs.packageDB(), impPkgInfo)) {
                 auto headerToPrint = string();
-                while (headerIndex < headers.size() &&
-                       impPkgInfo.strictDependenciesLevel >= headers[headerIndex].first) {
-                    headerToPrint = headers[headerIndex].second;
-                    headerIndex++;
+                while (headersIt != headers.end() && impPkgInfo.strictDependenciesLevel >= headersIt->first) {
+                    headerToPrint = headersIt->second;
+                    headersIt++;
                 }
                 if (headerToPrint != "") {
                     fmt::format_to(std::back_inserter(result), "\n{}", headerToPrint);

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -697,6 +697,169 @@ std::optional<core::AutocorrectSuggestion> PackageInfo::aggregateMissingVisibleT
     return core::AutocorrectSuggestion{fmt::format("Add missing `{}`", "visible_to"), std::move(allEdits)};
 }
 
+std::string PackageInfo::renderPackageRbContents(const core::GlobalState &gs) const {
+    fmt::memory_buffer result;
+
+    if (isPreludePackage()) {
+        fmt::format_to(std::back_inserter(result), "  prelude_package\n\n");
+    }
+
+    for (auto &directive : extraDirectives_) {
+        auto directiveSource = core::Loc(file, directive).source(gs);
+        ENFORCE(directiveSource.has_value());
+        fmt::format_to(std::back_inserter(result), "  {}\n", directiveSource.value());
+    }
+    if (locs.layer.exists()) {
+        fmt::format_to(std::back_inserter(result), "  layer '{}'\n", layer.show(gs));
+    }
+    if (locs.strictDependenciesLevel.exists()) {
+        fmt::format_to(std::back_inserter(result), "  strict_dependencies '{}'\n",
+                       strictDependenciesLevelToString(strictDependenciesLevel));
+    }
+    if (locs.minTypedLevel.exists() && locs.testsMinTypedLevel.exists()) {
+        ENFORCE(!gs.packageDB().testPackages());
+        fmt::format_to(std::back_inserter(result), "  sorbet min_typed_level: '{}', tests_min_typed_level: '{}'\n",
+                       core::SigilTraits<core::StrictLevel>::toString(minTypedLevel),
+                       core::SigilTraits<core::StrictLevel>::toString(testsMinTypedLevel));
+    } else if (locs.minTypedLevel.exists() && !locs.testsMinTypedLevel.exists()) {
+        ENFORCE(gs.packageDB().testPackages());
+        fmt::format_to(std::back_inserter(result), "  sorbet min_typed_level: '{}'\n",
+                       core::SigilTraits<core::StrictLevel>::toString(minTypedLevel));
+    }
+
+    // currentPackageStrictDependenciesLevel -> vector<StrictDependenciesLevelForCategory, header>
+    //
+    // The import list in a __package.rb has headers to organize imports by their strict_dependencies level. For
+    // example:
+    //
+    //   # strict_dependencies 'false':
+    //   import FalsePackage
+    //
+    //   # strict_dependencies 'layered' or higher:
+    //   import LayeredPackage
+    //   import DagPackage
+    //
+    // This map contains the information required to intersperse those headers. When an with a strict_dependencies level
+    // equal or higher to StrictDependenciesLevelForCategory is encountered, header will be printed once.
+    //
+    // NOTE: This information (the categories and how they are sorted) is duplicated with orderByStrictness.
+    static const UnorderedMap<StrictDependenciesLevel, vector<pair<StrictDependenciesLevel, string>>> headerMap = {
+        {StrictDependenciesLevel::False,
+         {{StrictDependenciesLevel::False, "  # strict_dependencies 'false':\n"},
+          {StrictDependenciesLevel::Layered, "  # strict_dependencies 'layered' or more strict:\n"}}},
+        {StrictDependenciesLevel::Layered,
+         {{StrictDependenciesLevel::False, "  # strict_dependencies 'false':\n"},
+          {StrictDependenciesLevel::Layered, "  # strict_dependencies 'layered' or 'layered_dag':\n"},
+          {StrictDependenciesLevel::Dag, "  # strict_dependencies 'dag':\n"}}},
+        {StrictDependenciesLevel::LayeredDag,
+         {{StrictDependenciesLevel::False, "  # strict_dependencies 'false':\n"},
+          {StrictDependenciesLevel::Layered, "  # strict_dependencies 'layered' or 'layered_dag':\n"},
+          {StrictDependenciesLevel::Dag, "  # strict_dependencies 'dag':\n"}}},
+        {StrictDependenciesLevel::Dag,
+         {{StrictDependenciesLevel::False, "  # strict_dependencies 'false', 'layered', or 'layered_dag':\n"},
+          {StrictDependenciesLevel::Dag, "  # strict_dependencies 'dag':\n"}}},
+    };
+
+    // NOTE: this loop assumes importedPackageNames are already sorted by orderImports
+    // TODO(neil): sort the imports
+    bool layeringViolationsHeaderShown = false;
+    bool testImportNewLineAdded = false;
+    uint8_t headerIndex = 0;
+    for (auto &import : importedPackageNames) {
+        auto impPackageName = import.mangledName.owner.show(gs);
+        auto &impPkgInfo = gs.packageDB().getPackageInfo(import.mangledName);
+        if (!impPkgInfo.exists()) {
+            continue;
+        }
+
+        if (gs.packageDB().enforceLayering() && import.type == ImportType::Normal) {
+            if (!layeringViolationsHeaderShown && causesLayeringViolation(gs.packageDB(), impPkgInfo)) {
+                fmt::format_to(std::back_inserter(result), "\n  # layering violations:\n");
+                layeringViolationsHeaderShown = true;
+            }
+
+            if (!causesLayeringViolation(gs.packageDB(), impPkgInfo) &&
+                strictDependenciesLevel != StrictDependenciesLevel::None) {
+                auto it = headerMap.find(strictDependenciesLevel);
+                if (it == headerMap.end()) {
+                    // This is already inside a `if (strictDependenciesLevel != StrictDependenciesLevel::None), so this
+                    // can only happen if a StrictDependenciesLevel is added.
+                    ENFORCE(false, "should not happen, was a new StrictDependenciesLevel added?");
+                }
+                auto &headers = it->second;
+                auto headerToPrint = string();
+                while (headerIndex < headers.size() &&
+                       impPkgInfo.strictDependenciesLevel >= headers[headerIndex].first) {
+                    headerToPrint = headers[headerIndex].second;
+                    headerIndex++;
+                }
+                if (headerToPrint != "") {
+                    fmt::format_to(std::back_inserter(result), "\n{}", headerToPrint);
+                }
+            }
+        }
+
+        if (!testImportNewLineAdded && import.type != ImportType::Normal) {
+            fmt::format_to(std::back_inserter(result), "\n");
+            testImportNewLineAdded = true;
+        }
+
+        switch (import.type) {
+            case ImportType::Normal:
+                if (import.usesInternals) {
+                    ENFORCE(gs.packageDB().testPackages());
+                    fmt::format_to(std::back_inserter(result), "  import {}, uses_internals: true\n", impPackageName);
+                } else {
+                    fmt::format_to(std::back_inserter(result), "  import {}\n", impPackageName);
+                }
+                break;
+            case ImportType::TestHelper:
+                ENFORCE(!gs.packageDB().testPackages());
+                fmt::format_to(std::back_inserter(result), "  test_import {}\n", impPackageName);
+                break;
+            case ImportType::TestUnit:
+                ENFORCE(!gs.packageDB().testPackages());
+                fmt::format_to(std::back_inserter(result), "  test_import {}, only: \"test_rb\"\n", impPackageName);
+                break;
+        }
+    }
+
+    if (locs.exportAll.exists() || !exports_.empty()) {
+        fmt::format_to(std::back_inserter(result), "\n");
+    }
+    if (locs.exportAll.exists()) {
+        fmt::format_to(std::back_inserter(result), "  export_all!\n");
+    } else {
+        // TODO(neil): sort the exports
+        for (auto &export_ : exports_) {
+            auto exportSource = core::Loc(file, export_.loc).source(gs);
+            ENFORCE(exportSource.has_value());
+            fmt::format_to(std::back_inserter(result), "  {}\n", exportSource.value());
+        }
+    }
+
+    if (!visibleTo().empty() || visibleToTests()) {
+        fmt::format_to(std::back_inserter(result), "\n");
+    }
+    // TODO(neil): sort the visible_to
+    for (auto &visibleTo : visibleTo()) {
+        auto visibleToPackageName = visibleTo.mangledName.owner.show(gs);
+        switch (visibleTo.type) {
+            case VisibleToType::Normal:
+                fmt::format_to(std::back_inserter(result), "  visible_to {}\n", visibleToPackageName);
+                break;
+            case VisibleToType::Wildcard:
+                fmt::format_to(std::back_inserter(result), "  visible_to {}::*\n", visibleToPackageName);
+                break;
+        }
+    }
+
+    if (visibleToTests()) {
+        fmt::format_to(std::back_inserter(result), "  visible_to 'tests'\n");
+    }
+    return to_string(result);
+}
+
 bool PackageInfo::operator==(const PackageInfo &rhs) const {
     return mangledName() == rhs.mangledName();
 }

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -785,7 +785,13 @@ std::string PackageInfo::renderPackageRbContents(const core::GlobalState &gs) co
 
             if (!causesLayeringViolation(gs.packageDB(), impPkgInfo)) {
                 auto headerToPrint = string();
-                while (headersIt != headers.end() && impPkgInfo.strictDependenciesLevel >= headersIt->first) {
+                // Find the last entry in [headersIt, headers.end()] that has a StrictDependenciesLevel less than or
+                // equal to the StrictDependenciesLevel of the package being imported. It has to be last one rather than
+                // just the next to handle headers being skipped.
+                //
+                // Ex. if only an dag package is imported, we want to skip the 'false' and 'layered'/'layered_dag'
+                // headers, even though they'll be less than the dag package being imported.
+                while (headersIt != headers.end() && headersIt->first <= impPkgInfo.strictDependenciesLevel) {
                     headerToPrint = headersIt->second;
                     headersIt++;
                 }

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -337,6 +337,8 @@ public:
     std::optional<core::AutocorrectSuggestion>
     aggregateMissingVisibleTo(const core::GlobalState &gs, std::vector<core::packages::MangledName> &visibleTos,
                               bool visibleToTests) const;
+
+    std::string renderPackageRbContents(const core::GlobalState &gs) const;
 };
 CheckSize(PackageInfo, 256, 8);
 

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -338,7 +338,7 @@ TEST_CASE("isPackageSpecSymbol") {
 
     {
         auto unfrezePackages = gs.packageDB().unfreeze();
-        gs.setPackagerOptions({}, {}, {}, {}, {}, {}, {}, "", false, false, false, false);
+        gs.setPackagerOptions({}, {}, {}, {}, {}, {}, {}, "", packages::GenPackagesMode::Disabled, false, false, false);
     }
 
     CHECK_FALSE(Symbols::root().isPackageSpecSymbol(gs));

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -271,22 +271,22 @@ TypecheckingPath LSPIndexer::getTypecheckingPath(const vector<shared_ptr<core::F
 }
 
 void LSPIndexer::transferInitializeState(InitializedTask &task) {
-    ENFORCE(!this->config->opts.genPackages);
+    ENFORCE(this->config->opts.genPackagesMode == core::packages::GenPackagesMode::Disabled);
     // Copying the global state here means that we snapshot before any files have been loaded. That means that the
     // indexer and typechecker's file tables will almost immediately diverge, but that's not an issue as we don't share
     // `core::FileRef` values between the two.
-    auto enableGenPackages = false;
     auto enableGenPackagesAllowRelaxingTestVisibility = false;
-    auto typecheckerGS = std::exchange(
-        this->gs, this->gs->copyForLSPTypechecker(
-                      this->config->opts.cacheSensitiveOptions.sorbetPackages,
-                      this->config->opts.extraPackageFilesDirectoryUnderscorePrefixes,
-                      this->config->opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
-                      this->config->opts.extraPackageFilesDirectorySlashPrefixes,
-                      this->config->opts.packageSkipRBIExportEnforcementDirs,
-                      this->config->opts.allowRelaxedPackagerChecksFor, this->config->opts.updateVisibilityFor,
-                      this->config->opts.packagerLayers, this->config->opts.sorbetPackagesHint, enableGenPackages,
-                      enableGenPackagesAllowRelaxingTestVisibility, this->config->opts.testPackages));
+    auto typecheckerGS =
+        std::exchange(this->gs, this->gs->copyForLSPTypechecker(
+                                    this->config->opts.cacheSensitiveOptions.sorbetPackages,
+                                    this->config->opts.extraPackageFilesDirectoryUnderscorePrefixes,
+                                    this->config->opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
+                                    this->config->opts.extraPackageFilesDirectorySlashPrefixes,
+                                    this->config->opts.packageSkipRBIExportEnforcementDirs,
+                                    this->config->opts.allowRelaxedPackagerChecksFor,
+                                    this->config->opts.updateVisibilityFor, this->config->opts.packagerLayers,
+                                    this->config->opts.sorbetPackagesHint, core::packages::GenPackagesMode::Disabled,
+                                    enableGenPackagesAllowRelaxingTestVisibility, this->config->opts.testPackages));
 
     task.setGlobalState(std::move(typecheckerGS));
     task.setKeyValueStore(std::move(this->kvstore));

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -412,7 +412,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                  "Remove the provided <prefix> from all printed paths. Defaults to the input "
                                  "directory passed to Sorbet, if any.",
                                  cxxopts::value<string>()->default_value(empty.pathPrefix), "<prefix>");
-    options.add_options(section)("gen-packages", "Generate package information", cxxopts::value<bool>());
+    options.add_options(section)("gen-packages", "Generate package information (normal or strict)",
+                                 cxxopts::value<string>()->implicit_value("normal"), "{normal,strict}");
     // }}}
 
     // ----- AUTOCORRECTS ------------------------------------------------- {{{
@@ -1287,14 +1288,34 @@ void readOptions(Options &opts,
             }
         }
 
-        opts.genPackages = raw["gen-packages"].as<bool>();
-        if (opts.genPackages && !opts.cacheSensitiveOptions.sorbetPackages) {
-            logger->error("--gen-packages can only be can only be used in --sorbet-packages mode");
+        if (raw.count("gen-packages")) {
+            auto genPackagesMode = raw["gen-packages"].as<string>();
+            if (genPackagesMode == "normal") {
+                opts.genPackagesMode = core::packages::GenPackagesMode::Normal;
+            } else if (genPackagesMode == "strict") {
+                opts.genPackagesMode = core::packages::GenPackagesMode::Strict;
+            } else {
+                logger->error("--gen-packages must be 'normal' or 'strict', got '{}'", genPackagesMode);
+                throw EarlyReturnWithCode(1);
+            }
+        }
+        auto genPackagesEnabled = opts.genPackagesMode != core::packages::GenPackagesMode::Disabled;
+        if (genPackagesEnabled && !opts.cacheSensitiveOptions.sorbetPackages) {
+            logger->error("--gen-packages can only be used in --sorbet-packages mode");
             throw EarlyReturnWithCode(1);
         }
-        if (opts.genPackages && opts.runLSP) {
+        if (genPackagesEnabled && opts.runLSP) {
             logger->error("--gen-packages can not be used when --lsp is also enabled");
             throw EarlyReturnWithCode(1);
+        }
+        if (opts.genPackagesMode == core::packages::GenPackagesMode::Strict) {
+            if (raw.count("gen-packages-update-visibility-for")) {
+                // TODO(neil): These 2 together are disabled for now so we don't have to think about how they interact.
+                // It's possible it makes sense to run them together, in which case, we can remove this restriction.
+                logger->error(
+                    "--gen-packages=strict can not be used when --gen-packages-update-visibility-for is also enabled");
+                throw EarlyReturnWithCode(1);
+            }
         }
         if (raw.count("allow-relaxed-packager-checks-for")) {
             if (!opts.cacheSensitiveOptions.sorbetPackages) {
@@ -1318,7 +1339,7 @@ void readOptions(Options &opts,
                 logger->error("--gen-packages-update-visibility-for can only be specified in --sorbet-packages mode");
                 throw EarlyReturnWithCode(1);
             }
-            if (!opts.genPackages) {
+            if (!genPackagesEnabled) {
                 logger->error("--gen-packages-update-visibility-for can only be specified in --gen-packages mode");
                 throw EarlyReturnWithCode(1);
             }
@@ -1334,7 +1355,7 @@ void readOptions(Options &opts,
         }
         opts.allowRelaxingTestVisibility = raw["gen-packages-allow-relaxing-test-visibility"].as<bool>();
         if (opts.allowRelaxingTestVisibility) {
-            if (!opts.genPackages) {
+            if (!genPackagesEnabled) {
                 logger->error("--gen-packages-allow-relaxing-test-visibility can only be used in --gen-packages mode");
                 throw EarlyReturnWithCode(1);
             }

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -6,6 +6,7 @@
 #include "common/strings/ConstExprStr.h"
 #include "core/StrictLevel.h"
 #include "core/TrackUntyped.h"
+#include "core/packages/PackageDB.h"
 #include "main/pipeline/semantic_extension/SemanticExtension.h"
 #include "spdlog/spdlog.h"
 #include <optional>
@@ -258,7 +259,7 @@ struct Options {
 
     std::string dumpPackageInfo = "";
     std::vector<std::string> packageSkipRBIExportEnforcementDirs;
-    bool genPackages = false;
+    core::packages::GenPackagesMode genPackagesMode = core::packages::GenPackagesMode::Disabled;
     bool allowRelaxingTestVisibility = false;
 
     // Contains the allowed extensions Sorbet can parse.

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -114,7 +114,7 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
             opts.extraPackageFilesDirectoryUnderscorePrefixes, opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
             opts.extraPackageFilesDirectorySlashPrefixes, opts.packageSkipRBIExportEnforcementDirs,
             opts.allowRelaxedPackagerChecksFor, opts.updateVisibilityFor, opts.packagerLayers, opts.sorbetPackagesHint,
-            opts.genPackages, opts.allowRelaxingTestVisibility, opts.packageAttributedErrors, opts.testPackages);
+            opts.genPackagesMode, opts.allowRelaxingTestVisibility, opts.packageAttributedErrors, opts.testPackages);
     }
 #endif
 }
@@ -130,7 +130,7 @@ unique_ptr<core::GlobalState> copyForSlowPath(const core::GlobalState &from, con
         opts.extraPackageFilesDirectoryUnderscorePrefixes, opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
         opts.extraPackageFilesDirectorySlashPrefixes, opts.packageSkipRBIExportEnforcementDirs,
         opts.allowRelaxedPackagerChecksFor, opts.updateVisibilityFor, opts.packagerLayers, opts.sorbetPackagesHint,
-        opts.genPackages, opts.allowRelaxingTestVisibility, opts.packageAttributedErrors, opts.testPackages);
+        opts.genPackagesMode, opts.allowRelaxingTestVisibility, opts.packageAttributedErrors, opts.testPackages);
 
     core::serialize::Serializer::loadSymbolTable(*result, PAYLOAD_SYMBOL_TABLE);
 
@@ -735,7 +735,7 @@ ast::ParsedFilesOrCancelled indexSuppliedFiles(core::GlobalState &baseGs, absl::
         opts.cacheSensitiveOptions.sorbetPackages, opts.extraPackageFilesDirectoryUnderscorePrefixes,
         opts.extraPackageFilesDirectorySlashDeprecatedPrefixes, opts.extraPackageFilesDirectorySlashPrefixes,
         opts.packageSkipRBIExportEnforcementDirs, opts.allowRelaxedPackagerChecksFor, opts.updateVisibilityFor,
-        opts.packagerLayers, opts.sorbetPackagesHint, opts.genPackages, opts.allowRelaxingTestVisibility,
+        opts.packagerLayers, opts.sorbetPackagesHint, opts.genPackagesMode, opts.allowRelaxingTestVisibility,
         opts.packageAttributedErrors, opts.testPackages);
 
     workers.multiplexJob("indexSuppliedFiles", [emptyGs, &opts, fileq, resultq, &kvstore, cancelable]() {
@@ -747,7 +747,7 @@ ast::ParsedFilesOrCancelled indexSuppliedFiles(core::GlobalState &baseGs, absl::
             opts.cacheSensitiveOptions.sorbetPackages, opts.extraPackageFilesDirectoryUnderscorePrefixes,
             opts.extraPackageFilesDirectorySlashDeprecatedPrefixes, opts.extraPackageFilesDirectorySlashPrefixes,
             opts.packageSkipRBIExportEnforcementDirs, opts.allowRelaxedPackagerChecksFor, opts.updateVisibilityFor,
-            opts.packagerLayers, opts.sorbetPackagesHint, opts.genPackages, opts.allowRelaxingTestVisibility,
+            opts.packagerLayers, opts.sorbetPackagesHint, opts.genPackagesMode, opts.allowRelaxingTestVisibility,
             opts.packageAttributedErrors, opts.testPackages);
         auto &epochManager = *localGs->epochManager;
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -727,7 +727,7 @@ int realmain(int argc, char *argv[]) {
             // A similar principle applies for inserting `visible_to`s with --gen-packages-update-visiblity-for
             switch (opts.genPackagesMode) {
                 case core::packages::GenPackagesMode::Strict:
-                    // TODO
+                    packager::GenPackages::runStrict(*gs);
                     break;
                 case core::packages::GenPackagesMode::Normal:
                     packager::GenPackages::run(*gs);

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -705,7 +705,7 @@ int realmain(int argc, char *argv[]) {
                     gs->errorQueue->flushAllErrors(*gs);
                 }
 
-                if (!opts.genPackages) {
+                if (opts.genPackagesMode == core::packages::GenPackagesMode::Disabled) {
                     // In --gen-packages mode, we skip typecheck because we only want to show packaging related errors,
                     // and skipping typecheck saves a significant amount of time.
                     pipeline::typecheck(*gs, move(stratumFiles), opts, *workers, /* cancelable */ false,
@@ -718,14 +718,23 @@ int realmain(int argc, char *argv[]) {
             }
         }
 
-        if (opts.genPackages) {
+        if (opts.genPackagesMode != core::packages::GenPackagesMode::Disabled) {
             // One of the things this pass does is insert missing exports. Because of this, it needs to run after
             // VisibilityChecker has been run for all strata; a symbol might be used in a strata after the strata for
             // the package that owns that symbol, and we need to be able to see that use to know that a export should be
             // generated for that symbol. Because of that, we need to put this pass outside of the loop above.
             //
             // A similar principle applies for inserting `visible_to`s with --gen-packages-update-visiblity-for
-            packager::GenPackages::run(*gs);
+            switch (opts.genPackagesMode) {
+                case core::packages::GenPackagesMode::Strict:
+                    // TODO
+                    break;
+                case core::packages::GenPackagesMode::Normal:
+                    packager::GenPackages::run(*gs);
+                    break;
+                case core::packages::GenPackagesMode::Disabled:
+                    ENFORCE(false);
+            }
 
             // One thing typecheck does is call flushErrorsForFile, which provides a consistent
             // ordering for errors when running in single threaded mode. To replicate that behaviour, we loop

--- a/packager/GenPackages.cc
+++ b/packager/GenPackages.cc
@@ -234,4 +234,25 @@ void GenPackages::run(core::GlobalState &gs) {
     }
 }
 
+void GenPackages::runStrict(core::GlobalState &gs) {
+    for (auto pkgName : gs.packageDB().packages()) {
+        auto &pkgInfo = gs.packageDB().getPackageInfo(pkgName);
+        ENFORCE(pkgInfo.exists());
+
+        auto existingContentsLoc = core::Loc(pkgInfo.file, pkgInfo.locs.loc)
+                                       .adjust(gs, pkgInfo.locs.declLoc.length() + 1, -1 * (int32_t) "end"sv.size());
+        auto existingContents = existingContentsLoc.source(gs);
+        ENFORCE(existingContents.has_value());
+
+        auto newContents = pkgInfo.renderPackageRbContents(gs);
+
+        if (existingContents.value() != newContents) {
+            if (auto e = gs.beginError(pkgInfo.declLoc(), core::errors::Packager::IncorrectPackageRB)) {
+                e.setHeader("`{}` has changes", pkgInfo.show(gs));
+                e.addAutocorrect({"Update __package.rb", {{existingContentsLoc, newContents}}});
+            }
+        }
+    }
+}
+
 } // namespace sorbet::packager

--- a/packager/GenPackages.cc
+++ b/packager/GenPackages.cc
@@ -249,7 +249,9 @@ void GenPackages::runStrict(core::GlobalState &gs) {
         if (existingContents.value() != newContents) {
             if (auto e = gs.beginError(pkgInfo.declLoc(), core::errors::Packager::IncorrectPackageRB)) {
                 e.setHeader("`{}` has changes", pkgInfo.show(gs));
-                e.addAutocorrect({"Update __package.rb", {{existingContentsLoc, newContents}}});
+                bool isDidYouMean = false;
+                bool hideEdit = true;
+                e.addAutocorrect({"Update __package.rb", {{existingContentsLoc, newContents}}, isDidYouMean, hideEdit});
             }
         }
     }

--- a/packager/GenPackages.h
+++ b/packager/GenPackages.h
@@ -10,6 +10,7 @@ class GenPackages final {
 
 public:
     static void run(core::GlobalState &gs);
+    static void runStrict(core::GlobalState &gs);
 };
 
 } // namespace sorbet::packager

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -680,7 +680,7 @@ public:
             bool hasModularityError = layeringViolation || strictDependenciesTooLow || causesCycle;
             referencedPackages[otherPackage].causesModularityError = hasModularityError;
             if (!hasModularityError && !causesVisibilityError) {
-                if (db.genPackages()) {
+                if (db.genPackagesMode() != core::packages::GenPackagesMode::Disabled) {
                     return;
                 }
 
@@ -913,7 +913,7 @@ public:
             barrier.DecrementCount();
         });
 
-        if (gs.packageDB().genPackages()) {
+        if (gs.packageDB().genPackagesMode() != core::packages::GenPackagesMode::Disabled) {
             std::optional<ThreadResult> threadResult;
             for (auto result = resultq->wait_pop_timed(threadResult, WorkerPool::BLOCK_INTERVAL(), gs.tracer());
                  !result.done();

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -799,7 +799,9 @@ struct PackageSpecBodyWalk {
             }
         } else {
             // Extra directives
-            info.extraDirectives_.push_back(send.loc);
+            if (send.fun != core::Names::star()) {
+                info.extraDirectives_.push_back(send.loc);
+            }
         }
     }
 

--- a/test/cli/package-gen-packages-strict/A/__package.rb
+++ b/test/cli/package-gen-packages-strict/A/__package.rb
@@ -1,0 +1,12 @@
+# typed: strict
+
+class A < PackageSpec
+  layer 'app'
+  strict_dependencies 'dag'
+
+  foo 'a'
+
+  export A::CONSTANT_FROM_A
+
+  test_import B
+end

--- a/test/cli/package-gen-packages-strict/A/constants.rb
+++ b/test/cli/package-gen-packages-strict/A/constants.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module A
+  CONSTANT_FROM_A = "Hello from Package A"
+end

--- a/test/cli/package-gen-packages-strict/B/__package.rb
+++ b/test/cli/package-gen-packages-strict/B/__package.rb
@@ -1,0 +1,13 @@
+# typed: strict
+
+class B < PackageSpec
+  layer 'util'
+  strict_dependencies 'false'
+
+  import A
+  import C
+
+  export B::CONSTANT_FROM_B
+
+  visible_to A
+end

--- a/test/cli/package-gen-packages-strict/B/constants.rb
+++ b/test/cli/package-gen-packages-strict/B/constants.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module B
+  CONSTANT_FROM_B = "Hello from Package B"
+end

--- a/test/cli/package-gen-packages-strict/C/__package.rb
+++ b/test/cli/package-gen-packages-strict/C/__package.rb
@@ -1,0 +1,11 @@
+# typed: strict
+
+class C < PackageSpec
+  layer 'util'
+  strict_dependencies 'dag'
+
+  # strict_dependencies 'false', 'layered', or 'layered_dag':
+  import B
+
+  export_all!
+end

--- a/test/cli/package-gen-packages-strict/packagespec.rbi
+++ b/test/cli/package-gen-packages-strict/packagespec.rbi
@@ -1,0 +1,7 @@
+# typed: true
+
+class Sorbet::Private::Static::PackageSpec
+  sig { params(x: String).void }
+  def foo(x)
+  end
+end

--- a/test/cli/package-gen-packages-strict/test.out
+++ b/test/cli/package-gen-packages-strict/test.out
@@ -1,0 +1,67 @@
+###### gen-packages=strict mode not allowed with gen-packages-update-visibility-for ######
+--gen-packages=strict can not be used when --gen-packages-update-visibility-for is also enabled
+
+###### Running gen-packages=strict ######
+A/__package.rb:3: `A` has changes https://srb.help/3734
+     3 |class A < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+
+C/__package.rb:8: Strict dependencies violation: All of `C`'s `import`s must be `dag` or higher https://srb.help/3727
+     8 |  import B
+          ^^^^^^^^
+    B/__package.rb:5: `B`'s `strict_dependencies` level declared here
+     5 |  strict_dependencies 'false'
+                              ^^^^^^^
+
+C/__package.rb:8: Strict dependencies violation: importing `B` will put `C` into a cycle, which is not valid at `strict_dependencies 'dag'` https://srb.help/3727
+     8 |  import B
+          ^^^^^^^^
+  Note:
+    Path from `B` to `C`:
+    `B` →
+    `C`
+
+
+C/__package.rb:8: Package `B` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3723
+     8 |  import B
+          ^^^^^^^^
+  Note:
+    Please consult with the owning team before adding a `visible_to` line to the package `B`
+
+B/__package.rb:3: `B` has changes https://srb.help/3734
+     3 |class B < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+Errors: 5
+
+###### cat A/__package.rb ######
+# typed: strict
+
+class A < PackageSpec
+  foo 'a'
+  layer 'app'
+  strict_dependencies 'dag'
+
+  test_import B
+
+  export A::CONSTANT_FROM_A
+end
+
+###### cat B/__package.rb ######
+# typed: strict
+
+class B < PackageSpec
+  layer 'util'
+  strict_dependencies 'false'
+
+  # layering violations:
+  import A
+
+  # strict_dependencies 'layered' or more strict:
+  import C
+
+  export B::CONSTANT_FROM_B
+
+  visible_to A
+end

--- a/test/cli/package-gen-packages-strict/test.sh
+++ b/test/cli/package-gen-packages-strict/test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+cwd="$(pwd)"
+
+tmp="$(mktemp -d)"
+cd test/cli/package-gen-packages-strict || exit 1
+for file in $(find . -name '*.rb' | sort); do
+    mkdir -p "$tmp/$(dirname "$file")"
+    cp "$file" "$tmp/$file"
+done
+cd "$tmp" || exit 1
+
+
+echo "###### gen-packages=strict mode not allowed with gen-packages-update-visibility-for ######"
+
+"$cwd/main/sorbet" --max-threads=0 --silence-dev-message --sorbet-packages --gen-packages=strict --packager-layers=util,app --gen-packages-update-visibility-for=B -a . 2>&1
+
+echo
+echo "###### Running gen-packages=strict ######"
+
+"$cwd/main/sorbet" --max-threads=0 --silence-dev-message --sorbet-packages --gen-packages=strict --packager-layers=util,app . -a 2>&1
+
+echo
+echo "###### cat A/__package.rb ######"
+cat A/__package.rb
+
+echo
+echo "###### cat B/__package.rb ######"
+cat B/__package.rb

--- a/test/cli/package-gen-packages/test.out
+++ b/test/cli/package-gen-packages/test.out
@@ -1,5 +1,5 @@
 ###### --gen-packages not allowed without --sorbet-packages ######
---gen-packages can only be can only be used in --sorbet-packages mode
+--gen-packages can only be used in --sorbet-packages mode
 ###### --gen-packages not allowed with --lsp ######
 --gen-packages can not be used when --lsp is also enabled
 ##################################

--- a/website/docs/cli-ref.md
+++ b/website/docs/cli-ref.md
@@ -97,7 +97,8 @@ Usage:
                                 Remove the provided <prefix> from all printed paths.
                                 Defaults to the input directory passed to Sorbet, if any.
                                 (default: "")
-      --gen-packages            Generate package information
+      --gen-packages [={normal,strict}(=normal)]
+                                Generate package information (normal or strict)
 
 ```
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR adds the skeleton of a new `--gen-packages-strict` mode, that aims to update `__package.rb` in a more "strict" mode: remove unused imports/exports, sort imports/exports, raise `strict_dependencies` etc.

In this PR, the mode is essentially a no-op: it just serializes the existing `PackageInfo` according to a fixed format. In future PRs, we'll pass in updated imports, exports etc. and serialize those instead.

Review commit-by-commit.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Move tooling for working with packages into Sorbet.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
