### PR TITLE
Fix RBS assertion comments on `end` of if/else/end

### DIFF
--- a/rbs/prism/CommentsAssociatorPrism.cc
+++ b/rbs/prism/CommentsAssociatorPrism.cc
@@ -768,7 +768,15 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
         case PM_ELSE_NODE: {
             auto *else_ = down_cast<pm_else_node_t>(node);
             walkNode(up_cast(else_->statements));
-            consumeCommentsInsideNode(node, "else");
+            // Leave comments on the `end` line for the parent node to associate.
+            auto beginLine = posToLine(translateLocation(node->location).beginPos());
+            int endLine;
+            if (else_->statements) {
+                endLine = posToLine(translateLocation(up_cast(else_->statements)->location).endPos());
+            } else {
+                endLine = beginLine;
+            }
+            consumeCommentsBetweenLines(beginLine, endLine, "else");
             break;
         }
         case PM_ENSURE_NODE: {

--- a/test/testdata/rbs/assertions_if.rb
+++ b/test/testdata/rbs/assertions_if.rb
@@ -59,3 +59,13 @@ end
 
 42 if ARGV.any? #: Integer?
 42 unless ARGV.empty? #: Integer?
+
+if ARGV.empty?
+  1
+else
+  2
+end #: Integer
+
+if ARGV.empty?
+else
+end #: NilClass

--- a/test/testdata/rbs/assertions_if.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_if.rb.rewrite-tree.exp
@@ -88,4 +88,16 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   else
     42
   end, <todo sym>, ::<root>::<C T>.nilable(<emptyTree>::<C Integer>))
+
+  <cast:let>(if <emptyTree>::<C ARGV>.empty?()
+    1
+  else
+    2
+  end, <todo sym>, <emptyTree>::<C Integer>)
+
+  <cast:let>(if <emptyTree>::<C ARGV>.empty?()
+    <emptyTree>
+  else
+    <emptyTree>
+  end, <todo sym>, <emptyTree>::<C NilClass>)
 end


### PR DESCRIPTION
The Prism ElseNode's location spans from `else` through `end`, so consumeCommentsInsideNode was consuming the comment on the `end` line before the parent IfNode could associate it. 

Narrow the range to only consume comments between the `else` keyword and the last statement, leaving `end`-line comments for the parent's walkConditionalNode. This matches the behaviour of RBS rewriting with the typedruby parser.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
RBS rewriting bugfix when using Prism parser.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
