### PR TITLE
Fix Prism multi-target node locations

### DIFF
--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -2379,11 +2379,10 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             }
 
             if (!statsStore.empty()) {
-                auto bodyLoc = body.loc();
-                if (!bodyLoc.exists()) {
-                    bodyLoc = location;
-                }
-                body = MK::InsSeq(bodyLoc, move(statsStore), move(body));
+                // The parameters list contains multi-target nodes, which get desugared to assignment statements, which
+                // we prepend to the start of the method's body.
+                // In this case, the legacy desugarer uses the entire method definition loc (from `def` to `end`).
+                body = MK::InsSeq(location, move(statsStore), move(body));
             }
 
             // Add an implicit block parameter, if no explicit one was declared in the parameter list.

--- a/test/BUILD
+++ b/test/BUILD
@@ -465,7 +465,6 @@ pipeline_tests(
             "testdata/rewriter/initializer_no_arg_with_local.rb",
 
             # Prism desugared tree doesn't match legacy desugared tree (desugar differences)
-            "testdata/desugar/destructure.rb",
             "testdata/desugar/destructure_rest.rb",
             "testdata/desugar/splat.rb",
             "testdata/desugar/star_in_block_arg.rb",
@@ -543,7 +542,6 @@ pipeline_tests(
         exclude = [
             # related to ruby 3.4 syntax changes
             "prism_regression/assign_to_index.rb",
-            "prism_regression/multi_target.rb",
             "prism_regression/call_block_param.rb",
         ],
     ),


### PR DESCRIPTION
### Motivation

Part of #9065. Fixes up Prism node locations to match the legacy desugared locations.

### Test plan

Fixes 2 preexisting tests.
