### PR TITLE
Remove unnecessary friend annotations

### DIFF
--- a/main/lsp/LSPLoop.h
+++ b/main/lsp/LSPLoop.h
@@ -25,9 +25,6 @@ class LSPConfiguration;
 class LSPQueuePreemptionTask;
 
 class LSPLoop {
-    friend class LSPWrapper;
-    friend class LSPQueuePreemptionTask;
-
     /** Encapsulates the active configuration for the language server. */
     const std::shared_ptr<const LSPConfiguration> config;
     /** Protects outgoingQueue. */


### PR DESCRIPTION
Neither of these `friend` annotations are necessary on `LSPLoop`.

### Motivation
Cleaning up.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Refactoring change only.
