### PR TITLE
Detect `raise` of abstract Exception classes

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -11,6 +11,7 @@
 #include "core/TypeConstraint.h"
 #include "core/TypeErrorDiagnostics.h"
 #include "core/Types.h"
+#include "core/errors/cfg.h"
 #include "core/errors/infer.h"
 #include "core/lsp/QueryResponse.h"
 #include <algorithm> // find_if, sort
@@ -4416,6 +4417,31 @@ public:
         auto classOfException = make_type<ClassType>(Symbols::Exception().data(gs)->lookupSingletonClass(gs));
         if (!classArg->type.isUntyped() && !Types::isSubType(gs, classArg->type, classOfException)) {
             return;
+        }
+
+        // Check if the class is abstract and has no custom .new method.
+        // This mirrors the check in cfg/builder/builder_walk.cc for `AbstractClass.new`,
+        // but catches the case where the instantiation is implicit via `raise`.
+        //
+        // Class singleton types can be either ClassType or AppliedType (the latter for
+        // classes with type members, which includes all singleton classes in practice).
+        auto singletonSym = ClassOrModuleRef{};
+        if (isa_type<ClassType>(classArg->type)) {
+            singletonSym = cast_type_nonnull<ClassType>(classArg->type).symbol;
+        } else if (auto at = cast_type<AppliedType>(classArg->type)) {
+            singletonSym = at->klass;
+        }
+        if (singletonSym.exists() && singletonSym.data(gs)->isSingletonClass(gs)) {
+            auto attachedClass = singletonSym.data(gs)->attachedClass(gs);
+            if (attachedClass.exists() && attachedClass.data(gs)->flags.isAbstract) {
+                auto method_new = singletonSym.data(gs)->findMethodTransitive(gs, Names::new_());
+                if (method_new.data(gs)->owner == Symbols::Class()) {
+                    if (auto e = gs.beginError(args.argLoc(0), errors::CFG::AbstractClassInstantiated)) {
+                        e.setHeader("Attempting to instantiate abstract class `{}`", attachedClass.show(gs));
+                        e.addErrorLine(attachedClass.data(gs)->loc(), "`{}` defined here", attachedClass.show(gs));
+                    }
+                }
+            }
         }
 
         uint16_t newNumPosArgs = args.args.size() >= 2 ? 1 : 0;

--- a/test/testdata/intrinsics/kernel_raise.rb
+++ b/test/testdata/intrinsics/kernel_raise.rb
@@ -101,3 +101,37 @@ def example(cls)
     #           ^ error: Missing required keyword argument `input` for method `MyError#initialize`
   end
 end
+
+class AbstractError < StandardError
+  extend T::Helpers
+  abstract!
+end
+
+class ConcreteError < AbstractError; end
+
+class AbstractErrorWithCustomNew < StandardError
+  extend T::Helpers
+  abstract!
+
+  def self.new
+    super
+  end
+end
+
+def raise_abstract
+  0.times do
+    raise AbstractError # error: Attempting to instantiate abstract class `AbstractError`
+  end
+
+  0.times do
+    raise ConcreteError # no error: concrete subclass
+  end
+
+  0.times do
+    raise AbstractErrorWithCustomNew # no error: has custom .new
+  end
+
+  0.times do
+    fail AbstractError # error: Attempting to instantiate abstract class `AbstractError`
+  end
+end

--- a/test/testdata/intrinsics/kernel_raise.rb.autocorrects.exp
+++ b/test/testdata/intrinsics/kernel_raise.rb.autocorrects.exp
@@ -102,4 +102,38 @@ def example(cls)
     #           ^ error: Missing required keyword argument `input` for method `MyError#initialize`
   end
 end
+
+class AbstractError < StandardError
+  extend T::Helpers
+  abstract!
+end
+
+class ConcreteError < AbstractError; end
+
+class AbstractErrorWithCustomNew < StandardError
+  extend T::Helpers
+  abstract!
+
+  def self.new
+    super
+  end
+end
+
+def raise_abstract
+  0.times do
+    raise AbstractError # error: Attempting to instantiate abstract class `AbstractError`
+  end
+
+  0.times do
+    raise ConcreteError # no error: concrete subclass
+  end
+
+  0.times do
+    raise AbstractErrorWithCustomNew # no error: has custom .new
+  end
+
+  0.times do
+    fail AbstractError # error: Attempting to instantiate abstract class `AbstractError`
+  end
+end
 # ------------------------------


### PR DESCRIPTION
Extends the existing `Kernel_raise` intrinsic (from #6681) so that `raise AbstractError` reports "Attempting to instantiate abstract class" when `AbstractError` is declared `abstract!` and has no custom `.new`. This mirrors the existing check for direct `AbstractClass.new` calls in the CFG builder.

No error is reported when the class has a custom `.new` override, matching the existing behavior.

### Motivation

`raise AbstractError` implicitly calls `AbstractError.new`, but the abstract class instantiation check in the CFG builder only fires for literal `.new` sends. This means abstract exception classes slip through `raise`/`fail` uncaught.

### Test plan

See included automated tests.

- Abstract class → error
- Concrete subclass → no error
- Abstract with custom `.new` → no error
- `fail` alias → error