### PR TITLE
Delete stale TODO

### DIFF
--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -3684,7 +3684,6 @@ ast::ExpressionPtr Desugarer::desugarPattern(pm_node_t *node) {
             }
 
             if (prismTrailingSplat != nullptr && PM_NODE_TYPE_P(prismTrailingSplat, PM_SPLAT_NODE)) {
-                // TODO: handle PM_NODE_TYPE_P(prismTrailingSplat, PM_MISSING_NODE)
                 desugarPattern(prismTrailingSplat);
             }
 


### PR DESCRIPTION
### Motivation

There's no permutation that can actually cause a `PM_FIND_PATTERN_NODE` to have a `PM_MISSING_NODE` on the right.

Confirmed by @havenwood and @earlopain