### PR TITLE
Remove immediately-executed lambda

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -254,23 +254,14 @@ parser::ParseResult runParser(core::GlobalState &gs, core::FileRef file, const o
     return result;
 }
 
-parser::Prism::ParseResult runPrismParser(core::GlobalState &gs, core::FileRef file, const options::Printers &print,
-                                          const options::Options &opts, bool preserveConcreteSyntax = false) {
-    parser::Prism::ParseResult parseResult;
-    {
-        Timer timeit(gs.tracer(), "runParser", {{"file", string(file.data(gs).path())}});
-        core::UnfreezeNameTable nameTableAccess(gs); // enters strings from source code as names
+parser::Prism::ParseResult runPrismParser(core::GlobalState &gs, core::FileRef file, const options::Options &opts,
+                                          bool preserveConcreteSyntax = false) {
+    Timer timeit(gs.tracer(), "runParser", {{"file", string(file.data(gs).path())}});
+    core::UnfreezeNameTable nameTableAccess(gs); // enters strings from source code as names
 
-        auto source = file.data(gs).source();
-        bool collectComments = gs.cacheSensitiveOptions.rbsEnabled;
-        parseResult = parser::Prism::Parser::parseWithoutTranslation(source, collectComments);
-    }
-
-    if (print.ParseTree.enabled) {
-        print.ParseTree.fmt("{}\n", parseResult.prettyPrint());
-    }
-
-    return parseResult;
+    auto source = file.data(gs).source();
+    bool collectComments = gs.cacheSensitiveOptions.rbsEnabled;
+    return parser::Prism::Parser::parseWithoutTranslation(source, collectComments);
 }
 
 parser::Prism::ParseResult runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file,
@@ -449,7 +440,12 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
                 }
 
                 case options::Parser::PRISM: {
-                    auto parseResult = runPrismParser(lgs, file, print, opts);
+                    auto parseResult = runPrismParser(lgs, file, opts);
+
+                    if (print.ParseTree.enabled) {
+                        print.ParseTree.fmt("{}\n", parseResult.prettyPrint());
+                    }
+
                     if (opts.stopAfterPhase == options::Phase::PARSER) {
                         return emptyParsedFile(file);
                     }

--- a/parser/prism/Parser.h
+++ b/parser/prism/Parser.h
@@ -92,7 +92,6 @@ class ParseResult final {
     std::vector<core::LocOffsets> commentLocations;
 
 public:
-    ParseResult() = default;
     ParseResult(std::unique_ptr<Parser> parser, pm_node_t *node, std::vector<ParseError> parseErrors,
                 std::vector<core::LocOffsets> commentLocations)
         : parser{std::move(parser)}, node{node}, parseErrors{std::move(parseErrors)}, commentLocations{std::move(


### PR DESCRIPTION
I chose to let `ParseResult` have move semantics, because there are
exceedingly few things that shouldn't have move semantics (basically,
only those things where the of the thing itself matters, which is not
the case for this struct).

If we don't want to have move semantics, we could also remove the lambda
with an explicit call to `setEndTime()` on the timer, or by storing the
`Timer` in a `unique_ptr` and setting it to `nullptr` when we want to
trigger the timer.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This comment:

<https://github.com/sorbet/sorbet/pull/9987/changes#r2919942735>

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests