### PR TITLE
Remove udpatedFinalGSFileIndexes from LSPFileUpdates

### DIFF
--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -20,9 +20,6 @@ public:
     // ownership from one thread to the other.
     std::vector<std::string> fastPathExtraFiles;
 
-    // Updated on typechecking thread. Contains indexes processed with typechecking global state.
-    std::vector<ast::ParsedFile> updatedFinalGSFileIndexes;
-
     // This specific update contains edits with the given epoch
     uint32_t epoch = 0;
 

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -154,11 +154,13 @@ bool LSPTypechecker::typecheck(unique_ptr<LSPFileUpdates> updates, WorkerPool &w
         auto errorFlusher = make_shared<ErrorFlusherLSP>(updates->epoch, errorReporter);
         if (isFastPath) {
             bool isNoopUpdateForRetypecheck = false;
-            filesTypechecked = runFastPath(*updates, workers, errorFlusher, isNoopUpdateForRetypecheck);
+            auto result = runFastPath(*updates, workers, errorFlusher, isNoopUpdateForRetypecheck);
+
+            filesTypechecked = move(result.filesTypechecked);
 
             ENFORCE(updates->updatedFiles.empty());
 
-            for (auto &ast : updates->updatedFinalGSFileIndexes) {
+            for (auto &ast : result.indexedTrees) {
                 this->indexedFinalGS[ast.file.id()] = move(ast);
             }
 
@@ -174,9 +176,9 @@ bool LSPTypechecker::typecheck(unique_ptr<LSPFileUpdates> updates, WorkerPool &w
     return committed;
 }
 
-vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, WorkerPool &workers,
-                                                  shared_ptr<core::ErrorFlusher> errorFlusher,
-                                                  bool isNoopUpdateForRetypecheck) const {
+LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updates, WorkerPool &workers,
+                                                           shared_ptr<core::ErrorFlusher> errorFlusher,
+                                                           bool isNoopUpdateForRetypecheck) const {
     ENFORCE(this_thread::get_id() == typecheckerThreadId, "Typechecker can only be used from the typechecker thread.");
     ENFORCE(this->initialized);
     // We assume gs has been through the slow path, which is guaranteed by the initialization path not being cancelable.
@@ -285,6 +287,9 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
         op.emplace(*config, ShowOperation::Kind::FastPath);
     }
     ENFORCE(gs->errorQueue->isEmpty());
+    vector<ast::ParsedFile> toCache;
+    toCache.reserve(toTypecheck.size());
+
     vector<ast::ParsedFile> updatedIndexed;
     for (core::FileRef fref : toTypecheck) {
         auto t = pipeline::indexOne(config->opts, *gs, fref);
@@ -292,7 +297,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
         // As the fast-path might pull in unrelated files in the incremental case, we make sure to only cache files that
         // are explicitly open in the editor.
         if (fref.data(*gs).isOpenInClient()) {
-            updates.updatedFinalGSFileIndexes.push_back(ast::ParsedFile{t.tree.deepCopy(), t.file});
+            toCache.emplace_back(ast::ParsedFile{t.tree.deepCopy(), t.file});
         }
 
         updatedIndexed.emplace_back(std::move(t));
@@ -336,7 +341,7 @@ vector<core::FileRef> LSPTypechecker::runFastPath(LSPFileUpdates &updates, Worke
         "Running fast path over num_files={} incrementalNamer={} preemption={} duration={} files=[{}]",
         toTypecheck.size(), shouldRunIncrementalNamer, isPreemption, duration.usec, files);
 
-    return toTypecheck;
+    return FastPathResult{move(toTypecheck), move(toCache)};
 }
 
 bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const OwnedKeyValueStore> ownedKvstore,

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -96,10 +96,17 @@ class LSPTypechecker final {
     bool runSlowPath(LSPFileUpdates &updates, std::unique_ptr<const OwnedKeyValueStore> ownedKvstore,
                      WorkerPool &workers, std::shared_ptr<core::ErrorFlusher> errorFlusher, SlowPathMode mode);
 
+    struct FastPathResult {
+        // All of the files that we typechecked during the fast path.
+        std::vector<core::FileRef> filesTypechecked;
+
+        // Copies of the indexed trees that were updated during the fast path, for updating the cache of open files.
+        std::vector<ast::ParsedFile> indexedTrees;
+    };
+
     /** Runs incremental typechecking on the provided updates. Returns the final list of files typechecked. */
-    std::vector<core::FileRef> runFastPath(LSPFileUpdates &updates, WorkerPool &workers,
-                                           std::shared_ptr<core::ErrorFlusher> errorFlusher,
-                                           bool isNoopUpdateForRetypecheck) const;
+    FastPathResult runFastPath(LSPFileUpdates &updates, WorkerPool &workers,
+                               std::shared_ptr<core::ErrorFlusher> errorFlusher, bool isNoopUpdateForRetypecheck) const;
 
     /**
      * Open the session-local kvstore.


### PR DESCRIPTION
We update this vector on the fast path because `LSPTypechecker::runFastPath` is a `const` function and cannot update the `indexedFinalGS` cache directly. Instead of smuggling this value out through `LSPFileUpdates`, let's return it directly from `runFastPath`.

### Motivation
Simplification.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavioral changes expected, pure refactoring.
