### PR TITLE
Store unions of enums in Vector instead of deeply nested `T.any`

### DIFF
--- a/core/TypePtr.cc
+++ b/core/TypePtr.cc
@@ -32,6 +32,7 @@ using namespace std;
         CASE_STATEMENT(CASE_BODY, BlamedUntyped)         \
         CASE_STATEMENT(CASE_BODY, UnresolvedClassType)   \
         CASE_STATEMENT(CASE_BODY, UnresolvedAppliedType) \
+        CASE_STATEMENT(CASE_BODY, EnumUnion)             \
     }
 
 namespace sorbet::core {
@@ -125,6 +126,8 @@ int TypePtr::kind() const {
             return 13;
         case Tag::SelfType:
             return 14;
+        case Tag::EnumUnion:
+            return 15;
     }
 }
 
@@ -180,6 +183,8 @@ bool TypePtr::isFullyDefined() const {
             auto &app = cast_type_nonnull<AppliedType>(*this);
             return absl::c_all_of(app.targs, [](const TypePtr &t) { return t.isFullyDefined(); });
         }
+        case Tag::EnumUnion:
+            return true;
     }
 }
 
@@ -224,6 +229,8 @@ bool TypePtr::hasUntyped() const {
             auto &shape = cast_type_nonnull<ShapeType>(*this);
             return absl::c_any_of(shape.values, [](const TypePtr &t) { return t.hasUntyped(); });
         }
+        case Tag::EnumUnion:
+            return false;
     }
 }
 
@@ -262,6 +269,8 @@ bool TypePtr::hasTopLevelVoid() const {
             auto &a = cast_type_nonnull<AndType>(*this);
             return a.left.hasTopLevelVoid() || a.right.hasTopLevelVoid();
         }
+        case Tag::EnumUnion:
+            return false;
     }
 }
 
@@ -317,7 +326,8 @@ TypePtr TypePtr::getCallArguments(const GlobalState &gs, NameRef name) const {
         case Tag::SelfTypeParam:
         case Tag::LambdaParam:
         case Tag::TypeVar:
-        case Tag::AliasType: {
+        case Tag::AliasType:
+        case Tag::EnumUnion: {
             Exception::raise("should never happen: getCallArguments on `{}`", typeName());
         }
     }
@@ -369,6 +379,7 @@ TypePtr TypePtr::_instantiateLambdaParams(const GlobalState &gs, InstantiationCo
         case Tag::FloatLiteralType:
         case Tag::SelfTypeParam:
         case Tag::SelfType:
+        case Tag::EnumUnion:
             // nullptr is a special value meaning that nothing changed (e.g., we didn't find a
             // LambdaParam that needed to be instantiated), so as an optimization the caller doesn't
             // have to allocate another type.

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -62,6 +62,7 @@ public:
         TupleType,
         AppliedType,
         MetaType,
+        EnumUnion,
     };
 
     // A mapping from type to its corresponding tag.

--- a/core/Types.h
+++ b/core/Types.h
@@ -26,6 +26,7 @@ class ClassOrModule;
 class TypeVar;
 class SendAndBlockLink;
 class TypeAndOrigins;
+class EnumUnion;
 
 class ParamInfo {
 public:
@@ -270,6 +271,7 @@ inline bool is_ground_type(const TypePtr &what) {
         case TypePtr::Tag::UnresolvedAppliedType:
         case TypePtr::Tag::OrType:
         case TypePtr::Tag::AndType:
+        case TypePtr::Tag::EnumUnion:
             return true;
         case TypePtr::Tag::NamedLiteralType:
         case TypePtr::Tag::IntegerLiteralType:
@@ -311,6 +313,7 @@ inline bool is_proxy_type(const TypePtr &what) {
         case TypePtr::Tag::AppliedType:
         case TypePtr::Tag::TypeVar:
         case TypePtr::Tag::MetaType:
+        case TypePtr::Tag::EnumUnion:
             return false;
     }
 }
@@ -405,6 +408,10 @@ template <> inline TypePtr make_type<ClassType, core::ClassOrModuleRef>(core::Cl
 }
 
 template <> inline TypePtr make_type<ClassType, core::ClassOrModuleRef &>(core::ClassOrModuleRef &ref) {
+    return TypePtr(TypePtr::Tag::ClassType, ref.id());
+}
+
+template <> inline TypePtr make_type<ClassType, const core::ClassOrModuleRef &>(const core::ClassOrModuleRef &ref) {
     return TypePtr(TypePtr::Tag::ClassType, ref.id());
 }
 
@@ -819,6 +826,7 @@ private:
     friend TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &t1);
     friend class ClassOrModule; // the actual method is `recordSealedSubclass(Mutableconst GlobalState &gs, SymbolRef
                                 // subclass)`, but referring to it introduces a cycle
+    friend class EnumUnion;
 
     static TypePtr make_shared(const TypePtr &left, const TypePtr &right);
 };
@@ -996,6 +1004,34 @@ public:
     void _sanityCheck(const GlobalState &gs) const;
 };
 CheckSize(MetaType, 16, 8);
+
+TYPE(EnumUnion) final : public Refcounted {
+public:
+    std::vector<ClassOrModuleRef> members;
+
+    EnumUnion(std::vector<ClassOrModuleRef> members);
+    EnumUnion(const EnumUnion &) = delete;
+    EnumUnion &operator=(const EnumUnion &) = delete;
+
+    std::string toStringWithTabs(const GlobalState &gs, int tabs = 0) const;
+    std::string show(const GlobalState &gs) const {
+        return show(gs, {});
+    };
+    std::string show(const GlobalState &gs, ShowOptions options) const;
+    uint32_t hash(const GlobalState &gs) const;
+    DispatchResult dispatchCall(const GlobalState &gs, const DispatchArgs &args) const;
+    bool derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const;
+    void _sanityCheck(const GlobalState &gs) const;
+
+    // If `sym` is a T::Enum variant class (e.g., X$1 < MyEnum), returns the parent enum class.
+    // Otherwise returns a non-existent ClassOrModuleRef.
+    static ClassOrModuleRef parentEnumClass(const GlobalState &gs, ClassOrModuleRef sym);
+
+    // Returns the parent enum class shared by all members.
+    ClassOrModuleRef parentEnumClass(const GlobalState &gs) const;
+
+    TypePtr toOrType(const GlobalState &gs) const;
+};
 
 class SendAndBlockLink {
     SendAndBlockLink(const SendAndBlockLink &) = default;

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -525,6 +525,14 @@ void SerializerImpl::pickle(Pickler &p, const TypePtr &what) {
         case TypePtr::Tag::SelfTypeParam: {
             Exception::notImplemented();
         }
+        case TypePtr::Tag::EnumUnion: {
+            auto &tp = cast_type_nonnull<EnumUnion>(what);
+            p.putU4(tp.members.size());
+            for (auto &member : tp.members) {
+                p.putU4(member.id());
+            }
+            break;
+        }
     }
 }
 
@@ -611,6 +619,15 @@ TypePtr SerializerImpl::unpickleType(UnPickler &p, const GlobalState *gs) {
         case TypePtr::Tag::MetaType:
         case TypePtr::Tag::SelfTypeParam:
             Exception::raise("Unknown type tag {}", tag);
+        case TypePtr::Tag::EnumUnion: {
+            int sz = p.getU4();
+            vector<ClassOrModuleRef> elems(sz);
+            for (auto &elem : elems) {
+                elem = ClassOrModuleRef::fromRaw(p.getU4());
+            }
+            auto result = make_type<EnumUnion>(std::move(elems));
+            return result;
+        }
     }
 }
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -81,6 +81,11 @@ DispatchResult OrType::dispatchCall(const GlobalState &gs, const DispatchArgs &a
     return DispatchResult::merge(gs, DispatchResult::Combinator::OR, std::move(leftRet), std::move(rightRet));
 }
 
+DispatchResult EnumUnion::dispatchCall(const GlobalState &gs, const DispatchArgs &args) const {
+    categoryCounterInc("dispatch_call", "enumunion");
+    return toOrType(gs).dispatchCall(gs, args);
+}
+
 TypePtr OrType::getCallArguments(const GlobalState &gs, NameRef name) const {
     auto largs = left.getCallArguments(gs, name);
     auto rargs = right.getCallArguments(gs, name);

--- a/core/types/hashing.cc
+++ b/core/types/hashing.cc
@@ -135,4 +135,12 @@ uint32_t MetaType::hash(const GlobalState &gs) const {
     return mix(result, this->wrapped.hash(gs));
 }
 
+uint32_t EnumUnion::hash(const GlobalState &gs) const {
+    uint32_t result = static_cast<uint32_t>(TypePtr::Tag::EnumUnion);
+    for (auto &member : members) {
+        result = mix(result, member.id());
+    }
+    return result;
+}
+
 } // namespace sorbet::core

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -563,18 +563,7 @@ string EnumUnion::toStringWithTabs(const GlobalState &gs, int tabs) const {
 }
 
 string EnumUnion::show(const GlobalState &gs, ShowOptions options) const {
-    fmt::memory_buffer buf;
-    fmt::format_to(std::back_inserter(buf), "T.any(");
-    bool first = true;
-    for (auto &member : members) {
-        if (!first) {
-            fmt::format_to(std::back_inserter(buf), ", ");
-        }
-        first = false;
-        fmt::format_to(std::back_inserter(buf), "{}", member.show(gs, options));
-    }
-    fmt::format_to(std::back_inserter(buf), ")");
-    return to_string(buf);
+    return fmt::format("T.any({})", fmt::map_join(members, ", ", [&](auto member) { member.show(gs, options); }));
 }
 
 } // namespace sorbet::core

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -547,4 +547,34 @@ string MetaType::show(const GlobalState &gs, ShowOptions options) const {
     return fmt::format("Runtime object representing type: {}", wrapped.show(gs, options));
 }
 
+string EnumUnion::toStringWithTabs(const GlobalState &gs, int tabs) const {
+    fmt::memory_buffer buf;
+    fmt::format_to(std::back_inserter(buf), "EnumUnion {{");
+    bool first = true;
+    for (auto &member : members) {
+        if (!first) {
+            fmt::format_to(std::back_inserter(buf), ", ");
+        }
+        first = false;
+        fmt::format_to(std::back_inserter(buf), "{}", member.toString(gs));
+    }
+    fmt::format_to(std::back_inserter(buf), "}}");
+    return to_string(buf);
+}
+
+string EnumUnion::show(const GlobalState &gs, ShowOptions options) const {
+    fmt::memory_buffer buf;
+    fmt::format_to(std::back_inserter(buf), "T.any(");
+    bool first = true;
+    for (auto &member : members) {
+        if (!first) {
+            fmt::format_to(std::back_inserter(buf), ", ");
+        }
+        first = false;
+        fmt::format_to(std::back_inserter(buf), "{}", member.show(gs, options));
+    }
+    fmt::format_to(std::back_inserter(buf), ")");
+    return to_string(buf);
+}
+
 } // namespace sorbet::core

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -560,6 +560,56 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         }
     }
 
+    if (auto eu2 = cast_type<EnumUnion>(t2)) {
+        if (auto eu1 = cast_type<EnumUnion>(t1)) {
+            auto parent1 = eu1->parentEnumClass(gs);
+            auto parent2 = eu2->parentEnumClass(gs);
+            if (parent1.exists() && parent1 == parent2) {
+                vector<ClassOrModuleRef> combined;
+                combined.reserve(eu1->members.size() + eu2->members.size());
+                combined.insert(combined.end(), eu1->members.begin(), eu1->members.end());
+                // TODO(neil): this is quadratic, should we use a set to dedup and convert to vector after?
+                for (auto &m : eu2->members) {
+                    if (absl::c_find(combined, m) == combined.end()) {
+                        combined.emplace_back(m);
+                    }
+                }
+                if (combined.size() == eu1->members.size()) {
+                    // eu2 is a subset of eu1
+                    return t1;
+                }
+                if (combined.size() == eu2->members.size()) {
+                    // eu2 is a superset of eu1
+                    return t2;
+                }
+                ENFORCE(combined.size() > eu1->members.size() && combined.size() > eu2->members.size());
+                return make_type<EnumUnion>(move(combined));
+            }
+            return OrType::make_shared(eu1->toOrType(gs), eu2->toOrType(gs));
+        }
+
+        if (isa_type<ClassType>(t1)) {
+            auto sym1 = cast_type_nonnull<ClassType>(t1).symbol;
+            auto parent1 = EnumUnion::parentEnumClass(gs, sym1);
+            if (parent1.exists()) {
+                auto parent2 = eu2->parentEnumClass(gs);
+                ENFORCE(parent2.exists());
+                if (parent1 == parent2) {
+                    if (absl::c_find(eu2->members, sym1) != eu2->members.end()) {
+                        return t2;
+                    }
+                    vector<ClassOrModuleRef> combined;
+                    combined.reserve(eu2->members.size() + 1);
+                    combined.emplace_back(sym1);
+                    combined.insert(combined.end(), eu2->members.begin(), eu2->members.end());
+                    return make_type<EnumUnion>(move(combined));
+                }
+            }
+        }
+
+        return OrType::make_shared(t1, eu2->toOrType(gs));
+    }
+
     // none is proxy
     return lubGround(gs, t1, t2);
 }
@@ -604,6 +654,10 @@ TypePtr lubGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
         return t2;
     } else {
         categoryCounterInc("lub.<class>.collapsed", "no");
+        auto parent1 = EnumUnion::parentEnumClass(gs, sym1);
+        if (parent1.exists() && parent1 == EnumUnion::parentEnumClass(gs, sym2)) {
+            return make_type<EnumUnion>(vector<ClassOrModuleRef>{sym1, sym2});
+        }
         return OrType::make_shared(t1, t2);
     }
 }
@@ -877,6 +931,26 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
 
             return Types::bottom();
         }
+    }
+
+    if (auto eu2 = cast_type<EnumUnion>(t2)) {
+        vector<ClassOrModuleRef> kept;
+        for (auto &member : eu2->members) {
+            auto res = Types::all(gs, t1, make_type<ClassType>(member));
+            if (!res.isBottom()) {
+                kept.emplace_back(member);
+            }
+        }
+        if (kept.empty()) {
+            return Types::bottom();
+        }
+        if (kept.size() == eu2->members.size()) {
+            return t2;
+        }
+        if (kept.size() == 1) {
+            return make_type<ClassType>(kept[0]);
+        }
+        return make_type<EnumUnion>(move(kept));
     }
 
     if (auto o2 = cast_type<OrType>(t2)) { // 3, 6
@@ -1591,6 +1665,27 @@ bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &cons
 
     // Note: order of cases here matters! We can't lose "and" information in t1 early and we can't
     // lose "or" information in t2 early.
+    if (auto eu1 = cast_type<EnumUnion>(t1)) { // 7, 8, 9
+        return isSubTypeUnderConstraint(gs, constr, eu1->toOrType(gs), t2, mode, errorDetailsCollector);
+    }
+    if (auto eu2 = cast_type<EnumUnion>(t2)) {
+        if (isa_type<ClassType>(t1)) {
+            auto c1 = cast_type_nonnull<ClassType>(t1);
+            if (c1.symbol == Symbols::untyped()) {
+                return mode == UntypedMode::AlwaysCompatible;
+            }
+            if (c1.symbol == Symbols::bottom()) {
+                return true;
+            }
+            if (isSubTypeUnderConstraint(gs, constr, make_type<ClassType>(eu2->parentEnumClass(gs)), t1, mode, errorDetailsCollector)) {
+                // TODO: add a test case for this
+                return true;
+            }
+            return absl::c_any_of(eu2->members, [&c1](auto member) { return c1.symbol == member; });
+        }
+        return isSubTypeUnderConstraint(gs, constr, t1, eu2->toOrType(gs), mode, errorDetailsCollector);
+    }
+
     if (auto o1 = cast_type<OrType>(t1)) { // 7, 8, 9
         auto subCollectorLeft = errorDetailsCollector.newCollector();
         auto isSubTypeOfLeft = Types::isSubTypeUnderConstraint(gs, constr, o1->left, t2, mode, subCollectorLeft);

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -247,6 +247,35 @@ TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from, absl::
                 result = from;
             }
         },
+        [&](const EnumUnion &eu) {
+            if (absl::c_any_of(klasses, [&](auto klass) {
+                    return isSubType(gs, make_type<ClassType>(eu.parentEnumClass(gs)), make_type<ClassType>(klass));
+                })) {
+                // One of the klasses is a superclass of the parentEnumClass.
+                // This means every element in the EnumUnion will be a subtype of that klass, and thus will be dropped.
+                result = Types::bottom();
+            } else {
+                // None of the klasses are a superclass of the parent enum. This means, for each, either:
+                // - they are exactly equal to one of the EnumUnion members
+                // - they are not superclass of any of the EnumUnion members
+                // So we can check for equality of the ClassOrModuleRef directly instead of using isSubType
+                vector<ClassOrModuleRef> kept;
+                for (auto &member : eu.members) {
+                    if (absl::c_all_of(klasses, [&](auto klass) { return klass != member; })) {
+                        kept.emplace_back(member);
+                    }
+                }
+                if (kept.size() == eu.members.size()) {
+                    result = from;
+                } else if (kept.empty()) {
+                    result = Types::bottom();
+                } else if (kept.size() == 1) {
+                    result = make_type<ClassType>(kept[0]);
+                } else {
+                    result = make_type<EnumUnion>(move(kept));
+                }
+            }
+        },
         [&](const SelfTypeParam &p) {
             if (!p.definition.isTypeMember()) {
                 // Only type members have upper bounds--type parameters do not
@@ -321,6 +350,8 @@ TypePtr Types::approximateSubtract(const GlobalState &gs, const TypePtr &from, c
         [&](const OrType &o) {
             result = Types::approximateSubtract(gs, Types::approximateSubtract(gs, from, o.left), o.right);
         },
+        [&](const EnumUnion &e) { result = Types::dropSubtypesOf(gs, from, absl::MakeSpan(e.members)); },
+
         [&](const TypePtr &) { result = from; });
     return result;
 }
@@ -770,6 +801,50 @@ bool MetaType::derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const 
     return false;
 }
 
+EnumUnion::EnumUnion(vector<ClassOrModuleRef> members) : members(move(members)) {
+    recordAllocatedType("enumunion");
+}
+
+void EnumUnion::_sanityCheck(const GlobalState &gs) const {
+    ENFORCE(members.size() >= 2);
+    auto firstParent = EnumUnion::parentEnumClass(gs, members[0]);
+    for (auto &member : members) {
+        ENFORCE(firstParent == EnumUnion::parentEnumClass(gs, member));
+    }
+}
+
+bool EnumUnion::derivesFrom(const GlobalState &gs, ClassOrModuleRef klass) const {
+    if (parentEnumClass(gs).data(gs)->derivesFrom(gs, klass)) {
+        return true;
+    }
+    // The common ancestor of all members of EnumUnion is parentEnumClass, so if it doesn't derive from klass, there's
+    // no way all of the members can derive from it too
+    return false;
+}
+
+ClassOrModuleRef EnumUnion::parentEnumClass(const GlobalState &gs, ClassOrModuleRef sym) {
+    if (!sym.data(gs)->name.isTEnumName(gs)) {
+        return ClassOrModuleRef();
+    }
+    return sym.data(gs)->superClass();
+}
+
+ClassOrModuleRef EnumUnion::parentEnumClass(const GlobalState &gs) const {
+    ENFORCE(!members.empty());
+    auto result = parentEnumClass(gs, members[0]);
+    ENFORCE(result.exists());
+    return result;
+}
+
+TypePtr EnumUnion::toOrType(const GlobalState &gs) const {
+    ENFORCE(members.size() >= 2);
+    auto result = make_type<ClassType>(members[0]);
+    for (size_t i = 1; i < members.size(); i++) {
+        result = OrType::make_shared(result, make_type<ClassType>(members[i]));
+    }
+    return result;
+}
+
 TypeVar::TypeVar(TypeParameterRef sym) : sym(sym) {
     recordAllocatedType("typevar");
 }
@@ -913,9 +988,9 @@ TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &type) {
     TypePtr ret;
     typecase(
         type, [&](const ClassType &klass) { ret = type; }, [&](const TypeVar &tv) { ret = type; },
-        [&](const LambdaParam &tv) { ret = type; }, [&](const SelfType &self) { ret = type; },
-        [&](const NamedLiteralType &lit) { ret = type; }, [&](const IntegerLiteralType &i) { ret = type; },
-        [&](const FloatLiteralType &i) { ret = type; },
+        [&](const EnumUnion &enumUnion) { ret = type; }, [&](const LambdaParam &tv) { ret = type; },
+        [&](const SelfType &self) { ret = type; }, [&](const NamedLiteralType &lit) { ret = type; },
+        [&](const IntegerLiteralType &i) { ret = type; }, [&](const FloatLiteralType &i) { ret = type; },
         [&](const AndType &andType) {
             ret = AndType::make_shared(unwrapSelfTypeParam(ctx, andType.left), unwrapSelfTypeParam(ctx, andType.right));
         },

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -34,6 +34,10 @@ private:
             case core::TypePtr::Tag::TypeVar:
                 break;
 
+            case core::TypePtr::Tag::EnumUnion:
+                // Essentially an OrType, but all members are concrete types (enum class variants)
+                break;
+
             case core::TypePtr::Tag::OrType: {
                 auto &any = core::cast_type_nonnull<core::OrType>(type);
                 validate(ctx, polarity, any.left);

--- a/test/testdata/infer/enum_union_different_parents_lub.rb
+++ b/test/testdata/infer/enum_union_different_parents_lub.rb
@@ -1,0 +1,39 @@
+# typed: true
+extend T::Sig
+
+class Suit < T::Enum
+  enums do
+    Hearts = new
+    Diamonds = new
+    Clubs = new
+    Spades = new
+  end
+end
+
+class Color < T::Enum
+  enums do
+    Red = new
+    Blue = new
+    Green = new
+  end
+end
+
+sig {params(cond: T::Boolean).void}
+def test_different_enum_lub(cond)
+  x = if cond
+    res = [Suit::Hearts, Suit::Diamonds].sample
+    T.must(res)
+  else
+    res = [Color::Red, Color::Blue].sample
+    T.must(res)
+  end
+
+  T.reveal_type(x) # error: Revealed type: `T.any(Suit::Hearts, Suit::Diamonds, Color::Red, Color::Blue)`
+
+  case x
+  when Suit::Hearts, Suit::Diamonds
+    T.reveal_type(x) # error: Revealed type: `T.any(Suit::Hearts, Suit::Diamonds)`
+  when Color::Red, Color::Blue
+    T.reveal_type(x) # error: Revealed type: `T.any(Color::Red, Color::Blue)`
+  end
+end

--- a/test/testdata/infer/narrowing_with_enum_parent.rb
+++ b/test/testdata/infer/narrowing_with_enum_parent.rb
@@ -1,0 +1,20 @@
+# typed: true
+extend T::Sig
+
+class Suit < T::Enum
+  enums do
+    Spades = new
+    Hearts = new
+    Clubs = new
+    Diamonds = new
+  end
+end
+
+a = T.let(nil, T.nilable(Suit))
+
+case a
+when Suit::Spades
+when nil, Suit
+else
+  T.absurd(a)
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

This PR adds a new internal type called `EnumUnion`, representing a union of enum variants, all of the same enum type. This type is added purely as an internal optimization; the meaning/subtyping rules should remain indentical.

This new type allows for faster subtyping checks in some common cases. In other cases, where it would not be useful, this type will be converted to a `T.any`, and the existing subtyping code is run

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Without this change, when an enum with many cases was narrowed (in a `case ... when` for example), a large nested `T.any` needed to be constructed. Constructing this `T.any` and performing subtyping on this large `T.any` would end up being slow.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

- Existing tests.
- Running over Stripe's codebase
- Newly added tests.