### PR TITLE
Improve narrowing for present?/blank? guards

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -27,6 +27,58 @@ core::TypePtr dropConstructor(core::Context ctx, core::Loc loc, core::TypePtr tp
 bool typeTestReferencesVar(const InlinedVector<pair<cfg::LocalRef, core::TypePtr>, 1> &typeTest, cfg::LocalRef var) {
     return absl::c_any_of(typeTest, [var](auto &test) { return test.first == var; });
 }
+
+// For each component of `type`, dispatches `methodName` and checks whether the
+// inferred return type satisfies `predicate`. Components that fail are replaced
+// with bottom(). Components that do not dispatch cleanly are conservatively kept.
+core::TypePtr filterByMethodReturnType(core::Context ctx, core::Loc loc, const core::TypePtr &type,
+                                       core::NameRef methodName,
+                                       bool (*predicate)(const core::GlobalState &, const core::TypePtr &)) {
+    core::TypePtr result;
+
+    if (type.isUntyped()) {
+        return type;
+    }
+
+    typecase(
+        type,
+        [&](const core::OrType &o) {
+            auto lhs = filterByMethodReturnType(ctx, loc, o.left, methodName, predicate);
+            auto rhs = filterByMethodReturnType(ctx, loc, o.right, methodName, predicate);
+            if (lhs == o.left && rhs == o.right) {
+                result = type;
+            } else {
+                result = core::Types::any(ctx, lhs, rhs);
+            }
+        },
+        [&](const core::TypePtr &) {
+            if (core::is_proxy_type(type)) {
+                result = filterByMethodReturnType(ctx, loc, type.underlying(ctx), methodName, predicate);
+                return;
+            }
+
+            core::TypeAndOrigins recvType{type, loc};
+            InlinedVector<const core::TypeAndOrigins *, 2> args;
+            InlinedVector<core::LocOffsets, 2> argLocs;
+            core::CallLocs locs{ctx.file, loc.offsets(), loc.offsets(), loc.offsets(), argLocs};
+            core::DispatchArgs dispatchArgs{methodName,          locs,
+                                            0,                   args,
+                                            recvType.type,       recvType,
+                                            recvType.type,       nullptr,
+                                            loc,                 true,
+                                            true,                core::NameRef::noName()};
+            auto dispatched = recvType.type.dispatchCall(ctx, dispatchArgs);
+            if (!dispatched.main.errors.empty() || dispatched.returnType == nullptr) {
+                result = type;
+                return;
+            }
+            result = predicate(ctx.state, dispatched.returnType) ? type : core::Types::bottom();
+        }
+    );
+
+    return result;
+}
+
 } // namespace
 
 void TypeTestReverseIndex::addToIndex(cfg::LocalRef from, cfg::LocalRef to) {
@@ -604,6 +656,14 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         // Note that this assumes that .blank? is a rails-compatible monkey patch.
         // In other cases this flow analysis might make incorrect assumptions.
         whoKnows.falsy().addNoTypeTest(local, typeTestsWithVar, send->recv.variable, core::Types::falsyTypes());
+
+        auto &originalType = send->recv.type;
+        auto narrowedForTruthy = filterByMethodReturnType(ctx, loc, originalType, send->fun, core::Types::canBeTruthy);
+        if (!core::Types::equiv(ctx, narrowedForTruthy, originalType) &&
+            !core::Types::equiv(ctx, narrowedForTruthy, core::Types::bottom())) {
+            whoKnows.truthy().addYesTypeTest(local, typeTestsWithVar, send->recv.variable, narrowedForTruthy);
+        }
+
         whoKnows.sanityCheck();
         return;
     }
@@ -612,6 +672,14 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
         // Note that this assumes that .present? is a rails-compatible monkey patch.
         // In other cases this flow analysis might make incorrect assumptions.
         whoKnows.truthy().addNoTypeTest(local, typeTestsWithVar, send->recv.variable, core::Types::falsyTypes());
+
+        auto &originalType = send->recv.type;
+        auto narrowedForFalsy = filterByMethodReturnType(ctx, loc, originalType, send->fun, core::Types::canBeFalsy);
+        if (!core::Types::equiv(ctx, narrowedForFalsy, originalType) &&
+            !core::Types::equiv(ctx, narrowedForFalsy, core::Types::bottom())) {
+            whoKnows.falsy().addYesTypeTest(local, typeTestsWithVar, send->recv.variable, narrowedForFalsy);
+        }
+
         whoKnows.sanityCheck();
         return;
     }

--- a/test/testdata/infer/control_flow/blank_p.rb
+++ b/test/testdata/infer/control_flow/blank_p.rb
@@ -24,6 +24,31 @@ class Object
   end
 end
 
+class Time
+  extend T::Sig
+
+  sig {returns(FalseClass)}
+  def blank?
+    false
+  end
+end
+
+TimeOrNil = T.type_alias { T.nilable(Time) }
+
+class Widget; end
+
+class Box
+  extend T::Sig
+  extend T::Generic
+
+  Elem = type_member
+
+  sig {returns(Elem)}
+  def blank?
+    T.unsafe(nil)
+  end
+end
+
 class A
   extend T::Sig
 
@@ -58,5 +83,43 @@ class A
     if !a.blank?
       puts a # error: This code is unreachable
     end
+  end
+
+  sig {params(time: T.nilable(Time)).returns(NilClass)}
+  def test_truthy_branch_narrows(time)
+    if time.blank?
+      T.reveal_type(time) # error: Revealed type: `NilClass`
+    else
+      T.reveal_type(time) # error: Revealed type: `Time`
+    end
+    nil
+  end
+
+  sig {params(time: TimeOrNil).returns(NilClass)}
+  def test_truthy_branch_narrows_alias(time)
+    if time.blank?
+      T.reveal_type(time) # error: Revealed type: `NilClass`
+    else
+      T.reveal_type(time) # error: Revealed type: `Time`
+    end
+    nil
+  end
+
+  sig {params(w: T.nilable(Widget)).returns(NilClass)}
+  def test_truthy_branch_no_narrow_without_sig(w)
+    # Widget inherits Object#blank? which has no sig, so we
+    # conservatively do not narrow away Widget in the truthy branch
+    if w.blank?
+      T.reveal_type(w) # error: Revealed type: `T.nilable(Widget)`
+    end
+    nil
+  end
+
+  sig {params(x: T.any(Box[TrueClass], Time)).returns(NilClass)}
+  def test_truthy_branch_narrows_instantiated_sig(x)
+    if x.blank?
+      T.reveal_type(x) # error: Revealed type: `Box[TrueClass]`
+    end
+    nil
   end
 end

--- a/test/testdata/infer/control_flow/present_p.rb
+++ b/test/testdata/infer/control_flow/present_p.rb
@@ -24,6 +24,31 @@ class Object
   end
 end
 
+class Time
+  extend T::Sig
+
+  sig {returns(TrueClass)}
+  def present?
+    true
+  end
+end
+
+TimeOrNil = T.type_alias { T.nilable(Time) }
+
+class Widget; end
+
+class Box
+  extend T::Sig
+  extend T::Generic
+
+  Elem = type_member
+
+  sig {returns(Elem)}
+  def present?
+    T.unsafe(nil)
+  end
+end
+
 class A
   extend T::Sig
 
@@ -56,5 +81,43 @@ class A
     if false.present?
       "foo" # error: This code is unreachable
     end
+  end
+
+  sig {params(time: T.nilable(Time)).returns(NilClass)}
+  def test_falsy_branch_narrows(time)
+    if time.present?
+      T.reveal_type(time) # error: Revealed type: `Time`
+    else
+      T.reveal_type(time) # error: Revealed type: `NilClass`
+    end
+    nil
+  end
+
+  sig {params(time: TimeOrNil).returns(NilClass)}
+  def test_falsy_branch_narrows_alias(time)
+    if time.present?
+      T.reveal_type(time) # error: Revealed type: `Time`
+    else
+      T.reveal_type(time) # error: Revealed type: `NilClass`
+    end
+    nil
+  end
+
+  sig {params(w: T.nilable(Widget)).returns(NilClass)}
+  def test_falsy_branch_no_narrow_without_sig(w)
+    # Widget inherits Object#present? which has no sig, so we
+    # conservatively do not narrow away Widget in the falsy branch
+    if !w.present?
+      T.reveal_type(w) # error: Revealed type: `T.nilable(Widget)`
+    end
+    nil
+  end
+
+  sig {params(x: T.any(Box[NilClass], Time)).returns(NilClass)}
+  def test_falsy_branch_narrows_instantiated_sig(x)
+    if !x.present?
+      T.reveal_type(x) # error: Revealed type: `Box[NilClass]`
+    end
+    nil
   end
 end


### PR DESCRIPTION
Previously, only one branch was narrowed for each method: `present?` narrowed the truthy branch and `blank?` narrowed the falsy branch. The opposite branches were left unnarrowed, missing cases like `!time.present?` failing to narrow `T.nilable(Time)` to `NilClass` when `Time#present?` is declared to return `TrueClass`.

Add a `filterByMethodReturnType` helper that dispatches the guard method on each receiver component and filters out components whose inferred return type is incompatible with the branch being analyzed. This preserves the original conservative behavior for receivers without a usable sig, while fixing the opposite-branch narrowing for typed `present?` and `blank?` methods.

### Motivation
Fixes https://github.com/sorbet/sorbet/issues/7494. I've kept seeing it regularly during my work and always wanted to fix it, but lacked the knowledge of (or time to learn) C++ just for that. So it was written with Claude and Codex. I've reviewed all output before submitting this.

### Test plan
See included automated tests.
