### PR TITLE
Fix RBI so that attr_ methods of Module returns an array of symbols

### DIFF
--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -277,7 +277,7 @@ class Module < Object
     params(
         arg0: T.any(Symbol, String),
     )
-    .returns(NilClass)
+    .returns(T::Array[Symbol])
   end
   def attr_accessor(*arg0); end
 
@@ -290,7 +290,7 @@ class Module < Object
     params(
         arg0: T.any(Symbol, String),
     )
-    .returns(NilClass)
+    .returns(T::Array[Symbol])
   end
   def attr_reader(*arg0); end
 
@@ -302,7 +302,7 @@ class Module < Object
     params(
         arg0: T.any(Symbol, String),
     )
-    .returns(NilClass)
+    .returns(T::Array[Symbol])
   end
   def attr_writer(*arg0); end
 


### PR DESCRIPTION
Fixes #8709 .
Since Ruby 3.0, `attr_reader` (and the like) return an Array of symbols instead of nil. The comment in the RBI says that it returns an array, but the actual code said it returns a NilClass. This patch fixes it.

- Implementation in current Ruby: https://github.com/ruby/ruby/blob/9228a1305acfd12b9df83ecb287985121a9ba52a/object.c#L2498-L2524

(btw, thanks @pocke for helping me find where to fix this)

### Motivation
using `private attr_reader` got me this error:

```
app/controllers/(redacted):(redacted): Expected T.any(Symbol, String) but found NilClass for argument arg0 https://srb.help/7002
    11 |  private attr_reader :attribute_name
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
```

### Test plan

As far as I understand from the contribution guideline this does not need additional tests; if any additional tests are needed I might need some help