### PR TITLE
Production log to try finding bad StubModule pickle calls

### DIFF
--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -1472,6 +1472,12 @@ void SerializerImpl::pickle(Pickler &p, const File &f, const ast::ExpressionPtr 
         case ast::Tag::ConstantLit: {
             auto &a = ast::cast_tree_nonnull<ast::ConstantLit>(what);
             pickle(p, a.loc());
+            if (a.symbol() == Symbols::StubModule()) {
+                fatalLogger->error(R"(msg="pickle ConstantLit StubModule" path="{}" beginPos={} endPos={})",
+                                   absl::CEscape(f.path()), a.loc().beginPos(), a.loc().endPos());
+                fatalLogger->error("source=\"{}\"", absl::CEscape(f.source()));
+                ENFORCE(false);
+            }
             p.putU4(a.symbol().rawId());
             // This encoding is the same encoding that would be used if we were
             // serializing an UnresolvedConstantLit as an ExpressionPtr, nullptr


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

A possible lead on resolutionScopes crashes.

I can't figure out how to abuse this, but the `serialize.cc` logic for
`ConstantLit` has never handled `resolutionScopes` (dating back to even before
the recent refactor to optimize `ConstantLit` space by making the three-way-tag
internal storage). Technically, if we could find a case where we were
serializing resolved trees, the file might have a stubbed constant in it, and
then round-tripping that constant through serialize would create a `ConstantLit`
where the resolved constant is `StubModule` but `resolutionScopes` is empty.

However, the code currently relies on an invariant that if
`constantLit->symbol() == core::Symbols::StubModule()`, then it necessarily has
a non-empty `resolutionScopes`. (This also means that it's invalid to ever call
`constantLit->setSymbol(x)` where `x` is `StubModule`. That was the reason why
we ended up renaming it so that it's called
`Sorbet::Private::Static::<StubModule>`, so that it was impossible for a valid
Ruby file to have a constant that resolves to this.)

I ran our test suite with an `ENFORCE` in `serialize.cc` that fires if the
`ConstantLit` we're about to serialize has a `StubModule` and didn't find
anything (but I guess if that were the issue, then probably we'd already have
found the crash).

I'm hoping that this log might reveal to us someplace where we're attempting to
pickle a resolved file that has `StubModule` errors, because that might be the
last smoking gun for the `resolutionScopes` crashes that we're seeing.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

If we could test it, we wouldn't need the log lines.