### PR TITLE
Delete unused `enclosingMethodLoc` fields

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -26,19 +26,17 @@ struct DesugarContext final {
     uint32_t &uniqueCounter;
     core::LocOffsets &enclosingBlockParamLoc;
     core::NameRef &enclosingBlockParamName;
-    core::LocOffsets enclosingMethodLoc;
     core::NameRef enclosingMethodName;
     bool inAnyBlock;
     bool inModule;
     bool preserveConcreteSyntax;
 
     DesugarContext(core::MutableContext ctx, uint32_t &uniqueCounter, core::LocOffsets &enclosingBlockParamLoc,
-                   core::NameRef &enclosingBlockParamName, core::LocOffsets enclosingMethodLoc,
-                   core::NameRef enclosingMethodName, bool inAnyBlock, bool inModule, bool preserveConcreteSyntax)
+                   core::NameRef &enclosingBlockParamName, core::NameRef enclosingMethodName, bool inAnyBlock,
+                   bool inModule, bool preserveConcreteSyntax)
         : ctx(ctx), uniqueCounter(uniqueCounter), enclosingBlockParamLoc(enclosingBlockParamLoc),
-          enclosingBlockParamName(enclosingBlockParamName), enclosingMethodLoc(enclosingMethodLoc),
-          enclosingMethodName(enclosingMethodName), inAnyBlock(inAnyBlock), inModule(inModule),
-          preserveConcreteSyntax(preserveConcreteSyntax){};
+          enclosingBlockParamName(enclosingBlockParamName), enclosingMethodName(enclosingMethodName),
+          inAnyBlock(inAnyBlock), inModule(inModule), preserveConcreteSyntax(preserveConcreteSyntax){};
 
     core::NameRef freshNameUnique(core::NameRef name) {
         return ctx.state.freshNameUnique(core::UniqueNameKind::Desugar, name, ++uniqueCounter);
@@ -225,8 +223,7 @@ ExpressionPtr desugarBlock(DesugarContext dctx, parser::Block *block) {
 
     auto inBlock = true;
     DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockParamLoc, dctx.enclosingBlockParamName,
-                         dctx.enclosingMethodLoc, dctx.enclosingMethodName, inBlock, dctx.inModule,
-                         dctx.preserveConcreteSyntax);
+                         dctx.enclosingMethodName, inBlock, dctx.inModule, dctx.preserveConcreteSyntax);
     auto desugaredBody = desugarBody(dctx1, block->loc, block->body, move(destructures));
 
     send->setBlock(MK::Block(block->loc, move(desugaredBody), move(Params)));
@@ -389,8 +386,8 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
     // Reset uniqueCounter within this scope (to keep numbers small)
     uint32_t uniqueCounter = 1;
     auto inModule = dctx.inModule && !isSelf;
-    DesugarContext dctx1(dctx.ctx, uniqueCounter, dctx.enclosingBlockParamLoc, dctx.enclosingBlockParamName, declLoc,
-                         name, dctx.inAnyBlock, inModule, dctx.preserveConcreteSyntax);
+    DesugarContext dctx1(dctx.ctx, uniqueCounter, dctx.enclosingBlockParamLoc, dctx.enclosingBlockParamName, name,
+                         dctx.inAnyBlock, inModule, dctx.preserveConcreteSyntax);
     auto [params, destructures] = desugarParams(dctx1, argnode);
 
     if (params.empty() || !isa_tree<BlockParam>(params.back())) {
@@ -404,7 +401,7 @@ ExpressionPtr buildMethod(DesugarContext dctx, core::LocOffsets loc, core::LocOf
     auto enclosingBlockParamName = blockParam2Name(dctx, *blockParam);
     auto initialBlockParamName = enclosingBlockParamName;
 
-    DesugarContext dctx2(dctx1.ctx, dctx1.uniqueCounter, enclosingBlockParamLoc, enclosingBlockParamName, declLoc, name,
+    DesugarContext dctx2(dctx1.ctx, dctx1.uniqueCounter, enclosingBlockParamLoc, enclosingBlockParamName, name,
                          dctx.inAnyBlock, inModule, dctx.preserveConcreteSyntax);
     ExpressionPtr desugaredBody = desugarBody(dctx2, loc, body, move(destructures));
     desugaredBody = validateRBIBody(dctx2, move(desugaredBody));
@@ -600,8 +597,7 @@ ClassDef::RHS_store scopeNodeToBody(DesugarContext dctx, unique_ptr<parser::Node
     // Blocks never persist across a class/module boundary
     auto inAnyBlock = false;
     DesugarContext dctx1(dctx.ctx, uniqueCounter, dctx.enclosingBlockParamLoc, dctx.enclosingBlockParamName,
-                         dctx.enclosingMethodLoc, dctx.enclosingMethodName, inAnyBlock, dctx.inModule,
-                         dctx.preserveConcreteSyntax);
+                         dctx.enclosingMethodName, inAnyBlock, dctx.inModule, dctx.preserveConcreteSyntax);
     if (auto *begin = parser::cast_node<parser::Begin>(node.get())) {
         body.reserve(begin->stmts.size());
         for (auto &stat : begin->stmts) {
@@ -778,7 +774,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     flags.isPrivateOk = true;
                 }
 
-                if (isCallToBlockGivenP(send, rec) && dctx.enclosingMethodLoc.exists()) {
+                if (isCallToBlockGivenP(send, rec) && dctx.enclosingMethodName.exists()) {
                     // Desugar:
                     //     def foo(&my_block)
                     //       x = block_given?
@@ -1570,8 +1566,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
             [&](parser::Kwbegin *kwbegin) { result = desugarBegin(dctx, loc, kwbegin->stmts); },
             [&](parser::Module *module) {
                 DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockParamLoc,
-                                     dctx.enclosingBlockParamName, dctx.enclosingMethodLoc, dctx.enclosingMethodName,
-                                     dctx.inAnyBlock, true, dctx.preserveConcreteSyntax);
+                                     dctx.enclosingBlockParamName, dctx.enclosingMethodName, dctx.inAnyBlock, true,
+                                     dctx.preserveConcreteSyntax);
                 ClassDef::RHS_store body = scopeNodeToBody(dctx1, move(module->body));
                 ExpressionPtr res =
                     MK::Module(module->loc, module->declLoc, node2TreeImpl(dctx, module->name), move(body));
@@ -1579,8 +1575,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
             },
             [&](parser::Class *klass) {
                 DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockParamLoc,
-                                     dctx.enclosingBlockParamName, dctx.enclosingMethodLoc, dctx.enclosingMethodName,
-                                     dctx.inAnyBlock, false, dctx.preserveConcreteSyntax);
+                                     dctx.enclosingBlockParamName, dctx.enclosingMethodName, dctx.inAnyBlock, false,
+                                     dctx.preserveConcreteSyntax);
                 ClassDef::RHS_store body = scopeNodeToBody(dctx1, move(klass->body));
                 ClassDef::ANCESTORS_store ancestors;
                 if (klass->superclass == nullptr) {
@@ -1664,8 +1660,8 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 }
 
                 DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockParamLoc,
-                                     dctx.enclosingBlockParamName, dctx.enclosingMethodLoc, dctx.enclosingMethodName,
-                                     dctx.inAnyBlock, false, dctx.preserveConcreteSyntax);
+                                     dctx.enclosingBlockParamName, dctx.enclosingMethodName, dctx.inAnyBlock, false,
+                                     dctx.preserveConcreteSyntax);
                 ClassDef::RHS_store body = scopeNodeToBody(dctx1, move(sclass->body));
                 ClassDef::ANCESTORS_store emptyAncestors;
                 ExpressionPtr res =
@@ -2488,7 +2484,7 @@ ExpressionPtr node2Tree(core::MutableContext ctx, unique_ptr<parser::Node> what,
         auto enclosingBlockParamLoc = core::LocOffsets::none();
         auto enclosingBlockParamName = core::NameRef::noName();
         DesugarContext dctx(ctx, uniqueCounter, enclosingBlockParamLoc, enclosingBlockParamName,
-                            core::LocOffsets::none(), core::NameRef::noName(), false, false, preserveConcreteSyntax);
+                            core::NameRef::noName(), false, false, preserveConcreteSyntax);
         auto liftedClassDefLoc = what->loc;
         auto result = node2TreeImpl(dctx, what);
         if (result.loc().exists()) {

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -54,11 +54,10 @@ class Desugarer final {
     uint32_t &desugarUniqueCounter;       // Points to the active `desugarUniqueCounterStorage`
 
     // Context variables
-    const core::LocOffsets enclosingMethodLoc; // The location of the method we're in, or `none()`
-    const core::NameRef enclosingMethodName;   // The name of the method we're in, or `noName()`
-    core::LocOffsets &enclosingBlockParamLoc;  // The loc of the `yield` or `block_given?` that triggered a block param
-                                               // to be created, or else the original location of the block parameter.
-    core::NameRef &enclosingBlockParamName;    // The name of the block param of the method we're in, or `noName()`
+    const core::NameRef enclosingMethodName;  // The name of the method we're in, or `noName()`
+    core::LocOffsets &enclosingBlockParamLoc; // The loc of the `yield` or `block_given?` that triggered a block param
+                                              // to be created, or else the original location of the block parameter.
+    core::NameRef &enclosingBlockParamName;   // The name of the block param of the method we're in, or `noName()`
     const bool isInModule = false;   // True if we're in a Module definition. False for classes and singleton classes
     const bool isInAnyBlock = false; // True if we're in a `{ }`/`do end` block
 
@@ -82,18 +81,17 @@ public:
 private:
     // This private constructor is used for creating child translators with modified context.
     // uniqueCounterStorage is passed as a dummy value and is never used
-    Desugarer(const Desugarer &parent, bool resetDesugarUniqueCounter, core::LocOffsets enclosingMethodLoc,
-              core::NameRef enclosingMethodName, core::LocOffsets &enclosingBlockParamLoc,
-              core::NameRef &enclosingBlockParamName, bool isInModule, bool isInAnyBlock)
+    Desugarer(const Desugarer &parent, bool resetDesugarUniqueCounter, core::NameRef enclosingMethodName,
+              core::LocOffsets &enclosingBlockParamLoc, core::NameRef &enclosingBlockParamName, bool isInModule,
+              bool isInAnyBlock)
         : parser(parent.parser), ctx(parent.ctx), parseErrors(parent.parseErrors),
           preserveConcreteSyntax(parent.preserveConcreteSyntax), parserUniqueCounterStorage(9999),
           desugarUniqueCounterStorage(resetDesugarUniqueCounter ? 1 : 999999),
           parserUniqueCounter(parent.parserUniqueCounter),
           desugarUniqueCounter(resetDesugarUniqueCounter ? this->desugarUniqueCounterStorage
                                                          : parent.desugarUniqueCounter),
-          enclosingMethodLoc(enclosingMethodLoc), enclosingMethodName(enclosingMethodName),
-          enclosingBlockParamLoc(enclosingBlockParamLoc), enclosingBlockParamName(enclosingBlockParamName),
-          isInModule(isInModule), isInAnyBlock(isInAnyBlock) {}
+          enclosingMethodName(enclosingMethodName), enclosingBlockParamLoc(enclosingBlockParamLoc),
+          enclosingBlockParamName(enclosingBlockParamName), isInModule(isInModule), isInAnyBlock(isInAnyBlock) {}
 
     ast::ExpressionPtr make_unsupported_node(core::LocOffsets loc, std::string_view nodeName) const;
 
@@ -292,8 +290,8 @@ private:
 
     // Context management helpers. These return a copy of `this` with some change to the context.
     bool isInMethodDef() const;
-    Desugarer enterMethodDef(bool isSingletonMethod, core::LocOffsets methodLoc, core::NameRef methodName,
-                             core::LocOffsets &enclosingBlockParamLoc, core::NameRef &enclosingBlockParamName) const;
+    Desugarer enterMethodDef(bool isSingletonMethod, core::NameRef methodName, core::LocOffsets &enclosingBlockParamLoc,
+                             core::NameRef &enclosingBlockParamName) const;
     Desugarer enterBlockContext() const;
     Desugarer enterModuleContext(core::LocOffsets &enclosingBlockParamLoc,
                                  core::NameRef &enclosingBlockParamName) const;
@@ -2347,7 +2345,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                                                                      : defNode->lparen_loc.start;
                 auto endLoc = defNode->rparen_loc.end == nullptr ? defNode->parameters->base.location.end
                                                                  : defNode->rparen_loc.end;
-                auto loc = translateLoc(pm_location_t{startLoc, endLoc});
+                auto loc = translateLoc(startLoc, endLoc);
                 declLoc = declLoc.join(loc);
 
                 std::tie(paramsStore, statsStore, enclosingBlockParamLoc, enclosingBlockParamName) =
@@ -2368,7 +2366,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             }
 
             Desugarer methodContext =
-                this->enterMethodDef(isSingletonMethod, declLoc, name, enclosingBlockParamLoc, enclosingBlockParamName);
+                this->enterMethodDef(isSingletonMethod, name, enclosingBlockParamLoc, enclosingBlockParamName);
 
             ast::ExpressionPtr body;
             if (defNode->body != nullptr) {
@@ -5381,27 +5379,23 @@ core::NameRef Desugarer::maybeTypedSuper() const {
 
 // Context management methods
 bool Desugarer::isInMethodDef() const {
-    ENFORCE(enclosingMethodLoc.exists() == enclosingMethodName.exists(),
-            "The enclosing method name and location should always both be present, "
-            "or both be absecent, depending on whether we're in a method def or not.")
-
     return enclosingMethodName.exists();
 }
 
-Desugarer Desugarer::enterMethodDef(bool isSingletonMethod, core::LocOffsets methodLoc, core::NameRef methodName,
+Desugarer Desugarer::enterMethodDef(bool isSingletonMethod, core::NameRef methodName,
                                     core::LocOffsets &enclosingBlockParamLoc,
                                     core::NameRef &enclosingBlockParamName) const {
     auto resetDesugarUniqueCounter = true;
     auto isInModule = this->isInModule && !isSingletonMethod;
-    return Desugarer(*this, resetDesugarUniqueCounter, methodLoc, methodName, enclosingBlockParamLoc,
-                     enclosingBlockParamName, isInModule, this->isInAnyBlock);
+    return Desugarer(*this, resetDesugarUniqueCounter, methodName, enclosingBlockParamLoc, enclosingBlockParamName,
+                     isInModule, this->isInAnyBlock);
 }
 
 Desugarer Desugarer::enterBlockContext() const {
     auto resetDesugarUniqueCounter = false; // Blocks inherit their parent's numbering
     auto isInAnyBlock = true;
-    return Desugarer(*this, resetDesugarUniqueCounter, this->enclosingMethodLoc, this->enclosingMethodName,
-                     this->enclosingBlockParamLoc, this->enclosingBlockParamName, this->isInModule, isInAnyBlock);
+    return Desugarer(*this, resetDesugarUniqueCounter, this->enclosingMethodName, this->enclosingBlockParamLoc,
+                     this->enclosingBlockParamName, this->isInModule, isInAnyBlock);
 }
 
 Desugarer Desugarer::enterModuleContext(core::LocOffsets &enclosingBlockParamLoc,
@@ -5409,8 +5403,8 @@ Desugarer Desugarer::enterModuleContext(core::LocOffsets &enclosingBlockParamLoc
     auto resetDesugarUniqueCounter = true;
     auto isInModule = true;
     auto isInAnyBlock = false; // Blocks never persist across a class/module boundary
-    return Desugarer(*this, resetDesugarUniqueCounter, this->enclosingMethodLoc, this->enclosingMethodName,
-                     enclosingBlockParamLoc, enclosingBlockParamName, isInModule, isInAnyBlock);
+    return Desugarer(*this, resetDesugarUniqueCounter, this->enclosingMethodName, enclosingBlockParamLoc,
+                     enclosingBlockParamName, isInModule, isInAnyBlock);
 }
 
 Desugarer Desugarer::enterClassContext(core::LocOffsets &enclosingBlockParamLoc,
@@ -5418,8 +5412,8 @@ Desugarer Desugarer::enterClassContext(core::LocOffsets &enclosingBlockParamLoc,
     auto resetDesugarUniqueCounter = true;
     auto isInModule = false;
     auto isInAnyBlock = false; // Blocks never persist across a class/module boundary
-    return Desugarer(*this, resetDesugarUniqueCounter, this->enclosingMethodLoc, this->enclosingMethodName,
-                     enclosingBlockParamLoc, enclosingBlockParamName, isInModule, isInAnyBlock);
+    return Desugarer(*this, resetDesugarUniqueCounter, this->enclosingMethodName, enclosingBlockParamLoc,
+                     enclosingBlockParamName, isInModule, isInAnyBlock);
 }
 
 void Desugarer::reportError(core::LocOffsets loc, const string &message) const {


### PR DESCRIPTION
### Motivation

Unused since #9791, except to check if we're in a method or not, which can be done via `enclosingMethodName` instead.

### Test plan

Pure refactor