### PR TITLE
Rework Prism's integration in the pipeline

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -229,11 +229,12 @@ ast::ExpressionPtr fetchTreeFromCache(core::GlobalState &gs, core::FileRef fref,
 
 parser::ParseResult runParser(core::GlobalState &gs, core::FileRef file, const options::Printers &print,
                               bool traceLexer, bool traceParser) {
-    Timer timeit(gs.tracer(), "runParser", {{"file", string(file.data(gs).path())}});
     parser::ParseResult result;
     {
+        Timer timeit(gs.tracer(), "runParser", {{"file", string(file.data(gs).path())}});
         core::UnfreezeNameTable nameTableAccess(gs); // enters strings from source code as names
-        auto indentationAware = false;               // Don't start in indentation-aware error recovery mode
+
+        auto indentationAware = false; // Don't start in indentation-aware error recovery mode
         auto collectComments = gs.cacheSensitiveOptions.rbsEnabled; // Collect comments for RBS signature translation
         auto settings = parser::Parser::Settings{traceLexer, traceParser, indentationAware, collectComments};
         result = parser::Parser::run(gs, file, settings);
@@ -254,59 +255,39 @@ parser::ParseResult runParser(core::GlobalState &gs, core::FileRef file, const o
     return result;
 }
 
-parser::ParseResult runPrismParser(core::GlobalState &gs, core::FileRef file, const options::Printers &print,
-                                   const options::Options &opts, bool preserveConcreteSyntax = false) {
-    Timer timeit(gs.tracer(), "runParser", {{"file", string(file.data(gs).path())}});
-
-    parser::ParseResult parseResult;
-    {
-        core::MutableContext ctx(gs, core::Symbols::root(), file);
+parser::Prism::ParseResult runPrismParser(core::GlobalState &gs, core::FileRef file, const options::Printers &print,
+                                          const options::Options &opts, bool preserveConcreteSyntax = false) {
+    auto parseResult = [&] {
+        Timer timeit(gs.tracer(), "runParser", {{"file", string(file.data(gs).path())}});
         core::UnfreezeNameTable nameTableAccess(gs); // enters strings from source code as names
-        // The RBS rewriter produces plain Whitequark nodes and not `NodeWithExpr` which causes errors in
-        // `PrismDesugar.cc`. For now, disable all direct translation, and fallback to `Desugar.cc`.
-        auto source = file.data(ctx).source();
-        parser::Prism::Parser parser{source};
+
+        auto source = file.data(gs).source();
         bool collectComments = gs.cacheSensitiveOptions.rbsEnabled;
-        parser::Prism::ParseResult prismResult = parser.parseWithoutTranslation(collectComments);
+        return parser::Prism::Parser::parseWithoutTranslation(source, collectComments);
+    }();
 
-        if (opts.stopAfterPhase == options::Phase::PARSER) {
-            return parser::ParseResult{nullptr, prismResult.getCommentLocations()};
-        }
-
-        auto node = prismResult.getRawNodePointer();
-
-        // TODO: Remove `&& false` once RBS rewriter with Prism AST migration is complete
-        // https://github.com/sorbet/sorbet/issues/9065
-        if (gs.cacheSensitiveOptions.rbsEnabled && false) {
-            node = rbs::runPrismRBSRewrite(gs, file, node, prismResult.getCommentLocations(), ctx, parser);
-            if (print.RBSRewriteTree.enabled) {
-                print.RBSRewriteTree.fmt("{}\n", parser.prettyPrint(node));
-            }
-        }
-
-        auto enclosingBlockParamLoc = core::LocOffsets::none();
-        auto enclosingBlockParamName = core::NameRef::noName();
-        auto translatedTree =
-            parser::Prism::Translator(parser, ctx, prismResult.getParseErrors(), preserveConcreteSyntax,
-                                      enclosingBlockParamLoc, enclosingBlockParamName)
-                .translate_TODO(node);
-
-        parseResult = parser::ParseResult{move(translatedTree), prismResult.getCommentLocations()};
+    if (print.ParseTree.enabled) {
+        print.ParseTree.fmt("{}\n", parseResult.prettyPrint());
     }
 
-    if (parseResult.tree) {
-        if (print.ParseTree.enabled) {
-            print.ParseTree.fmt("{}\n", parseResult.tree->toStringWithTabs(gs, 0));
-        }
-        if (print.ParseTreeJson.enabled) {
-            print.ParseTreeJson.fmt("{}\n", parseResult.tree->toJSON(gs, 0));
-        }
-        if (print.ParseTreeJsonWithLocs.enabled) {
-            print.ParseTreeJson.fmt("{}\n", parseResult.tree->toJSONWithLocs(gs, file, 0));
-        }
-        if (print.ParseTreeWhitequark.enabled) {
-            print.ParseTreeWhitequark.fmt("{}\n", parseResult.tree->toWhitequark(gs, 0));
-        }
+    return parseResult;
+}
+
+parser::Prism::ParseResult runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file,
+                                              parser::Prism::ParseResult parseResult, const options::Printers &print) {
+    if (gs.cacheSensitiveOptions.rbsEnabled) {
+        Timer timeit(gs.tracer(), "runRBSRewrite", {{"file", string(file.data(gs).path())}});
+        core::MutableContext ctx(gs, core::Symbols::root(), file);
+        core::UnfreezeNameTable nameTableAccess(gs);
+
+        auto &parser = parseResult.getParser();
+        auto node = rbs::runPrismRBSRewrite(gs, file, parseResult.getRawNodePointer(),
+                                            parseResult.getCommentLocations(), ctx, parser);
+        parseResult.replaceRootNode(node);
+    }
+
+    if (print.RBSRewriteTree.enabled) {
+        print.RBSRewriteTree.fmt("{}\n", parseResult.prettyPrint());
     }
 
     return parseResult;
@@ -339,18 +320,18 @@ unique_ptr<parser::Node> runRBSRewrite(core::GlobalState &gs, core::FileRef file
 }
 
 ast::ExpressionPtr runDesugar(core::GlobalState &gs, core::FileRef file, unique_ptr<parser::Node> parseTree,
-                              const options::Printers &print, bool preserveConcreteSyntax = false,
-                              bool usePrismDesugar = false) {
+                              const options::Printers &print, bool preserveConcreteSyntax = false) {
     ENFORCE(parseTree);
 
-    Timer timeit(gs.tracer(), "runDesugar", {{"file", string(file.data(gs).path())}});
     ast::ExpressionPtr ast;
-    core::MutableContext ctx(gs, core::Symbols::root(), file);
     {
         core::UnfreezeNameTable nameTableAccess(gs); // creates temporaries during desugaring
-        ast = usePrismDesugar ? ast::prismDesugar::node2Tree(ctx, move(parseTree), preserveConcreteSyntax)
-                              : ast::desugar::node2Tree(ctx, move(parseTree), preserveConcreteSyntax);
+        core::MutableContext ctx(gs, core::Symbols::root(), file);
+
+        Timer timeit(gs.tracer(), "runDesugar", {{"file", string(file.data(gs).path())}});
+        ast = ast::desugar::node2Tree(ctx, move(parseTree), preserveConcreteSyntax);
     }
+
     if (print.DesugarTree.enabled) {
         print.DesugarTree.fmt("{}\n", ast.toStringWithTabs(gs, 0));
     }
@@ -360,6 +341,37 @@ ast::ExpressionPtr runDesugar(core::GlobalState &gs, core::FileRef file, unique_
     if (print.DesugarTreeRawWithLocs.enabled) {
         print.DesugarTreeRawWithLocs.fmt("{}\n", ast.showRawWithLocs(gs, file));
     }
+
+    return ast;
+}
+
+ast::ExpressionPtr runPrismDesugar(core::GlobalState &gs, core::FileRef file, parser::Prism::ParseResult parseResult,
+                                   const options::Printers &print) {
+    ast::ExpressionPtr ast;
+    {
+        core::UnfreezeNameTable nameTableAccess(gs);
+        core::MutableContext ctx(gs, core::Symbols::root(), file);
+
+        auto enclosingBlockParamLoc = core::LocOffsets::none();
+        auto enclosingBlockParamName = core::NameRef::noName();
+        auto translatedTree = parser::Prism::Translator(parseResult.getParser(), ctx, parseResult.getParseErrors(),
+                                                        false, enclosingBlockParamLoc, enclosingBlockParamName)
+                                  .translate_TODO(parseResult.getRawNodePointer());
+
+        Timer timeit(gs.tracer(), "runDesugar", {{"file", string(file.data(gs).path())}});
+        ast = ast::prismDesugar::node2Tree(ctx, move(translatedTree));
+    }
+
+    if (print.DesugarTree.enabled) {
+        print.DesugarTree.fmt("{}\n", ast.toStringWithTabs(gs, 0));
+    }
+    if (print.DesugarTreeRaw.enabled) {
+        print.DesugarTreeRaw.fmt("{}\n", ast.showRaw(gs));
+    }
+    if (print.DesugarTreeRawWithLocs.enabled) {
+        print.DesugarTreeRawWithLocs.fmt("{}\n", ast.showRawWithLocs(gs, file));
+    }
+
     return ast;
 }
 
@@ -422,9 +434,6 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
                 return emptyParsedFile(file);
             }
 
-            bool usePrismDesugar = false;
-
-            unique_ptr<parser::Node> parseTree;
             switch (parser) {
                 case options::Parser::ORIGINAL: {
                     auto parseResult = runParser(lgs, file, print, opts.traceLexer, opts.traceParser);
@@ -432,34 +441,31 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
                         return emptyParsedFile(file);
                     }
 
-                    parseTree = runRBSRewrite(lgs, file, move(parseResult), print);
+                    auto rbsRewrittenParseResult = runRBSRewrite(lgs, file, move(parseResult), print);
 
-                    break;
-                }
-                case options::Parser::PRISM: {
-                    auto parseResult = runPrismParser(lgs, file, print, opts);
-
-                    // The RBS rewriter produces plain Whitequark nodes and not `NodeWithExpr` which causes errors
-                    // in `PrismDesugar.cc`. For now, disable all direct translation, and fallback to `Desugar.cc`.
-                    usePrismDesugar = !lgs.cacheSensitiveOptions.rbsEnabled;
-
-                    // parseResult is null if runPrismParser stopped after an intermediate phase
-                    if (parseResult.tree == nullptr) {
+                    tree = runDesugar(lgs, file, move(rbsRewrittenParseResult), print, false);
+                    if (opts.stopAfterPhase == options::Phase::DESUGARER) {
                         return emptyParsedFile(file);
                     }
 
-                    // TODO: Remove this check once runPrismRBSRewrite is no longer no-oped inside of runPrismParser
-                    // https://github.com/sorbet/sorbet/issues/9065
-                    parseTree = runRBSRewrite(lgs, file, move(parseResult), print);
+                    break;
+                }
+
+                case options::Parser::PRISM: {
+                    auto parseResult = runPrismParser(lgs, file, print, opts);
+                    if (opts.stopAfterPhase == options::Phase::PARSER) {
+                        return emptyParsedFile(file);
+                    }
+
+                    auto rbsRewrittenParseResult = runPrismRBSRewrite(lgs, file, move(parseResult), print);
+
+                    tree = runPrismDesugar(lgs, file, move(rbsRewrittenParseResult), print);
+                    if (opts.stopAfterPhase == options::Phase::DESUGARER) {
+                        return emptyParsedFile(file);
+                    }
 
                     break;
                 }
-            }
-
-            tree = runDesugar(lgs, file, move(parseTree), print, false, usePrismDesugar);
-
-            if (opts.stopAfterPhase == options::Phase::DESUGARER) {
-                return emptyParsedFile(file);
             }
 
             tree = runRewriter(lgs, file, move(tree));

--- a/parser/prism/Parser.cc
+++ b/parser/prism/Parser.cc
@@ -9,33 +9,24 @@ namespace sorbet::parser::Prism {
 
 using namespace std::literals::string_view_literals;
 
-parser::ParseResult Parser::run(core::MutableContext ctx, bool preserveConcreteSyntax) {
-    auto file = ctx.file;
-    auto source = file.data(ctx).source();
-    Prism::Parser parser{source};
+Prism::ParseResult Parser::run(core::MutableContext ctx, bool preserveConcreteSyntax) {
+    auto source = ctx.file.data(ctx).source();
     bool collectComments = ctx.state.cacheSensitiveOptions.rbsEnabled;
-    Prism::ParseResult parseResult = parser.parseWithoutTranslation(collectComments);
-
-    auto enclosingBlockParamLoc = core::LocOffsets::none();
-    auto enclosingBlockParamName = core::NameRef::noName();
-    auto translatedTree = Prism::Translator(parser, ctx, parseResult.parseErrors, preserveConcreteSyntax,
-                                            enclosingBlockParamLoc, enclosingBlockParamName)
-                              .translate_TODO(parseResult.getRawNodePointer());
-
-    return parser::ParseResult{move(translatedTree), move(parseResult.commentLocations)};
+    return Parser::parseWithoutTranslation(source, collectComments);
 }
 
 pm_parser_t *Parser::getRawParserPointer() {
     return &parser;
 }
 
-// Parses without translating and returns raw Prism nodes for intermediate processing (e.g., RBS rewriting)
-// Caller must keep Parser alive for later translation, unlike run() which parses + translates in one step
-ParseResult Parser::parseWithoutTranslation(bool collectComments) {
-    pm_node_t *root = pm_parse(&parser);
-    auto comments = collectComments ? collectCommentLocations() : vector<core::LocOffsets>{};
-    return ParseResult{*this, root, collectErrors(), move(comments)};
-};
+// Parses and returns raw Prism nodes for intermediate processing (e.g., RBS rewriting).
+ParseResult Parser::parseWithoutTranslation(string_view source, bool collectComments) {
+    auto parser = make_unique<Prism::Parser>(source);
+    pm_node_t *root = pm_parse(parser->getRawParserPointer());
+    auto errors = parser->collectErrors();
+    auto comments = collectComments ? parser->collectCommentLocations() : vector<core::LocOffsets>{};
+    return ParseResult{move(parser), root, move(errors), move(comments)};
+}
 
 core::LocOffsets Parser::translateLocation(pm_location_t location) const {
     return translateLocation(location.start, location.end);

--- a/parser/prism/Parser.h
+++ b/parser/prism/Parser.h
@@ -11,7 +11,6 @@ extern "C" {
 
 #include "core/LocOffsets.h"
 #include "parser/Node.h" // To clarify: these are Sorbet Parser nodes, not Prism ones.
-#include "parser/ParseResult.h"
 
 namespace sorbet::parser::Prism {
 
@@ -29,14 +28,6 @@ public:
     pm_error_level_t level;
 };
 
-struct SimpleParseResult {
-    std::vector<ParseError> parseErrors;
-    std::vector<core::LocOffsets> commentLocations;
-
-    SimpleParseResult(std::vector<ParseError> parseErrors, std::vector<core::LocOffsets> commentLocations)
-        : parseErrors(std::move(parseErrors)), commentLocations(std::move(commentLocations)) {}
-};
-
 class Parser final {
     // The version of Ruby syntax that we're parsing with Prism. This determines what syntax is supported or not.
     static constexpr std::string_view ParsedRubyVersion = "3.4.0";
@@ -45,7 +36,6 @@ class Parser final {
     pm_options_t options;
 
     friend class ParseResult;
-    friend struct NodeDeleter;
     friend class Factory;
 
 public:
@@ -65,9 +55,9 @@ public:
     Parser(Parser &&) = delete;
     Parser &operator=(Parser &&) = delete;
 
-    static parser::ParseResult run(core::MutableContext ctx, bool preserveConcreteSyntax = false);
+    static Prism::ParseResult run(core::MutableContext ctx, bool preserveConcreteSyntax = false);
 
-    ParseResult parseWithoutTranslation(bool collectComments = false);
+    static ParseResult parseWithoutTranslation(std::string_view source, bool collectComments = false);
     core::LocOffsets translateLocation(pm_location_t location) const;
     core::LocOffsets translateLocation(const uint8_t *start, const uint8_t *end) const;
     std::string_view resolveConstant(pm_constant_id_t constantId) const;
@@ -93,35 +83,49 @@ private:
 };
 
 class ParseResult final {
-    struct NodeDeleter {
-        Parser &parser;
-
-        void operator()(pm_node_t *node) {
-            pm_node_destroy(parser.getRawParserPointer(), node);
-        }
-    };
-
     friend class Parser;
     friend class Translator;
 
-    const Parser &parser;
-    const std::unique_ptr<pm_node_t, NodeDeleter> node;
-    const std::vector<ParseError> parseErrors;
+    std::unique_ptr<Parser> parser;
+    pm_node_t *node;
+    std::vector<ParseError> parseErrors;
     std::vector<core::LocOffsets> commentLocations;
 
 public:
-    ParseResult(Parser &parser, pm_node_t *node, std::vector<ParseError> parseErrors,
+    ParseResult(std::unique_ptr<Parser> parser, pm_node_t *node, std::vector<ParseError> parseErrors,
                 std::vector<core::LocOffsets> commentLocations)
-        : parser{parser}, node{node, NodeDeleter{parser}}, parseErrors{parseErrors}, commentLocations{
-                                                                                         commentLocations} {}
+        : parser{std::move(parser)}, node{node}, parseErrors{std::move(parseErrors)}, commentLocations{std::move(
+                                                                                          commentLocations)} {}
+
+    ~ParseResult() {
+        if (node) {
+            ENFORCE(parser != nullptr, "The parser must live longer than the nodes it creates.");
+            parser->destroyNode(node);
+        }
+    }
+
+    ParseResult(ParseResult &&other) noexcept
+        : parser{std::move(other.parser)}, node{other.node}, parseErrors{std::move(other.parseErrors)},
+          commentLocations{std::move(other.commentLocations)} {
+        other.node = nullptr;
+    }
 
     ParseResult(const ParseResult &) = delete;            // Copy constructor
-    ParseResult &operator=(const ParseResult &) = delete; // Copy assignment
-    ParseResult(ParseResult &&) = delete;                 // Move constructor
     ParseResult &operator=(ParseResult &&) = delete;      // Move assignment
+    ParseResult &operator=(const ParseResult &) = delete; // Copy assignment
 
     pm_node_t *getRawNodePointer() const {
-        return node.get();
+        return node;
+    }
+
+    // Replace the root node, e.g. after RBS rewriting.
+    void replaceRootNode(pm_node_t *newNode) {
+        // Does not destroy the old node, since the rewriter mutates the tree in-place.
+        node = newNode;
+    }
+
+    std::string prettyPrint() const {
+        return parser->prettyPrint(node);
     }
 
     const std::vector<core::LocOffsets> &getCommentLocations() const {
@@ -132,8 +136,8 @@ public:
         return parseErrors;
     }
 
-    const Parser &getParser() const {
-        return parser;
+    Parser &getParser() {
+        return *parser;
     }
 };
 

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -38,10 +38,12 @@
 #include "packager/packager.h"
 #include "parser/parser.h"
 #include "parser/prism/Parser.h"
+#include "parser/prism/Translator.h"
 #include "payload/binary/binary.h"
 #include "payload/payload.h"
 #include "rbs/AssertionsRewriter.h"
 #include "rbs/SigsRewriter.h"
+#include "rbs/prism/RBSRewriterPrism.h"
 #include "resolver/resolver.h"
 #include "rewriter/rewriter.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
@@ -244,7 +246,7 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> f
 
         // Parser
         parser::ParseResult legacyParseResult;
-        parser::ParseResult prismParseResult;
+        std::optional<parser::Prism::ParseResult> prismParseResult;
         {
             core::UnfreezeNameTable nameTableAccess(gs); // enters original strings
             core::MutableContext ctx(gs, core::Symbols::root(), file);
@@ -262,6 +264,20 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> f
                     handler.addObserved(gs, "parse-tree-whitequark", [&]() { return nodes->toWhitequark(gs); });
                     handler.addObserved(gs, "parse-tree-json", [&]() { return nodes->toJSON(gs); });
 
+                    if (gs.cacheSensitiveOptions.rbsEnabled) {
+                        core::MutableContext ctx(gs, core::Symbols::root(), file);
+                        auto associator = rbs::CommentsAssociator(ctx, legacyParseResult.commentLocations);
+                        auto commentMap = associator.run(nodes);
+
+                        auto rbsSignatures = rbs::SigsRewriter(ctx, commentMap.signaturesForNode);
+                        nodes = rbsSignatures.run(std::move(nodes));
+
+                        auto rbsAssertions = rbs::AssertionsRewriter(ctx, commentMap.assertionsForNode);
+                        nodes = rbsAssertions.run(std::move(nodes));
+                    }
+
+                    handler.addObserved(gs, "rbs-rewrite-tree", [&]() { return nodes->toString(gs); });
+
                     break;
                 }
                 case realmain::options::Parser::PRISM: {
@@ -269,32 +285,11 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> f
                         continue;
                     }
 
-                    prismParseResult = parser::Prism::Parser::run(ctx);
+                    prismParseResult.emplace(parser::Prism::Parser::run(ctx));
 
                     break;
                 }
             }
-        }
-
-        parser::ParseResult &parseResult = prismParseResult.tree ? prismParseResult : legacyParseResult;
-
-        {
-            auto &nodes = parseResult.tree;
-
-            if (gs.cacheSensitiveOptions.rbsEnabled) {
-                core::UnfreezeNameTable nameTableAccess(gs); // enters original strings
-                core::MutableContext ctx(gs, core::Symbols::root(), file);
-                auto associator = rbs::CommentsAssociator(ctx, parseResult.commentLocations);
-                auto commentMap = associator.run(nodes);
-
-                auto rbsSignatures = rbs::SigsRewriter(ctx, commentMap.signaturesForNode);
-                nodes = rbsSignatures.run(std::move(nodes));
-
-                auto rbsAssertions = rbs::AssertionsRewriter(ctx, commentMap.assertionsForNode);
-                nodes = rbsAssertions.run(std::move(nodes));
-            }
-
-            handler.addObserved(gs, "rbs-rewrite-tree", [&]() { return nodes->toString(gs); });
         }
 
         // Desugarer
@@ -307,8 +302,16 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> f
                 BooleanPropertyAssertion::getValue("disable-parser-comparison", assertions).value_or(false);
 
             ast::ExpressionPtr resultAST;
-            if (prismParseResult.tree != nullptr) {
-                auto prismDirectDesugarAST = ast::prismDesugar::node2Tree(ctx, move(prismParseResult.tree));
+            if (prismParseResult.has_value()) {
+                // Translate the raw Prism AST into a Whitequark-compatible parser::Node for desugaring.
+                auto enclosingBlockParamLoc = core::LocOffsets::none();
+                auto enclosingBlockParamName = core::NameRef::noName();
+                auto translatedTree =
+                    parser::Prism::Translator(prismParseResult->getParser(), ctx, prismParseResult->getParseErrors(),
+                                              false, enclosingBlockParamLoc, enclosingBlockParamName)
+                        .translate_TODO(prismParseResult->getRawNodePointer());
+
+                auto prismDirectDesugarAST = ast::prismDesugar::node2Tree(ctx, move(translatedTree));
 
                 if (!disableParserComparison) {
                     ast::ExpressionPtr legacyDesugarAST = ast::desugar::node2Tree(ctx, move(legacyParseResult.tree));
@@ -777,57 +780,82 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         handler.drainErrors(*gs);
 
         // this replicates the logic of pipeline::indexOne
-        parser::ParseResult parseResult;
+        ast::ExpressionPtr ast;
         switch (parser) {
             case realmain::options::Parser::ORIGINAL: {
-                auto settings = parser::Parser::Settings{false, false, false, gs->cacheSensitiveOptions.rbsEnabled};
-                parseResult = parser::Parser::run(*gs, f, settings);
+                // Parser
+                parser::ParseResult parseResult;
+                {
+                    auto settings = parser::Parser::Settings{false, false, false, gs->cacheSensitiveOptions.rbsEnabled};
+                    parseResult = parser::Parser::run(*gs, f, settings);
+                }
 
                 handler.addObserved(*gs, "parse-tree", [&]() { return parseResult.tree->toString(*gs); });
                 handler.addObserved(*gs, "parse-tree-whitequark",
                                     [&]() { return parseResult.tree->toWhitequark(*gs); });
                 handler.addObserved(*gs, "parse-tree-json", [&]() { return parseResult.tree->toJSON(*gs); });
 
+                if (gs->cacheSensitiveOptions.rbsEnabled) {
+                    auto associator = rbs::CommentsAssociator(ctx, parseResult.commentLocations);
+                    auto commentMap = associator.run(parseResult.tree);
+
+                    auto rbsSignatures = rbs::SigsRewriter(ctx, commentMap.signaturesForNode);
+                    parseResult.tree = rbsSignatures.run(std::move(parseResult.tree));
+
+                    auto rbsAssertions = rbs::AssertionsRewriter(ctx, commentMap.assertionsForNode);
+                    parseResult.tree = rbsAssertions.run(std::move(parseResult.tree));
+
+                    handler.addObserved(*gs, "rbs-rewrite-tree", [&]() { return parseResult.tree->toString(*gs); });
+                }
+
+                // Desugarer
+                {
+                    core::UnfreezeNameTable nameTableAccess(ctx);
+                    ast = ast::desugar::node2Tree(ctx, move(parseResult.tree));
+                }
+
+                handler.addObserved(*gs, "desguar-tree", [&]() { return ast.toString(*gs); });
+                handler.addObserved(*gs, "desugar-tree-raw", [&]() { return ast.showRaw(*gs); });
+
                 break;
             }
+
             case realmain::options::Parser::PRISM: {
-                parseResult = parser::Prism::Parser::run(ctx);
+                core::UnfreezeNameTable nameTableAccess(*gs);
+
+                auto prismResult = parser::Prism::Parser::run(ctx);
+
+                // Run the Prism-level RBS rewriter
+                if (gs->cacheSensitiveOptions.rbsEnabled) {
+                    auto &prismParser = prismResult.getParser();
+                    auto node = rbs::runPrismRBSRewrite(*gs, f, prismResult.getRawNodePointer(),
+                                                        prismResult.getCommentLocations(), ctx, prismParser);
+                    prismResult.replaceRootNode(node);
+
+                    handler.addObserved(*gs, "rbs-rewrite-tree", [&]() { return prismResult.prettyPrint(); });
+                }
+
+                // Prism Desugarer
+                {
+                    auto enclosingBlockParamLoc = core::LocOffsets::none();
+                    auto enclosingBlockParamName = core::NameRef::noName();
+                    auto translatedTree =
+                        parser::Prism::Translator(prismResult.getParser(), ctx, prismResult.getParseErrors(), false,
+                                                  enclosingBlockParamLoc, enclosingBlockParamName)
+                            .translate_TODO(prismResult.getRawNodePointer());
+
+                    ast = ast::prismDesugar::node2Tree(ctx, move(translatedTree));
+                }
+
+                // Do *not* check the `desugar-tree` and `desugar-tree-raw` expectations for the Prism parser,
+                // which can be subtly different (e.g. the numbering of unique identifiers).
+                // Instead, we compare the two ASTs in the `index()` function.
 
                 break;
             }
-        }
-
-        if (gs->cacheSensitiveOptions.rbsEnabled) {
-            auto associator = rbs::CommentsAssociator(ctx, parseResult.commentLocations);
-            auto commentMap = associator.run(parseResult.tree);
-
-            auto rbsSignatures = rbs::SigsRewriter(ctx, commentMap.signaturesForNode);
-            parseResult.tree = rbsSignatures.run(std::move(parseResult.tree));
-
-            auto rbsAssertions = rbs::AssertionsRewriter(ctx, commentMap.assertionsForNode);
-            parseResult.tree = rbsAssertions.run(std::move(parseResult.tree));
-        }
-
-        auto nodes = move(parseResult.tree);
-
-        handler.addObserved(*gs, "rbs-rewrite-tree", [&]() { return nodes->toString(*gs); });
-
-        // Desugarer
-        ast::ExpressionPtr ast;
-        {
-            core::UnfreezeNameTable nameTableAccess(ctx); // enters original strings
-            ast = parser == realmain::options::Parser::PRISM ? ast::prismDesugar::node2Tree(ctx, move(nodes))
-                                                             : ast::desugar::node2Tree(ctx, move(nodes));
         }
 
         auto file = ast::ParsedFile{move(ast), f};
-
-        if (parser != realmain::options::Parser::PRISM) {
-            // These expectations match the legacy parser's desugar tree, which can be subtly different
-            // (e.g. the numbering of unique identifiers). Only test these for the legacy parser.
-            handler.addObserved(*gs, "desguar-tree", [&]() { return file.tree.toString(*gs); });
-            handler.addObserved(*gs, "desugar-tree-raw", [&]() { return file.tree.showRaw(*gs); });
-        }
 
         // Rewriter pass
         file.tree = rewriter::Rewriter::run(ctx, move(file.tree));


### PR DESCRIPTION
### Motivation

Part of #9065, stacked on #9982

The way the Prism phases were integrated into the pipeline was pretty rough, mainly complicated by the fact that a `pm_node_t *` is owned by the parser that allocated it, so we're not free to just return it.

This restructures the code so that `runParser()` and `runPrismParser()` no long return the same `parser::ParseResult`. Instead, `runPrismParser()` returns `parser::Prism::ParseResult`, which I reworked to take ownership of the Prism parser. This helps ensure the parser out-lives the nodes that depend on it.

### Test plan

Covered by existing tests, though I did need to modify the test pipeline to match the `realmain` one.
