### PR TITLE
Add RBS regression test for multi-byte characters

### DIFF
--- a/test/testdata/rbs/multibyte_loc_offsets.rb
+++ b/test/testdata/rbs/multibyte_loc_offsets.rb
@@ -1,0 +1,11 @@
+# typed: true
+# enable-experimental-rbs-comments: true
+
+# Regression test for multibyte character loc offsets, to catch any conflation of character count with byte count.
+# * The emoji family (👨‍👩‍👧‍👦) is 7 characters but 25 bytes (4 people + 3 ZWJ).
+# * The pizza is 1 character but 4 bytes.
+
+#: ("👨‍👩‍👧‍👦", "🍕") -> void
+#    ^^^^^^^^^^^^^^^^^^^^^^^^^ error: RBS literal types are not supported
+#                               ^^^^ error: RBS literal types are not supported
+def f(i, j) = i.to_s


### PR DESCRIPTION
### Motivation

Add test for the fix in #9958.

Stacked on #10022

### Test plan

Adds new `//test:test_PrismPosTests/testdata/rbs/multibyte_loc_offsets` test.