### PR TITLE
Don't ignore block-local variables if there are no other parameters

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1312,7 +1312,10 @@ string OptionalParam::toStringWithTabs(const core::GlobalState &gs, int tabs) co
 }
 
 string ShadowArg::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
-    return this->expr.toStringWithTabs(gs, tabs);
+    auto name = this->expr.toStringWithTabs(gs, tabs);
+
+    // Shadow args can have an empty name in an error case like `do |;| end`
+    return name.empty() ? "<missing_block_local_params>" : name;
 }
 
 string BlockParam::toStringWithTabs(const core::GlobalState &gs, int tabs) const {

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -4182,9 +4182,9 @@ ast::ExpressionPtr Desugarer::desugarLiteralBlock(pm_node *blockBodyNode, pm_nod
 
                 auto paramsLoc = translateLoc(paramsNode->base.location);
 
-                if (paramsNode->parameters) {
-                    auto blockLocalVariables = absl::MakeSpan(paramsNode->locals.nodes, paramsNode->locals.size);
+                auto blockLocalVariables = absl::MakeSpan(paramsNode->locals.nodes, paramsNode->locals.size);
 
+                if (paramsNode->parameters) {
                     ast::InsSeq::STATS_store blockStatsStore;
 
                     std::tie(blockParamsStore, blockStatsStore, std::ignore, std::ignore) =
@@ -4193,11 +4193,13 @@ ast::ExpressionPtr Desugarer::desugarLiteralBlock(pm_node *blockBodyNode, pm_nod
                     if (!blockStatsStore.empty()) {
                         blockBody = MK::InsSeq(blockLoc, move(blockStatsStore), move(blockBody));
                     }
+                } else {
+                    blockParamsStore.reserve(blockLocalVariables.size());
+                }
 
-                    // Add in the block-local variables, if any.
-                    for (auto *node : blockLocalVariables) {
-                        blockParamsStore.emplace_back(desugar(node));
-                    }
+                // Add in the block-local variables, if any.
+                for (auto *node : blockLocalVariables) {
+                    blockParamsStore.emplace_back(desugar(node));
                 }
 
                 break;

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -98,8 +98,7 @@ private:
 
     std::tuple<ast::MethodDef::PARAMS_store, ast::InsSeq::STATS_store, core::LocOffsets /* enclosingBlockParamLoc */,
                core::NameRef /* enclosingBlockParamName */>
-    desugarParametersNode(pm_parameters_node *paramsNode, core::LocOffsets location,
-                          absl::Span<pm_node_t *> blockLocalVariables = {});
+    desugarParametersNode(pm_parameters_node *paramsNode, core::LocOffsets location, size_t extraReserveCount = 0);
 
     core::LocOffsets findItParamUsageLoc(pm_statements_node *statements);
 
@@ -3842,20 +3841,10 @@ ast::ExpressionPtr Desugarer::desugarPattern(pm_node_t *node) {
 
 tuple<ast::MethodDef::PARAMS_store, ast::InsSeq::STATS_store, core::LocOffsets /* enclosingBlockParamLoc */,
       core::NameRef /* enclosingBlockParamName */>
-Desugarer::desugarParametersNode(pm_parameters_node *paramsNode, core::LocOffsets location,
-                                 absl::Span<pm_node_t *> blockLocalVariables) {
+Desugarer::desugarParametersNode(pm_parameters_node *paramsNode, core::LocOffsets location, size_t extraReserveCount) {
     if (paramsNode == nullptr) {
-        auto paramsStore = ast::MethodDef::PARAMS_store{};
-
-        // Add in the block-local variables, if any.
-        paramsStore.reserve(blockLocalVariables.size());
-        for (auto *node : blockLocalVariables) {
-            ENFORCE(isa_node<pm_block_local_variable_node>(node));
-            // TODO: move `PM_BLOCK_LOCAL_VARIABLE_NODE` case logic to here
-            paramsStore.emplace_back(desugar(node));
-        }
-
-        return {move(paramsStore), ast::InsSeq::STATS_store{}, core::LocOffsets::none(), core::Names::blkArg()};
+        return {ast::MethodDef::PARAMS_store{}, ast::InsSeq::STATS_store{}, core::LocOffsets::none(),
+                core::Names::blkArg()};
     }
 
     auto requireds = absl::MakeSpan(paramsNode->requireds.nodes, paramsNode->requireds.size);
@@ -3871,7 +3860,7 @@ Desugarer::desugarParametersNode(pm_parameters_node *paramsNode, core::LocOffset
     ast::InsSeq::STATS_store statsStore;
 
     paramsStore.reserve(requireds.size() + optionals.size() + restSize + posts.size() + keywords.size() + kwrestSize +
-                        blockSize + blockLocalVariables.size());
+                        blockSize + extraReserveCount);
 
     auto desugarPositionalParam = [this, &paramsStore, &statsStore](auto *n) {
         if (auto *multiTargetNode = down_cast<pm_multi_target_node>(n)) {
@@ -4000,12 +3989,6 @@ Desugarer::desugarParametersNode(pm_parameters_node *paramsNode, core::LocOffset
         // Desugaring a method def like `def foo(a, b)` should behave like `def foo(a, b, &<blk>)`,
         // so we set a synthetic name here for `yield` to use.
         enclosingBlockParamName = core::Names::blkArg();
-    }
-
-    // Add in the block-local variables, if any.
-    for (auto *node : blockLocalVariables) {
-        ENFORCE(isa_node<pm_block_local_variable_node>(node));
-        paramsStore.emplace_back(desugar(node));
     }
 
     return make_tuple(move(paramsStore), move(statsStore), enclosingBlockParamLoc, enclosingBlockParamName);
@@ -4205,10 +4188,15 @@ ast::ExpressionPtr Desugarer::desugarLiteralBlock(pm_node *blockBodyNode, pm_nod
                     ast::InsSeq::STATS_store blockStatsStore;
 
                     std::tie(blockParamsStore, blockStatsStore, std::ignore, std::ignore) =
-                        desugarParametersNode(paramsNode->parameters, paramsLoc, blockLocalVariables);
+                        desugarParametersNode(paramsNode->parameters, paramsLoc, blockLocalVariables.size());
 
                     if (!blockStatsStore.empty()) {
                         blockBody = MK::InsSeq(blockLoc, move(blockStatsStore), move(blockBody));
+                    }
+
+                    // Add in the block-local variables, if any.
+                    for (auto *node : blockLocalVariables) {
+                        blockParamsStore.emplace_back(desugar(node));
                     }
                 }
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -505,9 +505,6 @@ pipeline_tests(
             "testdata/cfg/rescue_var_expression.rb",
             "testdata/parser/misc.rb",
 
-            # The Prism desugarer doesn't check for block-local variables if there are no other parameters
-            "testdata/desugar/shadow_args.rb",
-
             # Legacy-parser variant of `missing_shadow_args_prism.rb` (different parser errors and desugar tree).
             "testdata/parser/error_recovery/missing_shadow_args.rb",
 

--- a/test/testdata/desugar/shadow_args.rb
+++ b/test/testdata/desugar/shadow_args.rb
@@ -1,5 +1,4 @@
 # typed: false
-# disable-parser-comparison: true
 
 lambda do |; block_local1| end
 lambda do |; block_local1, block_local2| end

--- a/test/testdata/parser/error_recovery/missing_shadow_args_prism.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/missing_shadow_args_prism.rb.desugar-tree.exp
@@ -1,13 +1,13 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  <self>.lambda() do ||
+  <self>.lambda() do |; <missing_block_local_params>|
     <emptyTree>
   end
 
-  <self>.lambda() do ||
+  <self>.lambda() do |; <missing_block_local_params>|
     <emptyTree>
   end
 
-  ::Kernel.lambda() do ||
+  ::Kernel.lambda() do |; <missing_block_local_params>|
     <emptyTree>
   end
 end


### PR DESCRIPTION
### Motivation

Part of #9065.

The Prism desugarer wasn't considering block-local variables unless there were other parameters. This PR fixes that.

Easiest to review the two commits separately.
* The first commit is just some "pre-work", pure refactoring.
* The second commit has the actual fix, which is super simple.

### Test plan

Fixes `/bazel test --config=dbg --test_output=errors //test:test_PrismPosTests/testdata/desugar/shadow_args`. Improves the error case when you have `;` but no actual block-local variables.
