### PR TITLE
Simplify ENFORCE_NO_TIMER

### DIFF
--- a/common/enforce_no_timer/EnforceNoTimer.h
+++ b/common/enforce_no_timer/EnforceNoTimer.h
@@ -11,9 +11,8 @@
 // are O(1). Please avoid using unless ENFORCE shows up in profiles.
 #define ENFORCE_NO_TIMER(x, ...)                                                                            \
     do {                                                                                                    \
-        if constexpr (::sorbet::debug_mode) {                                                               \
+        if (::sorbet::debug_mode) {                                                                         \
             if (!(x)) {                                                                                     \
-                (void)!(x);                                                                                 \
                 ::sorbet::Exception::enforce_handler(#x, __FILE__, __LINE__ _MAYBE_ADD_COMMA(__VA_ARGS__)); \
             }                                                                                               \
         }                                                                                                   \


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The `Exception::enforce_handler` function always also calls
`failInFuzzer` and `stopInDebugger`. There's no need to have it trigger
twice.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

no-op