### PR TITLE
Fix `attr` rewriter to handle boolean

### DIFF
--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -158,16 +158,43 @@ vector<ast::ExpressionPtr> AttrReader::run(core::MutableContext ctx, ast::Send *
 
     bool makeReader = false;
     bool makeWriter = false;
-    if (send->fun == core::Names::attr() || send->fun == core::Names::attrReader() ||
-        send->fun == core::Names::attrAccessor()) {
-        makeReader = true;
+    int attrNameArgCount = send->numPosArgs();
+    switch (send->fun.rawId()) {
+        case core::Names::attrReader().rawId():
+            makeReader = true;
+            break;
+
+        case core::Names::attrWriter().rawId():
+            makeWriter = true;
+            break;
+
+        case core::Names::attrAccessor().rawId():
+            makeReader = true;
+            makeWriter = true;
+            break;
+
+        case core::Names::attr().rawId(): {
+            makeReader = true;
+
+            // `attr` has two forms:
+            // 1. `attr :x, :y, :z` (multiple readers)
+            // 2. `attr :x, true` (single reader + a bool to indicate whether to make a writer)
+            if (send->numPosArgs() == 2) {
+                auto lit = ast::cast_tree<ast::Literal>(send->getPosArg(1));
+                if (lit && (lit->isTrue(ctx.state) || lit->isFalse(ctx.state))) {
+                    makeWriter = lit->isTrue(ctx.state);
+                    attrNameArgCount = 1;
+                }
+            }
+
+            break;
+        };
+
+        default:
+            return empty;
     }
-    if (send->fun == core::Names::attrWriter() || send->fun == core::Names::attrAccessor()) {
-        makeWriter = true;
-    }
-    if (!makeReader && !makeWriter) {
-        return empty;
-    }
+
+    auto attrNameArgs = send->posArgs().subspan(0, attrNameArgCount);
 
     auto loc = send->loc;
     vector<ast::ExpressionPtr> stats;
@@ -200,7 +227,7 @@ vector<ast::ExpressionPtr> AttrReader::run(core::MutableContext ctx, ast::Send *
     bool usedPrevSig = false;
 
     if (makeReader) {
-        for (auto &arg : send->posArgs()) {
+        for (auto &arg : attrNameArgs) {
             auto [name, argLoc] = ASTUtil::getAttrName(ctx, send->fun, arg);
             if (!name.exists()) {
                 return empty;
@@ -223,7 +250,7 @@ vector<ast::ExpressionPtr> AttrReader::run(core::MutableContext ctx, ast::Send *
     }
 
     if (makeWriter) {
-        for (auto &arg : send->posArgs()) {
+        for (auto &arg : attrNameArgs) {
             auto [name, argLoc] = ASTUtil::getAttrName(ctx, send->fun, arg);
             if (!name.exists()) {
                 return empty;

--- a/test/testdata/rewriter/attr.rb
+++ b/test/testdata/rewriter/attr.rb
@@ -4,6 +4,14 @@ class TestAttr
 
   sig {void}
   def initialize
+    @attr1 = T.let(0, Integer)
+    @attr2 = T.let(0, Integer)
+    @attr3 = T.let(0, Integer)
+    @attr4 = T.let(0, Integer)
+    @attr5 = T.let(0, Integer)
+    @attr_no_writer = T.let(0, Integer)
+    @attr_with_writer = T.let(0, Integer)
+
     @v1 = T.let(0, Integer)
     @v2 = T.let("", String)
     @v6 = T.let("", String)
@@ -12,8 +20,25 @@ class TestAttr
     @strv9 = T.let(0.0, Float)
   end
 
-  sig {returns(Integer)}
-  attr :v1
+  sig { returns(Integer) }
+# ^^^^^^^^^^^^^^^^^^^^^^^^ error: Unused type annotation. No method def before next annotation
+  attr
+
+  sig { returns(Integer) }
+  attr :attr1
+
+  sig { returns(Integer) }
+  attr :attr2, :attr3
+
+  sig { returns(Integer) }
+  attr :attr3, :attr4, :attr5
+
+  sig { returns(Integer) }
+  attr :attr_no_writer, false
+
+  sig { returns(Integer) }
+  attr :attr_with_writer, true
+
   sig {params(v1: Integer).returns(Integer)}
   attr_writer :v1
 
@@ -37,4 +62,5 @@ class TestAttr
 
   sig {returns(Float)}
   attr_accessor "strv9"
+
 end

--- a/test/testdata/rewriter/attr.rb.flatten-tree.exp
+++ b/test/testdata/rewriter/attr.rb.flatten-tree.exp
@@ -6,6 +6,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     def initialize(<blk>)
       begin
+        @attr1 = <cast:let>(0, Integer, ::Integer)
+        @attr2 = <cast:let>(0, Integer, ::Integer)
+        @attr3 = <cast:let>(0, Integer, ::Integer)
+        @attr4 = <cast:let>(0, Integer, ::Integer)
+        @attr5 = <cast:let>(0, Integer, ::Integer)
+        @attr_no_writer = <cast:let>(0, Integer, ::Integer)
+        @attr_with_writer = <cast:let>(0, Integer, ::Integer)
         @v1 = <cast:let>(0, Integer, ::Integer)
         @v2 = <cast:let>("", String, ::String)
         @v6 = <cast:let>("", String, ::String)
@@ -19,8 +26,76 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.returns(::Integer)
     end
 
-    def v1(<blk>)
-      @v1
+    <self>.sig() do ||
+      <self>.returns(::Integer)
+    end
+
+    def attr1(<blk>)
+      @attr1
+    end
+
+    <self>.sig() do ||
+      <self>.returns(::Integer)
+    end
+
+    def attr2(<blk>)
+      @attr2
+    end
+
+    <self>.sig() do ||
+      <self>.returns(::Integer)
+    end
+
+    def attr3(<blk>)
+      @attr3
+    end
+
+    <self>.sig() do ||
+      <self>.returns(::Integer)
+    end
+
+    def attr3(<blk>)
+      @attr3
+    end
+
+    <self>.sig() do ||
+      <self>.returns(::Integer)
+    end
+
+    def attr4(<blk>)
+      @attr4
+    end
+
+    <self>.sig() do ||
+      <self>.returns(::Integer)
+    end
+
+    def attr5(<blk>)
+      @attr5
+    end
+
+    <self>.sig() do ||
+      <self>.returns(::Integer)
+    end
+
+    def attr_no_writer(<blk>)
+      @attr_no_writer
+    end
+
+    <self>.sig() do ||
+      <self>.returns(::Integer)
+    end
+
+    def attr_with_writer(<blk>)
+      @attr_with_writer
+    end
+
+    <self>.sig() do ||
+      <self>.params(:attr_with_writer, ::Integer).returns(::Integer)
+    end
+
+    def attr_with_writer=(attr_with_writer, <blk>)
+      @attr_with_writer = attr_with_writer
     end
 
     <self>.sig() do ||
@@ -99,7 +174,25 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of initialize>
 
-    <runtime method definition of v1>
+    <self>.attr()
+
+    <runtime method definition of attr1>
+
+    <runtime method definition of attr2>
+
+    <runtime method definition of attr3>
+
+    <runtime method definition of attr3>
+
+    <runtime method definition of attr4>
+
+    <runtime method definition of attr5>
+
+    <runtime method definition of attr_no_writer>
+
+    <runtime method definition of attr_with_writer>
+
+    <runtime method definition of attr_with_writer=>
 
     <runtime method definition of v1=>
 

--- a/test/testdata/rewriter/attr.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/attr.rb.symbol-table-raw.exp
@@ -1,46 +1,68 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/attr.rb start=2:1 end=40:4}
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/attr.rb start=2:1 end=66:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
   class <C <U TestAttr>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/attr.rb start=2:1 end=2:15}
-    field <C <U TestAttr>>#<U @strv7> -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=10:5 end=10:11}
-    field <C <U TestAttr>>#<U @strv8> -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=11:5 end=11:11}
-    field <C <U TestAttr>>#<U @strv9> -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=12:5 end=12:11}
-    field <C <U TestAttr>>#<U @v1> -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=7:5 end=7:8}
-    field <C <U TestAttr>>#<U @v2> -> String @ Loc {file=test/testdata/rewriter/attr.rb start=8:5 end=8:8}
-    field <C <U TestAttr>>#<U @v6> -> String @ Loc {file=test/testdata/rewriter/attr.rb start=9:5 end=9:8}
+    field <C <U TestAttr>>#<U @attr1> -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=7:5 end=7:11}
+    field <C <U TestAttr>>#<U @attr2> -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=8:5 end=8:11}
+    field <C <U TestAttr>>#<U @attr3> -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=9:5 end=9:11}
+    field <C <U TestAttr>>#<U @attr4> -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=10:5 end=10:11}
+    field <C <U TestAttr>>#<U @attr5> -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=11:5 end=11:11}
+    field <C <U TestAttr>>#<U @attr_no_writer> -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=12:5 end=12:20}
+    field <C <U TestAttr>>#<U @attr_with_writer> -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=13:5 end=13:22}
+    field <C <U TestAttr>>#<U @strv7> -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=18:5 end=18:11}
+    field <C <U TestAttr>>#<U @strv8> -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=19:5 end=19:11}
+    field <C <U TestAttr>>#<U @strv9> -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=20:5 end=20:11}
+    field <C <U TestAttr>>#<U @v1> -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=15:5 end=15:8}
+    field <C <U TestAttr>>#<U @v2> -> String @ Loc {file=test/testdata/rewriter/attr.rb start=16:5 end=16:8}
+    field <C <U TestAttr>>#<U @v6> -> String @ Loc {file=test/testdata/rewriter/attr.rb start=17:5 end=17:8}
+    method <C <U TestAttr>>#<U attr1> (<blk>) -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=28:3 end=28:14}
+      argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
+    method <C <U TestAttr>>#<U attr2> (<blk>) -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=31:3 end=31:22}
+      argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
+    method <C <U TestAttr>>#<U attr3> (<blk>) -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=34:3 end=34:30}
+      argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
+    method <C <U TestAttr>>#<U attr4> (<blk>) -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=34:3 end=34:30}
+      argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
+    method <C <U TestAttr>>#<U attr5> (<blk>) -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=34:3 end=34:30}
+      argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
+    method <C <U TestAttr>>#<U attr_no_writer> (<blk>) -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=37:3 end=37:30}
+      argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
+    method <C <U TestAttr>>#<U attr_with_writer> (<blk>) -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=40:3 end=40:31}
+      argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
+    method <C <U TestAttr>>#<U attr_with_writer=> (attr_with_writer, <blk>) -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=40:3 end=40:31}
+      argument attr_with_writer<> -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=40:9 end=40:25}
+      argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
     method <C <U TestAttr>>#<U initialize> : private (<blk>) -> Sorbet::Private::Static::Void @ Loc {file=test/testdata/rewriter/attr.rb start=6:3 end=6:17}
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
-    method <C <U TestAttr>>#<U strv7> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=33:3 end=33:22}
+    method <C <U TestAttr>>#<U strv7> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=58:3 end=58:22}
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
-    method <C <U TestAttr>>#<U strv8=> (strv8, <blk>) -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=36:3 end=36:22}
-      argument strv8<> -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=35:15 end=35:20}
+    method <C <U TestAttr>>#<U strv8=> (strv8, <blk>) -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=61:3 end=61:22}
+      argument strv8<> -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=60:15 end=60:20}
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
-    method <C <U TestAttr>>#<U strv9> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=39:3 end=39:24}
+    method <C <U TestAttr>>#<U strv9> (<blk>) -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=64:3 end=64:24}
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
-    method <C <U TestAttr>>#<U strv9=> (strv9, <blk>) -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=39:3 end=39:24}
-      argument strv9<> -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=39:18 end=39:23}
+    method <C <U TestAttr>>#<U strv9=> (strv9, <blk>) -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=64:3 end=64:24}
+      argument strv9<> -> Float @ Loc {file=test/testdata/rewriter/attr.rb start=64:18 end=64:23}
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
-    method <C <U TestAttr>>#<U v1> (<blk>) -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=16:3 end=16:11}
+    method <C <U TestAttr>>#<U v1=> (v1, <blk>) -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=43:3 end=43:18}
+      argument v1<> -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=42:15 end=42:17}
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
-    method <C <U TestAttr>>#<U v1=> (v1, <blk>) -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=18:3 end=18:18}
-      argument v1<> -> Integer @ Loc {file=test/testdata/rewriter/attr.rb start=17:15 end=17:17}
+    method <C <U TestAttr>>#<U v2> (<blk>) -> String @ Loc {file=test/testdata/rewriter/attr.rb start=46:3 end=46:20}
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
-    method <C <U TestAttr>>#<U v2> (<blk>) -> String @ Loc {file=test/testdata/rewriter/attr.rb start=21:3 end=21:20}
+    method <C <U TestAttr>>#<U v2=> (v2, <blk>) -> String @ Loc {file=test/testdata/rewriter/attr.rb start=46:3 end=46:20}
+      argument v2<> -> String @ Loc {file=test/testdata/rewriter/attr.rb start=46:18 end=46:20}
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
-    method <C <U TestAttr>>#<U v2=> (v2, <blk>) -> String @ Loc {file=test/testdata/rewriter/attr.rb start=21:3 end=21:20}
-      argument v2<> -> String @ Loc {file=test/testdata/rewriter/attr.rb start=21:18 end=21:20}
+    method <C <U TestAttr>>#<U v3> (<blk>) -> String @ Loc {file=test/testdata/rewriter/attr.rb start=49:3 end=49:18}
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
-    method <C <U TestAttr>>#<U v3> (<blk>) -> String @ Loc {file=test/testdata/rewriter/attr.rb start=24:3 end=24:18}
-      argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
-    method <C <U TestAttr>>#<U v4=> (v4, <blk>) @ Loc {file=test/testdata/rewriter/attr.rb start=26:3 end=26:23}
-      argument v4<> @ Loc {file=test/testdata/rewriter/attr.rb start=26:16 end=26:18}
+    method <C <U TestAttr>>#<U v4=> (v4, <blk>) @ Loc {file=test/testdata/rewriter/attr.rb start=51:3 end=51:23}
+      argument v4<> @ Loc {file=test/testdata/rewriter/attr.rb start=51:16 end=51:18}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
-    method <C <U TestAttr>>#<U v5=> (v5, <blk>) @ Loc {file=test/testdata/rewriter/attr.rb start=26:3 end=26:23}
-      argument v5<> @ Loc {file=test/testdata/rewriter/attr.rb start=26:21 end=26:23}
+    method <C <U TestAttr>>#<U v5=> (v5, <blk>) @ Loc {file=test/testdata/rewriter/attr.rb start=51:3 end=51:23}
+      argument v5<> @ Loc {file=test/testdata/rewriter/attr.rb start=51:21 end=51:23}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
   class <S <C <U TestAttr>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U Sig>>) @ Loc {file=test/testdata/rewriter/attr.rb start=2:1 end=2:15}
     type-member(+) <S <C <U TestAttr>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U TestAttr>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=TestAttr) @ Loc {file=test/testdata/rewriter/attr.rb start=2:1 end=2:15}
-    method <S <C <U TestAttr>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/attr.rb start=2:1 end=40:4}
+    method <S <C <U TestAttr>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/attr.rb start=2:1 end=66:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/attr.rb start=??? end=???}
 


### PR DESCRIPTION
### Motivation

I fixed some mistakes in the `Module#attr` RBIs in #10004, but it turns out that the rewriter encodes similar rules. This leads to inconsistent handling of `attr`, depending on whether it's at the top level of a class or not:

```ruby
p(attr(:ok, true))

attr(:not_ok, true)
#             ^^^^ Argument to attr must be a Symbol or String https://srb.help/3501
```

This PR just fixes that.

### Test plan

Improved the existing `//test:test_PosTests/testdata/rewriter/attr` test.