### PR TITLE
Deprecate RBS without Prism

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -1045,6 +1045,12 @@ void readOptions(Options &opts,
 
         auto parser = extractParser(raw["parser"].as<string>(), logger).value_or(Parser::ORIGINAL);
         opts.cacheSensitiveOptions.usePrismParser = (parser == Parser::PRISM);
+        if (opts.cacheSensitiveOptions.rbsEnabled && !opts.cacheSensitiveOptions.usePrismParser) {
+            logger->warn(
+                "⚠️ Going forward, Sorbet will only support RBS mode when parsing with Prism.\n"
+                "Please add `--parser=prism` to your Sorbet config. This will become an error at the end of May 2026.");
+        }
+
         opts.silenceErrors = raw["quiet"].as<bool>();
         opts.autocorrect = raw["autocorrect"].as<bool>();
         opts.didYouMean = raw["did-you-mean"].as<bool>();

--- a/test/cli/enable-experimental-rbs-comments/test.out
+++ b/test/cli/enable-experimental-rbs-comments/test.out
@@ -1,0 +1,34 @@
+==== test correct usage ====
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.params(:x, <emptyTree>::<C Object>).returns(<emptyTree>::<C Integer>)
+  end
+
+  def demo<<todo method>>(x, &<blk>)
+    ::<root>::<C T>.cast(x, <emptyTree>::<C String>)
+  end
+end
+==== test deprecated use with unset parser ====
+⚠️ Going forward, Sorbet will only support RBS mode when parsing with Prism.
+Please add `--parser=prism` to your Sorbet config. This will become an error at the end of May 2026.
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.params(:x, <emptyTree>::<C Object>).returns(<emptyTree>::<C Integer>)
+  end
+
+  def demo<<todo method>>(x, &<blk>)
+    ::<root>::<C T>.cast(x, <emptyTree>::<C String>)
+  end
+end
+==== test deprecated use with original parser ====
+⚠️ Going forward, Sorbet will only support RBS mode when parsing with Prism.
+Please add `--parser=prism` to your Sorbet config. This will become an error at the end of May 2026.
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.params(:x, <emptyTree>::<C Object>).returns(<emptyTree>::<C Integer>)
+  end
+
+  def demo<<todo method>>(x, &<blk>)
+    ::<root>::<C T>.cast(x, <emptyTree>::<C String>)
+  end
+end

--- a/test/cli/enable-experimental-rbs-comments/test.sh
+++ b/test/cli/enable-experimental-rbs-comments/test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -euo pipefail
+
+rbs_example=$(cat <<'EOF'
+#: (Object) -> Integer
+def demo(x)
+  x #: as String
+end
+EOF
+)
+
+common_args=(
+  -e "$rbs_example"
+  --silence-dev-message
+  --quiet
+  --no-error-count
+  --print=desugar-tree
+  --stop-after=desugarer
+)
+
+echo "==== test correct usage ===="
+main/sorbet "${common_args[@]}" --enable-experimental-rbs-comments --parser=prism 2>&1
+
+echo "==== test deprecated use with unset parser ===="
+main/sorbet "${common_args[@]}" --enable-experimental-rbs-comments 2>&1
+
+echo "==== test deprecated use with original parser ===="
+main/sorbet "${common_args[@]}" --enable-experimental-rbs-comments --parser=original 2>&1
+

--- a/test/cli/rbs-cache-dir/test.sh
+++ b/test/cli/rbs-cache-dir/test.sh
@@ -9,6 +9,7 @@ main/sorbet \
   --print=index-tree \
   --cache-dir=my-cache-dir \
   --enable-experimental-rbs-comments \
+  --parser=prism \
   test/cli/rbs-cache-dir/test.rb 2>&1
 
 echo --------------------------------------------------------------------------

--- a/test/cli/rbs-print-rewrite-tree/test.out
+++ b/test/cli/rbs-print-rewrite-tree/test.out
@@ -1,74 +1,128 @@
-No errors! Great job.
-Begin {
-  stmts = [
-    Send {
-      receiver = NULL
-      method = <U extend>
-      args = [
-        Const {
-          scope = Const {
-            scope = NULL
-            name = <C <U T>>
-          }
-          name = <C <U Sig>>
-        }
-      ]
-    }
-    Block {
-      send = Send {
-        receiver = ResolvedConst {
-          symbol = (module ::T::Sig::WithoutRuntime)
-        }
-        method = <U sig>
-        args = [
-        ]
-      }
-      params = NULL
-      body = Send {
-        receiver = Self {
-        }
-        method = <U returns>
-        args = [
-          Const {
-            scope = NULL
-            name = <C <U String>>
-          }
-        ]
-      }
-    }
-    DefMethod {
-      name = <U foo>
-      params = NULL
-      body = Assign {
-        lhs = LVarLhs {
-          name = <U x>
-        }
-        rhs = Send {
-          receiver = Const {
-            scope = Cbase {
-            }
-            name = <C <U T>>
-          }
-          method = <U let>
-          args = [
-            Send {
-              receiver = Const {
-                scope = NULL
-                name = <C <U ARGV>>
-              }
-              method = <U first>
-              args = [
-              ]
-            }
-            Const {
-              scope = NULL
-              name = <C <U String>>
-            }
-          ]
-        }
-      }
-    }
-  ]
-}
+@ ProgramNode (location: (2,0)-(7,3))
++-- locals: []
++-- statements:
+    @ StatementsNode (location: (2,0)-(7,3))
+    +-- body: (length: 3)
+        +-- @ CallNode (location: (2,0)-(2,13))
+        |   +-- CallNodeFlags: ignore_visibility
+        |   +-- receiver: nil
+        |   +-- call_operator_loc: nil
+        |   +-- name: :extend
+        |   +-- message_loc: (2,0)-(2,6) = "extend"
+        |   +-- opening_loc: nil
+        |   +-- arguments:
+        |   |   @ ArgumentsNode (location: (2,7)-(2,13))
+        |   |   +-- ArgumentsNodeFlags: nil
+        |   |   +-- arguments: (length: 1)
+        |   |       +-- @ ConstantPathNode (location: (2,7)-(2,13))
+        |   |           +-- parent:
+        |   |           |   @ ConstantReadNode (location: (2,7)-(2,8))
+        |   |           |   +-- name: :T
+        |   |           +-- name: :Sig
+        |   |           +-- delimiter_loc: (2,8)-(2,10) = "::"
+        |   |           +-- name_loc: (2,10)-(2,13) = "Sig"
+        |   +-- closing_loc: nil
+        |   +-- block: nil
+        +-- @ CallNode (location: (4,2)-(4,12))
+        |   +-- CallNodeFlags: nil
+        |   +-- receiver:
+        |   |   @ ConstantPathNode (location: (4,2)-(4,12))
+        |   |   +-- parent:
+        |   |   |   @ ConstantPathNode (location: (4,2)-(4,12))
+        |   |   |   +-- parent:
+        |   |   |   |   @ ConstantPathNode (location: (4,2)-(4,12))
+        |   |   |   |   +-- parent: nil
+        |   |   |   |   +-- name: :T
+        |   |   |   |   +-- delimiter_loc: (4,2)-(4,12) = " -> String"
+        |   |   |   |   +-- name_loc: (4,2)-(4,12) = " -> String"
+        |   |   |   +-- name: :Sig
+        |   |   |   +-- delimiter_loc: (4,2)-(4,12) = " -> String"
+        |   |   |   +-- name_loc: (4,2)-(4,12) = " -> String"
+        |   |   +-- name: :WithoutRuntime
+        |   |   +-- delimiter_loc: (4,2)-(4,12) = " -> String"
+        |   |   +-- name_loc: (4,2)-(4,12) = " -> String"
+        |   +-- call_operator_loc: (4,2)-(4,2) = ""
+        |   +-- name: :sig
+        |   +-- message_loc: (4,2)-(4,2) = ""
+        |   +-- opening_loc: (4,2)-(4,2) = ""
+        |   +-- arguments: nil
+        |   +-- closing_loc: (4,2)-(4,2) = ""
+        |   +-- block:
+        |       @ BlockNode (location: (4,0)-(4,12))
+        |       +-- locals: []
+        |       +-- parameters: nil
+        |       +-- body:
+        |       |   @ CallNode (location: (4,6)-(4,12))
+        |       |   +-- CallNodeFlags: nil
+        |       |   +-- receiver:
+        |       |   |   @ SelfNode (location: (4,2)-(4,12))
+        |       |   +-- call_operator_loc: (4,6)-(4,6) = ""
+        |       |   +-- name: :returns
+        |       |   +-- message_loc: (4,6)-(4,6) = ""
+        |       |   +-- opening_loc: (4,6)-(4,6) = ""
+        |       |   +-- arguments:
+        |       |   |   @ ArgumentsNode (location: (4,6)-(4,12))
+        |       |   |   +-- ArgumentsNodeFlags: nil
+        |       |   |   +-- arguments: (length: 1)
+        |       |   |       +-- @ ConstantReadNode (location: (4,6)-(4,12))
+        |       |   |           +-- name: :String
+        |       |   +-- closing_loc: (4,6)-(4,6) = ""
+        |       |   +-- block: nil
+        |       +-- opening_loc: (0,0)-(0,0) = ""
+        |       +-- closing_loc: (0,0)-(0,0) = ""
+        +-- @ DefNode (location: (5,0)-(7,3))
+            +-- name: :foo
+            +-- name_loc: (5,4)-(5,7) = "foo"
+            +-- receiver: nil
+            +-- parameters: nil
+            +-- body:
+            |   @ StatementsNode (location: (6,2)-(6,16))
+            |   +-- body: (length: 1)
+            |       +-- @ LocalVariableWriteNode (location: (6,2)-(6,16))
+            |           +-- name: :x
+            |           +-- depth: 0
+            |           +-- name_loc: (6,2)-(6,3) = "x"
+            |           +-- value:
+            |           |   @ CallNode (location: (6,20)-(6,26))
+            |           |   +-- CallNodeFlags: nil
+            |           |   +-- receiver:
+            |           |   |   @ ConstantPathNode (location: (6,20)-(6,26))
+            |           |   |   +-- parent: nil
+            |           |   |   +-- name: :T
+            |           |   |   +-- delimiter_loc: (6,20)-(6,26) = "String"
+            |           |   |   +-- name_loc: (6,20)-(6,26) = "String"
+            |           |   +-- call_operator_loc: (6,20)-(6,20) = ""
+            |           |   +-- name: :let
+            |           |   +-- message_loc: (6,20)-(6,20) = ""
+            |           |   +-- opening_loc: (6,20)-(6,20) = ""
+            |           |   +-- arguments:
+            |           |   |   @ ArgumentsNode (location: (6,20)-(6,26))
+            |           |   |   +-- ArgumentsNodeFlags: nil
+            |           |   |   +-- arguments: (length: 2)
+            |           |   |       +-- @ CallNode (location: (6,6)-(6,16))
+            |           |   |       |   +-- CallNodeFlags: nil
+            |           |   |       |   +-- receiver:
+            |           |   |       |   |   @ ConstantReadNode (location: (6,6)-(6,10))
+            |           |   |       |   |   +-- name: :ARGV
+            |           |   |       |   +-- call_operator_loc: (6,10)-(6,11) = "."
+            |           |   |       |   +-- name: :first
+            |           |   |       |   +-- message_loc: (6,11)-(6,16) = "first"
+            |           |   |       |   +-- opening_loc: nil
+            |           |   |       |   +-- arguments: nil
+            |           |   |       |   +-- closing_loc: nil
+            |           |   |       |   +-- block: nil
+            |           |   |       +-- @ ConstantReadNode (location: (6,20)-(6,26))
+            |           |   |           +-- name: :String
+            |           |   +-- closing_loc: (6,20)-(6,20) = ""
+            |           |   +-- block: nil
+            |           +-- operator_loc: (6,4)-(6,5) = "="
+            +-- locals: [:x]
+            +-- def_keyword_loc: (5,0)-(5,3) = "def"
+            +-- operator_loc: nil
+            +-- lparen_loc: nil
+            +-- rparen_loc: nil
+            +-- equal_loc: nil
+            +-- end_keyword_loc: (7,0)-(7,3) = "end"
+
 --------------------------------------------------------------------------
 --print=rbs-rewrite-tree must also include `--enable-experimental-rbs-comments`

--- a/test/cli/rbs-print-rewrite-tree/test.sh
+++ b/test/cli/rbs-print-rewrite-tree/test.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 main/sorbet \
   --print=rbs-rewrite-tree \
   --enable-experimental-rbs-comments \
+  --parser=prism \
   --silence-dev-message \
+  --no-error-count \
+  --quiet \
   test/cli/rbs-print-rewrite-tree/test.rb 2>&1
 
 echo --------------------------------------------------------------------------
@@ -12,4 +15,6 @@ echo --------------------------------------------------------------------------
 main/sorbet \
   --print=rbs-rewrite-tree \
   --silence-dev-message \
+  --no-error-count \
+  --quiet \
   test/cli/rbs-print-rewrite-tree/test.rb 2>&1


### PR DESCRIPTION
### Motivation

Now that Prism mode is fully merged and working our core monolith, we no longer want to double-implementing feature across the two RBS rewriters. We would like to have a short 1 month deprecation period where we keep it around, but with a warning.

After that, we'll make it an error, and entirely delete the legacy (non-Prism) RBS rewriter.

**Open question:** Should we eventually require an explicit `--parser=prism` param, or implicitly switch to it when RBS is on? Clarity vs convenience... open to suggestions.

### Test plan

None.
