### PR TITLE
Tag slow_path with cancelable status

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -356,6 +356,8 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
     UnorderedSet<core::FileRef> openFiles;
     ENFORCE(this->cancellationUndoState == nullptr);
     if (cancelable) {
+        timeit.setTag("cancelable", "true");
+
         auto savedGS = std::exchange(this->gs, pipeline::copyForSlowPath(*this->gs, this->config->opts));
 
         // Seed open files with the previous set from `indexedFinalGS`
@@ -365,6 +367,8 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
 
         this->cancellationUndoState =
             make_unique<UndoState>(std::move(savedGS), std::move(this->indexedFinalGS), updates.epoch);
+    } else {
+        timeit.setTag("cancelable", "false");
     }
 
     const uint32_t epoch = updates.epoch;


### PR DESCRIPTION
We use the same timer (`slow_path`) for lsp initialization and the slow path, wihch means that any latency we see from reading files during init will be grouped in with the same metrics for slow path typechecking in the course of normal editing.

### Motivation
More clear metrics.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Metrics change only.
