### PR TITLE
Add caveat to rbs-support.md for type templates

### DIFF
--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -749,6 +749,18 @@ module Factory
 end
 ```
 
+The RBS syntax requires that the type template be accessed inside the scope of the `class << self` declaration (instead of with methods defined like `def self.*` in the enclosing class definition). Concretely, the following reports a static error on the declaration of `make2` saying that `InstanceType` cannot be resolved:
+
+```ruby
+module Factory
+  #: [InstanceType]
+  class << self; end
+
+  #: -> InstanceType
+  def self.make2; end
+end
+```
+
 ### Variance
 
 [Variance](generics.md#in-out-and-variance) can be specified using the `in` and `out` keywords:


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The handling for `type_template` is special. Writing

```ruby
class A
  X = type_template
end
```

defines two constants:

1.  `<Class:A>::X`, a type member symbol owned by (in the members of) the
    singleton class of `A`
2.  `A::X`, a static field "class" alias that aliases to `<Class:A>::X` (using the
    same `AliasType` trick that normal class aliases use).

This allows `X` to be a symbol in the members of the singleton class, while
still resolving when mentioned in a nesting scope that has not opened that
singleton class (e.g., `class << self` is not necessary).

None of this applies to the rewriting logic used for RBS comments. Since there
is only type member declaration syntax, there is only the `<Class:A>::X` symbol
that gets defined.

It would be neat to think about ways to alleviate that, but I don't have any
clean ideas so until someone else thinks of one, I figure it should at least be
documented.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

docs-only change