### PR TITLE
Use `InlinedVector` for RBS declarations

### DIFF
--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -40,9 +40,7 @@ parseComment(core::MutableContext ctx, InlineComment comment,
     }
 
     auto signatureTranslator = rbs::SignatureTranslator(ctx);
-    vector<Comment> comments;
-    comments.push_back(comment.comment);
-    auto declaration = RBSDeclaration(comments);
+    auto declaration = RBSDeclaration({comment.comment});
     auto type = signatureTranslator.translateAssertionType(typeParams, declaration);
 
     if (type == nullptr) {

--- a/rbs/SigsRewriter.cc
+++ b/rbs/SigsRewriter.cc
@@ -47,7 +47,7 @@ unique_ptr<parser::Node> extractHelperArgument(core::MutableContext ctx, Comment
         annotation.string.substr(offset),
     };
 
-    return rbs::SignatureTranslator(ctx).translateType(RBSDeclaration{vector<Comment>{comment}});
+    return rbs::SignatureTranslator(ctx).translateType(RBSDeclaration{{comment}});
 }
 
 /**
@@ -226,7 +226,7 @@ Comments SigsRewriter::commentsForNode(parser::Node *node) {
 
     if (auto commentsNodesEntry = commentsByNode.find(node); commentsNodesEntry != commentsByNode.end()) {
         auto commentsNodes = commentsNodesEntry->second;
-        auto declaration_comments = vector<Comment>();
+        auto declaration_comments = RBSDeclaration::CommentsVector();
 
         for (auto &commentNode : commentsNodes) {
             // If the comment starts with `# @`, it's an annotation
@@ -354,7 +354,7 @@ unique_ptr<parser::Node> SigsRewriter::replaceSyntheticTypeAlias(unique_ptr<pars
     auto aliasDeclaration = comments.signatures[0];
     auto typeBeginLoc = (uint32_t)aliasDeclaration.string.find("=");
 
-    auto typeDeclaration = RBSDeclaration{vector<Comment>{Comment{
+    auto typeDeclaration = RBSDeclaration{{Comment{
         .commentLoc = aliasDeclaration.commentLoc(),
         .typeLoc = core::LocOffsets{aliasDeclaration.fullTypeLoc().beginPos() + typeBeginLoc + 1,
                                     aliasDeclaration.fullTypeLoc().endPos()},

--- a/rbs/prism/SigsRewriterPrism.cc
+++ b/rbs/prism/SigsRewriterPrism.cc
@@ -59,7 +59,7 @@ pm_node_t *extractHelperArgument(core::MutableContext ctx, parser::Prism::Parser
         annotation.string.substr(offset),
     };
 
-    return rbs::SignatureTranslatorPrism(ctx, parser).translateType(RBSDeclaration{vector<Comment>{comment}});
+    return rbs::SignatureTranslatorPrism(ctx, parser).translateType(RBSDeclaration{{comment}});
 }
 
 /**
@@ -265,7 +265,7 @@ CommentsPrism SigsRewriterPrism::commentsForNode(pm_node_t *node) {
     auto state = SignatureState::None;
 
     auto &nodes = it->second;
-    auto declarationComments = vector<Comment>{};
+    auto declarationComments = RBSDeclaration::CommentsVector{};
 
     for (auto &commentNode : nodes) {
         if (absl::StartsWith(commentNode.string, "# @")) {
@@ -387,7 +387,7 @@ pm_node_t *SigsRewriterPrism::replaceSyntheticTypeAlias(pm_node_t *node) {
         return prism.TTypeAlias(loc, prism.TUntyped(loc));
     }
 
-    auto typeDeclaration = RBSDeclaration{vector<Comment>{Comment{
+    auto typeDeclaration = RBSDeclaration{{Comment{
         .commentLoc = aliasDeclaration.commentLoc(),
         .typeLoc = core::LocOffsets{aliasDeclaration.fullTypeLoc().beginPos() + (uint32_t)typeBeginLoc + 1,
                                     aliasDeclaration.fullTypeLoc().endPos()},

--- a/rbs/rbs_common.h
+++ b/rbs/rbs_common.h
@@ -7,6 +7,7 @@ extern "C" {
 #include "include/rbs.h"
 }
 
+#include "absl/container/inlined_vector.h"
 #include "core/LocOffsets.h"
 #include "rbs/Parser.h"
 
@@ -76,12 +77,14 @@ struct Comment {
  */
 class RBSDeclaration {
 public:
+    using CommentsVector = absl::InlinedVector<Comment, 1>;
+
     /**
      * All the comments into a single string.
      */
     std::string string;
 
-    RBSDeclaration(std::vector<Comment> comments) : comments(std::move(comments)) {
+    RBSDeclaration(CommentsVector comments) : comments(std::move(comments)) {
         std::string result;
         for (const auto &comment : this->comments) {
             result += comment.string;
@@ -161,7 +164,7 @@ public:
     }
 
 private:
-    std::vector<Comment> comments;
+    CommentsVector comments;
 };
 
 } // namespace sorbet::rbs


### PR DESCRIPTION
### Motivation

The overwhelming number of declarations are one a single line. From our core monolith:

```
Total: 177,191
    1: 170,671,  96.3% ###################################################################
    2:     191,   0.1%
    3:     444,   0.3%
    4:   1,278,   0.7%
    5:   1,403,   0.8%
    6:   1,045,   0.6%
    7:     731,   0.4%
    8:     442,   0.2%
    9:     283,   0.2%
   10:     190,   0.1%
>= 11:     513,   0.3%
```

Plus, we can remove a bunch of local vector allocations. This leads to about a 2% speed up in the pipeline up to `--stop-after=rbs`.

### Test plan

None.