### PR TITLE
`--gen-packages` strict mode: exports

### DIFF
--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -850,9 +850,9 @@ std::string PackageInfo::renderPackageRbContents(const core::GlobalState &gs,
         fmt::format_to(std::back_inserter(result), "  export_all!\n");
     } else {
         auto newExportsNames = vector<string>{};
-        transform(newExports.begin(), newExports.end(), back_inserter(newExportsNames),
-                  [&gs](SymbolRef export_) { return export_.show(gs); });
-        fast_sort(newExportsNames, [](string l, string r) { return l < r; });
+        absl::c_transform(newExports, back_inserter(newExportsNames),
+                          [&gs](SymbolRef export_) { return export_.show(gs); });
+        fast_sort(newExportsNames, [](string &l, string &r) { return l < r; });
         for (auto &export_ : newExportsNames) {
             fmt::format_to(back_inserter(result), "  export {}\n", export_);
         }

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -713,7 +713,8 @@ std::optional<core::AutocorrectSuggestion> PackageInfo::aggregateMissingVisibleT
     return core::AutocorrectSuggestion{fmt::format("Add missing `{}`", "visible_to"), std::move(allEdits)};
 }
 
-std::string PackageInfo::renderPackageRbContents(const core::GlobalState &gs) const {
+std::string PackageInfo::renderPackageRbContents(const core::GlobalState &gs,
+                                                 std::vector<core::SymbolRef> newExports) const {
     fmt::memory_buffer result;
 
     if (isPreludePackage()) {
@@ -848,11 +849,9 @@ std::string PackageInfo::renderPackageRbContents(const core::GlobalState &gs) co
     if (locs.exportAll.exists()) {
         fmt::format_to(std::back_inserter(result), "  export_all!\n");
     } else {
-        // TODO(neil): sort the exports
-        for (auto &export_ : exports_) {
-            auto exportSource = core::Loc(file, export_.loc).source(gs);
-            ENFORCE(exportSource.has_value());
-            fmt::format_to(std::back_inserter(result), "  {}\n", exportSource.value());
+        fast_sort(newExports, [&gs](SymbolRef l, SymbolRef r) { return l.show(gs) < r.show(gs); });
+        for (auto &export_ : newExports) {
+            fmt::format_to(std::back_inserter(result), "  export {}\n", export_.show(gs));
         }
     }
 

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -849,9 +849,12 @@ std::string PackageInfo::renderPackageRbContents(const core::GlobalState &gs,
     if (locs.exportAll.exists()) {
         fmt::format_to(std::back_inserter(result), "  export_all!\n");
     } else {
-        fast_sort(newExports, [&gs](SymbolRef l, SymbolRef r) { return l.show(gs) < r.show(gs); });
-        for (auto &export_ : newExports) {
-            fmt::format_to(std::back_inserter(result), "  export {}\n", export_.show(gs));
+        auto newExportsNames = vector<string>{};
+        transform(newExports.begin(), newExports.end(), back_inserter(newExportsNames),
+                  [&gs](SymbolRef export_) { return export_.show(gs); });
+        fast_sort(newExportsNames, [](string l, string r) { return l < r; });
+        for (auto &export_ : newExportsNames) {
+            fmt::format_to(back_inserter(result), "  export {}\n", export_);
         }
     }
 

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -655,6 +655,22 @@ std::optional<core::AutocorrectSuggestion>
 PackageInfo::aggregateMissingExports(const core::GlobalState &gs, vector<core::SymbolRef> &toExport) const {
     std::vector<core::AutocorrectSuggestion::Edit> allEdits;
     for (auto &symbol : toExport) {
+        switch (symbol.kind()) {
+            case core::SymbolRef::Kind::ClassOrModule:
+                if (symbol.asClassOrModuleRef().data(gs)->flags.isExported) {
+                    continue;
+                }
+                break;
+            case core::SymbolRef::Kind::FieldOrStaticField:
+                if (symbol.asFieldRef().data(gs)->flags.isExported) {
+                    continue;
+                }
+                break;
+            case core::SymbolRef::Kind::TypeMember:
+            case core::SymbolRef::Kind::Method:
+            case core::SymbolRef::Kind::TypeParameter:
+                ENFORCE(false, "trying to export something other than ClassOrModule or FieldOrStaticField");
+        }
         auto autocorrect = addExport(gs, symbol);
         if (autocorrect.has_value()) {
             allEdits.insert(allEdits.end(), make_move_iterator(autocorrect.value().edits.begin()),

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -338,7 +338,7 @@ public:
     aggregateMissingVisibleTo(const core::GlobalState &gs, std::vector<core::packages::MangledName> &visibleTos,
                               bool visibleToTests) const;
 
-    std::string renderPackageRbContents(const core::GlobalState &gs) const;
+    std::string renderPackageRbContents(const core::GlobalState &gs, std::vector<core::SymbolRef> newExports) const;
 };
 CheckSize(PackageInfo, 256, 8);
 

--- a/packager/GenPackages.cc
+++ b/packager/GenPackages.cc
@@ -243,6 +243,8 @@ void GenPackages::run(core::GlobalState &gs) {
 }
 
 void GenPackages::runStrict(core::GlobalState &gs) {
+    auto toExport = computeToExport(gs);
+
     for (auto pkgName : gs.packageDB().packages()) {
         auto &pkgInfo = gs.packageDB().getPackageInfo(pkgName);
         ENFORCE(pkgInfo.exists());
@@ -252,7 +254,7 @@ void GenPackages::runStrict(core::GlobalState &gs) {
         auto existingContents = existingContentsLoc.source(gs);
         ENFORCE(existingContents.has_value());
 
-        auto newContents = pkgInfo.renderPackageRbContents(gs);
+        auto newContents = pkgInfo.renderPackageRbContents(gs, move(toExport[pkgName]));
 
         if (existingContents.value() != newContents) {
             if (auto e = gs.beginError(pkgInfo.declLoc(), core::errors::Packager::IncorrectPackageRB)) {

--- a/packager/GenPackages.cc
+++ b/packager/GenPackages.cc
@@ -35,8 +35,7 @@ void exportClassOrModule(const core::GlobalState &gs,
                          core::ClassOrModuleRef symbol, vector<core::FileRef> &referencingFiles) {
     auto data = symbol.data(gs);
     auto owningPackage = data->package;
-    if (!owningPackage.exists() || gs.packageDB().getPackageInfo(owningPackage).locs.exportAll.exists() ||
-        data->flags.isExported) {
+    if (!owningPackage.exists() || gs.packageDB().getPackageInfo(owningPackage).locs.exportAll.exists()) {
         return;
     }
 
@@ -61,8 +60,7 @@ void exportField(const core::GlobalState &gs,
                  vector<core::FileRef> &referencingFiles) {
     auto data = symbol.data(gs);
     auto owningPackage = data->owner.data(gs)->package;
-    if (!owningPackage.exists() || gs.packageDB().getPackageInfo(owningPackage).locs.exportAll.exists() ||
-        data->flags.isExported) {
+    if (!owningPackage.exists() || gs.packageDB().getPackageInfo(owningPackage).locs.exportAll.exists()) {
         return;
     }
 

--- a/packager/GenPackages.cc
+++ b/packager/GenPackages.cc
@@ -91,7 +91,7 @@ UnorderedMap<core::SymbolRef, vector<core::FileRef>> computeReferencingFiles(con
     auto referencingFiles = UnorderedMap<core::SymbolRef, vector<core::FileRef>>{};
     // symbolsReferencedByFile is a map from file -> [symbol] referenced in that file
     // This loop computes the inverse: referencingFiles is a map from symbol -> [file] that reference that symbol
-    Timer timeit(gs.tracer(), "gen_packages.run.build_referencing_files");
+    Timer timeit(gs.tracer(), "gen_packages.compute_referencing_files");
     auto numFiles = gs.getFiles().size();
     for (auto i = 1; i < numFiles; i++) {
         core::FileRef fref(i);
@@ -104,6 +104,7 @@ UnorderedMap<core::SymbolRef, vector<core::FileRef>> computeReferencingFiles(con
 }
 
 UnorderedMap<core::packages::MangledName, vector<core::SymbolRef>> computeToExport(const core::GlobalState &gs) {
+    Timer timeit(gs.tracer(), "gen_packages.compute_to_export");
     auto referencingFiles = computeReferencingFiles(gs);
     auto toExport = UnorderedMap<core::packages::MangledName, vector<core::SymbolRef>>{};
 
@@ -243,6 +244,8 @@ void GenPackages::run(core::GlobalState &gs) {
 }
 
 void GenPackages::runStrict(core::GlobalState &gs) {
+    Timer timeit(gs.tracer(), "gen_packages.run_strict");
+
     auto toExport = computeToExport(gs);
 
     for (auto pkgName : gs.packageDB().packages()) {

--- a/packager/GenPackages.cc
+++ b/packager/GenPackages.cc
@@ -88,26 +88,27 @@ void exportField(const core::GlobalState &gs,
         break;
     }
 }
-}; // namespace
 
-void GenPackages::run(core::GlobalState &gs) {
-    Timer timeit(gs.tracer(), "gen_packages.run");
+UnorderedMap<core::SymbolRef, vector<core::FileRef>> computeReferencingFiles(const core::GlobalState &gs) {
     auto referencingFiles = UnorderedMap<core::SymbolRef, vector<core::FileRef>>{};
-    {
-        // symbolsReferencedByFile is a map from file -> [symbol] referenced in that file
-        // This loop computes the inverse: referencingFiles is a map from symbol -> [file] that reference that symbol
-        Timer timeit(gs.tracer(), "gen_packages.run.build_referencing_files");
-        auto numFiles = gs.getFiles().size();
-        for (auto i = 1; i < numFiles; i++) {
-            core::FileRef fref(i);
-            auto referencedSymbols = gs.getSymbolsReferencedByFile(fref);
-            for (auto &symbol : referencedSymbols) {
-                referencingFiles[symbol].push_back(fref);
-            }
+    // symbolsReferencedByFile is a map from file -> [symbol] referenced in that file
+    // This loop computes the inverse: referencingFiles is a map from symbol -> [file] that reference that symbol
+    Timer timeit(gs.tracer(), "gen_packages.run.build_referencing_files");
+    auto numFiles = gs.getFiles().size();
+    for (auto i = 1; i < numFiles; i++) {
+        core::FileRef fref(i);
+        auto referencedSymbols = gs.getSymbolsReferencedByFile(fref);
+        for (auto &symbol : referencedSymbols) {
+            referencingFiles[symbol].push_back(fref);
         }
     }
+    return referencingFiles;
+}
 
+UnorderedMap<core::packages::MangledName, vector<core::SymbolRef>> computeToExport(const core::GlobalState &gs) {
+    auto referencingFiles = computeReferencingFiles(gs);
     auto toExport = UnorderedMap<core::packages::MangledName, vector<core::SymbolRef>>{};
+
     for (uint32_t i = 1; i < gs.classAndModulesUsed(); ++i) {
         auto classOrModuleRef = core::ClassOrModuleRef(gs, i);
         exportClassOrModule(gs, toExport, classOrModuleRef, referencingFiles[classOrModuleRef]);
@@ -116,6 +117,15 @@ void GenPackages::run(core::GlobalState &gs) {
         auto fieldRef = core::FieldRef(gs, i);
         exportField(gs, toExport, fieldRef, referencingFiles[fieldRef]);
     }
+
+    return toExport;
+}
+}; // namespace
+
+void GenPackages::run(core::GlobalState &gs) {
+    Timer timeit(gs.tracer(), "gen_packages.run");
+
+    auto toExport = computeToExport(gs);
 
     auto neededVisibleTo = UnorderedMap<core::packages::MangledName, vector<core::packages::MangledName>>{};
     auto neededVisibleToTests = UnorderedMap<core::packages::MangledName, bool>{};

--- a/test/cli/package-gen-packages-strict/A/__package.rb
+++ b/test/cli/package-gen-packages-strict/A/__package.rb
@@ -2,7 +2,7 @@
 
 class A < PackageSpec
   layer 'app'
-  strict_dependencies 'dag'
+  strict_dependencies 'false'
 
   foo 'a'
 

--- a/test/cli/package-gen-packages-strict/A/constants.rb
+++ b/test/cli/package-gen-packages-strict/A/constants.rb
@@ -2,4 +2,6 @@
 
 module A
   CONSTANT_FROM_A = "Hello from Package A"
+  puts B::CONSTANT_FROM_B
+  puts B::ANOTHER_CONSTANT_FROM_B
 end

--- a/test/cli/package-gen-packages-strict/B/__package.rb
+++ b/test/cli/package-gen-packages-strict/B/__package.rb
@@ -8,6 +8,7 @@ class B < PackageSpec
   import C
 
   export B::CONSTANT_FROM_B
+  export B::ANOTHER_CONSTANT_FROM_B
 
   visible_to A
 end

--- a/test/cli/package-gen-packages-strict/B/constants.rb
+++ b/test/cli/package-gen-packages-strict/B/constants.rb
@@ -2,4 +2,5 @@
 
 module B
   CONSTANT_FROM_B = "Hello from Package B"
+  ANOTHER_CONSTANT_FROM_B = "Hello from Package B"
 end

--- a/test/cli/package-gen-packages-strict/test.out
+++ b/test/cli/package-gen-packages-strict/test.out
@@ -41,11 +41,10 @@ Errors: 5
 class A < PackageSpec
   foo 'a'
   layer 'app'
-  strict_dependencies 'dag'
+  strict_dependencies 'false'
 
   test_import B
 
-  export A::CONSTANT_FROM_A
 end
 
 ###### cat B/__package.rb ######
@@ -61,6 +60,7 @@ class B < PackageSpec
   # strict_dependencies 'layered' or more strict:
   import C
 
+  export B::ANOTHER_CONSTANT_FROM_B
   export B::CONSTANT_FROM_B
 
   visible_to A

--- a/test/cli/package-gen-packages/C/app.rb
+++ b/test/cli/package-gen-packages/C/app.rb
@@ -15,6 +15,8 @@ module C
       puts D::ClassFromD
       puts D::ClassFromD::CONSTANT_FROM_D_CLASS
       puts D::EnumFromD::Variant
+
+      D::AlreadyExportedClass.new
     end
   end
 end

--- a/test/cli/package-gen-packages/D/__package.rb
+++ b/test/cli/package-gen-packages/D/__package.rb
@@ -5,4 +5,5 @@ class D < PackageSpec
   layer 'util'
 
   import B
+  export D::AlreadyExportedClass
 end

--- a/test/cli/package-gen-packages/D/already_exported_class.rb
+++ b/test/cli/package-gen-packages/D/already_exported_class.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+module D
+  class AlreadyExportedClass
+  end
+end

--- a/test/cli/package-gen-packages/test.out
+++ b/test/cli/package-gen-packages/test.out
@@ -66,12 +66,14 @@ D/__package.rb:3: `D` is missing imports and exports https://srb.help/3734
      3 |class D < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    D/__package.rb:7: Inserted `export D::CONSTANT_FROM_D
-      export D::ClassFromD
-      export D::EnumFromD
-      test_import E`
+    D/__package.rb:7: Inserted `test_import E`
      7 |  import B
                   ^
+    D/__package.rb:8: Inserted `export D::CONSTANT_FROM_D
+      export D::ClassFromD
+      export D::EnumFromD`
+     8 |  export D::AlreadyExportedClass
+                                        ^
 
 C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
      8 |      puts F::CONSTANT_FROM_F
@@ -128,10 +130,11 @@ class D < PackageSpec
   layer 'util'
 
   import B
+  test_import E
+  export D::AlreadyExportedClass
   export D::CONSTANT_FROM_D
   export D::ClassFromD
   export D::EnumFromD
-  test_import E
 end
 
 ###### cat E/__package.rb ######
@@ -193,12 +196,14 @@ D/__package.rb:3: `D` is missing imports and exports https://srb.help/3734
      3 |class D < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    D/__package.rb:7: Inserted `export D::CONSTANT_FROM_D
-      export D::ClassFromD
-      export D::EnumFromD
-      test_import E`
+    D/__package.rb:7: Inserted `test_import E`
      7 |  import B
                   ^
+    D/__package.rb:8: Inserted `export D::CONSTANT_FROM_D
+      export D::ClassFromD
+      export D::EnumFromD`
+     8 |  export D::AlreadyExportedClass
+                                        ^
 
 A/constants.rb:5: Unable to resolve constant `G` https://srb.help/5002
      5 |  puts G::ANOTHER_CONSTANT_FROM_G
@@ -268,10 +273,11 @@ class D < PackageSpec
   layer 'util'
 
   import B
+  test_import E
+  export D::AlreadyExportedClass
   export D::CONSTANT_FROM_D
   export D::ClassFromD
   export D::EnumFromD
-  test_import E
 end
 
 ###### cat E/__package.rb ######


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Depends on #9978. That PR just writes the `exports_` in `PackageInfo` as-is. This PR changes that to instead use the information from `symbolsReferencedByFile` that's used for the non-strict mode. This means that unused exports will get deleted, and missing exports will get added.

Similar to #10115

Review with `?w=1` and commit-by-commit:
1. Extract the logic to construct the `toExport` map to a new helper (so that we can use that logic in `runStrict` later).
2. Constants that are already exported were filtered out when constructing the `toExport` map. Instead, include exported constants in `toExport`, and filter them out in `aggregateMissingExports`. This means that `toExport` now contains all the exports a given package should have.
3. Pass in `toExport` to `renderPackageRbContents`, and emit based on that, rather than `exports_` stored in the `PackageInfo`.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Move tooling for working with packages into Sorbet.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
