### PR TITLE
Add `--stop-after=rbs`

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -250,6 +250,7 @@ struct StopAfterOptions {
 const vector<StopAfterOptions> stop_after_options({
     {"init", Phase::INIT},
     {"parser", Phase::PARSER},
+    {"rbs", Phase::RBS_REWRITER},
     {"desugarer", Phase::DESUGARER},
     {"rewriter", Phase::REWRITER},
     {"local-vars", Phase::LOCAL_VARS},

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -98,6 +98,7 @@ struct Printers {
 enum class Phase {
     INIT,
     PARSER,
+    RBS_REWRITER,
     DESUGARER,
     REWRITER,
     LOCAL_VARS,

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -442,6 +442,9 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
                     }
 
                     auto rbsRewrittenParseResult = runRBSRewrite(lgs, file, move(parseResult), print);
+                    if (opts.stopAfterPhase == options::Phase::RBS_REWRITER) {
+                        return emptyParsedFile(file);
+                    }
 
                     tree = runDesugar(lgs, file, move(rbsRewrittenParseResult), print, false);
                     if (opts.stopAfterPhase == options::Phase::DESUGARER) {
@@ -458,6 +461,9 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
                     }
 
                     auto rbsRewrittenParseResult = runPrismRBSRewrite(lgs, file, move(parseResult), print);
+                    if (opts.stopAfterPhase == options::Phase::RBS_REWRITER) {
+                        return emptyParsedFile(file);
+                    }
 
                     tree = runPrismDesugar(lgs, file, move(rbsRewrittenParseResult), print);
                     if (opts.stopAfterPhase == options::Phase::DESUGARER) {

--- a/website/docs/cli-ref.md
+++ b/website/docs/cli-ref.md
@@ -155,8 +155,9 @@ Usage:
                                 debugging. Also useful when overwhelmed with errors,
                                 because errors from earlier phases (like resolver) can
                                 cause errors downstream (in inferencer).
-                                Phases: [init, parser, desugarer, rewriter, local-vars,
-                                namer, resolver, cfg, inferencer] (default: inferencer)
+                                Phases: [init, parser, rbs, desugarer, rewriter,
+                                local-vars, namer, resolver, cfg, inferencer] (default:
+                                inferencer)
 
 ```
 


### PR DESCRIPTION
### Motivation

For benchmarking the process up to and including RBS rewriting, but not desugaring.