### PR TITLE
Allow `--e-rbi` on its own

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -1425,9 +1425,10 @@ void readOptions(Options &opts,
             throw EarlyReturnWithCode(1);
         }
 
-        if (raw.count("e") == 0 && opts.inputFileNames.empty() && !raw["version"].as<bool>() && !opts.runLSP &&
-            opts.storeState.empty() && !opts.print.PayloadSources.enabled) {
-            logger->error("You must pass either `{}` or at least one folder or ruby file.\n\n{}", "-e",
+        if (raw.count("e") == 0 && raw.count("e-rbi") == 0 && opts.inputFileNames.empty() &&
+            !raw["version"].as<bool>() && !opts.runLSP && opts.storeState.empty() &&
+            !opts.print.PayloadSources.enabled) {
+            logger->error("You must pass `{}`, `{}`, or at least one folder or ruby file.\n\n{}", "-e", "--e-rbi",
                           options.help({groupToString(Group::INPUT)}));
             throw EarlyReturnWithCode(1);
         }

--- a/test/cli/e-rbi/test.out
+++ b/test/cli/e-rbi/test.out
@@ -10,3 +10,6 @@
      1 |Foo.foo("abc")
                 ^^^^^
 Errors: 1
+
+--- --e-rbi on its own ---
+No errors! Great job.

--- a/test/cli/e-rbi/test.sh
+++ b/test/cli/e-rbi/test.sh
@@ -8,3 +8,15 @@ main/sorbet --silence-dev-message --censor-for-snapshot-tests \
     end
   ' \
   -e $'Foo.foo("abc")' 2>&1
+
+echo
+echo "--- --e-rbi on its own ---"
+
+main/sorbet --silence-dev-message --censor-for-snapshot-tests \
+  --e-rbi $'
+    module Foo
+      sig { returns(T::Boolean) }
+      sig { params(x: Integer).returns(Integer) }
+      def self.foo(x); end;
+    end
+  ' 2>&1

--- a/test/cli/files-dirs/test.out
+++ b/test/cli/files-dirs/test.out
@@ -11,7 +11,7 @@
  ]
 }
 ------------------------------------------------------------------------
-You must pass either `-e` or at least one folder or ruby file.
+You must pass `-e`, `--e-rbi`, or at least one folder or ruby file.
 
 Sorbet: A fast, powerful typechecker designed for Ruby
 Usage:

--- a/test/cli/help/test.out
+++ b/test/cli/help/test.out
@@ -1,6 +1,6 @@
 ----- Abbreviated help output: -------------------------------------------
 
-You must pass either `-e` or at least one folder or ruby file.
+You must pass `-e`, `--e-rbi`, or at least one folder or ruby file.
 
 Sorbet: A fast, powerful typechecker designed for Ruby
 Usage:
@@ -43,7 +43,7 @@ Usage:
 
 ----- Abbreviated help output with empty config file: --------------------
 
-You must pass either `-e` or at least one folder or ruby file.
+You must pass `-e`, `--e-rbi`, or at least one folder or ruby file.
 
 Sorbet: A fast, powerful typechecker designed for Ruby
 Usage:


### PR DESCRIPTION
### Motivation

Previously, you couldn't use it without also passing `-e` or a file path (or a dummy `-e ""`):

```console
$ ./bazel run //main:sorbet --config=dbg -- --e-rbi "1"
You must pass either `-e` or at least one folder or ruby file.
```
