### PR TITLE
Remove unused forward declaration

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -11,7 +11,6 @@
 #include "core/Unfreeze.h"
 #include "core/errors/errors.h"
 #include "core/hashing/hashing.h"
-#include "core/lsp/Task.h"
 #include "core/lsp/TypecheckEpochManager.h"
 #include <string_view>
 #include <utility>

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -33,7 +33,6 @@ class ErrorQueue;
 struct LocalSymbolTableHashes;
 
 namespace lsp {
-class Task;
 class TypecheckEpochManager;
 } // namespace lsp
 


### PR DESCRIPTION
We don't have any public interface that deals with `core::lsp::Task` values in `GlobalState.h`, so this forward declaration isn't necessary. I also removed the corresponding include in `GlobalState.cc`, as it's not used.

### Motivation
Cleaning up.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Refactoring only.
