### PR TITLE
Desugar unsupported nodes to error nodes instead of empty trees

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -448,7 +448,7 @@ ExpressionPtr unsupportedNode(DesugarContext dctx, parser::Node *node) {
     if (auto e = dctx.ctx.beginIndexerError(node->loc, core::errors::Desugar::UnsupportedNode)) {
         e.setHeader("Unsupported node type `{}`", node->nodeName());
     }
-    return MK::EmptyTree();
+    return MK::Constant(node->loc, core::Symbols::ErrorNode());
 }
 
 // Desugar multiple left hand side assignments into a sequence of assignments

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -499,7 +499,7 @@ ast::ExpressionPtr Desugarer::make_unsupported_node(core::LocOffsets loc, std::s
         e.setHeader("Unsupported node type `{}`", nodeName);
     }
 
-    return MK::EmptyTree();
+    return MK::Constant(loc, core::Symbols::ErrorNode());
 }
 
 // Helper function to check if an AST expression is a string literal
@@ -819,17 +819,8 @@ ast::ExpressionPtr Desugarer::desugarMlhs(core::LocOffsets loc, PrismNode *lhs, 
                     receiver = desugar(receiverNode);
                 }
 
-                // Unsupported nodes are desugared to an empty tree.
-                // Treat them as if they were `self` to match `Desugar.cc`.
-                // TODO: Clean up after direct desugaring is complete.
-                // https://github.com/Shopify/sorbet/issues/671
                 ast::Send::Flags flags;
-                if (ast::isa_tree<ast::EmptyTree>(receiver)) {
-                    receiver = MK::Self(zcloc);
-                    flags.isPrivateOk = true;
-                } else {
-                    flags.isPrivateOk = PM_NODE_FLAG_P(callTargetNode, PM_CALL_NODE_FLAGS_IGNORE_VISIBILITY);
-                }
+                flags.isPrivateOk = PM_NODE_FLAG_P(callTargetNode, PM_CALL_NODE_FLAGS_IGNORE_VISIBILITY);
 
                 ast::Send::ARGS_store arguments;
                 arguments.emplace_back(move(val));
@@ -1892,17 +1883,8 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                 receiver = desugar(receiverNode);
             }
 
-            // Unsupported nodes are desugared to an empty tree.
-            // Treat them as if they were `self` to match `Desugar.cc`.
-            // TODO: Clean up after direct desugaring is complete.
-            // https://github.com/Shopify/sorbet/issues/671
             bool isPrivateOk;
-            if (ast::isa_tree<ast::EmptyTree>(receiver)) {
-                receiver = MK::Self(location.copyWithZeroLength());
-                isPrivateOk = true;
-            } else {
-                isPrivateOk = PM_NODE_FLAG_P(callNode, PM_CALL_NODE_FLAGS_IGNORE_VISIBILITY);
-            }
+            isPrivateOk = PM_NODE_FLAG_P(callNode, PM_CALL_NODE_FLAGS_IGNORE_VISIBILITY);
 
             if (isCallToBlockGivenP(callNode, methodName, receiver) && isInMethodDef()) {
                 // Workaround to match legacy desugarer behaviour in `Dugar.cc`'s version of `desugarBlock().

--- a/test/prism_regression/flip_flop.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/flip_flop.rb.desugar-tree-raw.exp
@@ -8,31 +8,46 @@ ClassDef{
     }]
   rhs = [
     If{
-      cond = EmptyTree
+      cond = ConstantLit{
+        symbol = (static-field ::<ErrorNode>)
+        orig = nullptr
+      }
       thenp = Literal{ value = "body 1" }
       elsep = EmptyTree
     }
 
     If{
-      cond = EmptyTree
+      cond = ConstantLit{
+        symbol = (static-field ::<ErrorNode>)
+        orig = nullptr
+      }
       thenp = Literal{ value = "body 2" }
       elsep = EmptyTree
     }
 
     If{
-      cond = EmptyTree
+      cond = ConstantLit{
+        symbol = (static-field ::<ErrorNode>)
+        orig = nullptr
+      }
       thenp = Literal{ value = "body 3" }
       elsep = EmptyTree
     }
 
     If{
-      cond = EmptyTree
+      cond = ConstantLit{
+        symbol = (static-field ::<ErrorNode>)
+        orig = nullptr
+      }
       thenp = EmptyTree
       elsep = Literal{ value = "body 4" }
     }
 
     If{
-      cond = EmptyTree
+      cond = ConstantLit{
+        symbol = (static-field ::<ErrorNode>)
+        orig = nullptr
+      }
       thenp = EmptyTree
       elsep = Literal{ value = "body 5" }
     }
@@ -43,8 +58,11 @@ ClassDef{
         name = <U b>
       }
       rhs = Send{
-        flags = {privateOk}
-        recv = Self
+        flags = {}
+        recv = ConstantLit{
+          symbol = (static-field ::<ErrorNode>)
+          orig = nullptr
+        }
         fun = <U !>
         block = nullptr
         pos_args = 0

--- a/test/prism_regression/keyword_redo.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/keyword_redo.rb.desugar-tree-raw.exp
@@ -7,6 +7,9 @@ ClassDef{
       orig = nullptr
     }]
   rhs = [
-    EmptyTree
+    ConstantLit{
+      symbol = (static-field ::<ErrorNode>)
+      orig = nullptr
+    }
   ]
 }

--- a/test/prism_regression/match_last_line.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/match_last_line.rb.desugar-tree-raw.exp
@@ -8,13 +8,19 @@ ClassDef{
     }]
   rhs = [
     If{
-      cond = EmptyTree
+      cond = ConstantLit{
+        symbol = (static-field ::<ErrorNode>)
+        orig = nullptr
+      }
       thenp = EmptyTree
       elsep = EmptyTree
     }
 
     If{
-      cond = EmptyTree
+      cond = ConstantLit{
+        symbol = (static-field ::<ErrorNode>)
+        orig = nullptr
+      }
       thenp = InsSeq{
         stats = [
           Literal{ value = "This is _not_ a truthiness test of a Regexp literal," }
@@ -25,7 +31,10 @@ ClassDef{
     }
 
     If{
-      cond = EmptyTree
+      cond = ConstantLit{
+        symbol = (static-field ::<ErrorNode>)
+        orig = nullptr
+      }
       thenp = Literal{ value = "This one uses an interpolated regexp" }
       elsep = EmptyTree
     }
@@ -36,8 +45,11 @@ ClassDef{
         name = <U b>
       }
       rhs = Send{
-        flags = {privateOk}
-        recv = Self
+        flags = {}
+        recv = ConstantLit{
+          symbol = (static-field ::<ErrorNode>)
+          orig = nullptr
+        }
         fun = <U !>
         block = nullptr
         pos_args = 0
@@ -52,8 +64,11 @@ ClassDef{
         name = <U b>
       }
       rhs = Send{
-        flags = {privateOk}
-        recv = Self
+        flags = {}
+        recv = ConstantLit{
+          symbol = (static-field ::<ErrorNode>)
+          orig = nullptr
+        }
         fun = <U !>
         block = nullptr
         pos_args = 0

--- a/test/prism_regression/post_execution.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/post_execution.rb.desugar-tree-raw.exp
@@ -7,14 +7,29 @@ ClassDef{
       orig = nullptr
     }]
   rhs = [
-    EmptyTree
+    ConstantLit{
+      symbol = (static-field ::<ErrorNode>)
+      orig = nullptr
+    }
 
-    EmptyTree
+    ConstantLit{
+      symbol = (static-field ::<ErrorNode>)
+      orig = nullptr
+    }
 
-    EmptyTree
+    ConstantLit{
+      symbol = (static-field ::<ErrorNode>)
+      orig = nullptr
+    }
 
-    EmptyTree
+    ConstantLit{
+      symbol = (static-field ::<ErrorNode>)
+      orig = nullptr
+    }
 
-    EmptyTree
+    ConstantLit{
+      symbol = (static-field ::<ErrorNode>)
+      orig = nullptr
+    }
   ]
 }

--- a/test/prism_regression/pre_execution.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/pre_execution.rb.desugar-tree-raw.exp
@@ -7,14 +7,29 @@ ClassDef{
       orig = nullptr
     }]
   rhs = [
-    EmptyTree
+    ConstantLit{
+      symbol = (static-field ::<ErrorNode>)
+      orig = nullptr
+    }
 
-    EmptyTree
+    ConstantLit{
+      symbol = (static-field ::<ErrorNode>)
+      orig = nullptr
+    }
 
-    EmptyTree
+    ConstantLit{
+      symbol = (static-field ::<ErrorNode>)
+      orig = nullptr
+    }
 
-    EmptyTree
+    ConstantLit{
+      symbol = (static-field ::<ErrorNode>)
+      orig = nullptr
+    }
 
-    EmptyTree
+    ConstantLit{
+      symbol = (static-field ::<ErrorNode>)
+      orig = nullptr
+    }
   ]
 }

--- a/test/testdata/desugar/assign_keyword.rb
+++ b/test/testdata/desugar/assign_keyword.rb
@@ -1,4 +1,3 @@
 # typed: strict
   U = redo
-# ^^^^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
 #     ^^^^ error: Unsupported node type `Redo`

--- a/test/testdata/parser/error_recovery/missing_operator.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/missing_operator.rb.desugar-tree.exp
@@ -20,7 +20,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    if <emptyTree>
+    if ::<ErrorNode>
       <self>.puts("hello")
     else
       <emptyTree>
@@ -37,7 +37,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  if <emptyTree>
+  if ::<ErrorNode>
     <self>.puts("hello")
   else
     <emptyTree>

--- a/test/testdata/parser/misc.rb.desugar-tree.exp
+++ b/test/testdata/parser/misc.rb.desugar-tree.exp
@@ -172,9 +172,9 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   {x => y, :foo => 1}
 
-  <emptyTree>
+  ::<ErrorNode>
 
-  <emptyTree>
+  ::<ErrorNode>
 
   ::Kernel.Rational("4")
 


### PR DESCRIPTION
### Motivation

Today, unsupported nodes report an error and desugar to an empty tree:

https://github.com/sorbet/sorbet/blob/6942b4ec19e03357bebe900ee4d3eecca6b5ded1/ast/desugar/Desugar.cc#L447-L452

This empty tree behaves weirdly with the `parser::Send *`, which rewrites it into a `self` node with `isPrivateOk = true`.

https://github.com/sorbet/sorbet/blob/6942b4ec19e03357bebe900ee4d3eecca6b5ded1/ast/desugar/Desugar.cc#L766-L770

This PR changes the desugaring to emit an error node, which gets left as-is without rewriting to `self`.

Here's the diff change for this example:

```ruby
loop do
    redo.foo()
end

b = !(/MatchCurLine/)
```

```diff
  <self>.loop() do ||
-   <self>.foo()       # with isPrivateOk = true
+  ::<ErrorNode>.foo() # with isPrivateOk = false
  end
  
- b = <self>.!()          # with isPrivateOk = true
+ b = ::<ErrorNode>.foo() # with isPrivateOk = false
```


### Test plan

Covered by existing tests, whose expectations I updated.