### PR TITLE
Unset `top`'s superclass (previously `Object`)

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -357,6 +357,7 @@ void GlobalState::initEmpty() {
     ENFORCE_NO_TIMER(klass == Symbols::TSingleton());
     klass = synthesizeClass(core::Names::Constants::Class(), 0);
     ENFORCE_NO_TIMER(klass == Symbols::Class());
+    // Unlike some other classes that pass `0` here, BasicObject *actually* has no superclass, similar to `top`.
     klass = synthesizeClass(core::Names::Constants::BasicObject(), 0);
     ENFORCE_NO_TIMER(klass == Symbols::BasicObject());
     method = enterMethod(*this, Symbols::BasicObject(), Names::initialize()).build();
@@ -904,6 +905,10 @@ void GlobalState::initEmpty() {
         }
         classAndModules[i].singletonClass(*this);
     }
+
+    // BasicObject has no superclass, so its singleton class can't use the
+    // normal "follow the attached class's superclass" logic in finalizeAncestors.
+    Symbols::BasicObject().data(*this)->singletonClass(*this).data(*this)->setSuperClass(Symbols::Class());
 
     // This fills in all the way up to MAX_SYNTHETIC_CLASS_SYMBOLS
     ENFORCE_NO_TIMER(classAndModules.size() < Symbols::Proc0().id());

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -906,8 +906,9 @@ void GlobalState::initEmpty() {
         classAndModules[i].singletonClass(*this);
     }
 
-    // BasicObject has no superclass, so its singleton class can't use the
+    // top() and BasicObject have no superclass, so their singleton classes can't use the
     // normal "follow the attached class's superclass" logic in finalizeAncestors.
+    Symbols::top().data(*this)->singletonClass(*this).data(*this)->setSuperClass(Symbols::Class());
     Symbols::BasicObject().data(*this)->singletonClass(*this).data(*this)->setSuperClass(Symbols::Class());
 
     // This fills in all the way up to MAX_SYNTHETIC_CLASS_SYMBOLS

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -773,9 +773,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
     if (targetName == Names::super()) {
         targetName = args.enclosingMethodForSuper;
         mayBeOverloaded = symbol.data(gs)->findParentMethodTransitive(gs, targetName);
-    } else if (symbol != core::Symbols::top()) {
-        // TODO(jez) It would be nice to make `core::Symbols::top()` not have `Object` as its ancestor,
-        // in which case we could simply let the findMethodTransitive run and fail to find any methods
+    } else {
         mayBeOverloaded = symbol.data(gs)->findMethodTransitive(gs, targetName);
     }
 

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -327,7 +327,7 @@ void Resolver::finalizeAncestors(core::GlobalState &gs) {
             }
         } else {
             if (ref.data(gs)->isClass()) {
-                if (core::Symbols::BasicObject() != ref) {
+                if (core::Symbols::BasicObject() != ref && core::Symbols::top() != ref) {
                     ref.data(gs)->setSuperClass(core::Symbols::Object());
                 }
             } else {

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -330,7 +330,7 @@ void Resolver::finalizeAncestors(core::GlobalState &gs) {
             }
         } else {
             if (ref.data(gs)->isClass()) {
-                if (!core::Symbols::Object().data(gs)->derivesFrom(gs, ref) && core::Symbols::Object() != ref) {
+                if (core::Symbols::BasicObject() != ref) {
                     ref.data(gs)->setSuperClass(core::Symbols::Object());
                 }
             } else {

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -314,10 +314,7 @@ void Resolver::finalizeAncestors(core::GlobalState &gs) {
         bool isSingleton = attached.exists() && attached != core::Symbols::untyped();
         if (isSingleton) {
             singletonClassCount++;
-            if (attached == core::Symbols::BasicObject()) {
-                ref.data(gs)->setSuperClass(core::Symbols::Class());
-            } else if (attached.data(gs)->superClass() ==
-                       core::Symbols::Sorbet_Private_Static_ImplicitModuleSuperClass()) {
+            if (attached.data(gs)->superClass() == core::Symbols::Sorbet_Private_Static_ImplicitModuleSuperClass()) {
                 // Note: this depends on attached classes having lower indexes in name table than their singletons
                 ref.data(gs)->setSuperClass(core::Symbols::Module());
             } else {


### PR DESCRIPTION
### Motivation

Resolves a TODO, removes and edgecase from `dispatchCallSymbol()`, and conceptually just makes sense. `Object <: top`, not the other way around.

### Test plan

Passes existing tests.

I don't think this actually makes any observable differences from Ruby land. You already couldn't call `Object` methods on `T.untyped` (that's the exact point of this edge case).