### PR TITLE
Support multiple modifiers per method `def`

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -519,7 +519,17 @@ public:
             }
             return sym->asSymbol();
         } else if (auto def = ast::cast_tree<ast::RuntimeMethodDefinition>(expr)) {
+            // this handles the `private def foo` case
             return def->name;
+        } else if (auto send = ast::cast_tree<ast::Send>(expr)) {
+            // Handles combinations of modifiers like
+            // - `private abstract def foo` (`private(abstract(def foo; end))`)
+            // - `abstract private def foo` (`abstract(private(def foo; end))`)
+            if (send->numPosArgs() == 1 && send->fun.isMethodDefModifierName()) {
+                return unwrapLiteralToMethodName(ctx, send->getPosArg(0));
+            }
+
+            return core::NameRef::noName();
         } else {
             ENFORCE(!ast::isa_tree<ast::MethodDef>(expr), "methods inside sends should be gone");
             return core::NameRef::noName();

--- a/test/testdata/namer/method_modifiers_multiple_visibility.rb
+++ b/test/testdata/namer/method_modifiers_multiple_visibility.rb
@@ -1,0 +1,46 @@
+# typed: true
+
+# Multiple visibility modifiers apply at once. The left-most one (which is called last) wins.
+
+class Demo
+  public public       def public_public; end
+  public protected    def public_protected; end
+  public private      def public_private; end
+
+  protected public    def protected_public; end
+  protected protected def protected_protected; end
+  protected private   def protected_private; end
+
+  private public      def private_public; end
+  private protected   def private_protected; end
+  private private     def private_private; end
+end
+
+x = Demo.new
+
+x.public_public
+x.public_protected
+x.public_private
+
+x.protected_public
+x.protected_protected
+x.protected_private
+# ^^^^^^^^^^^^^^^^^ error: Non-private call to private method `protected_private` on `Demo`
+# TODO: `protected` is not properly clearing the `isPrivate` flag https://github.com/sorbet/sorbet/issues/10089
+
+x.private_public
+# ^^^^^^^^^^^^^^ error: Non-private call to private method `private_public` on `Demo`
+x.private_protected
+# ^^^^^^^^^^^^^^^^^ error: Non-private call to private method `private_protected` on `Demo`
+x.private_private
+# ^^^^^^^^^^^^^^^ error: Non-private call to private method `private_private` on `Demo`
+
+class ClassMethodDemo
+  # Class method modifiers cannot be nested the same way, because they return `T.self_type` instead of the method name.
+
+  # public_class_method public_class_method   def self.public_public; end
+  # public_class_method private_class_method  def self.public_private; end
+
+  # private_class_method public_class_method  def self.private_public; end
+  # private_class_method private_class_method def self.private_private; end
+end

--- a/test/testdata/namer/method_modifiers_multiple_visibility.rb
+++ b/test/testdata/namer/method_modifiers_multiple_visibility.rb
@@ -1,0 +1,45 @@
+# typed: true
+
+# Multiple visibility modifiers apply at once. The left-most one (which is called last) wins.
+
+class Demo
+  public public       def public_public; end
+  public protected    def public_protected; end
+  public private      def public_private; end
+
+  protected public    def protected_public; end
+  protected protected def protected_protected; end
+  protected private   def protected_private; end
+
+  private public      def private_public; end
+  private protected   def private_protected; end
+  private private     def private_private; end
+end
+
+x = Demo.new
+
+x.public_public
+x.public_protected
+x.public_private
+
+x.protected_public
+x.protected_protected
+x.protected_private
+# ^^^^^^^^^^^^^^^^^ error: Non-private call to private method `protected_private` on `Demo`
+# TODO: `protected` is not properly clearing the `isPrivate` flag https://github.com/sorbet/sorbet/issues/10089
+
+x.private_public
+# ^^^^^^^^^^^^^^ error: Non-private call to private method `private_public` on `Demo`
+x.private_protected
+# ^^^^^^^^^^^^^^^^^ error: Non-private call to private method `private_protected` on `Demo`
+x.private_private
+# ^^^^^^^^^^^^^^^ error: Non-private call to private method `private_private` on `Demo`
+
+# These modifiers cannot be nested the same way, because they return `T.self_type` instead of the method name.
+class ClassMethodDemo
+  # public_class_method public_class_method   def self.public_public; end
+  # public_class_method private_class_method  def self.public_private; end
+  #
+  # private_class_method public_class_method  def self.private_public; end
+  # private_class_method private_class_method def self.private_private; end
+end

--- a/test/testdata/namer/method_modifiers_multiple_visibility.rb.symbol-table.exp
+++ b/test/testdata/namer/method_modifiers_multiple_visibility.rb.symbol-table.exp
@@ -1,0 +1,33 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:5
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+  class ::ClassMethodDemo < ::Object () @ test/testdata/namer/method_modifiers_multiple_visibility.rb:38
+  class ::<Class:ClassMethodDemo>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/namer/method_modifiers_multiple_visibility.rb:38
+    type-member(+) ::<Class:ClassMethodDemo>::<AttachedClass> -> T.attached_class (of ClassMethodDemo) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:38
+    method ::<Class:ClassMethodDemo>#<static-init> (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:38
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+  class ::Demo < ::Object () @ test/testdata/namer/method_modifiers_multiple_visibility.rb:5
+    method ::Demo#private_private : private (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:16
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+    method ::Demo#private_protected : private (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:15
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+    method ::Demo#private_public : private (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:14
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+    method ::Demo#protected_private : private (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:12
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+    method ::Demo#protected_protected : protected (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:11
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+    method ::Demo#protected_public : protected (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:10
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+    method ::Demo#public_private (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:8
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+    method ::Demo#public_protected (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:7
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+    method ::Demo#public_public (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:6
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+  class ::<Class:Demo>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/namer/method_modifiers_multiple_visibility.rb:5
+    type-member(+) ::<Class:Demo>::<AttachedClass> -> T.attached_class (of Demo) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:5
+    method ::<Class:Demo>#<static-init> (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:5
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+

--- a/test/testdata/namer/method_modifiers_multiple_visibility.rb.symbol-table.exp
+++ b/test/testdata/namer/method_modifiers_multiple_visibility.rb.symbol-table.exp
@@ -1,0 +1,33 @@
+class ::<root> < ::Object ()
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:5
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+  class ::ClassMethodDemo < ::Object () @ test/testdata/namer/method_modifiers_multiple_visibility.rb:39
+  class ::<Class:ClassMethodDemo>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/namer/method_modifiers_multiple_visibility.rb:39
+    type-member(+) ::<Class:ClassMethodDemo>::<AttachedClass> -> T.attached_class (of ClassMethodDemo) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:39
+    method ::<Class:ClassMethodDemo>#<static-init> (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:39
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+  class ::Demo < ::Object () @ test/testdata/namer/method_modifiers_multiple_visibility.rb:5
+    method ::Demo#private_private : private (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:16
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+    method ::Demo#private_protected : private (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:15
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+    method ::Demo#private_public : private (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:14
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+    method ::Demo#protected_private : private (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:12
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+    method ::Demo#protected_protected : protected (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:11
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+    method ::Demo#protected_public : protected (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:10
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+    method ::Demo#public_private (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:8
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+    method ::Demo#public_protected (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:7
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+    method ::Demo#public_public (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:6
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+  class ::<Class:Demo>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/namer/method_modifiers_multiple_visibility.rb:5
+    type-member(+) ::<Class:Demo>::<AttachedClass> -> T.attached_class (of Demo) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:5
+    method ::<Class:Demo>#<static-init> (<blk>) @ test/testdata/namer/method_modifiers_multiple_visibility.rb:5
+      argument <blk><block> @ Loc {file=test/testdata/namer/method_modifiers_multiple_visibility.rb start=??? end=???}
+


### PR DESCRIPTION
### Motivation

This is the first of several steps towards supporting `abstract` as a modifier (#9963).

Previously, only one method modifier was allowed per method.

1. The right-most one was active, and others to the left are ignored:

    ```ruby
    class Demo
      unknown private def x; end # ✅ private
    end
    ```

2. If the right-most modifier was unknown by Sorbet, it wasn't merely no-op. It would get in the way of recognizing the other modifiers to the left:

    ```ruby
    class Demo
      private unknown def x; end # ❌ not private
    end
    ```

This PR addresses both of these.

### Implementation note

I considered splitting this into two PRs, one to allow multiple, then another to allow unknown ones.

But allowing multiple naturally just allows unknown ones, unless you add new filtering logic to detect particular method names. I didn't bother doing this, just to delete it in the next PR.

### Test plan

New tests added.