### PR TITLE
Simplify handling of `present?` and `blank?`

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -603,7 +603,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
     if (send->fun == core::Names::blank_p()) {
         // Note that this assumes that .blank? is a rails-compatible monkey patch.
         // In other cases this flow analysis might make incorrect assumptions.
-        whoKnows.falsy().addYesTypeTest(local, typeTestsWithVar, send->recv.variable, core::Types::falsyTypes());
+        whoKnows.falsy().addNoTypeTest(local, typeTestsWithVar, send->recv.variable, core::Types::falsyTypes());
         whoKnows.sanityCheck();
         return;
     }


### PR DESCRIPTION

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The whole point of `noTypeTests` is that each of these types will translate to
an `approximateSubtract` eventually, in `assumeKnowledge`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
