### PR TITLE
Don't unfreeze for incremental fast path, take 2

### DIFF
--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -807,10 +807,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
                 }
 
                 // Desugarer
-                {
-                    core::UnfreezeNameTable nameTableAccess(ctx);
-                    ast = ast::desugar::node2Tree(ctx, move(parseResult.tree));
-                }
+                ast = ast::desugar::node2Tree(ctx, move(parseResult.tree));
 
                 handler.addObserved(*gs, "desguar-tree", [&]() { return ast.toString(*gs); });
                 handler.addObserved(*gs, "desugar-tree-raw", [&]() { return ast.showRaw(*gs); });
@@ -819,8 +816,6 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             }
 
             case realmain::options::Parser::PRISM: {
-                core::UnfreezeNameTable nameTableAccess(*gs);
-
                 auto prismResult = parser::Prism::Parser::run(ctx);
 
                 // Run the Prism-level RBS rewriter


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

See 351ba6fce9029fd4c3952647561181a60decc6b2. Original description:

The file hasn't changed, so if there are names that need entered still,
it means that something weird is going on, as in: we didn't parse it
correctly the first time.

This unfreeze was added in error in the original changes to retrofit
prism parsing into the `pipeline_test_runner.cc` in #9131. Before that
PR, it was intentional that this phase of the test runner did not
re-open the name table for new additions.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

test-only change