### PR TITLE
Fix RBS assertion comments leaking from else branch into if body

### DIFF
--- a/rbs/prism/CommentsAssociatorPrism.cc
+++ b/rbs/prism/CommentsAssociatorPrism.cc
@@ -351,7 +351,9 @@ void CommentsAssociatorPrism::walkConditionalNode(pm_node_t *node, pm_node_t *pr
     lastLine = posToLine(nodeLoc.beginPos());
 
     pm_node_t *thenBody = up_cast(statements);
-    pm_node_t *thenResult = walkBody(node, thenBody);
+    // Bound to thenBody so processTrailingComments doesn't scan into the else branch.
+    pm_node_t *thenBound = thenBody ? thenBody : node;
+    pm_node_t *thenResult = walkBody(thenBound, thenBody);
     statements = down_cast<pm_statements_node_t>(thenResult);
 
     if (thenResult) {

--- a/test/testdata/rbs/assertions_bind.rb
+++ b/test/testdata/rbs/assertions_bind.rb
@@ -94,6 +94,27 @@ else
   end
 end
 
+# Test bind inside a block with args in if/else branches inside a method
+class BindInMethod
+  def call(arg)
+    yield
+  end
+
+  def example
+    if ARGV.empty?
+      call(1) do
+        #: self as Foo
+        T.reveal_type(self) # error: Revealed type: `Foo`
+      end
+    else
+      call(2) do
+        #: self as Foo
+        T.reveal_type(self) # error: Revealed type: `Foo`
+      end
+    end
+  end
+end
+
 begin
   #: self as Foo
   T.reveal_type(self) # error: Revealed type: `Foo`

--- a/test/testdata/rbs/assertions_bind.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_bind.rb.rewrite-tree.exp
@@ -136,6 +136,34 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
+  class <emptyTree>::<C BindInMethod><<C <todo sym>>> < (::<todo sym>)
+    def call<<todo method>>(arg, &<implicit yield>)
+      <implicit yield>.call()
+    end
+
+    def example<<todo method>>(&<blk>)
+      if <emptyTree>::<C ARGV>.empty?()
+        <self>.call(1) do ||
+          begin
+            <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+            <emptyTree>::<C T>.reveal_type(<self>)
+          end
+        end
+      else
+        <self>.call(2) do ||
+          begin
+            <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+            <emptyTree>::<C T>.reveal_type(<self>)
+          end
+        end
+      end
+    end
+
+    <runtime method definition of call>
+
+    <runtime method definition of example>
+  end
+
   begin
     <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
     <emptyTree>::<C T>.reveal_type(<self>)


### PR DESCRIPTION
`processTrailingComments` in `walkBody` used the parent `IfNode`'s end position as the scan boundary, so it picked up standalone `#: self as T` comments from the `else` branch while walking the `then` branch. Pass the then-body's own node as the boundary to limit the scan.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes an RBS rewriting error where the assertion wasn't correctly being rewritten.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
