### PR TITLE
Remove unused absl::Notification in TypecheckerTask

### DIFF
--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -27,7 +27,6 @@ class TypecheckerTask final : public core::lsp::Task {
     const unique_ptr<LSPTask> task;
     const unique_ptr<LSPTypecheckerDelegate> delegate;
     const bool collectCounters;
-    absl::Notification started;
     absl::Notification complete;
     CounterState counters;
     unique_ptr<Timer> timeUntilRun;
@@ -51,7 +50,6 @@ public:
     void run() override {
         // Destruct timer, if specified. Causes metric to be reported.
         timeUntilRun = nullptr;
-        started.Notify();
         {
             Timer timeit(config.logger, "LSPTask::run");
             timeit.setTag("method", task->methodString());


### PR DESCRIPTION
The `absl::Notification` for when a `TypecheckerTask` starts in `LSPTypecheckerCoordinator.cc` is never listened to, so we are free to remove it. This cuts out 8 bytes from the size of each `TypecheckerTask` allocated, and avoids the unnecessary overhead of managing the notification that's never subscribed to.

### Motivation
Cleaning up.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavioral changes expected, refactoring only.
