### PR TITLE
Delete `PrismFallback`

### DIFF
--- a/ast/desugar/PrismDesugar.cc
+++ b/ast/desugar/PrismDesugar.cc
@@ -13,11 +13,6 @@
 #include "core/errors/desugar.h"
 #include "core/errors/internal.h"
 
-// Redefinition to avoid including parser/prism/Parser.h which has additional dependencies
-namespace sorbet::parser::Prism {
-struct PrismFallback {};
-} // namespace sorbet::parser::Prism
-
 namespace sorbet::ast::prismDesugar {
 
 using namespace std;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -437,18 +437,11 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
                     break;
                 }
                 case options::Parser::PRISM: {
-                    parser::ParseResult parseResult;
-                    try {
-                        parseResult = runPrismParser(lgs, file, print, opts);
+                    auto parseResult = runPrismParser(lgs, file, print, opts);
 
-                        // The RBS rewriter produces plain Whitequark nodes and not `NodeWithExpr` which causes errors
-                        // in `PrismDesugar.cc`. For now, disable all direct translation, and fallback to `Desugar.cc`.
-                        usePrismDesugar = !lgs.cacheSensitiveOptions.rbsEnabled;
-                        categoryCounterInc("Prism parse kind", "direct");
-                    } catch (parser::Prism::PrismFallback &) {
-                        parseResult = runParser(lgs, file, print, opts.traceLexer, opts.traceParser);
-                        categoryCounterInc("Prism parse kind", "fallback");
-                    }
+                    // The RBS rewriter produces plain Whitequark nodes and not `NodeWithExpr` which causes errors
+                    // in `PrismDesugar.cc`. For now, disable all direct translation, and fallback to `Desugar.cc`.
+                    usePrismDesugar = !lgs.cacheSensitiveOptions.rbsEnabled;
 
                     // parseResult is null if runPrismParser stopped after an intermediate phase
                     if (parseResult.tree == nullptr) {

--- a/parser/prism/Parser.h
+++ b/parser/prism/Parser.h
@@ -137,7 +137,5 @@ public:
     }
 };
 
-struct PrismFallback {};
-
 } // namespace sorbet::parser::Prism
 #endif // SORBET_PARSER_PRISM_PARSER_H

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -269,11 +269,7 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> f
                         continue;
                     }
 
-                    try {
-                        prismParseResult = parser::Prism::Parser::run(ctx);
-                    } catch (parser::Prism::PrismFallback &) {
-                        continue;
-                    }
+                    prismParseResult = parser::Prism::Parser::run(ctx);
 
                     break;
                 }
@@ -782,7 +778,6 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
         // this replicates the logic of pipeline::indexOne
         parser::ParseResult parseResult;
-        bool usePrismDesugar = false;
         switch (parser) {
             case realmain::options::Parser::ORIGINAL: {
                 auto settings = parser::Parser::Settings{false, false, false, gs->cacheSensitiveOptions.rbsEnabled};
@@ -796,14 +791,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
                 break;
             }
             case realmain::options::Parser::PRISM: {
-                try {
-                    parseResult = parser::Prism::Parser::run(ctx);
-                    usePrismDesugar = true;
-                } catch (parser::Prism::PrismFallback &) {
-                    // Hit a fallback case during Prism parsing, fallback to the legacy parser.
-                    auto settings = parser::Parser::Settings{false, false, false, gs->cacheSensitiveOptions.rbsEnabled};
-                    parseResult = parser::Parser::run(*gs, f, settings);
-                }
+                parseResult = parser::Prism::Parser::run(ctx);
 
                 break;
             }
@@ -825,12 +813,16 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         handler.addObserved(*gs, "rbs-rewrite-tree", [&]() { return nodes->toString(*gs); });
 
         // Desugarer
-        auto ast = usePrismDesugar ? ast::prismDesugar::node2Tree(ctx, move(nodes))
-                                   : ast::desugar::node2Tree(ctx, move(nodes));
+        ast::ExpressionPtr ast;
+        {
+            core::UnfreezeNameTable nameTableAccess(ctx); // enters original strings
+            ast = parser == realmain::options::Parser::PRISM ? ast::prismDesugar::node2Tree(ctx, move(nodes))
+                                                             : ast::desugar::node2Tree(ctx, move(nodes));
+        }
 
         auto file = ast::ParsedFile{move(ast), f};
 
-        if (!usePrismDesugar) {
+        if (parser != realmain::options::Parser::PRISM) {
             // These expectations match the legacy parser's desugar tree, which can be subtly different
             // (e.g. the numbering of unique identifiers). Only test these for the legacy parser.
             handler.addObserved(*gs, "desguar-tree", [&]() { return file.tree.toString(*gs); });


### PR DESCRIPTION
### Motivation

Part of #9065. The Prism translator is complete, and no longer throws `PrismFallback` in any cases.

This PR cleans up the fallback logic that it used to trigger.

### Test plan

Not covered by any tests, because this is all dead code since #9976.
