### PR TITLE
Add ERB::Escape to stdlib erb.rbi

### DIFF
--- a/rbi/stdlib/erb.rbi
+++ b/rbi/stdlib/erb.rbi
@@ -839,6 +839,16 @@ module ERB::DefMethod
   def self.def_erb_method(methodname, erb_or_fname); end
 end
 
+# A module providing C-accelerated HTML escaping, loaded via `require "erb/escape"`.
+# When the native C extension is unavailable, a pure-Ruby fallback is used instead.
+# See: https://github.com/ruby/erb/blob/2fd0a6/lib/erb/util.rb#L11-L28
+module ERB::Escape
+  # Escapes HTML special characters in +s+.
+  # Equivalent to ERB::Util#html_escape but provided as a C extension for speed.
+  sig { params(s: Object).returns(String) }
+  def html_escape(s); end
+end
+
 # A utility module for conversion routines, often handy in HTML generation.
 module ERB::Util
   # Alias for:


### PR DESCRIPTION
## Summary

`ERB::Escape` is a module providing C-accelerated HTML escaping, loaded via `require "erb/escape"` (typically pulled in by erubi). It is defined as a C extension with a pure-Ruby fallback. Source: https://github.com/ruby/erb/blob/2fd0a6/lib/erb/util.rb#L11-L28

Without this definition, Sorbet reports `Unable to resolve constant ERB::Escape` for any gem RBI that includes it — which became visible after [Shopify/tapioca#2555](https://github.com/Shopify/tapioca/pull/2555) corrected the attribution of C-extension constants to their consumer gems.

## Test plan

No test plan.