### PR TITLE
Fix printing of block-local variables when there are no parameters

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -455,13 +455,11 @@ void printElems(const core::GlobalState &gs, fmt::memory_buffer &buf, absl::Span
         if (isa_tree<Block>(a)) {
             continue;
         }
-        if (!first) {
-            if (isa_tree<ShadowArg>(a) && !didshadow) {
-                fmt::format_to(std::back_inserter(buf), "; ");
-                didshadow = true;
-            } else {
-                fmt::format_to(std::back_inserter(buf), ", ");
-            }
+        if (isa_tree<ShadowArg>(a) && !didshadow) {
+            fmt::format_to(std::back_inserter(buf), "; ");
+            didshadow = true;
+        } else if (!first) {
+            fmt::format_to(std::back_inserter(buf), ", ");
         }
         first = false;
         fmt::format_to(std::back_inserter(buf), "{}", a.toStringWithTabs(gs, tabs + 1));

--- a/test/BUILD
+++ b/test/BUILD
@@ -274,6 +274,9 @@ pipeline_tests(
         exclude = [
             "testdata/rbs/**/*.rb",
             "testdata/rbs/**/*.exp",
+
+            # Prism-specific variant of `missing_shadow_args.rb` (different parser errors and desugar tree).
+            "testdata/parser/error_recovery/missing_shadow_args_prism.rb",
         ],
     ),
     "PosTests",
@@ -502,6 +505,12 @@ pipeline_tests(
             "testdata/cfg/rescue_var_expression.rb",
             "testdata/parser/misc.rb",
 
+            # The Prism desugarer doesn't check for block-local variables if there are no other parameters
+            "testdata/desugar/shadow_args.rb",
+
+            # Legacy-parser variant of `missing_shadow_args_prism.rb` (different parser errors and desugar tree).
+            "testdata/parser/error_recovery/missing_shadow_args.rb",
+
             # Fixing a bug in pipeline_test_runner.cc revealed that these tests
             # were not actually running because they have RBS support enabled
             "testdata/lsp/hover_rbs.rb",
@@ -538,6 +547,9 @@ pipeline_tests(
             # which will not be back-ported to the whitequark-based RBS rewriter.
             "testdata/rbs/annotations_literal_types.rb",
             "testdata/rbs/signatures_types.rb",
+
+            # Prism-specific variant of `missing_shadow_args.rb` (different parser errors).
+            "testdata/parser/error_recovery/missing_shadow_args_prism.rb",
         ],
     ),
     "LSPTests",

--- a/test/prism_regression/call_block_param.rb
+++ b/test/prism_regression/call_block_param.rb
@@ -21,9 +21,6 @@ foo do |positional, (multi, target)|
   "block with multi-target node in parameter list"
 end
 
-# block with parameter `bar` and block locals `baz` and `qux`
-foo { |bar; baz, qux| }
-
 foo do |positional, (multi, target); baz, qux|
   "block with multi-target node in parameter list and block locals"
 end

--- a/test/prism_regression/call_block_param.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_block_param.rb.desugar-tree-raw.exp
@@ -229,32 +229,6 @@ ClassDef{
         params = [
           UnresolvedIdent{
             kind = Local
-            name = <U bar>
-          }
-          ShadowArg{ expr = UnresolvedIdent{
-            kind = Local
-            name = <U baz>
-          } }
-          ShadowArg{ expr = UnresolvedIdent{
-            kind = Local
-            name = <U qux>
-          } }
-        ]
-        body = EmptyTree
-      }
-      pos_args = 0
-      args = [
-      ]
-    }
-
-    Send{
-      flags = {privateOk}
-      recv = Self
-      fun = <U foo>
-      block = Block {
-        params = [
-          UnresolvedIdent{
-            kind = Local
             name = <U positional>
           }
           UnresolvedIdent{

--- a/test/testdata/desugar/shadow_args.rb
+++ b/test/testdata/desugar/shadow_args.rb
@@ -1,0 +1,32 @@
+# typed: false
+# disable-parser-comparison: true
+
+lambda do |; block_local1| end
+lambda do |; block_local1, block_local2| end
+lambda do |; block_local1, block_local2, block_local3| end
+lambda do |param1; block_local1| end
+lambda do |param1; block_local1, block_local2| end
+lambda do |param1; block_local1, block_local2, block_local3| end
+lambda do |param1, param2; block_local1| end
+lambda do |param1, param2; block_local1, block_local2| end
+lambda do |param1, param2; block_local1, block_local2, block_local3| end
+
+lambda { |; block_local1| }
+lambda { |; block_local1, block_local2| }
+lambda { |; block_local1, block_local2, block_local3| }
+lambda { |param1; block_local1| }
+lambda { |param1; block_local1, block_local2| }
+lambda { |param1; block_local1, block_local2, block_local3| }
+lambda { |param1, param2; block_local1| }
+lambda { |param1, param2; block_local1, block_local2| }
+lambda { |param1, param2; block_local1, block_local2, block_local3| }
+
+-> (; block_local1) {}
+-> (; block_local1, block_local2) {}
+-> (; block_local1, block_local2, block_local3) {}
+-> (param1; block_local1) {}
+-> (param1; block_local1, block_local2) {}
+-> (param1; block_local1, block_local2, block_local3) {}
+-> (param1, param2; block_local1) {}
+-> (param1, param2; block_local1, block_local2) {}
+-> (param1, param2; block_local1, block_local2, block_local3) {}

--- a/test/testdata/desugar/shadow_args.rb.desugar-tree.exp
+++ b/test/testdata/desugar/shadow_args.rb.desugar-tree.exp
@@ -1,0 +1,109 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  <self>.lambda() do |block_local1|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |block_local1; block_local2|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |block_local1; block_local2, block_local3|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |param1; block_local1|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |param1; block_local1, block_local2|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |param1; block_local1, block_local2, block_local3|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |param1, param2; block_local1|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |param1, param2; block_local1, block_local2|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |param1, param2; block_local1, block_local2, block_local3|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |block_local1|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |block_local1; block_local2|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |block_local1; block_local2, block_local3|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |param1; block_local1|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |param1; block_local1, block_local2|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |param1; block_local1, block_local2, block_local3|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |param1, param2; block_local1|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |param1, param2; block_local1, block_local2|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |param1, param2; block_local1, block_local2, block_local3|
+    <emptyTree>
+  end
+
+  ::Kernel.lambda() do |block_local1|
+    <emptyTree>
+  end
+
+  ::Kernel.lambda() do |block_local1; block_local2|
+    <emptyTree>
+  end
+
+  ::Kernel.lambda() do |block_local1; block_local2, block_local3|
+    <emptyTree>
+  end
+
+  ::Kernel.lambda() do |param1; block_local1|
+    <emptyTree>
+  end
+
+  ::Kernel.lambda() do |param1; block_local1, block_local2|
+    <emptyTree>
+  end
+
+  ::Kernel.lambda() do |param1; block_local1, block_local2, block_local3|
+    <emptyTree>
+  end
+
+  ::Kernel.lambda() do |param1, param2; block_local1|
+    <emptyTree>
+  end
+
+  ::Kernel.lambda() do |param1, param2; block_local1, block_local2|
+    <emptyTree>
+  end
+
+  ::Kernel.lambda() do |param1, param2; block_local1, block_local2, block_local3|
+    <emptyTree>
+  end
+end

--- a/test/testdata/desugar/shadow_args.rb.desugar-tree.exp
+++ b/test/testdata/desugar/shadow_args.rb.desugar-tree.exp
@@ -1,49 +1,13 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  <self>.lambda() do |block_local1|
+  <self>.lambda() do |; block_local1|
     <emptyTree>
   end
 
-  <self>.lambda() do |block_local1; block_local2|
+  <self>.lambda() do |; block_local1, block_local2|
     <emptyTree>
   end
 
-  <self>.lambda() do |block_local1; block_local2, block_local3|
-    <emptyTree>
-  end
-
-  <self>.lambda() do |param1; block_local1|
-    <emptyTree>
-  end
-
-  <self>.lambda() do |param1; block_local1, block_local2|
-    <emptyTree>
-  end
-
-  <self>.lambda() do |param1; block_local1, block_local2, block_local3|
-    <emptyTree>
-  end
-
-  <self>.lambda() do |param1, param2; block_local1|
-    <emptyTree>
-  end
-
-  <self>.lambda() do |param1, param2; block_local1, block_local2|
-    <emptyTree>
-  end
-
-  <self>.lambda() do |param1, param2; block_local1, block_local2, block_local3|
-    <emptyTree>
-  end
-
-  <self>.lambda() do |block_local1|
-    <emptyTree>
-  end
-
-  <self>.lambda() do |block_local1; block_local2|
-    <emptyTree>
-  end
-
-  <self>.lambda() do |block_local1; block_local2, block_local3|
+  <self>.lambda() do |; block_local1, block_local2, block_local3|
     <emptyTree>
   end
 
@@ -71,15 +35,51 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  ::Kernel.lambda() do |block_local1|
+  <self>.lambda() do |; block_local1|
     <emptyTree>
   end
 
-  ::Kernel.lambda() do |block_local1; block_local2|
+  <self>.lambda() do |; block_local1, block_local2|
     <emptyTree>
   end
 
-  ::Kernel.lambda() do |block_local1; block_local2, block_local3|
+  <self>.lambda() do |; block_local1, block_local2, block_local3|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |param1; block_local1|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |param1; block_local1, block_local2|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |param1; block_local1, block_local2, block_local3|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |param1, param2; block_local1|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |param1, param2; block_local1, block_local2|
+    <emptyTree>
+  end
+
+  <self>.lambda() do |param1, param2; block_local1, block_local2, block_local3|
+    <emptyTree>
+  end
+
+  ::Kernel.lambda() do |; block_local1|
+    <emptyTree>
+  end
+
+  ::Kernel.lambda() do |; block_local1, block_local2|
+    <emptyTree>
+  end
+
+  ::Kernel.lambda() do |; block_local1, block_local2, block_local3|
     <emptyTree>
   end
 

--- a/test/testdata/parser/error_recovery/missing_shadow_args.rb
+++ b/test/testdata/parser/error_recovery/missing_shadow_args.rb
@@ -1,0 +1,13 @@
+# typed: true
+# disable-parser-comparison: true
+
+lambda do |;| end
+#         ^ error: unmatched "|" in block argument list
+#           ^ error: unexpected token "|"
+
+lambda { |;| }
+#        ^ error: unmatched "|" in block argument list
+#          ^ error: unexpected token "|"
+
+-> (;) {}
+#    ^ error-with-dupes: unexpected token ")"

--- a/test/testdata/parser/error_recovery/missing_shadow_args.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/missing_shadow_args.rb.desugar-tree.exp
@@ -1,0 +1,3 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  <emptyTree>::<C <ErrorNode>>
+end

--- a/test/testdata/parser/error_recovery/missing_shadow_args_prism.rb
+++ b/test/testdata/parser/error_recovery/missing_shadow_args_prism.rb
@@ -1,0 +1,11 @@
+# typed: true
+# disable-parser-comparison: true
+
+lambda do |;| end
+#           ^ error: expected a local variable name in the block parameters
+
+lambda { |;| }
+#          ^ error: expected a local variable name in the block parameters
+
+-> (;) {}
+#    ^ error-with-dupes: expected a local variable name in the block parameters

--- a/test/testdata/parser/error_recovery/missing_shadow_args_prism.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/missing_shadow_args_prism.rb.desugar-tree.exp
@@ -1,0 +1,13 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  <self>.lambda() do ||
+    <emptyTree>
+  end
+
+  <self>.lambda() do ||
+    <emptyTree>
+  end
+
+  ::Kernel.lambda() do ||
+    <emptyTree>
+  end
+end

--- a/test/testdata/parser/misc.rb
+++ b/test/testdata/parser/misc.rb
@@ -146,9 +146,6 @@ undef x, y
 # shellout (xstring)
 %x{true}
 
-# shadowarg
-proc{|;x|}
-
 # Whacky parsing edge case around keyword break and blocks
 break cfoo 1 do end
 

--- a/test/testdata/parser/misc.rb.desugar-tree.exp
+++ b/test/testdata/parser/misc.rb.desugar-tree.exp
@@ -213,10 +213,6 @@ rescue <emptyTree>::<C E> => x
 
   <self>.`("true")
 
-  <self>.proc() do |x|
-    <emptyTree>
-  end
-
   break(<self>.cfoo(1) do ||
       <emptyTree>
     end)

--- a/test/testdata/parser/misc.rb.parse-tree.exp
+++ b/test/testdata/parser/misc.rb.parse-tree.exp
@@ -595,22 +595,6 @@ Begin {
         }
       ]
     }
-    Block {
-      send = Send {
-        receiver = NULL
-        method = <U proc>
-        args = [
-        ]
-      }
-      params = Params {
-        params = [
-          Shadowarg {
-            name = <U x>
-          }
-        ]
-      }
-      body = NULL
-    }
     Break {
       exprs = [
         Block {


### PR DESCRIPTION
### Motivation

If there are no parameters, the first block-local parameter ("shadow args") is mis-printed as if it were a regular parameter. This PR fixes that.

```rb
lambda { |; x| }

lambda { |; x, y| }
```

Desugar tree diff:

```diff
- <self>.lambda() do |x|
+ <self>.lambda() do |; x|
    <emptyTree>
  end

- <self>.lambda() do |x; y|
+ <self>.lambda() do |; x, y|
    <emptyTree>
  end
```

~Stacked on #10021, which allow us to have better error-recovery tests specific to Prism.~

### Test plan

Adds new tests which are much more exhaustive, and test all combinations for `do`/`end` blocks, `{ }` blocks, and `-> { }` lambdas.