### PR TITLE
Update the workspaceFiles vector instead of rebuilding it

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -370,8 +370,8 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
             openFiles.insert(entry.first);
         }
 
-        this->cancellationUndoState =
-            make_unique<UndoState>(std::move(savedGS), std::move(this->indexedFinalGS), updates.epoch);
+        this->cancellationUndoState = make_unique<UndoState>(std::move(savedGS), std::move(this->indexedFinalGS),
+                                                             this->workspaceFiles, updates.epoch);
     } else {
         timeit.setTag("cancelable", "false");
     }
@@ -408,6 +408,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
                         auto fref = this->gs->findFileByPath(file->path());
                         if (!fref.exists()) {
                             fref = this->gs->enterFile(std::move(file));
+                            this->workspaceFiles.push_back(fref);
                         } else {
                             this->gs->replaceFile(fref, std::move(file));
                         }
@@ -424,29 +425,6 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
                     }
 
                     updates.updatedFiles.clear();
-                }
-
-                this->workspaceFiles.clear();
-                this->workspaceFiles.reserve(this->gs->filesUsed());
-
-                // Rebuild the set of filerefs we're going to index. We're explicitly skipping the `0` file, as
-                // that's always a nullptr.
-                auto ix = 0;
-                for (const auto &file : this->gs->getFiles().subspan(1)) {
-                    ++ix;
-
-                    ENFORCE(file != nullptr);
-
-                    switch (file->sourceType) {
-                        case core::File::Type::NotYetRead:
-                        case core::File::Type::Normal:
-                            this->workspaceFiles.emplace_back(ix);
-                            break;
-
-                        case core::File::Type::PayloadGeneration:
-                        case core::File::Type::Payload:
-                            break;
-                    }
                 }
 
                 break;
@@ -679,7 +657,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
         // Eagerly restore the state to how it was before this slow path, so that we're not holding the old state for an
         // arbitrarily long time. The next update will be responsible for freeing the underlying UndoState after it
         // makes use of the epoch field to determine additional files to include in the edit.
-        cancellationUndoState->restore(this->gs, this->indexedFinalGS);
+        cancellationUndoState->restore(this->gs, this->indexedFinalGS, this->workspaceFiles);
         logger->debug("[Typechecker] Typecheck run for epoch {} was canceled.", updates.epoch);
     }
 

--- a/main/lsp/UndoState.cc
+++ b/main/lsp/UndoState.cc
@@ -9,12 +9,19 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 UndoState::UndoState(unique_ptr<core::GlobalState> evictedGs, UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS,
-                     uint32_t epoch)
-    : evictedGs(move(evictedGs)), evictedIndexedFinalGS(std::move(evictedIndexedFinalGS)), epoch(epoch) {}
+                     const vector<core::FileRef> &workspaceFiles, uint32_t epoch)
+    : evictedGs(move(evictedGs)),
+      evictedIndexedFinalGS(std::move(evictedIndexedFinalGS)), initialWorkspaceFilesSize{workspaceFiles.size()},
+      epoch(epoch) {}
 
-void UndoState::restore(unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast::ParsedFile> &indexedFinalGS) {
+void UndoState::restore(unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast::ParsedFile> &indexedFinalGS,
+                        vector<core::FileRef> &workspaceFiles) {
     indexedFinalGS = std::move(evictedIndexedFinalGS);
     gs = move(evictedGs);
+
+    if (workspaceFiles.size() != this->initialWorkspaceFilesSize) {
+        workspaceFiles.erase(workspaceFiles.begin() + this->initialWorkspaceFilesSize, workspaceFiles.end());
+    }
 }
 
 const unique_ptr<core::GlobalState> &UndoState::getEvictedGs() {

--- a/main/lsp/UndoState.h
+++ b/main/lsp/UndoState.h
@@ -14,20 +14,26 @@ class LSPConfiguration;
 class UndoState final {
     // Stores the pre-slow-path global state.
     std::unique_ptr<core::GlobalState> evictedGs;
+
     // Stores index trees containing data stored in `gs` that have been evicted during the slow path operation.
     UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS;
+
+    // The size of the workspaceFiles vector when the slow path started. Tracked so that we can roll back additions to
+    // the vector from new files added in the canceled edit.
+    const size_t initialWorkspaceFilesSize;
 
 public:
     // Epoch of the running slow path
     const uint32_t epoch;
 
     UndoState(std::unique_ptr<core::GlobalState> evictedGs, UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS,
-              uint32_t epoch);
+              const std::vector<core::FileRef> &workspaceFiles, uint32_t epoch);
 
     /**
      * Undoes the slow path changes represented by this class.
      */
-    void restore(std::unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast::ParsedFile> &indexedFinalGS);
+    void restore(std::unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast::ParsedFile> &indexedFinalGS,
+                 std::vector<core::FileRef> &workspaceFiles);
 
     /**
      * Retrieves the evicted global state.


### PR DESCRIPTION
As prework for keeping the file tables in sync between the indexer and typechecker global states, I noticed that we could avoid rebuilding the workspaceFiles vector for each slow path. Instead of scanning the whole file table again, if we instead track how big the vector was when we start we're setup to truncate the new entries in the event of a cancellation. This removes a costly loop over the whole file table from slow path initialization.

It's worth noting that if we ever start tombstoning files, we would need to change the approach here. However, we currently never set a file's type to `TombStone`, so this change should be safe.

### Motivation
Performance.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavioral change expected, refactoring only.
