### PR TITLE
Remove File::Type::TombStone

### DIFF
--- a/core/Files.cc
+++ b/core/Files.cc
@@ -137,14 +137,12 @@ FileRef::FileRef(unsigned int id) : _id(id) {}
 
 const File &FileRef::data(const GlobalState &gs) const {
     ENFORCE(gs.files->get(_id));
-    ENFORCE(gs.files->get(_id)->sourceType != File::Type::TombStone);
     ENFORCE(gs.files->get(_id)->sourceType != File::Type::NotYetRead);
     return dataAllowingUnsafe(gs);
 }
 
 File &FileRef::data(GlobalState &gs) const {
     ENFORCE(gs.files->get(_id));
-    ENFORCE(gs.files->get(_id)->sourceType != File::Type::TombStone);
     ENFORCE(gs.files->get(_id)->sourceType != File::Type::NotYetRead);
     return dataAllowingUnsafe(gs);
 }
@@ -161,13 +159,11 @@ File &FileRef::dataAllowingUnsafe(GlobalState &gs) const {
 
 bool FileRef::isPackage(const GlobalState &gs) const {
     ENFORCE(gs.files->get(_id));
-    ENFORCE(gs.files->get(_id)->sourceType != File::Type::TombStone);
     return dataAllowingUnsafe(gs).isPackage(gs);
 }
 
 bool FileRef::isTestPackage(const GlobalState &gs) const {
     ENFORCE(gs.files->get(_id));
-    ENFORCE(gs.files->get(_id)->sourceType != File::Type::TombStone);
     return dataAllowingUnsafe(gs).isTestPackage(gs);
 }
 
@@ -176,7 +172,6 @@ string_view File::path() const {
 }
 
 string_view File::source() const {
-    ENFORCE(this->sourceType != File::Type::TombStone);
     ENFORCE(this->sourceType != File::Type::NotYetRead);
     return this->source_;
 }
@@ -238,7 +233,6 @@ void File::setIsOpenInClient(bool isOpenInClient) {
 }
 
 absl::Span<const uint32_t> File::lineBreaks() const {
-    ENFORCE(this->sourceType != File::Type::TombStone);
     ENFORCE(this->sourceType != File::Type::NotYetRead);
     auto ptr = atomic_load(&lineBreaks_);
     if (ptr != nullptr) {

--- a/core/Files.h
+++ b/core/Files.h
@@ -23,7 +23,6 @@ public:
         PayloadGeneration, // Files marked during --store-state
         Payload,           // Files loaded from the binary payload
         Normal,
-        TombStone,
     };
 
     // Epoch is _only_ used in LSP mode. Do not depend on it elsewhere.

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2350,12 +2350,6 @@ packages::UnfreezePackages GlobalState::unfreezePackages() {
     return packageDB_.unfreeze();
 }
 
-unique_ptr<GlobalState> GlobalState::markFileAsTombStone(unique_ptr<GlobalState> what, FileRef fref) {
-    ENFORCE_NO_TIMER(fref.id() < what->filesUsed());
-    what->files->get(fref.id())->sourceType = File::Type::TombStone;
-    return what;
-}
-
 unique_ptr<LocalSymbolTableHashes> GlobalState::hash(uint32_t foundClassesHash) const {
     constexpr bool DEBUG_HASHING_TAIL = false;
     uint32_t hierarchyHash = foundClassesHash;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -425,7 +425,6 @@ public:
     FileRef enterFile(std::shared_ptr<File> file);
     FileRef reserveFileRef(std::string path);
     std::shared_ptr<File> replaceFile(FileRef whatFile, std::shared_ptr<File> withWhat);
-    static std::unique_ptr<GlobalState> markFileAsTombStone(std::unique_ptr<GlobalState>, FileRef fref);
     FileRef findFileByPath(std::string_view path) const {
         return this->files->findFileByPath(path);
     }

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -67,15 +67,6 @@ public:
         return storage.fileRef;
     }
 
-    bool isTombStoned(const GlobalState &gs) const {
-        auto f = file();
-        if (!f.exists()) {
-            return false;
-        } else {
-            return file().data(gs).sourceType == File::Type::TombStone;
-        }
-    }
-
     inline Loc(FileRef file, uint32_t begin, uint32_t end) : storage{{begin, end}, file} {
         ENFORCE_NO_TIMER(storage.offsets.exists());
     }

--- a/main/lsp/LSPPreprocessor.cc
+++ b/main/lsp/LSPPreprocessor.cc
@@ -20,7 +20,9 @@ string readFile(const string &path, const FileSystem &fs) {
         // NOTE: It is not appropriate to throw an error here. Sorbet does not differentiate between Watchman
         // updates that specify if a file has changed or has been deleted, so this is the 'golden path' for deleted
         // files.
-        // TODO(jvilk): Use Tombstone files instead.
+        // An alternative would be to track deleted files in the file table as tombstoned. If we go that direction,
+        // we'll need to make sure to update the handling of those files in the `workspaceFiles` vector that the
+        // LSPTypechecker manages.
         return "";
     }
 }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -445,7 +445,6 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
 
                         case core::File::Type::PayloadGeneration:
                         case core::File::Type::Payload:
-                        case core::File::Type::TombStone:
                             break;
                     }
                 }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -582,7 +582,6 @@ ast::ExpressionPtr readFileWithStrictnessOverrides(core::GlobalState &gs, core::
         }
         case core::File::Type::PayloadGeneration:
         case core::File::Type::Payload:
-        case core::File::Type::TombStone:
             return nullptr;
     }
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1570,8 +1570,7 @@ private:
                 alias.data(ctx)->addLoc(ctx, ctx.locAt(typeMember.asgnLoc));
             } else {
                 auto oldSym = context.data(ctx)->findMemberNoDealias(typeTemplateAliasName);
-                if (oldSym.exists() &&
-                    !(oldSym.loc(ctx) == ctx.locAt(typeMember.asgnLoc) || oldSym.loc(ctx).isTombStoned(ctx))) {
+                if (oldSym.exists() && oldSym.loc(ctx) != ctx.locAt(typeMember.asgnLoc)) {
                     emitRedefinedConstantError(ctx, typeMember.nameLoc, typeMemberName,
                                                core::SymbolRef::Kind::TypeMember, oldSym);
                     typeTemplateAliasName = ctx.state.nextMangledName(context, typeTemplateAliasName);


### PR DESCRIPTION
We don't mark files as `File::Type::TombStone` anywhere in Sorbet, and doing do trips a load of `ENFORCE` failures. Let's remove the file type and work through more targeted support if we decide to handle tombstoned files in the future.

### Motivation
Simplification.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No changes expected, pure refactoring.
