### PR TITLE
Remove some comments about const resolver

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1678,8 +1678,6 @@ public:
         bool progress = true;
         bool first = true; // we need to run at least once to force class aliases and type aliases
 
-        // If the constant didn't immediately resolve during the initial treewalk, and we're not
-        // allowed to mutate GlobalState, it will never resolve. Let's just skip to the error phase.
         while (progress && (first || !todo.empty() || !todoAncestors.empty())) {
             first = false;
             counterInc("resolve.constants.retries");
@@ -1836,9 +1834,6 @@ public:
                 }
             }
 
-            // Only purpose of resolveAncestorJob is to mutate the symbol table, not the tree, so
-            // in non-mutating resolver mode we don't have to do anything (because we don't care
-            // about errors).
             for (auto &job : todoAncestors) {
                 core::MutableContext ctx(gs, core::Symbols::root(), job.file);
                 for (auto &item : job.items) {


### PR DESCRIPTION
We used to have a templated version of resolver that worked with a const GlobalState to attempt to serve stale IDE requests, but we don't have that anymore, and these comments are referring to things that don't exist anymore.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
