### PR TITLE
Fix incorrect `attr` RBIs

### DIFF
--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -1836,13 +1836,10 @@ class Module < Object
   # The second form is equivalent to `attr_accessor(name)` but deprecated. The
   # last form is equivalent to `attr_reader(name)` but deprecated. Returns an
   # array of defined method names as symbols.
-  sig do
-    params(
-        arg0: T.any(Symbol, String),
-    )
-    .returns(NilClass)
-  end
-  def attr(*arg0); end
+  sig { returns(T::Array[Symbol]) }
+  sig { params(attribute_name: T.any(Symbol, String), make_writer: T::Boolean).returns(T::Array[Symbol]) }
+  sig { params(attribute_name: T.any(Symbol, String), rest: T.any(Symbol, String)).returns(T::Array[Symbol]) }
+  def attr(attribute_name, make_writer = false, *rest); end
 
   # Returns an array of all modules used in the current scope. The ordering of
   # modules in the resulting array is not defined.

--- a/test/cli/rspec/test.out
+++ b/test/cli/rspec/test.out
@@ -253,8 +253,8 @@ test/cli/rspec/rspec6.rb:122: Method `after` does not exist on `T.class_of(<root
      122 |  after(:each) do
             ^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Defined here
-      NN |  def attr(*arg0); end
-            ^^^^^^^^^^^^^^^
+      NN |  def attr(attribute_name, make_writer = false, *rest); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 test/cli/rspec/rspec6.rb:123: Method `setup_value` does not exist on `T.class_of(<root>)` https://srb.help/7003
      123 |    setup_value
@@ -276,8 +276,8 @@ test/cli/rspec/rspec6.rb:127: Method `after` does not exist on `T.class_of(<root
      127 |  after(:all) do
             ^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Defined here
-      NN |  def attr(*arg0); end
-            ^^^^^^^^^^^^^^^
+      NN |  def attr(attribute_name, make_writer = false, *rest); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 test/cli/rspec/rspec6.rb:128: Method `setup_value` does not exist on `T.class_of(<root>)` https://srb.help/7003
      128 |    setup_value
@@ -392,8 +392,8 @@ test/cli/rspec/rspec6.rb:161: Method `after` does not exist on `T.class_of(<root
      161 |  after(:each, :slow) do
             ^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Defined here
-      NN |  def attr(*arg0); end
-            ^^^^^^^^^^^^^^^
+      NN |  def attr(attribute_name, make_writer = false, *rest); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 test/cli/rspec/rspec6.rb:162: Method `filtered_value` does not exist on `T.class_of(<root>)` https://srb.help/7003
      162 |    filtered_value
@@ -415,8 +415,8 @@ test/cli/rspec/rspec6.rb:166: Method `after` does not exist on `T.class_of(<root
      166 |  after(:example, cleanup: true) do
             ^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Defined here
-      NN |  def attr(*arg0); end
-            ^^^^^^^^^^^^^^^
+      NN |  def attr(attribute_name, make_writer = false, *rest); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 test/cli/rspec/rspec6.rb:167: Method `filtered_value` does not exist on `T.class_of(<root>)` https://srb.help/7003
      167 |    filtered_value
@@ -438,8 +438,8 @@ test/cli/rspec/rspec6.rb:171: Method `after` does not exist on `T.class_of(<root
      171 |  after(:all, :integration, requires_cleanup: true) do
             ^^^^^
     https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Defined here
-      NN |  def attr(*arg0); end
-            ^^^^^^^^^^^^^^^
+      NN |  def attr(attribute_name, make_writer = false, *rest); end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 test/cli/rspec/rspec6.rb:172: Method `filtered_value` does not exist on `T.class_of(<root>)` https://srb.help/7003
      172 |    filtered_value


### PR DESCRIPTION
### Motivation

Fix these incorrect sigs.

```ruby
class Demo
  p attr # => []
  
  # with Symbol names
  p attr :x            # => [:x]
  p attr :x, false     # => [:x]
  p attr :x, true      # => [:x, :x=]
  p attr :x1, :x2, :x3 # => [:x1, :x2, :x3]
  # p attr :x1, :x2, :x3, true  # (TypeError) true is not a symbol nor a string
  # p attr :x1, :x2, :x3, false # (TypeError) false is not a symbol nor a string

  # with String names, the results are still always Symbols
  p attr "x"            # => [:x]
  p attr "x", false     # => [:x]
  p attr "x", true      # => [:x, :x=]
  p attr "x1", "x2", "x3" # => [:x1, :x2, :x3]
  # p attr "x1", "x2", "x3", true  # (TypeError) true is not a symbol nor a string
  # p attr "x1", "x2", "x3", false # (TypeError) false is not a symbol nor a string
end
```