### PR TITLE
Desugar parameters in the method body's context

### DIFF
--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -2335,6 +2335,12 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
 
             core::LocOffsets enclosingBlockParamLoc;
             core::NameRef enclosingBlockParamName;
+            // Desugaring parameters can introduce new statements which define new temporarily local variables at the
+            // start of the method. We enter the method def before desugaring parameters, so those temporaries are
+            // numebred using the method's unique counter, rather than the parent context's counter.
+            Desugarer methodContext =
+                this->enterMethodDef(isSingletonMethod, name, enclosingBlockParamLoc, enclosingBlockParamName);
+
             ast::MethodDef::PARAMS_store paramsStore;
             ast::InsSeq::STATS_store statsStore;
             if (defNode->parameters != nullptr) {
@@ -2349,7 +2355,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                 declLoc = declLoc.join(loc);
 
                 std::tie(paramsStore, statsStore, enclosingBlockParamLoc, enclosingBlockParamName) =
-                    desugarParametersNode(defNode->parameters, loc);
+                    methodContext.desugarParametersNode(defNode->parameters, loc);
             } else {
                 if (rparenLoc.start != nullptr) {
                     // The definition has no parameters but still has parentheses, e.g. `def foo(); end`
@@ -2357,16 +2363,13 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                     auto loc = translateLoc(defNode->lparen_loc.start, defNode->rparen_loc.end);
 
                     std::tie(paramsStore, statsStore, enclosingBlockParamLoc, enclosingBlockParamName) =
-                        desugarParametersNode(nullptr, loc);
+                        methodContext.desugarParametersNode(nullptr, loc);
                 }
 
                 // Desugaring a method def like `def foo()` should behave like `def foo(&<blk>)`,
                 // so we set a synthetic name here for `yield` to use.
                 enclosingBlockParamName = core::Names::blkArg();
             }
-
-            Desugarer methodContext =
-                this->enterMethodDef(isSingletonMethod, name, enclosingBlockParamLoc, enclosingBlockParamName);
 
             ast::ExpressionPtr body;
             if (defNode->body != nullptr) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation

Part of #9065. Makes the Prism behaviour match the legacy desugarer's.

```ruby
# typed: true

outside_a, outside_b = []

def foo((param_a, param_b))
  body_c, body_d = []
end
```

The desugar tree is now renumbered more top-to-bottomy:

```diff
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def foo<<todo method>>(<destructure>$4, &<blk>)
+  def foo<<todo method>>(<destructure>$2, &<blk>)
     begin
       begin
-        <assignTemp>$5 = <destructure>$4
+        <assignTemp>$3 = <destructure>$2
-        <assignTemp>$6 = ::<Magic>.<expand-splat>(<assignTemp>$5, 2, 0)
+        <assignTemp>$4 = ::<Magic>.<expand-splat>(<assignTemp>$3, 2, 0)
-        param_a = <assignTemp>$6.[](0)
-        param_b = <assignTemp>$6.[](1)
+        param_a = <assignTemp>$4.[](0)
+        param_b = <assignTemp>$4.[](1)
-        <assignTemp>$5
+        <assignTemp>$3
       end
       begin
-        <assignTemp>$2 = []
+        <assignTemp>$5 = []
-        <assignTemp>$3 = ::<Magic>.<expand-splat>(<assignTemp>$2, 2, 0)
+        <assignTemp>$6 = ::<Magic>.<expand-splat>(<assignTemp>$5, 2, 0)
-        body_c = <assignTemp>$3.[](0)
-        body_d = <assignTemp>$3.[](1)
+        body_c = <assignTemp>$6.[](0)
+        body_d = <assignTemp>$6.[](1)
-        <assignTemp>$2
+        <assignTemp>$5
       end
     end
   end
 end
```
### Test plan

Fixes huge parts of the diff of some of the existing multi-assignment tests. They still fail for other reasons, which will be addressed in separate PRs.