### PR TITLE
Support zero-arg `expect {}` in RSpec mode

### DIFF
--- a/test/cli/rspec/rspec2.rb
+++ b/test/cli/rspec/rspec2.rb
@@ -11,7 +11,8 @@ module RSpec
       def is_expected
       end
 
-      def expect(arg)
+      # https://github.com/rspec/rspec/blob/rspec-expectations-v3.13.5/rspec-expectations/lib/rspec/expectations/syntax.rb#L72-L74
+      def expect(value = nil, &block)
       end
 
       def eq(arg)
@@ -27,7 +28,8 @@ class A
 
   def is_expected; end
 
-  def expect(arg); end
+  # https://github.com/rspec/rspec/blob/rspec-expectations-v3.13.5/rspec-expectations/lib/rspec/expectations/syntax.rb#L72-L74
+  def expect(value = nil, &block); end
 
   def eq(arg); end
 

--- a/test/cli/rspec/rspec3.rb
+++ b/test/cli/rspec/rspec3.rb
@@ -4,7 +4,8 @@
 module RSpec
   module Core
     class ExampleGroup
-      def expect(arg)
+      # https://github.com/rspec/rspec/blob/rspec-expectations-v3.13.5/rspec-expectations/lib/rspec/expectations/syntax.rb#L72-L74
+      def expect(value = nil, &block)
       end
 
       def eq(arg)

--- a/test/cli/rspec/rspec4.rb
+++ b/test/cli/rspec/rspec4.rb
@@ -4,7 +4,8 @@
 module RSpec
   module Core
     class ExampleGroup
-      def expect(arg)
+      # https://github.com/rspec/rspec/blob/rspec-expectations-v3.13.5/rspec-expectations/lib/rspec/expectations/syntax.rb#L72-L74
+      def expect(value = nil, &block)
       end
 
       def eq(arg)

--- a/test/cli/rspec/rspec7.rb
+++ b/test/cli/rspec/rspec7.rb
@@ -1,0 +1,57 @@
+# typed: true
+# enable-experimental-rspec: true
+
+# This test validates that `expect` can be called with zero positional arguments
+# (block-only form), which is used for testing that code raises/does not raise errors.
+# Example: `expect { some_code }.to raise_error`
+#          `expect { some_code }.not_to raise_error`
+
+module RSpec
+  module Core
+    class ExampleGroup
+      # https://github.com/rspec/rspec/blob/rspec-expectations-v3.13.5/rspec-expectations/lib/rspec/expectations/syntax.rb#L72-L74
+      def expect(value = nil, &block)
+      end
+
+      def raise_error
+      end
+
+      def eq(arg)
+      end
+    end
+  end
+
+  def self.describe(*args, &block); end
+end
+
+class MyClass
+  def self.delete(key)
+  end
+
+  def self.write(key, value)
+  end
+end
+
+RSpec.describe MyClass do
+  # Block-only form: expect { }.not_to raise_error
+  it "does not raise on delete" do
+    expect { MyClass.delete(:bar) }
+  end
+
+  # Block-only form: expect { }.to raise_error
+  it "raises on invalid input" do
+    expect { MyClass.write(nil, nil) }
+  end
+
+  # Mixed: one describe with both forms
+  describe "expect forms" do
+    it "supports value form" do
+      result = MyClass.delete(:foo)
+      expect(result)
+    end
+
+    it "supports block form" do
+      expect { MyClass.delete(:baz) }
+    end
+  end
+end

--- a/test/cli/rspec/test.out
+++ b/test/cli/rspec/test.out
@@ -825,639 +825,639 @@ test/cli/rspec/rspec6.rb:302: Method `item` does not exist on `T.class_of(<root>
       NN |  def gem(dep, *reqs); end
             ^^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec2.rb:68: Only valid `it`, `before`, `after`, and `describe` blocks can appear within `test_each` https://srb.help/3507
-    68 |        include_examples("some examples")
+test/cli/rspec/rspec2.rb:70: Only valid `it`, `before`, `after`, and `describe` blocks can appear within `test_each` https://srb.help/3507
+    70 |        include_examples("some examples")
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
     For other things, like constant and variable assignments,    hoist them to constants or methods defined outside the `test_each` block.
 
-test/cli/rspec/rspec2.rb:174: Method `it` does not exist on `T.class_of(<root>)` https://srb.help/7003
-     174 |  it "inside B" do
+test/cli/rspec/rspec2.rb:176: Method `it` does not exist on `T.class_of(<root>)` https://srb.help/7003
+     176 |  it "inside B" do
             ^^
   Got `T.class_of(<root>)` originating from:
     test/cli/rspec/rspec2.rb:4:
      4 |module RSpec
         ^
 
-test/cli/rspec/rspec2.rb:178: Method `context` does not exist on `T.class_of(<root>)` https://srb.help/7003
-     178 |  context("Nested, no RSpec") do
+test/cli/rspec/rspec2.rb:180: Method `context` does not exist on `T.class_of(<root>)` https://srb.help/7003
+     180 |  context("Nested, no RSpec") do
             ^^^^^^^
   Got `T.class_of(<root>)` originating from:
     test/cli/rspec/rspec2.rb:4:
      4 |module RSpec
         ^
 
-test/cli/rspec/rspec2.rb:179: Method `it` does not exist on `T.class_of(<root>)` https://srb.help/7003
-     179 |    it "inside Nested" do
+test/cli/rspec/rspec2.rb:181: Method `it` does not exist on `T.class_of(<root>)` https://srb.help/7003
+     181 |    it "inside Nested" do
               ^^
   Got `T.class_of(<root>)` originating from:
     test/cli/rspec/rspec2.rb:4:
      4 |module RSpec
         ^
 
-test/cli/rspec/rspec2.rb:181: Method `described_class` does not exist on `T.class_of(<root>)` https://srb.help/7003
-     181 |      described_class
+test/cli/rspec/rspec2.rb:183: Method `described_class` does not exist on `T.class_of(<root>)` https://srb.help/7003
+     183 |      described_class
                 ^^^^^^^^^^^^^^^
   Got `T.class_of(<root>)` originating from:
     test/cli/rspec/rspec2.rb:4:
      4 |module RSpec
         ^
 
-test/cli/rspec/rspec2.rb:77: Method `example` does not exist on `T.class_of(A)` https://srb.help/7003
-    77 |  example do # error: Method `example` does not exist
+test/cli/rspec/rspec2.rb:79: Method `example` does not exist on `T.class_of(A)` https://srb.help/7003
+    79 |  example do # error: Method `example` does not exist
           ^^^^^^^
   Got `T.class_of(A)` originating from:
-    test/cli/rspec/rspec2.rb:23:
-    23 |class A
+    test/cli/rspec/rspec2.rb:24:
+    24 |class A
         ^
 
-test/cli/rspec/rspec2.rb:78: Method `outer_helper` does not exist on `T.class_of(A)` https://srb.help/7003
-    78 |    outer_helper # error: Method `outer_helper` does not exist
+test/cli/rspec/rspec2.rb:80: Method `outer_helper` does not exist on `T.class_of(A)` https://srb.help/7003
+    80 |    outer_helper # error: Method `outer_helper` does not exist
             ^^^^^^^^^^^^
   Got `T.class_of(A)` originating from:
-    test/cli/rspec/rspec2.rb:23:
-    23 |class A
+    test/cli/rspec/rspec2.rb:24:
+    24 |class A
         ^
   Did you mean `attr_reader`? Use `-a` to autocorrect
-    test/cli/rspec/rspec2.rb:78: Replace with `attr_reader`
-    78 |    outer_helper # error: Method `outer_helper` does not exist
+    test/cli/rspec/rspec2.rb:80: Replace with `attr_reader`
+    80 |    outer_helper # error: Method `outer_helper` does not exist
             ^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Defined here
       NN |  def attr_reader(*arg0); end
             ^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec2.rb:81: Method `example_group` does not exist on `T.class_of(A)` https://srb.help/7003
-    81 |  example_group "example_group group" do # error: Method `example_group` does not exist
+test/cli/rspec/rspec2.rb:83: Method `example_group` does not exist on `T.class_of(A)` https://srb.help/7003
+    83 |  example_group "example_group group" do # error: Method `example_group` does not exist
           ^^^^^^^^^^^^^
   Got `T.class_of(A)` originating from:
-    test/cli/rspec/rspec2.rb:23:
-    23 |class A
+    test/cli/rspec/rspec2.rb:24:
+    24 |class A
         ^
 
-test/cli/rspec/rspec2.rb:82: Method `it` does not exist on `T.class_of(A)` https://srb.help/7003
-    82 |    it do # error: does not exist
+test/cli/rspec/rspec2.rb:84: Method `it` does not exist on `T.class_of(A)` https://srb.help/7003
+    84 |    it do # error: does not exist
             ^^
   Got `T.class_of(A)` originating from:
-    test/cli/rspec/rspec2.rb:23:
-    23 |class A
+    test/cli/rspec/rspec2.rb:24:
+    24 |class A
         ^
 
-test/cli/rspec/rspec2.rb:83: Method `outer_helper` does not exist on `T.class_of(A)` https://srb.help/7003
-    83 |      outer_helper # error: Method `outer_helper` does not exist
+test/cli/rspec/rspec2.rb:85: Method `outer_helper` does not exist on `T.class_of(A)` https://srb.help/7003
+    85 |      outer_helper # error: Method `outer_helper` does not exist
               ^^^^^^^^^^^^
   Got `T.class_of(A)` originating from:
-    test/cli/rspec/rspec2.rb:23:
-    23 |class A
+    test/cli/rspec/rspec2.rb:24:
+    24 |class A
         ^
   Did you mean `attr_reader`? Use `-a` to autocorrect
-    test/cli/rspec/rspec2.rb:83: Replace with `attr_reader`
-    83 |      outer_helper # error: Method `outer_helper` does not exist
+    test/cli/rspec/rspec2.rb:85: Replace with `attr_reader`
+    85 |      outer_helper # error: Method `outer_helper` does not exist
               ^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Defined here
       NN |  def attr_reader(*arg0); end
             ^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec2.rb:87: Method `context` does not exist on `T.class_of(A)` https://srb.help/7003
-    87 |  context "context group" do # error: Method `context` does not exist
+test/cli/rspec/rspec2.rb:89: Method `context` does not exist on `T.class_of(A)` https://srb.help/7003
+    89 |  context "context group" do # error: Method `context` does not exist
           ^^^^^^^
   Got `T.class_of(A)` originating from:
-    test/cli/rspec/rspec2.rb:23:
-    23 |class A
+    test/cli/rspec/rspec2.rb:24:
+    24 |class A
         ^
 
-test/cli/rspec/rspec2.rb:88: Method `it` does not exist on `T.class_of(A)` https://srb.help/7003
-    88 |    it do # error: does not exist
+test/cli/rspec/rspec2.rb:90: Method `it` does not exist on `T.class_of(A)` https://srb.help/7003
+    90 |    it do # error: does not exist
             ^^
   Got `T.class_of(A)` originating from:
-    test/cli/rspec/rspec2.rb:23:
-    23 |class A
+    test/cli/rspec/rspec2.rb:24:
+    24 |class A
         ^
 
-test/cli/rspec/rspec2.rb:89: Method `outer_helper` does not exist on `T.class_of(A)` https://srb.help/7003
-    89 |      outer_helper # error: Method `outer_helper` does not exist
+test/cli/rspec/rspec2.rb:91: Method `outer_helper` does not exist on `T.class_of(A)` https://srb.help/7003
+    91 |      outer_helper # error: Method `outer_helper` does not exist
               ^^^^^^^^^^^^
   Got `T.class_of(A)` originating from:
-    test/cli/rspec/rspec2.rb:23:
-    23 |class A
+    test/cli/rspec/rspec2.rb:24:
+    24 |class A
         ^
   Did you mean `attr_reader`? Use `-a` to autocorrect
-    test/cli/rspec/rspec2.rb:89: Replace with `attr_reader`
-    89 |      outer_helper # error: Method `outer_helper` does not exist
+    test/cli/rspec/rspec2.rb:91: Replace with `attr_reader`
+    91 |      outer_helper # error: Method `outer_helper` does not exist
               ^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Defined here
       NN |  def attr_reader(*arg0); end
             ^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec2.rb:50: Method `shared_examples` does not exist on `T.class_of(A::<describe 'inside describe'>)` https://srb.help/7003
-    50 |    shared_examples "some examples" do
+test/cli/rspec/rspec2.rb:52: Method `shared_examples` does not exist on `T.class_of(A::<describe 'inside describe'>)` https://srb.help/7003
+    52 |    shared_examples "some examples" do
             ^^^^^^^^^^^^^^^
   Got `T.class_of(A::<describe 'inside describe'>)` originating from:
-    test/cli/rspec/rspec2.rb:34:
-    34 |  describe "inside describe" do
+    test/cli/rspec/rspec2.rb:36:
+    36 |  describe "inside describe" do
           ^
 
-test/cli/rspec/rspec2.rb:51: Method `let` does not exist on `T.class_of(A::<describe 'inside describe'>)` https://srb.help/7003
-    51 |      let(:defined_in_shared_examples) { "foo" }
+test/cli/rspec/rspec2.rb:53: Method `let` does not exist on `T.class_of(A::<describe 'inside describe'>)` https://srb.help/7003
+    53 |      let(:defined_in_shared_examples) { "foo" }
               ^^^
   Got `T.class_of(A::<describe 'inside describe'>)` originating from:
-    test/cli/rspec/rspec2.rb:34:
-    34 |  describe "inside describe" do
+    test/cli/rspec/rspec2.rb:36:
+    36 |  describe "inside describe" do
           ^
 
-test/cli/rspec/rspec2.rb:53: Method `it` does not exist on `T.class_of(A::<describe 'inside describe'>)` https://srb.help/7003
-    53 |      it("a shared example") do
+test/cli/rspec/rspec2.rb:55: Method `it` does not exist on `T.class_of(A::<describe 'inside describe'>)` https://srb.help/7003
+    55 |      it("a shared example") do
               ^^
   Got `T.class_of(A::<describe 'inside describe'>)` originating from:
-    test/cli/rspec/rspec2.rb:34:
-    34 |  describe "inside describe" do
+    test/cli/rspec/rspec2.rb:36:
+    36 |  describe "inside describe" do
           ^
 
-test/cli/rspec/rspec2.rb:54: Method `described_class` does not exist on `T.class_of(A::<describe 'inside describe'>)` https://srb.help/7003
-    54 |        described_class
+test/cli/rspec/rspec2.rb:56: Method `described_class` does not exist on `T.class_of(A::<describe 'inside describe'>)` https://srb.help/7003
+    56 |        described_class
                 ^^^^^^^^^^^^^^^
   Got `T.class_of(A::<describe 'inside describe'>)` originating from:
-    test/cli/rspec/rspec2.rb:34:
-    34 |  describe "inside describe" do
+    test/cli/rspec/rspec2.rb:36:
+    36 |  describe "inside describe" do
           ^
 
-test/cli/rspec/rspec2.rb:68: Method `include_examples` does not exist on `T.class_of(A::<describe 'inside describe'>)` https://srb.help/7003
-    68 |        include_examples("some examples")
+test/cli/rspec/rspec2.rb:70: Method `include_examples` does not exist on `T.class_of(A::<describe 'inside describe'>)` https://srb.help/7003
+    70 |        include_examples("some examples")
                 ^^^^^^^^^^^^^^^^
   Got `T.class_of(A::<describe 'inside describe'>)` originating from:
-    test/cli/rspec/rspec2.rb:34:
-    34 |  describe "inside describe" do
+    test/cli/rspec/rspec2.rb:36:
+    36 |  describe "inside describe" do
           ^
   Did you mean `included_modules`? Use `-a` to autocorrect
-    test/cli/rspec/rspec2.rb:68: Replace with `included_modules`
-    68 |        include_examples("some examples")
+    test/cli/rspec/rspec2.rb:70: Replace with `included_modules`
+    70 |        include_examples("some examples")
                 ^^^^^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Defined here
       NN |  def included_modules(); end
             ^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec2.rb:39: Method `described_class` does not exist on `A::<describe 'inside describe'>` https://srb.help/7003
-    39 |      described_class # error: does not exist
+test/cli/rspec/rspec2.rb:41: Method `described_class` does not exist on `A::<describe 'inside describe'>` https://srb.help/7003
+    41 |      described_class # error: does not exist
               ^^^^^^^^^^^^^^^
   Got `A::<describe 'inside describe'>` originating from:
-    test/cli/rspec/rspec2.rb:37:
-    37 |    xit do
+    test/cli/rspec/rspec2.rb:39:
+    39 |    xit do
             ^
 
-test/cli/rspec/rspec2.rb:71: Method `defined_in_shared_examples` does not exist on `A::<describe 'inside describe'>` https://srb.help/7003
-    71 |          defined_in_shared_examples # error: does not exist
+test/cli/rspec/rspec2.rb:73: Method `defined_in_shared_examples` does not exist on `A::<describe 'inside describe'>` https://srb.help/7003
+    73 |          defined_in_shared_examples # error: does not exist
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
   Got `A::<describe 'inside describe'>` originating from:
-    test/cli/rspec/rspec2.rb:70:
-    70 |        it "has access to defined_in_shared_examples" do
+    test/cli/rspec/rspec2.rb:72:
+    72 |        it "has access to defined_in_shared_examples" do
                 ^
 
-test/cli/rspec/rspec2.rb:59: Method `include_examples` does not exist on `T.class_of(A::<describe 'inside describe'>::<describe 'will include shared examples'>)` https://srb.help/7003
-    59 |      include_examples("some examples")
+test/cli/rspec/rspec2.rb:61: Method `include_examples` does not exist on `T.class_of(A::<describe 'inside describe'>::<describe 'will include shared examples'>)` https://srb.help/7003
+    61 |      include_examples("some examples")
               ^^^^^^^^^^^^^^^^
   Got `T.class_of(A::<describe 'inside describe'>::<describe 'will include shared examples'>)` originating from:
-    test/cli/rspec/rspec2.rb:58:
-    58 |    describe "will include shared examples" do # error: `A::<describe 'inside describe'>::<describe 'will include shared examples'>` must inherit `RSpec::Core::ExampleGroup` (required by `A::<describe 'inside describe'>::<shared_examples 'some examples'>`)
+    test/cli/rspec/rspec2.rb:60:
+    60 |    describe "will include shared examples" do # error: `A::<describe 'inside describe'>::<describe 'will include shared examples'>` must inherit `RSpec::Core::ExampleGroup` (required by `A::<describe 'inside describe'>::<shared_examples 'some examples'>`)
             ^
   Did you mean `included_modules`? Use `-a` to autocorrect
-    test/cli/rspec/rspec2.rb:59: Replace with `included_modules`
-    59 |      include_examples("some examples")
+    test/cli/rspec/rspec2.rb:61: Replace with `included_modules`
+    61 |      include_examples("some examples")
               ^^^^^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Defined here
       NN |  def included_modules(); end
             ^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec2.rb:62: Method `defined_in_shared_examples` does not exist on `A::<describe 'inside describe'>::<describe 'will include shared examples'>` https://srb.help/7003
-    62 |        defined_in_shared_examples
+test/cli/rspec/rspec2.rb:64: Method `defined_in_shared_examples` does not exist on `A::<describe 'inside describe'>::<describe 'will include shared examples'>` https://srb.help/7003
+    64 |        defined_in_shared_examples
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
   Got `A::<describe 'inside describe'>::<describe 'will include shared examples'>` originating from:
-    test/cli/rspec/rspec2.rb:61:
-    61 |      it "has access to defined_in_shared_examples" do
+    test/cli/rspec/rspec2.rb:63:
+    63 |      it "has access to defined_in_shared_examples" do
               ^
 
-test/cli/rspec/rspec2.rb:116: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>` https://srb.help/7003
-     116 |    its(:bar) { is_expected.to eq(foo) } # error: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>`
+test/cli/rspec/rspec2.rb:118: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>` https://srb.help/7003
+     118 |    its(:bar) { is_expected.to eq(foo) } # error: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>`
                           ^^^^^^^^^^^
   Got `A::<describe 'its support'>::<describe 'bar'>` originating from:
-    test/cli/rspec/rspec2.rb:116: Possibly uninitialized (`NilClass`) in:
-     116 |    its(:bar) { is_expected.to eq(foo) } # error: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>`
+    test/cli/rspec/rspec2.rb:118: Possibly uninitialized (`NilClass`) in:
+     118 |    its(:bar) { is_expected.to eq(foo) } # error: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>`
               ^
 
-test/cli/rspec/rspec2.rb:119: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>` https://srb.help/7003
-     119 |    its('bar') { is_expected.to eq(foo) } # error: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>`
+test/cli/rspec/rspec2.rb:121: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>` https://srb.help/7003
+     121 |    its('bar') { is_expected.to eq(foo) } # error: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>`
                            ^^^^^^^^^^^
   Got `A::<describe 'its support'>::<describe 'bar'>` originating from:
-    test/cli/rspec/rspec2.rb:119: Possibly uninitialized (`NilClass`) in:
-     119 |    its('bar') { is_expected.to eq(foo) } # error: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>`
+    test/cli/rspec/rspec2.rb:121: Possibly uninitialized (`NilClass`) in:
+     121 |    its('bar') { is_expected.to eq(foo) } # error: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>`
               ^
 
-test/cli/rspec/rspec2.rb:124: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'size'>` https://srb.help/7003
-     124 |      is_expected.to eq(X) # error: Method `subject` does not exist
+test/cli/rspec/rspec2.rb:126: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'size'>` https://srb.help/7003
+     126 |      is_expected.to eq(X) # error: Method `subject` does not exist
                 ^^^^^^^^^^^
   Got `A::<describe 'its support'>::<describe 'size'>` originating from:
-    test/cli/rspec/rspec2.rb:122: Possibly uninitialized (`NilClass`) in:
-     122 |    its(:size) do
+    test/cli/rspec/rspec2.rb:124: Possibly uninitialized (`NilClass`) in:
+     124 |    its(:size) do
               ^
 
-test/cli/rspec/rspec2.rb:136: Revealed type: `A::<describe 'its support'>::<describe 'size'>` https://srb.help/7014
-     136 |      T.reveal_type(self) # error: Revealed type: `A::<describe 'its support'>::<describe 'size'>`
+test/cli/rspec/rspec2.rb:138: Revealed type: `A::<describe 'its support'>::<describe 'size'>` https://srb.help/7014
+     138 |      T.reveal_type(self) # error: Revealed type: `A::<describe 'its support'>::<describe 'size'>`
                 ^^^^^^^^^^^^^^^^^^^
   Got `A::<describe 'its support'>::<describe 'size'>` originating from:
-    test/cli/rspec/rspec2.rb:135: Possibly uninitialized (`NilClass`) in:
-     135 |    its(:size) do
+    test/cli/rspec/rspec2.rb:137: Possibly uninitialized (`NilClass`) in:
+     137 |    its(:size) do
               ^
 
-test/cli/rspec/rspec2.rb:160: Revealed type: `A::<describe 'its with typed subject'>::ThingWithSize` https://srb.help/7014
-     160 |      T.reveal_type(subject) # error: Revealed type: `A::<describe 'its with typed subject'>::ThingWithSize`
+test/cli/rspec/rspec2.rb:162: Revealed type: `A::<describe 'its with typed subject'>::ThingWithSize` https://srb.help/7014
+     162 |      T.reveal_type(subject) # error: Revealed type: `A::<describe 'its with typed subject'>::ThingWithSize`
                 ^^^^^^^^^^^^^^^^^^^^^^
   Got `A::<describe 'its with typed subject'>::ThingWithSize` originating from:
-    test/cli/rspec/rspec2.rb:160:
-     160 |      T.reveal_type(subject) # error: Revealed type: `A::<describe 'its with typed subject'>::ThingWithSize`
+    test/cli/rspec/rspec2.rb:162:
+     162 |      T.reveal_type(subject) # error: Revealed type: `A::<describe 'its with typed subject'>::ThingWithSize`
                               ^^^^^^^
 
-test/cli/rspec/rspec2.rb:166: Method `no_such_method` does not exist on `A::<describe 'its with typed subject'>::ThingWithSize` https://srb.help/7003
-     166 |      is_expected.to eq(0) # error: Method `no_such_method` does not exist on `A::<describe 'its with typed subject'>::ThingWithSize`
+test/cli/rspec/rspec2.rb:168: Method `no_such_method` does not exist on `A::<describe 'its with typed subject'>::ThingWithSize` https://srb.help/7003
+     168 |      is_expected.to eq(0) # error: Method `no_such_method` does not exist on `A::<describe 'its with typed subject'>::ThingWithSize`
                 ^^^^^^^^^^^
   Got `A::<describe 'its with typed subject'>::ThingWithSize` originating from:
-    test/cli/rspec/rspec2.rb:166:
-     166 |      is_expected.to eq(0) # error: Method `no_such_method` does not exist on `A::<describe 'its with typed subject'>::ThingWithSize`
+    test/cli/rspec/rspec2.rb:168:
+     168 |      is_expected.to eq(0) # error: Method `no_such_method` does not exist on `A::<describe 'its with typed subject'>::ThingWithSize`
                 ^^^^^^^^^^^
 
-test/cli/rspec/rspec4.rb:18: Method `shared_examples` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
-    18 |    shared_examples "my shared example" do |my_param|
+test/cli/rspec/rspec4.rb:19: Method `shared_examples` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
+    19 |    shared_examples "my shared example" do |my_param|
             ^^^^^^^^^^^^^^^
   Got `T.class_of(MyClass::<describe 'single shared example with context'>)` originating from:
-    test/cli/rspec/rspec4.rb:17:
-    17 |  describe("single shared example with context") do
+    test/cli/rspec/rspec4.rb:18:
+    18 |  describe("single shared example with context") do
           ^
 
-test/cli/rspec/rspec4.rb:19: Revealed type: `T.untyped` https://srb.help/7014
-    19 |      T.reveal_type(my_param) # error: `NilClass`
+test/cli/rspec/rspec4.rb:20: Revealed type: `T.untyped` https://srb.help/7014
+    20 |      T.reveal_type(my_param) # error: `NilClass`
               ^^^^^^^^^^^^^^^^^^^^^^^
   Got `T.untyped` originating from:
-    test/cli/rspec/rspec4.rb:18:
-    18 |    shared_examples "my shared example" do |my_param|
+    test/cli/rspec/rspec4.rb:19:
+    19 |    shared_examples "my shared example" do |my_param|
                                                     ^^^^^^^^
 
-test/cli/rspec/rspec4.rb:20: Method `let` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
-    20 |      let(:foo_exists) { 'bar' }
+test/cli/rspec/rspec4.rb:21: Method `let` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
+    21 |      let(:foo_exists) { 'bar' }
               ^^^
   Got `T.class_of(MyClass::<describe 'single shared example with context'>)` originating from:
-    test/cli/rspec/rspec4.rb:17:
-    17 |  describe("single shared example with context") do
+    test/cli/rspec/rspec4.rb:18:
+    18 |  describe("single shared example with context") do
           ^
 
-test/cli/rspec/rspec4.rb:22: Method `let` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
-    22 |      let(:uses_my_param) {
+test/cli/rspec/rspec4.rb:23: Method `let` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
+    23 |      let(:uses_my_param) {
               ^^^
   Got `T.class_of(MyClass::<describe 'single shared example with context'>)` originating from:
-    test/cli/rspec/rspec4.rb:17:
-    17 |  describe("single shared example with context") do
+    test/cli/rspec/rspec4.rb:18:
+    18 |  describe("single shared example with context") do
           ^
 
-test/cli/rspec/rspec4.rb:23: Revealed type: `T.untyped` https://srb.help/7014
-    23 |        T.reveal_type(my_param) # error: `NilClass`
+test/cli/rspec/rspec4.rb:24: Revealed type: `T.untyped` https://srb.help/7014
+    24 |        T.reveal_type(my_param) # error: `NilClass`
                 ^^^^^^^^^^^^^^^^^^^^^^^
   Got `T.untyped` originating from:
-    test/cli/rspec/rspec4.rb:18:
-    18 |    shared_examples "my shared example" do |my_param|
+    test/cli/rspec/rspec4.rb:19:
+    19 |    shared_examples "my shared example" do |my_param|
                                                     ^^^^^^^^
 
-test/cli/rspec/rspec4.rb:26: Method `it` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
-    26 |      it "works for #{my_param}" do
+test/cli/rspec/rspec4.rb:27: Method `it` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
+    27 |      it "works for #{my_param}" do
               ^^
   Got `T.class_of(MyClass::<describe 'single shared example with context'>)` originating from:
-    test/cli/rspec/rspec4.rb:17:
-    17 |  describe("single shared example with context") do
+    test/cli/rspec/rspec4.rb:18:
+    18 |  describe("single shared example with context") do
           ^
 
-test/cli/rspec/rspec4.rb:27: Revealed type: `T.untyped` https://srb.help/7014
-    27 |        T.reveal_type(my_param) # error: `T.untyped`
+test/cli/rspec/rspec4.rb:28: Revealed type: `T.untyped` https://srb.help/7014
+    28 |        T.reveal_type(my_param) # error: `T.untyped`
                 ^^^^^^^^^^^^^^^^^^^^^^^
   Got `T.untyped` originating from:
-    test/cli/rspec/rspec4.rb:18:
-    18 |    shared_examples "my shared example" do |my_param|
+    test/cli/rspec/rspec4.rb:19:
+    19 |    shared_examples "my shared example" do |my_param|
                                                     ^^^^^^^^
 
-test/cli/rspec/rspec4.rb:28: Method `foo_exists` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
-    28 |        expect(foo_exists).to eq('bar')
+test/cli/rspec/rspec4.rb:29: Method `foo_exists` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
+    29 |        expect(foo_exists).to eq('bar')
                        ^^^^^^^^^^
   Got `T.class_of(MyClass::<describe 'single shared example with context'>)` originating from:
-    test/cli/rspec/rspec4.rb:17:
-    17 |  describe("single shared example with context") do
+    test/cli/rspec/rspec4.rb:18:
+    18 |  describe("single shared example with context") do
           ^
   Did you mean `at_exit`? Use `-a` to autocorrect
-    test/cli/rspec/rspec4.rb:28: Replace with `at_exit`
-    28 |        expect(foo_exists).to eq('bar')
+    test/cli/rspec/rspec4.rb:29: Replace with `at_exit`
+    29 |        expect(foo_exists).to eq('bar')
                        ^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
       NN |  def at_exit(&blk); end
             ^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec4.rb:28: Method `expect` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
-    28 |        expect(foo_exists).to eq('bar')
+test/cli/rspec/rspec4.rb:29: Method `expect` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
+    29 |        expect(foo_exists).to eq('bar')
                 ^^^^^^
   Got `T.class_of(MyClass::<describe 'single shared example with context'>)` originating from:
-    test/cli/rspec/rspec4.rb:17:
-    17 |  describe("single shared example with context") do
+    test/cli/rspec/rspec4.rb:18:
+    18 |  describe("single shared example with context") do
           ^
   Did you mean `exec`? Use `-a` to autocorrect
-    test/cli/rspec/rspec4.rb:28: Replace with `exec`
-    28 |        expect(foo_exists).to eq('bar')
+    test/cli/rspec/rspec4.rb:29: Replace with `exec`
+    29 |        expect(foo_exists).to eq('bar')
                 ^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
       NN |  def exec(env, argv0 = T.unsafe(nil), *args, **options); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec4.rb:28: Method `eq` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
-    28 |        expect(foo_exists).to eq('bar')
+test/cli/rspec/rspec4.rb:29: Method `eq` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
+    29 |        expect(foo_exists).to eq('bar')
                                       ^^
   Got `T.class_of(MyClass::<describe 'single shared example with context'>)` originating from:
-    test/cli/rspec/rspec4.rb:17:
-    17 |  describe("single shared example with context") do
+    test/cli/rspec/rspec4.rb:18:
+    18 |  describe("single shared example with context") do
           ^
 
-test/cli/rspec/rspec4.rb:29: Method `this_does_not_exist` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
-    29 |        this_does_not_exist
+test/cli/rspec/rspec4.rb:30: Method `this_does_not_exist` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
+    30 |        this_does_not_exist
                 ^^^^^^^^^^^^^^^^^^^
   Got `T.class_of(MyClass::<describe 'single shared example with context'>)` originating from:
-    test/cli/rspec/rspec4.rb:17:
-    17 |  describe("single shared example with context") do
+    test/cli/rspec/rspec4.rb:18:
+    18 |  describe("single shared example with context") do
           ^
 
-test/cli/rspec/rspec4.rb:36: Method `shared_context` does not exist on `T.class_of(MyClass::<describe 'shared context with 2 params'>)` https://srb.help/7003
-    36 |    shared_context "context with 2 params" do |param1, param2|
+test/cli/rspec/rspec4.rb:37: Method `shared_context` does not exist on `T.class_of(MyClass::<describe 'shared context with 2 params'>)` https://srb.help/7003
+    37 |    shared_context "context with 2 params" do |param1, param2|
             ^^^^^^^^^^^^^^
   Got `T.class_of(MyClass::<describe 'shared context with 2 params'>)` originating from:
-    test/cli/rspec/rspec4.rb:35:
-    35 |  describe("shared context with 2 params") do
-          ^
-
-test/cli/rspec/rspec4.rb:37: Method `let` does not exist on `T.class_of(MyClass::<describe 'shared context with 2 params'>)` https://srb.help/7003
-    37 |      let(:value1) { param1 }
-              ^^^
-  Got `T.class_of(MyClass::<describe 'shared context with 2 params'>)` originating from:
-    test/cli/rspec/rspec4.rb:35:
-    35 |  describe("shared context with 2 params") do
+    test/cli/rspec/rspec4.rb:36:
+    36 |  describe("shared context with 2 params") do
           ^
 
 test/cli/rspec/rspec4.rb:38: Method `let` does not exist on `T.class_of(MyClass::<describe 'shared context with 2 params'>)` https://srb.help/7003
-    38 |      let(:value2) { param2 }
+    38 |      let(:value1) { param1 }
               ^^^
   Got `T.class_of(MyClass::<describe 'shared context with 2 params'>)` originating from:
-    test/cli/rspec/rspec4.rb:35:
-    35 |  describe("shared context with 2 params") do
+    test/cli/rspec/rspec4.rb:36:
+    36 |  describe("shared context with 2 params") do
           ^
 
-test/cli/rspec/rspec4.rb:40: Method `it` does not exist on `T.class_of(MyClass::<describe 'shared context with 2 params'>)` https://srb.help/7003
-    40 |      it "uses the params" do
+test/cli/rspec/rspec4.rb:39: Method `let` does not exist on `T.class_of(MyClass::<describe 'shared context with 2 params'>)` https://srb.help/7003
+    39 |      let(:value2) { param2 }
+              ^^^
+  Got `T.class_of(MyClass::<describe 'shared context with 2 params'>)` originating from:
+    test/cli/rspec/rspec4.rb:36:
+    36 |  describe("shared context with 2 params") do
+          ^
+
+test/cli/rspec/rspec4.rb:41: Method `it` does not exist on `T.class_of(MyClass::<describe 'shared context with 2 params'>)` https://srb.help/7003
+    41 |      it "uses the params" do
               ^^
   Got `T.class_of(MyClass::<describe 'shared context with 2 params'>)` originating from:
-    test/cli/rspec/rspec4.rb:35:
-    35 |  describe("shared context with 2 params") do
+    test/cli/rspec/rspec4.rb:36:
+    36 |  describe("shared context with 2 params") do
           ^
 
-test/cli/rspec/rspec4.rb:41: Revealed type: `T.untyped` https://srb.help/7014
-    41 |        T.reveal_type(param1) # error: `T.untyped`
+test/cli/rspec/rspec4.rb:42: Revealed type: `T.untyped` https://srb.help/7014
+    42 |        T.reveal_type(param1) # error: `T.untyped`
                 ^^^^^^^^^^^^^^^^^^^^^
   Got `T.untyped` originating from:
-    test/cli/rspec/rspec4.rb:36:
-    36 |    shared_context "context with 2 params" do |param1, param2|
+    test/cli/rspec/rspec4.rb:37:
+    37 |    shared_context "context with 2 params" do |param1, param2|
                                                        ^^^^^^
 
-test/cli/rspec/rspec4.rb:42: Revealed type: `T.untyped` https://srb.help/7014
-    42 |        T.reveal_type(param2) # error: `T.untyped`
+test/cli/rspec/rspec4.rb:43: Revealed type: `T.untyped` https://srb.help/7014
+    43 |        T.reveal_type(param2) # error: `T.untyped`
                 ^^^^^^^^^^^^^^^^^^^^^
   Got `T.untyped` originating from:
-    test/cli/rspec/rspec4.rb:36:
-    36 |    shared_context "context with 2 params" do |param1, param2|
+    test/cli/rspec/rspec4.rb:37:
+    37 |    shared_context "context with 2 params" do |param1, param2|
                                                                ^^^^^^
 
-test/cli/rspec/rspec4.rb:47: Method `include_context` does not exist on `T.class_of(MyClass::<describe 'shared context with 2 params'>::<describe 'including context'>)` https://srb.help/7003
-    47 |      include_context("context with 2 params", "value1", "value2")
+test/cli/rspec/rspec4.rb:48: Method `include_context` does not exist on `T.class_of(MyClass::<describe 'shared context with 2 params'>::<describe 'including context'>)` https://srb.help/7003
+    48 |      include_context("context with 2 params", "value1", "value2")
               ^^^^^^^^^^^^^^^
   Got `T.class_of(MyClass::<describe 'shared context with 2 params'>::<describe 'including context'>)` originating from:
-    test/cli/rspec/rspec4.rb:46:
-    46 |    describe "including context" do
+    test/cli/rspec/rspec4.rb:47:
+    47 |    describe "including context" do
             ^
   Did you mean `included_modules`? Use `-a` to autocorrect
-    test/cli/rspec/rspec4.rb:47: Replace with `included_modules`
-    47 |      include_context("context with 2 params", "value1", "value2")
+    test/cli/rspec/rspec4.rb:48: Replace with `included_modules`
+    48 |      include_context("context with 2 params", "value1", "value2")
               ^^^^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Defined here
       NN |  def included_modules(); end
             ^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec4.rb:50: Method `value1` does not exist on `MyClass::<describe 'shared context with 2 params'>::<describe 'including context'>` https://srb.help/7003
-    50 |        value1
+test/cli/rspec/rspec4.rb:51: Method `value1` does not exist on `MyClass::<describe 'shared context with 2 params'>::<describe 'including context'>` https://srb.help/7003
+    51 |        value1
                 ^^^^^^
   Got `MyClass::<describe 'shared context with 2 params'>::<describe 'including context'>` originating from:
-    test/cli/rspec/rspec4.rb:49:
-    49 |      it "has access to values" do
-              ^
-  Did you mean `caller`? Use `-a` to autocorrect
-    test/cli/rspec/rspec4.rb:50: Replace with `caller`
-    50 |        value1
-                ^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
-      NN |  def caller(start_or_range=T.unsafe(nil), length=T.unsafe(nil)); end
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-test/cli/rspec/rspec4.rb:51: Method `value2` does not exist on `MyClass::<describe 'shared context with 2 params'>::<describe 'including context'>` https://srb.help/7003
-    51 |        value2
-                ^^^^^^
-  Got `MyClass::<describe 'shared context with 2 params'>::<describe 'including context'>` originating from:
-    test/cli/rspec/rspec4.rb:49:
-    49 |      it "has access to values" do
+    test/cli/rspec/rspec4.rb:50:
+    50 |      it "has access to values" do
               ^
   Did you mean `caller`? Use `-a` to autocorrect
     test/cli/rspec/rspec4.rb:51: Replace with `caller`
-    51 |        value2
+    51 |        value1
                 ^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
       NN |  def caller(start_or_range=T.unsafe(nil), length=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec4.rb:57: Method `shared_context` does not exist on `T.class_of(MyClass::<describe 'shared context with 5 params'>)` https://srb.help/7003
-    57 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
+test/cli/rspec/rspec4.rb:52: Method `value2` does not exist on `MyClass::<describe 'shared context with 2 params'>::<describe 'including context'>` https://srb.help/7003
+    52 |        value2
+                ^^^^^^
+  Got `MyClass::<describe 'shared context with 2 params'>::<describe 'including context'>` originating from:
+    test/cli/rspec/rspec4.rb:50:
+    50 |      it "has access to values" do
+              ^
+  Did you mean `caller`? Use `-a` to autocorrect
+    test/cli/rspec/rspec4.rb:52: Replace with `caller`
+    52 |        value2
+                ^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
+      NN |  def caller(start_or_range=T.unsafe(nil), length=T.unsafe(nil)); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/cli/rspec/rspec4.rb:58: Method `shared_context` does not exist on `T.class_of(MyClass::<describe 'shared context with 5 params'>)` https://srb.help/7003
+    58 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
             ^^^^^^^^^^^^^^
   Got `T.class_of(MyClass::<describe 'shared context with 5 params'>)` originating from:
-    test/cli/rspec/rspec4.rb:56:
-    56 |  describe("shared context with 5 params") do
-          ^
-
-test/cli/rspec/rspec4.rb:58: Method `let` does not exist on `T.class_of(MyClass::<describe 'shared context with 5 params'>)` https://srb.help/7003
-    58 |      let(:value1) { param1 }
-              ^^^
-  Got `T.class_of(MyClass::<describe 'shared context with 5 params'>)` originating from:
-    test/cli/rspec/rspec4.rb:56:
-    56 |  describe("shared context with 5 params") do
+    test/cli/rspec/rspec4.rb:57:
+    57 |  describe("shared context with 5 params") do
           ^
 
 test/cli/rspec/rspec4.rb:59: Method `let` does not exist on `T.class_of(MyClass::<describe 'shared context with 5 params'>)` https://srb.help/7003
-    59 |      let(:value2) { param2 }
+    59 |      let(:value1) { param1 }
               ^^^
   Got `T.class_of(MyClass::<describe 'shared context with 5 params'>)` originating from:
-    test/cli/rspec/rspec4.rb:56:
-    56 |  describe("shared context with 5 params") do
+    test/cli/rspec/rspec4.rb:57:
+    57 |  describe("shared context with 5 params") do
           ^
 
 test/cli/rspec/rspec4.rb:60: Method `let` does not exist on `T.class_of(MyClass::<describe 'shared context with 5 params'>)` https://srb.help/7003
-    60 |      let(:value3) { param3 }
+    60 |      let(:value2) { param2 }
               ^^^
   Got `T.class_of(MyClass::<describe 'shared context with 5 params'>)` originating from:
-    test/cli/rspec/rspec4.rb:56:
-    56 |  describe("shared context with 5 params") do
+    test/cli/rspec/rspec4.rb:57:
+    57 |  describe("shared context with 5 params") do
           ^
 
 test/cli/rspec/rspec4.rb:61: Method `let` does not exist on `T.class_of(MyClass::<describe 'shared context with 5 params'>)` https://srb.help/7003
-    61 |      let(:value4) { param4 }
+    61 |      let(:value3) { param3 }
               ^^^
   Got `T.class_of(MyClass::<describe 'shared context with 5 params'>)` originating from:
-    test/cli/rspec/rspec4.rb:56:
-    56 |  describe("shared context with 5 params") do
+    test/cli/rspec/rspec4.rb:57:
+    57 |  describe("shared context with 5 params") do
           ^
 
 test/cli/rspec/rspec4.rb:62: Method `let` does not exist on `T.class_of(MyClass::<describe 'shared context with 5 params'>)` https://srb.help/7003
-    62 |      let(:value5) { param5 }
+    62 |      let(:value4) { param4 }
               ^^^
   Got `T.class_of(MyClass::<describe 'shared context with 5 params'>)` originating from:
-    test/cli/rspec/rspec4.rb:56:
-    56 |  describe("shared context with 5 params") do
+    test/cli/rspec/rspec4.rb:57:
+    57 |  describe("shared context with 5 params") do
           ^
 
-test/cli/rspec/rspec4.rb:64: Method `it` does not exist on `T.class_of(MyClass::<describe 'shared context with 5 params'>)` https://srb.help/7003
-    64 |      it "uses the params" do
+test/cli/rspec/rspec4.rb:63: Method `let` does not exist on `T.class_of(MyClass::<describe 'shared context with 5 params'>)` https://srb.help/7003
+    63 |      let(:value5) { param5 }
+              ^^^
+  Got `T.class_of(MyClass::<describe 'shared context with 5 params'>)` originating from:
+    test/cli/rspec/rspec4.rb:57:
+    57 |  describe("shared context with 5 params") do
+          ^
+
+test/cli/rspec/rspec4.rb:65: Method `it` does not exist on `T.class_of(MyClass::<describe 'shared context with 5 params'>)` https://srb.help/7003
+    65 |      it "uses the params" do
               ^^
   Got `T.class_of(MyClass::<describe 'shared context with 5 params'>)` originating from:
-    test/cli/rspec/rspec4.rb:56:
-    56 |  describe("shared context with 5 params") do
+    test/cli/rspec/rspec4.rb:57:
+    57 |  describe("shared context with 5 params") do
           ^
 
-test/cli/rspec/rspec4.rb:65: Revealed type: `T.untyped` https://srb.help/7014
-    65 |        T.reveal_type(param1) # error: `T.untyped`
+test/cli/rspec/rspec4.rb:66: Revealed type: `T.untyped` https://srb.help/7014
+    66 |        T.reveal_type(param1) # error: `T.untyped`
                 ^^^^^^^^^^^^^^^^^^^^^
   Got `T.untyped` originating from:
-    test/cli/rspec/rspec4.rb:57:
-    57 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
+    test/cli/rspec/rspec4.rb:58:
+    58 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
                                                        ^^^^^^
 
-test/cli/rspec/rspec4.rb:66: Revealed type: `T.untyped` https://srb.help/7014
-    66 |        T.reveal_type(param2) # error: `T.untyped`
+test/cli/rspec/rspec4.rb:67: Revealed type: `T.untyped` https://srb.help/7014
+    67 |        T.reveal_type(param2) # error: `T.untyped`
                 ^^^^^^^^^^^^^^^^^^^^^
   Got `T.untyped` originating from:
-    test/cli/rspec/rspec4.rb:57:
-    57 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
+    test/cli/rspec/rspec4.rb:58:
+    58 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
                                                                ^^^^^^
 
-test/cli/rspec/rspec4.rb:67: Revealed type: `T.untyped` https://srb.help/7014
-    67 |        T.reveal_type(param3) # error: `T.untyped`
+test/cli/rspec/rspec4.rb:68: Revealed type: `T.untyped` https://srb.help/7014
+    68 |        T.reveal_type(param3) # error: `T.untyped`
                 ^^^^^^^^^^^^^^^^^^^^^
   Got `T.untyped` originating from:
-    test/cli/rspec/rspec4.rb:57:
-    57 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
+    test/cli/rspec/rspec4.rb:58:
+    58 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
                                                                        ^^^^^^
 
-test/cli/rspec/rspec4.rb:68: Revealed type: `T.untyped` https://srb.help/7014
-    68 |        T.reveal_type(param4) # error: `T.untyped`
+test/cli/rspec/rspec4.rb:69: Revealed type: `T.untyped` https://srb.help/7014
+    69 |        T.reveal_type(param4) # error: `T.untyped`
                 ^^^^^^^^^^^^^^^^^^^^^
   Got `T.untyped` originating from:
-    test/cli/rspec/rspec4.rb:57:
-    57 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
+    test/cli/rspec/rspec4.rb:58:
+    58 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
                                                                                ^^^^^^
 
-test/cli/rspec/rspec4.rb:69: Revealed type: `T.untyped` https://srb.help/7014
-    69 |        T.reveal_type(param5) # error: `T.untyped`
+test/cli/rspec/rspec4.rb:70: Revealed type: `T.untyped` https://srb.help/7014
+    70 |        T.reveal_type(param5) # error: `T.untyped`
                 ^^^^^^^^^^^^^^^^^^^^^
   Got `T.untyped` originating from:
-    test/cli/rspec/rspec4.rb:57:
-    57 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
+    test/cli/rspec/rspec4.rb:58:
+    58 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
                                                                                        ^^^^^^
 
-test/cli/rspec/rspec4.rb:74: Method `include_context` does not exist on `T.class_of(MyClass::<describe 'shared context with 5 params'>::<describe 'including context'>)` https://srb.help/7003
-    74 |      include_context("context with 5 params", "value1", "value2", "value3", "value4", "value5")
+test/cli/rspec/rspec4.rb:75: Method `include_context` does not exist on `T.class_of(MyClass::<describe 'shared context with 5 params'>::<describe 'including context'>)` https://srb.help/7003
+    75 |      include_context("context with 5 params", "value1", "value2", "value3", "value4", "value5")
               ^^^^^^^^^^^^^^^
   Got `T.class_of(MyClass::<describe 'shared context with 5 params'>::<describe 'including context'>)` originating from:
-    test/cli/rspec/rspec4.rb:73:
-    73 |    describe "including context" do
+    test/cli/rspec/rspec4.rb:74:
+    74 |    describe "including context" do
             ^
   Did you mean `included_modules`? Use `-a` to autocorrect
-    test/cli/rspec/rspec4.rb:74: Replace with `included_modules`
-    74 |      include_context("context with 5 params", "value1", "value2", "value3", "value4", "value5")
+    test/cli/rspec/rspec4.rb:75: Replace with `included_modules`
+    75 |      include_context("context with 5 params", "value1", "value2", "value3", "value4", "value5")
               ^^^^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Defined here
       NN |  def included_modules(); end
             ^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec4.rb:77: Method `value1` does not exist on `MyClass::<describe 'shared context with 5 params'>::<describe 'including context'>` https://srb.help/7003
-    77 |        value1
+test/cli/rspec/rspec4.rb:78: Method `value1` does not exist on `MyClass::<describe 'shared context with 5 params'>::<describe 'including context'>` https://srb.help/7003
+    78 |        value1
                 ^^^^^^
   Got `MyClass::<describe 'shared context with 5 params'>::<describe 'including context'>` originating from:
-    test/cli/rspec/rspec4.rb:76:
-    76 |      it "has access to values" do
-              ^
-  Did you mean `caller`? Use `-a` to autocorrect
-    test/cli/rspec/rspec4.rb:77: Replace with `caller`
-    77 |        value1
-                ^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
-      NN |  def caller(start_or_range=T.unsafe(nil), length=T.unsafe(nil)); end
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-test/cli/rspec/rspec4.rb:78: Method `value2` does not exist on `MyClass::<describe 'shared context with 5 params'>::<describe 'including context'>` https://srb.help/7003
-    78 |        value2
-                ^^^^^^
-  Got `MyClass::<describe 'shared context with 5 params'>::<describe 'including context'>` originating from:
-    test/cli/rspec/rspec4.rb:76:
-    76 |      it "has access to values" do
+    test/cli/rspec/rspec4.rb:77:
+    77 |      it "has access to values" do
               ^
   Did you mean `caller`? Use `-a` to autocorrect
     test/cli/rspec/rspec4.rb:78: Replace with `caller`
-    78 |        value2
+    78 |        value1
                 ^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
       NN |  def caller(start_or_range=T.unsafe(nil), length=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec4.rb:79: Method `value3` does not exist on `MyClass::<describe 'shared context with 5 params'>::<describe 'including context'>` https://srb.help/7003
-    79 |        value3
+test/cli/rspec/rspec4.rb:79: Method `value2` does not exist on `MyClass::<describe 'shared context with 5 params'>::<describe 'including context'>` https://srb.help/7003
+    79 |        value2
                 ^^^^^^
   Got `MyClass::<describe 'shared context with 5 params'>::<describe 'including context'>` originating from:
-    test/cli/rspec/rspec4.rb:76:
-    76 |      it "has access to values" do
+    test/cli/rspec/rspec4.rb:77:
+    77 |      it "has access to values" do
               ^
   Did you mean `caller`? Use `-a` to autocorrect
     test/cli/rspec/rspec4.rb:79: Replace with `caller`
-    79 |        value3
+    79 |        value2
                 ^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
       NN |  def caller(start_or_range=T.unsafe(nil), length=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec4.rb:80: Method `value4` does not exist on `MyClass::<describe 'shared context with 5 params'>::<describe 'including context'>` https://srb.help/7003
-    80 |        value4
+test/cli/rspec/rspec4.rb:80: Method `value3` does not exist on `MyClass::<describe 'shared context with 5 params'>::<describe 'including context'>` https://srb.help/7003
+    80 |        value3
                 ^^^^^^
   Got `MyClass::<describe 'shared context with 5 params'>::<describe 'including context'>` originating from:
-    test/cli/rspec/rspec4.rb:76:
-    76 |      it "has access to values" do
+    test/cli/rspec/rspec4.rb:77:
+    77 |      it "has access to values" do
               ^
   Did you mean `caller`? Use `-a` to autocorrect
     test/cli/rspec/rspec4.rb:80: Replace with `caller`
-    80 |        value4
+    80 |        value3
                 ^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
       NN |  def caller(start_or_range=T.unsafe(nil), length=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec4.rb:81: Method `value5` does not exist on `MyClass::<describe 'shared context with 5 params'>::<describe 'including context'>` https://srb.help/7003
-    81 |        value5
+test/cli/rspec/rspec4.rb:81: Method `value4` does not exist on `MyClass::<describe 'shared context with 5 params'>::<describe 'including context'>` https://srb.help/7003
+    81 |        value4
                 ^^^^^^
   Got `MyClass::<describe 'shared context with 5 params'>::<describe 'including context'>` originating from:
-    test/cli/rspec/rspec4.rb:76:
-    76 |      it "has access to values" do
+    test/cli/rspec/rspec4.rb:77:
+    77 |      it "has access to values" do
               ^
   Did you mean `caller`? Use `-a` to autocorrect
     test/cli/rspec/rspec4.rb:81: Replace with `caller`
-    81 |        value5
+    81 |        value4
+                ^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
+      NN |  def caller(start_or_range=T.unsafe(nil), length=T.unsafe(nil)); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/cli/rspec/rspec4.rb:82: Method `value5` does not exist on `MyClass::<describe 'shared context with 5 params'>::<describe 'including context'>` https://srb.help/7003
+    82 |        value5
+                ^^^^^^
+  Got `MyClass::<describe 'shared context with 5 params'>::<describe 'including context'>` originating from:
+    test/cli/rspec/rspec4.rb:77:
+    77 |      it "has access to values" do
+              ^
+  Did you mean `caller`? Use `-a` to autocorrect
+    test/cli/rspec/rspec4.rb:82: Replace with `caller`
+    82 |        value5
                 ^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
       NN |  def caller(start_or_range=T.unsafe(nil), length=T.unsafe(nil)); end
@@ -1653,82 +1653,182 @@ test/cli/rspec/rspec5.rb:88: Method `result` does not exist on `T.class_of(<root
       NN |  def test(cmd, file1, file2=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec3.rb:18: Method `shared_examples` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
-    18 |    shared_examples "my shared example" do
+test/cli/rspec/rspec7.rb:37: Method `it` does not exist on `T.class_of(<root>)` https://srb.help/7003
+    37 |  it "does not raise on delete" do
+          ^^
+  Got `T.class_of(<root>)` originating from:
+    test/cli/rspec/rspec7.rb:9:
+     9 |module RSpec
+        ^
+
+test/cli/rspec/rspec7.rb:38: Method `expect` does not exist on `T.class_of(<root>)` https://srb.help/7003
+    38 |    expect { MyClass.delete(:bar) }
+            ^^^^^^
+  Got `T.class_of(<root>)` originating from:
+    test/cli/rspec/rspec7.rb:9:
+     9 |module RSpec
+        ^
+  Did you mean `exec`? Use `-a` to autocorrect
+    test/cli/rspec/rspec7.rb:38: Replace with `exec`
+    38 |    expect { MyClass.delete(:bar) }
+            ^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
+      NN |  def exec(env, argv0 = T.unsafe(nil), *args, **options); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/cli/rspec/rspec7.rb:42: Method `it` does not exist on `T.class_of(<root>)` https://srb.help/7003
+    42 |  it "raises on invalid input" do
+          ^^
+  Got `T.class_of(<root>)` originating from:
+    test/cli/rspec/rspec7.rb:9:
+     9 |module RSpec
+        ^
+
+test/cli/rspec/rspec7.rb:43: Method `expect` does not exist on `T.class_of(<root>)` https://srb.help/7003
+    43 |    expect { MyClass.write(nil, nil) }
+            ^^^^^^
+  Got `T.class_of(<root>)` originating from:
+    test/cli/rspec/rspec7.rb:9:
+     9 |module RSpec
+        ^
+  Did you mean `exec`? Use `-a` to autocorrect
+    test/cli/rspec/rspec7.rb:43: Replace with `exec`
+    43 |    expect { MyClass.write(nil, nil) }
+            ^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
+      NN |  def exec(env, argv0 = T.unsafe(nil), *args, **options); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/cli/rspec/rspec7.rb:47: Method `describe` does not exist on `T.class_of(<root>)` https://srb.help/7003
+    47 |  describe "expect forms" do
+          ^^^^^^^^
+  Got `T.class_of(<root>)` originating from:
+    test/cli/rspec/rspec7.rb:9:
+     9 |module RSpec
+        ^
+
+test/cli/rspec/rspec7.rb:48: Method `it` does not exist on `T.class_of(<root>)` https://srb.help/7003
+    48 |    it "supports value form" do
+            ^^
+  Got `T.class_of(<root>)` originating from:
+    test/cli/rspec/rspec7.rb:9:
+     9 |module RSpec
+        ^
+
+test/cli/rspec/rspec7.rb:50: Method `expect` does not exist on `T.class_of(<root>)` https://srb.help/7003
+    50 |      expect(result)
+              ^^^^^^
+  Got `T.class_of(<root>)` originating from:
+    test/cli/rspec/rspec7.rb:9:
+     9 |module RSpec
+        ^
+  Did you mean `exec`? Use `-a` to autocorrect
+    test/cli/rspec/rspec7.rb:50: Replace with `exec`
+    50 |      expect(result)
+              ^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
+      NN |  def exec(env, argv0 = T.unsafe(nil), *args, **options); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/cli/rspec/rspec7.rb:53: Method `it` does not exist on `T.class_of(<root>)` https://srb.help/7003
+    53 |    it "supports block form" do
+            ^^
+  Got `T.class_of(<root>)` originating from:
+    test/cli/rspec/rspec7.rb:9:
+     9 |module RSpec
+        ^
+
+test/cli/rspec/rspec7.rb:54: Method `expect` does not exist on `T.class_of(<root>)` https://srb.help/7003
+    54 |      expect { MyClass.delete(:baz) }
+              ^^^^^^
+  Got `T.class_of(<root>)` originating from:
+    test/cli/rspec/rspec7.rb:9:
+     9 |module RSpec
+        ^
+  Did you mean `exec`? Use `-a` to autocorrect
+    test/cli/rspec/rspec7.rb:54: Replace with `exec`
+    54 |      expect { MyClass.delete(:baz) }
+              ^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
+      NN |  def exec(env, argv0 = T.unsafe(nil), *args, **options); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/cli/rspec/rspec3.rb:19: Method `shared_examples` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
+    19 |    shared_examples "my shared example" do
             ^^^^^^^^^^^^^^^
   Got `T.class_of(MyClass::<describe 'single shared example with context'>)` originating from:
-    test/cli/rspec/rspec3.rb:17:
-    17 |  describe("single shared example with context") do
+    test/cli/rspec/rspec3.rb:18:
+    18 |  describe("single shared example with context") do
           ^
 
-test/cli/rspec/rspec3.rb:19: Method `let` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
-    19 |      let(:foo_exists) { 'bar' }
+test/cli/rspec/rspec3.rb:20: Method `let` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
+    20 |      let(:foo_exists) { 'bar' }
               ^^^
   Got `T.class_of(MyClass::<describe 'single shared example with context'>)` originating from:
-    test/cli/rspec/rspec3.rb:17:
-    17 |  describe("single shared example with context") do
+    test/cli/rspec/rspec3.rb:18:
+    18 |  describe("single shared example with context") do
           ^
 
-test/cli/rspec/rspec3.rb:21: Method `context` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
-    21 |      context 'context' do
+test/cli/rspec/rspec3.rb:22: Method `context` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
+    22 |      context 'context' do
               ^^^^^^^
   Got `T.class_of(MyClass::<describe 'single shared example with context'>)` originating from:
-    test/cli/rspec/rspec3.rb:17:
-    17 |  describe("single shared example with context") do
+    test/cli/rspec/rspec3.rb:18:
+    18 |  describe("single shared example with context") do
           ^
 
-test/cli/rspec/rspec3.rb:22: Method `it` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
-    22 |        it 'works' do
+test/cli/rspec/rspec3.rb:23: Method `it` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
+    23 |        it 'works' do
                 ^^
   Got `T.class_of(MyClass::<describe 'single shared example with context'>)` originating from:
-    test/cli/rspec/rspec3.rb:17:
-    17 |  describe("single shared example with context") do
+    test/cli/rspec/rspec3.rb:18:
+    18 |  describe("single shared example with context") do
           ^
 
-test/cli/rspec/rspec3.rb:23: Method `foo_exists` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
-    23 |          expect(foo_exists).to eq('bar')
+test/cli/rspec/rspec3.rb:24: Method `foo_exists` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
+    24 |          expect(foo_exists).to eq('bar')
                          ^^^^^^^^^^
   Got `T.class_of(MyClass::<describe 'single shared example with context'>)` originating from:
-    test/cli/rspec/rspec3.rb:17:
-    17 |  describe("single shared example with context") do
+    test/cli/rspec/rspec3.rb:18:
+    18 |  describe("single shared example with context") do
           ^
   Did you mean `at_exit`? Use `-a` to autocorrect
-    test/cli/rspec/rspec3.rb:23: Replace with `at_exit`
-    23 |          expect(foo_exists).to eq('bar')
+    test/cli/rspec/rspec3.rb:24: Replace with `at_exit`
+    24 |          expect(foo_exists).to eq('bar')
                          ^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
       NN |  def at_exit(&blk); end
             ^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec3.rb:23: Method `expect` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
-    23 |          expect(foo_exists).to eq('bar')
+test/cli/rspec/rspec3.rb:24: Method `expect` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
+    24 |          expect(foo_exists).to eq('bar')
                   ^^^^^^
   Got `T.class_of(MyClass::<describe 'single shared example with context'>)` originating from:
-    test/cli/rspec/rspec3.rb:17:
-    17 |  describe("single shared example with context") do
+    test/cli/rspec/rspec3.rb:18:
+    18 |  describe("single shared example with context") do
           ^
   Did you mean `exec`? Use `-a` to autocorrect
-    test/cli/rspec/rspec3.rb:23: Replace with `exec`
-    23 |          expect(foo_exists).to eq('bar')
+    test/cli/rspec/rspec3.rb:24: Replace with `exec`
+    24 |          expect(foo_exists).to eq('bar')
                   ^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
       NN |  def exec(env, argv0 = T.unsafe(nil), *args, **options); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec3.rb:23: Method `eq` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
-    23 |          expect(foo_exists).to eq('bar')
+test/cli/rspec/rspec3.rb:24: Method `eq` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
+    24 |          expect(foo_exists).to eq('bar')
                                         ^^
   Got `T.class_of(MyClass::<describe 'single shared example with context'>)` originating from:
-    test/cli/rspec/rspec3.rb:17:
-    17 |  describe("single shared example with context") do
+    test/cli/rspec/rspec3.rb:18:
+    18 |  describe("single shared example with context") do
           ^
 
-test/cli/rspec/rspec3.rb:24: Method `this_does_not_exist` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
-    24 |          this_does_not_exist
+test/cli/rspec/rspec3.rb:25: Method `this_does_not_exist` does not exist on `T.class_of(MyClass::<describe 'single shared example with context'>)` https://srb.help/7003
+    25 |          this_does_not_exist
                   ^^^^^^^^^^^^^^^^^^^
   Got `T.class_of(MyClass::<describe 'single shared example with context'>)` originating from:
-    test/cli/rspec/rspec3.rb:17:
-    17 |  describe("single shared example with context") do
+    test/cli/rspec/rspec3.rb:18:
+    18 |  describe("single shared example with context") do
           ^
 
 test/cli/rspec/rspec1.rb:18: Method `let` does not exist on `T.class_of(<root>)` https://srb.help/7003
@@ -1778,257 +1878,257 @@ test/cli/rspec/rspec1.rb:29: Method `verified` does not exist on `T.class_of(<ro
     test/cli/rspec/rspec1.rb:7:
      7 |module RSpec
         ^
-Errors: 187
+Errors: 196
 --------------------------------------------------------------------------
-test/cli/rspec/rspec2.rb:58: `A::<describe 'inside describe'>::<describe 'will include shared examples'>` must inherit `RSpec::Core::ExampleGroup` (required by `A::<describe 'inside describe'>::<shared_examples 'some examples'>`) https://srb.help/5064
-    58 |    describe "will include shared examples" do # error: `A::<describe 'inside describe'>::<describe 'will include shared examples'>` must inherit `RSpec::Core::ExampleGroup` (required by `A::<describe 'inside describe'>::<shared_examples 'some examples'>`)
+test/cli/rspec/rspec2.rb:60: `A::<describe 'inside describe'>::<describe 'will include shared examples'>` must inherit `RSpec::Core::ExampleGroup` (required by `A::<describe 'inside describe'>::<shared_examples 'some examples'>`) https://srb.help/5064
+    60 |    describe "will include shared examples" do # error: `A::<describe 'inside describe'>::<describe 'will include shared examples'>` must inherit `RSpec::Core::ExampleGroup` (required by `A::<describe 'inside describe'>::<shared_examples 'some examples'>`)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    test/cli/rspec/rspec2.rb:50: required by `A::<describe 'inside describe'>::<shared_examples 'some examples'>` here
-    50 |    shared_examples "some examples" do
+    test/cli/rspec/rspec2.rb:52: required by `A::<describe 'inside describe'>::<shared_examples 'some examples'>` here
+    52 |    shared_examples "some examples" do
                                             ^
 
-test/cli/rspec/rspec2.rb:77: Method `example` does not exist on `T.class_of(A)` https://srb.help/7003
-    77 |  example do # error: Method `example` does not exist
+test/cli/rspec/rspec2.rb:79: Method `example` does not exist on `T.class_of(A)` https://srb.help/7003
+    79 |  example do # error: Method `example` does not exist
           ^^^^^^^
   Got `T.class_of(A)` originating from:
-    test/cli/rspec/rspec2.rb:23:
-    23 |class A
+    test/cli/rspec/rspec2.rb:24:
+    24 |class A
         ^
 
-test/cli/rspec/rspec2.rb:78: Method `outer_helper` does not exist on `T.class_of(A)` https://srb.help/7003
-    78 |    outer_helper # error: Method `outer_helper` does not exist
+test/cli/rspec/rspec2.rb:80: Method `outer_helper` does not exist on `T.class_of(A)` https://srb.help/7003
+    80 |    outer_helper # error: Method `outer_helper` does not exist
             ^^^^^^^^^^^^
   Got `T.class_of(A)` originating from:
-    test/cli/rspec/rspec2.rb:23:
-    23 |class A
+    test/cli/rspec/rspec2.rb:24:
+    24 |class A
         ^
   Did you mean `attr_reader`? Use `-a` to autocorrect
-    test/cli/rspec/rspec2.rb:78: Replace with `attr_reader`
-    78 |    outer_helper # error: Method `outer_helper` does not exist
+    test/cli/rspec/rspec2.rb:80: Replace with `attr_reader`
+    80 |    outer_helper # error: Method `outer_helper` does not exist
             ^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Defined here
       NN |  def attr_reader(*arg0); end
             ^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec2.rb:81: Method `example_group` does not exist on `T.class_of(A)` https://srb.help/7003
-    81 |  example_group "example_group group" do # error: Method `example_group` does not exist
+test/cli/rspec/rspec2.rb:83: Method `example_group` does not exist on `T.class_of(A)` https://srb.help/7003
+    83 |  example_group "example_group group" do # error: Method `example_group` does not exist
           ^^^^^^^^^^^^^
   Got `T.class_of(A)` originating from:
-    test/cli/rspec/rspec2.rb:23:
-    23 |class A
+    test/cli/rspec/rspec2.rb:24:
+    24 |class A
         ^
 
-test/cli/rspec/rspec2.rb:82: Method `it` does not exist on `T.class_of(A)` https://srb.help/7003
-    82 |    it do # error: does not exist
+test/cli/rspec/rspec2.rb:84: Method `it` does not exist on `T.class_of(A)` https://srb.help/7003
+    84 |    it do # error: does not exist
             ^^
   Got `T.class_of(A)` originating from:
-    test/cli/rspec/rspec2.rb:23:
-    23 |class A
+    test/cli/rspec/rspec2.rb:24:
+    24 |class A
         ^
 
-test/cli/rspec/rspec2.rb:83: Method `outer_helper` does not exist on `T.class_of(A)` https://srb.help/7003
-    83 |      outer_helper # error: Method `outer_helper` does not exist
+test/cli/rspec/rspec2.rb:85: Method `outer_helper` does not exist on `T.class_of(A)` https://srb.help/7003
+    85 |      outer_helper # error: Method `outer_helper` does not exist
               ^^^^^^^^^^^^
   Got `T.class_of(A)` originating from:
-    test/cli/rspec/rspec2.rb:23:
-    23 |class A
+    test/cli/rspec/rspec2.rb:24:
+    24 |class A
         ^
   Did you mean `attr_reader`? Use `-a` to autocorrect
-    test/cli/rspec/rspec2.rb:83: Replace with `attr_reader`
-    83 |      outer_helper # error: Method `outer_helper` does not exist
+    test/cli/rspec/rspec2.rb:85: Replace with `attr_reader`
+    85 |      outer_helper # error: Method `outer_helper` does not exist
               ^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Defined here
       NN |  def attr_reader(*arg0); end
             ^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec2.rb:87: Method `context` does not exist on `T.class_of(A)` https://srb.help/7003
-    87 |  context "context group" do # error: Method `context` does not exist
+test/cli/rspec/rspec2.rb:89: Method `context` does not exist on `T.class_of(A)` https://srb.help/7003
+    89 |  context "context group" do # error: Method `context` does not exist
           ^^^^^^^
   Got `T.class_of(A)` originating from:
-    test/cli/rspec/rspec2.rb:23:
-    23 |class A
+    test/cli/rspec/rspec2.rb:24:
+    24 |class A
         ^
 
-test/cli/rspec/rspec2.rb:88: Method `it` does not exist on `T.class_of(A)` https://srb.help/7003
-    88 |    it do # error: does not exist
+test/cli/rspec/rspec2.rb:90: Method `it` does not exist on `T.class_of(A)` https://srb.help/7003
+    90 |    it do # error: does not exist
             ^^
   Got `T.class_of(A)` originating from:
-    test/cli/rspec/rspec2.rb:23:
-    23 |class A
+    test/cli/rspec/rspec2.rb:24:
+    24 |class A
         ^
 
-test/cli/rspec/rspec2.rb:89: Method `outer_helper` does not exist on `T.class_of(A)` https://srb.help/7003
-    89 |      outer_helper # error: Method `outer_helper` does not exist
+test/cli/rspec/rspec2.rb:91: Method `outer_helper` does not exist on `T.class_of(A)` https://srb.help/7003
+    91 |      outer_helper # error: Method `outer_helper` does not exist
               ^^^^^^^^^^^^
   Got `T.class_of(A)` originating from:
-    test/cli/rspec/rspec2.rb:23:
-    23 |class A
+    test/cli/rspec/rspec2.rb:24:
+    24 |class A
         ^
   Did you mean `attr_reader`? Use `-a` to autocorrect
-    test/cli/rspec/rspec2.rb:89: Replace with `attr_reader`
-    89 |      outer_helper # error: Method `outer_helper` does not exist
+    test/cli/rspec/rspec2.rb:91: Replace with `attr_reader`
+    91 |      outer_helper # error: Method `outer_helper` does not exist
               ^^^^^^^^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Defined here
       NN |  def attr_reader(*arg0); end
             ^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec2.rb:39: Method `described_class` does not exist on `A::<describe 'inside describe'>` https://srb.help/7003
-    39 |      described_class # error: does not exist
+test/cli/rspec/rspec2.rb:41: Method `described_class` does not exist on `A::<describe 'inside describe'>` https://srb.help/7003
+    41 |      described_class # error: does not exist
               ^^^^^^^^^^^^^^^
   Got `A::<describe 'inside describe'>` originating from:
-    test/cli/rspec/rspec2.rb:37:
-    37 |    xit do
+    test/cli/rspec/rspec2.rb:39:
+    39 |    xit do
             ^
 
-test/cli/rspec/rspec2.rb:71: Method `defined_in_shared_examples` does not exist on `A::<describe 'inside describe'>` https://srb.help/7003
-    71 |          defined_in_shared_examples # error: does not exist
+test/cli/rspec/rspec2.rb:73: Method `defined_in_shared_examples` does not exist on `A::<describe 'inside describe'>` https://srb.help/7003
+    73 |          defined_in_shared_examples # error: does not exist
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
   Got `A::<describe 'inside describe'>` originating from:
-    test/cli/rspec/rspec2.rb:70:
-    70 |        it "has access to defined_in_shared_examples" do
+    test/cli/rspec/rspec2.rb:72:
+    72 |        it "has access to defined_in_shared_examples" do
                 ^
 
-test/cli/rspec/rspec2.rb:116: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>` https://srb.help/7003
-     116 |    its(:bar) { is_expected.to eq(foo) } # error: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>`
+test/cli/rspec/rspec2.rb:118: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>` https://srb.help/7003
+     118 |    its(:bar) { is_expected.to eq(foo) } # error: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>`
                           ^^^^^^^^^^^
   Got `A::<describe 'its support'>::<describe 'bar'>` originating from:
-    test/cli/rspec/rspec2.rb:116: Possibly uninitialized (`NilClass`) in:
-     116 |    its(:bar) { is_expected.to eq(foo) } # error: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>`
+    test/cli/rspec/rspec2.rb:118: Possibly uninitialized (`NilClass`) in:
+     118 |    its(:bar) { is_expected.to eq(foo) } # error: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>`
               ^
 
-test/cli/rspec/rspec2.rb:119: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>` https://srb.help/7003
-     119 |    its('bar') { is_expected.to eq(foo) } # error: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>`
+test/cli/rspec/rspec2.rb:121: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>` https://srb.help/7003
+     121 |    its('bar') { is_expected.to eq(foo) } # error: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>`
                            ^^^^^^^^^^^
   Got `A::<describe 'its support'>::<describe 'bar'>` originating from:
-    test/cli/rspec/rspec2.rb:119: Possibly uninitialized (`NilClass`) in:
-     119 |    its('bar') { is_expected.to eq(foo) } # error: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>`
+    test/cli/rspec/rspec2.rb:121: Possibly uninitialized (`NilClass`) in:
+     121 |    its('bar') { is_expected.to eq(foo) } # error: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'bar'>`
               ^
 
-test/cli/rspec/rspec2.rb:124: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'size'>` https://srb.help/7003
-     124 |      is_expected.to eq(X) # error: Method `subject` does not exist
+test/cli/rspec/rspec2.rb:126: Method `subject` does not exist on `A::<describe 'its support'>::<describe 'size'>` https://srb.help/7003
+     126 |      is_expected.to eq(X) # error: Method `subject` does not exist
                 ^^^^^^^^^^^
   Got `A::<describe 'its support'>::<describe 'size'>` originating from:
-    test/cli/rspec/rspec2.rb:122: Possibly uninitialized (`NilClass`) in:
-     122 |    its(:size) do
+    test/cli/rspec/rspec2.rb:124: Possibly uninitialized (`NilClass`) in:
+     124 |    its(:size) do
               ^
 
-test/cli/rspec/rspec2.rb:136: Revealed type: `A::<describe 'its support'>::<describe 'size'>` https://srb.help/7014
-     136 |      T.reveal_type(self) # error: Revealed type: `A::<describe 'its support'>::<describe 'size'>`
+test/cli/rspec/rspec2.rb:138: Revealed type: `A::<describe 'its support'>::<describe 'size'>` https://srb.help/7014
+     138 |      T.reveal_type(self) # error: Revealed type: `A::<describe 'its support'>::<describe 'size'>`
                 ^^^^^^^^^^^^^^^^^^^
   Got `A::<describe 'its support'>::<describe 'size'>` originating from:
-    test/cli/rspec/rspec2.rb:135: Possibly uninitialized (`NilClass`) in:
-     135 |    its(:size) do
+    test/cli/rspec/rspec2.rb:137: Possibly uninitialized (`NilClass`) in:
+     137 |    its(:size) do
               ^
 
-test/cli/rspec/rspec2.rb:160: Revealed type: `A::<describe 'its with typed subject'>::ThingWithSize` https://srb.help/7014
-     160 |      T.reveal_type(subject) # error: Revealed type: `A::<describe 'its with typed subject'>::ThingWithSize`
+test/cli/rspec/rspec2.rb:162: Revealed type: `A::<describe 'its with typed subject'>::ThingWithSize` https://srb.help/7014
+     162 |      T.reveal_type(subject) # error: Revealed type: `A::<describe 'its with typed subject'>::ThingWithSize`
                 ^^^^^^^^^^^^^^^^^^^^^^
   Got `A::<describe 'its with typed subject'>::ThingWithSize` originating from:
-    test/cli/rspec/rspec2.rb:160:
-     160 |      T.reveal_type(subject) # error: Revealed type: `A::<describe 'its with typed subject'>::ThingWithSize`
+    test/cli/rspec/rspec2.rb:162:
+     162 |      T.reveal_type(subject) # error: Revealed type: `A::<describe 'its with typed subject'>::ThingWithSize`
                               ^^^^^^^
 
-test/cli/rspec/rspec2.rb:166: Method `no_such_method` does not exist on `A::<describe 'its with typed subject'>::ThingWithSize` https://srb.help/7003
-     166 |      is_expected.to eq(0) # error: Method `no_such_method` does not exist on `A::<describe 'its with typed subject'>::ThingWithSize`
+test/cli/rspec/rspec2.rb:168: Method `no_such_method` does not exist on `A::<describe 'its with typed subject'>::ThingWithSize` https://srb.help/7003
+     168 |      is_expected.to eq(0) # error: Method `no_such_method` does not exist on `A::<describe 'its with typed subject'>::ThingWithSize`
                 ^^^^^^^^^^^
   Got `A::<describe 'its with typed subject'>::ThingWithSize` originating from:
-    test/cli/rspec/rspec2.rb:166:
-     166 |      is_expected.to eq(0) # error: Method `no_such_method` does not exist on `A::<describe 'its with typed subject'>::ThingWithSize`
+    test/cli/rspec/rspec2.rb:168:
+     168 |      is_expected.to eq(0) # error: Method `no_such_method` does not exist on `A::<describe 'its with typed subject'>::ThingWithSize`
                 ^^^^^^^^^^^
 
-test/cli/rspec/rspec4.rb:19: Revealed type: `NilClass` https://srb.help/7014
-    19 |      T.reveal_type(my_param) # error: `NilClass`
+test/cli/rspec/rspec4.rb:20: Revealed type: `NilClass` https://srb.help/7014
+    20 |      T.reveal_type(my_param) # error: `NilClass`
               ^^^^^^^^^^^^^^^^^^^^^^^
   Got `NilClass` originating from:
-    test/cli/rspec/rspec4.rb:18: Possibly uninitialized (`NilClass`) in:
-    18 |    shared_examples "my shared example" do |my_param|
+    test/cli/rspec/rspec4.rb:19: Possibly uninitialized (`NilClass`) in:
+    19 |    shared_examples "my shared example" do |my_param|
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec4.rb:23: Revealed type: `NilClass` https://srb.help/7014
-    23 |        T.reveal_type(my_param) # error: `NilClass`
+test/cli/rspec/rspec4.rb:24: Revealed type: `NilClass` https://srb.help/7014
+    24 |        T.reveal_type(my_param) # error: `NilClass`
                 ^^^^^^^^^^^^^^^^^^^^^^^
   Got `NilClass` originating from:
-    test/cli/rspec/rspec4.rb:22: Possibly uninitialized (`NilClass`) in:
-    22 |      let(:uses_my_param) {
+    test/cli/rspec/rspec4.rb:23: Possibly uninitialized (`NilClass`) in:
+    23 |      let(:uses_my_param) {
               ^^^^^^^^^^^^^^^^^^
 
-test/cli/rspec/rspec4.rb:27: Revealed type: `T.untyped` https://srb.help/7014
-    27 |        T.reveal_type(my_param) # error: `T.untyped`
+test/cli/rspec/rspec4.rb:28: Revealed type: `T.untyped` https://srb.help/7014
+    28 |        T.reveal_type(my_param) # error: `T.untyped`
                 ^^^^^^^^^^^^^^^^^^^^^^^
   Got `T.untyped` originating from:
-    test/cli/rspec/rspec4.rb:18:
-    18 |    shared_examples "my shared example" do |my_param|
+    test/cli/rspec/rspec4.rb:19:
+    19 |    shared_examples "my shared example" do |my_param|
                                                     ^^^^^^^^
 
-test/cli/rspec/rspec4.rb:29: Method `this_does_not_exist` does not exist on `MyClass::<describe 'single shared example with context'>::<shared_examples 'my shared example'>` https://srb.help/7003
-    29 |        this_does_not_exist
+test/cli/rspec/rspec4.rb:30: Method `this_does_not_exist` does not exist on `MyClass::<describe 'single shared example with context'>::<shared_examples 'my shared example'>` https://srb.help/7003
+    30 |        this_does_not_exist
                 ^^^^^^^^^^^^^^^^^^^
   Got `MyClass::<describe 'single shared example with context'>::<shared_examples 'my shared example'>` originating from:
-    test/cli/rspec/rspec4.rb:26:
-    26 |      it "works for #{my_param}" do
+    test/cli/rspec/rspec4.rb:27:
+    27 |      it "works for #{my_param}" do
               ^
 
-test/cli/rspec/rspec4.rb:41: Revealed type: `T.untyped` https://srb.help/7014
-    41 |        T.reveal_type(param1) # error: `T.untyped`
-                ^^^^^^^^^^^^^^^^^^^^^
-  Got `T.untyped` originating from:
-    test/cli/rspec/rspec4.rb:36:
-    36 |    shared_context "context with 2 params" do |param1, param2|
-                                                       ^^^^^^
-
 test/cli/rspec/rspec4.rb:42: Revealed type: `T.untyped` https://srb.help/7014
-    42 |        T.reveal_type(param2) # error: `T.untyped`
+    42 |        T.reveal_type(param1) # error: `T.untyped`
                 ^^^^^^^^^^^^^^^^^^^^^
   Got `T.untyped` originating from:
-    test/cli/rspec/rspec4.rb:36:
-    36 |    shared_context "context with 2 params" do |param1, param2|
-                                                               ^^^^^^
-
-test/cli/rspec/rspec4.rb:65: Revealed type: `T.untyped` https://srb.help/7014
-    65 |        T.reveal_type(param1) # error: `T.untyped`
-                ^^^^^^^^^^^^^^^^^^^^^
-  Got `T.untyped` originating from:
-    test/cli/rspec/rspec4.rb:57:
-    57 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
+    test/cli/rspec/rspec4.rb:37:
+    37 |    shared_context "context with 2 params" do |param1, param2|
                                                        ^^^^^^
+
+test/cli/rspec/rspec4.rb:43: Revealed type: `T.untyped` https://srb.help/7014
+    43 |        T.reveal_type(param2) # error: `T.untyped`
+                ^^^^^^^^^^^^^^^^^^^^^
+  Got `T.untyped` originating from:
+    test/cli/rspec/rspec4.rb:37:
+    37 |    shared_context "context with 2 params" do |param1, param2|
+                                                               ^^^^^^
 
 test/cli/rspec/rspec4.rb:66: Revealed type: `T.untyped` https://srb.help/7014
-    66 |        T.reveal_type(param2) # error: `T.untyped`
+    66 |        T.reveal_type(param1) # error: `T.untyped`
                 ^^^^^^^^^^^^^^^^^^^^^
   Got `T.untyped` originating from:
-    test/cli/rspec/rspec4.rb:57:
-    57 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
-                                                               ^^^^^^
+    test/cli/rspec/rspec4.rb:58:
+    58 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
+                                                       ^^^^^^
 
 test/cli/rspec/rspec4.rb:67: Revealed type: `T.untyped` https://srb.help/7014
-    67 |        T.reveal_type(param3) # error: `T.untyped`
+    67 |        T.reveal_type(param2) # error: `T.untyped`
                 ^^^^^^^^^^^^^^^^^^^^^
   Got `T.untyped` originating from:
-    test/cli/rspec/rspec4.rb:57:
-    57 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
-                                                                       ^^^^^^
+    test/cli/rspec/rspec4.rb:58:
+    58 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
+                                                               ^^^^^^
 
 test/cli/rspec/rspec4.rb:68: Revealed type: `T.untyped` https://srb.help/7014
-    68 |        T.reveal_type(param4) # error: `T.untyped`
+    68 |        T.reveal_type(param3) # error: `T.untyped`
                 ^^^^^^^^^^^^^^^^^^^^^
   Got `T.untyped` originating from:
-    test/cli/rspec/rspec4.rb:57:
-    57 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
-                                                                               ^^^^^^
+    test/cli/rspec/rspec4.rb:58:
+    58 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
+                                                                       ^^^^^^
 
 test/cli/rspec/rspec4.rb:69: Revealed type: `T.untyped` https://srb.help/7014
-    69 |        T.reveal_type(param5) # error: `T.untyped`
+    69 |        T.reveal_type(param4) # error: `T.untyped`
                 ^^^^^^^^^^^^^^^^^^^^^
   Got `T.untyped` originating from:
-    test/cli/rspec/rspec4.rb:57:
-    57 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
+    test/cli/rspec/rspec4.rb:58:
+    58 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
+                                                                               ^^^^^^
+
+test/cli/rspec/rspec4.rb:70: Revealed type: `T.untyped` https://srb.help/7014
+    70 |        T.reveal_type(param5) # error: `T.untyped`
+                ^^^^^^^^^^^^^^^^^^^^^
+  Got `T.untyped` originating from:
+    test/cli/rspec/rspec4.rb:58:
+    58 |    shared_context "context with 5 params" do |param1, param2, param3, param4, param5|
                                                                                        ^^^^^^
 
-test/cli/rspec/rspec3.rb:24: Method `this_does_not_exist` does not exist on `MyClass::<describe 'single shared example with context'>::<shared_examples 'my shared example'>::<context 'context'>` https://srb.help/7003
-    24 |          this_does_not_exist
+test/cli/rspec/rspec3.rb:25: Method `this_does_not_exist` does not exist on `MyClass::<describe 'single shared example with context'>::<shared_examples 'my shared example'>::<context 'context'>` https://srb.help/7003
+    25 |          this_does_not_exist
                   ^^^^^^^^^^^^^^^^^^^
   Got `MyClass::<describe 'single shared example with context'>::<shared_examples 'my shared example'>::<context 'context'>` originating from:
-    test/cli/rspec/rspec3.rb:22:
-    22 |        it 'works' do
+    test/cli/rspec/rspec3.rb:23:
+    23 |        it 'works' do
                 ^
 Errors: 29

--- a/test/cli/rspec/test.sh
+++ b/test/cli/rspec/test.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Files are numbered to ensure consistent glob expansion order across platforms
-inputs=(test/cli/rspec/rspec{1..6}.rb)
+inputs=(test/cli/rspec/rspec{1..7}.rb)
 
 if main/sorbet --max-threads=0 --censor-for-snapshot-tests --silence-dev-message --enable-experimental-requires-ancestor "${inputs[@]}" 2>&1 ; then
   echo "expected to fail!!"

--- a/test/testdata/rewriter/rspec_example.rb
+++ b/test/testdata/rewriter/rspec_example.rb
@@ -12,7 +12,8 @@ module RSpec
       def is_expected
       end
 
-      def expect(arg)
+      # https://github.com/rspec/rspec/blob/rspec-expectations-v3.13.5/rspec-expectations/lib/rspec/expectations/syntax.rb#L72-L74
+      def expect(value = nil, &block)
       end
 
       def eq(arg)
@@ -28,7 +29,8 @@ class A
 
   def is_expected; end
 
-  def expect(arg); end
+  # https://github.com/rspec/rspec/blob/rspec-expectations-v3.13.5/rspec-expectations/lib/rspec/expectations/syntax.rb#L72-L74
+  def expect(value = nil, &block); end
 
   def eq(arg); end
 

--- a/test/testdata/rewriter/rspec_example.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_example.rb.rewrite-tree.exp
@@ -16,7 +16,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           <emptyTree>
         end
 
-        def expect<<todo method>>(arg, &<blk>)
+        def expect<<todo method>>(value = nil, &block)
           <emptyTree>
         end
 
@@ -48,7 +48,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    def expect<<todo method>>(arg, &<blk>)
+    def expect<<todo method>>(value = nil, &block)
       <emptyTree>
     end
 

--- a/test/testdata/rewriter/rspec_it_behaves_like_isolation.rb
+++ b/test/testdata/rewriter/rspec_it_behaves_like_isolation.rb
@@ -5,7 +5,8 @@
 module RSpec
   module Core
     class ExampleGroup
-      def expect(arg)
+      # https://github.com/rspec/rspec/blob/rspec-expectations-v3.13.5/rspec-expectations/lib/rspec/expectations/syntax.rb#L72-L74
+      def expect(value = nil, &block)
       end
 
       def eq(arg)

--- a/test/testdata/rewriter/rspec_it_behaves_like_isolation.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_it_behaves_like_isolation.rb.rewrite-tree.exp
@@ -2,7 +2,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   module <emptyTree>::<C RSpec><<C <todo sym>>> < ()
     module <emptyTree>::<C Core><<C <todo sym>>> < ()
       class <emptyTree>::<C ExampleGroup><<C <todo sym>>> < (::<todo sym>)
-        def expect<<todo method>>(arg, &<blk>)
+        def expect<<todo method>>(value = nil, &block)
           <emptyTree>
         end
 

--- a/test/testdata/rewriter/rspec_shared_examples_context.rb
+++ b/test/testdata/rewriter/rspec_shared_examples_context.rb
@@ -5,7 +5,8 @@
 module RSpec
   module Core
     class ExampleGroup
-      def expect(arg)
+      # https://github.com/rspec/rspec/blob/rspec-expectations-v3.13.5/rspec-expectations/lib/rspec/expectations/syntax.rb#L72-L74
+      def expect(value = nil, &block)
       end
 
       def eq(arg)

--- a/test/testdata/rewriter/rspec_shared_examples_context.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/rspec_shared_examples_context.rb.rewrite-tree-raw.exp
@@ -40,12 +40,15 @@ ClassDef{
                 MethodDef{
                   flags = {}
                   name = <U expect><<U <todo method>>>
-                  params = [UnresolvedIdent{
-                      kind = Local
-                      name = <U arg>
+                  params = [OptionalParam{
+                      expr = UnresolvedIdent{
+                        kind = Local
+                        name = <U value>
+                      }
+                      default_ = Literal{ value = nil }
                     }, BlockParam{ expr = UnresolvedIdent{
                       kind = Local
-                      name = <U <blk>>
+                      name = <U block>
                     } }]
                   rhs = EmptyTree
                 }

--- a/test/testdata/rewriter/rspec_shared_examples_param.rb
+++ b/test/testdata/rewriter/rspec_shared_examples_param.rb
@@ -5,7 +5,8 @@
 module RSpec
   module Core
     class ExampleGroup
-      def expect(arg)
+      # https://github.com/rspec/rspec/blob/rspec-expectations-v3.13.5/rspec-expectations/lib/rspec/expectations/syntax.rb#L72-L74
+      def expect(value = nil, &block)
       end
 
       def eq(arg)

--- a/test/testdata/rewriter/rspec_shared_examples_param.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_shared_examples_param.rb.rewrite-tree.exp
@@ -2,7 +2,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   module <emptyTree>::<C RSpec><<C <todo sym>>> < ()
     module <emptyTree>::<C Core><<C <todo sym>>> < ()
       class <emptyTree>::<C ExampleGroup><<C <todo sym>>> < (::<todo sym>)
-        def expect<<todo method>>(arg, &<blk>)
+        def expect<<todo method>>(value = nil, &block)
           <emptyTree>
         end
 


### PR DESCRIPTION
RSpec's `expect` takes an optional value argument and a block — see the source:
https://github.com/rspec/rspec/blob/rspec-expectations-v3.13.5/rspec-expectations/lib/rspec/expectations/syntax.rb#L72-L74

The block-only form `expect { code }.not_to raise_error` is common in real-world RSpec suites (e.g. the Homebrew test suite), but Sorbet previously errored on it because all RSpec test stubs defined `expect` with one required positional argument.

## Changes

Update all RSpec test stubs from `def expect(arg)` to `def expect(value = nil, &block)` to match the actual RSpec signature. This allows both forms without error:

```ruby
# value form
expect(result).to eq('foo')

# block-only form
expect { some_code }.not_to raise_error
```

- Update `def expect` in all affected test stubs (`rspec_example.rb`, `rspec_shared_examples_context.rb`, `rspec_shared_examples_param.rb`, `rspec_it_behaves_like_isolation.rb`, `rspec2.rb`, `rspec3.rb`, `rspec4.rb`)
- Add `rspec7.rb` exercising both the value form and block-only form under `--enable-experimental-rspec`
- Regenerate all affected snapshot files (`.exp`)