### PR TITLE
Switch back to mimalloc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -93,7 +93,6 @@ build:dbg-linux --config=dbg --platforms=@//tools/platforms:linux_x86_64
 ##
 # release version: optimized, with debug symbols and version information
 build:release-common --define release=true
-build:release-common --define jemalloc=true
 build:release-common --compilation_mode=opt
 build:release-common --config=backtracesymbols
 build:release-common --config=versioned
@@ -127,8 +126,8 @@ build:release-linux-aarch64 --config=static-libs
 # We only use rules_foreign_cc for mimalloc and we only use mimalloc in release
 # builds, so I'm moving this here until we can figure out a better workaround,
 # or a fix lands upstream.
-# build:release-linux --define mimalloc=true
-# build:release-linux-aarch64 --define mimalloc=true
+build:release-linux --define mimalloc=true
+build:release-linux-aarch64 --define mimalloc=true
 
 # This is to turn on vector instructions where available.
 # We used to do this unconditionally, but Rosetta 2 doesn't translate all vector instructions well.


### PR DESCRIPTION
At Stripe, jemalloc is showing an increase in memory usage in CI. We're going to switch back to mimalloc until we have more headroom with package-directed mode.

### Motivation
Performance.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Allocator switch, no other behavior changes expected.
