### PR TITLE
Keep the indexer and typechecker's file refs in sync

### DIFF
--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -5,10 +5,8 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 void LSPFileUpdates::mergeOlder(const LSPFileUpdates &older) {
-    ENFORCE(this->updatedFiles.size() == this->updatedFileRefs.size(), "updatedFiles: {}, updatedFileRefs: {}",
-            this->updatedFiles.size(), this->updatedFileRefs.size());
-    ENFORCE(older.updatedFiles.size() == older.updatedFileRefs.size(), "updatedFiles: {}, updatedFileRefs: {}",
-            older.updatedFiles.size(), older.updatedFileRefs.size());
+    ENFORCE(this->updatedFiles.size() == this->updatedFileRefs.size());
+    ENFORCE(older.updatedFiles.size() == older.updatedFileRefs.size());
 
     editCount += older.editCount;
     committedEditCount += older.committedEditCount;

--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -5,6 +5,11 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 void LSPFileUpdates::mergeOlder(const LSPFileUpdates &older) {
+    ENFORCE(this->updatedFiles.size() == this->updatedFileRefs.size(), "updatedFiles: {}, updatedFileRefs: {}",
+            this->updatedFiles.size(), this->updatedFileRefs.size());
+    ENFORCE(older.updatedFiles.size() == older.updatedFileRefs.size(), "updatedFiles: {}, updatedFileRefs: {}",
+            older.updatedFiles.size(), older.updatedFileRefs.size());
+
     editCount += older.editCount;
     committedEditCount += older.committedEditCount;
     hasNewFiles = hasNewFiles || older.hasNewFiles;
@@ -12,17 +17,18 @@ void LSPFileUpdates::mergeOlder(const LSPFileUpdates &older) {
     preemptionsExpected += older.preemptionsExpected;
 
     // For updates, we prioritize _newer_ updates.
-    UnorderedSet<string> encountered;
-    for (auto &f : updatedFiles) {
-        encountered.emplace(f->path());
-    }
+    UnorderedSet<core::FileRef> encountered(this->updatedFileRefs.begin(), this->updatedFileRefs.end());
 
-    for (auto &f : older.updatedFiles) {
-        if (encountered.contains(f->path())) {
+    auto ix = -1;
+    for (auto fref : older.updatedFileRefs) {
+        ++ix;
+
+        if (encountered.contains(fref)) {
             continue;
         }
-        encountered.emplace(f->path());
-        updatedFiles.push_back(f);
+        encountered.emplace(fref);
+        this->updatedFileRefs.push_back(fref);
+        this->updatedFiles.push_back(older.updatedFiles[ix]);
     }
     typecheckingPath = TypecheckingPath::Slow;
 }
@@ -34,6 +40,7 @@ LSPFileUpdates LSPFileUpdates::copy() const {
     copy.committedEditCount = committedEditCount;
     copy.typecheckingPath = typecheckingPath;
     copy.hasNewFiles = hasNewFiles;
+    copy.updatedFileRefs = updatedFileRefs;
     copy.updatedFiles = updatedFiles;
     copy.cancellationExpected = cancellationExpected;
     copy.preemptionsExpected = preemptionsExpected;

--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -12,6 +12,11 @@ namespace sorbet::realmain::lsp {
  */
 class LSPFileUpdates final {
 public:
+    // The file refs in the indexer's global state that correspond to files at the same index in the `updatedFiles`
+    // vector.
+    std::vector<core::FileRef> updatedFileRefs;
+
+    // Files that have been updated in this edit, and need to be sync'd with the typechecker's global state.
     std::vector<std::shared_ptr<core::File>> updatedFiles;
 
     // The paths of any additional files implicated in a fast path edit. This vector stores path

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -326,9 +326,9 @@ unique_ptr<LSPFileUpdates> LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edi
 
     UnorderedMap<core::FileRef, shared_ptr<core::File>> newlyEvictedFiles;
     // Update globalStateHashes. Keep track of file IDs for these files, along with old hashes for these files.
-    vector<core::FileRef> frefs;
     {
         core::UnfreezeFileTable fileTableAccess(*gs);
+        update.updatedFileRefs.reserve(update.updatedFiles.size());
         for (auto &file : update.updatedFiles) {
             auto fref = gs->findFileByPath(file->path());
             if (fref.exists()) {
@@ -339,7 +339,7 @@ unique_ptr<LSPFileUpdates> LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edi
                 fref = gs->enterFile(file);
                 fref.data(*gs).strictLevel = pipeline::decideStrictLevel(*gs, fref, config->opts);
             }
-            frefs.emplace_back(fref);
+            update.updatedFileRefs.emplace_back(fref);
         }
     }
 
@@ -350,8 +350,8 @@ unique_ptr<LSPFileUpdates> LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edi
         // which one it will be.
         gs->errorQueue = make_shared<core::ErrorQueue>(gs->errorQueue->logger, gs->errorQueue->tracer,
                                                        make_shared<core::NullFlusher>());
-        auto trees = hashing::Hashing::indexAndComputeFileHashes(*gs, config->opts, *config->logger,
-                                                                 absl::Span<core::FileRef>(frefs), workers, kvstore);
+        auto trees = hashing::Hashing::indexAndComputeFileHashes(
+            *gs, config->opts, *config->logger, absl::MakeSpan(update.updatedFileRefs), workers, kvstore);
         ENFORCE(trees.hasResult(), "The indexer thread doesn't support cancellation");
     }
 

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -300,12 +300,22 @@ void LSPIndexer::initialize(IndexerInitializationTask &task, vector<shared_ptr<c
     {
         core::UnfreezeFileTable unfreezeFiles{*this->gs};
 
+        auto ix = 0;
         for (auto &file : files) {
+            ++ix;
             auto fref = this->gs->findFileByPath(file->path());
             if (fref.exists()) {
                 this->gs->replaceFile(fref, std::move(file));
             } else {
-                this->gs->enterFile(std::move(file));
+                fref = this->gs->enterFile(std::move(file));
+            }
+
+            auto expectedFref = core::FileRef(ix);
+            if (fref != expectedFref) {
+                ENFORCE(false);
+
+                config->logger->error("Mismatched ref during indexer initialization path=\"{}\" expected={} actual={}",
+                                      file->path(), expectedFref.id(), fref.id());
             }
         }
     }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -410,15 +410,62 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
                 if (!updates.updatedFiles.empty()) {
                     core::UnfreezeFileTable updateFileTable{*this->gs};
 
+                    vector<pair<core::FileRef, shared_ptr<core::File>>> newFiles;
+                    newFiles.reserve(updates.updatedFiles.size());
+
+                    auto usedFiles = this->gs->filesUsed();
+                    auto ix = -1;
                     for (auto &file : updates.updatedFiles) {
-                        auto fref = this->gs->findFileByPath(file->path());
-                        if (!fref.exists()) {
-                            fref = this->gs->enterFile(std::move(file));
-                            this->workspaceFiles.push_back(fref);
-                        } else {
-                            this->gs->replaceFile(fref, std::move(file));
+                        ++ix;
+
+                        auto fref = updates.updatedFileRefs[ix];
+                        ENFORCE(fref.exists());
+
+                        if (fref.id() >= usedFiles) {
+                            newFiles.emplace_back(fref, move(file));
+                            continue;
                         }
 
+                        ENFORCE(fref == this->gs->findFileByPath(file->path()),
+                                "FileRef mismatch between indexer and typechecker");
+                        this->gs->replaceFile(fref, std::move(file));
+                    }
+
+                    if (!newFiles.empty()) {
+                        // Sort the files by their ref so that we match the order of insertions into the indexer's file
+                        // table.
+                        fast_sort(newFiles, [](auto &l, auto &r) { return l.first.id() < r.first.id(); });
+
+                        this->workspaceFiles.reserve(this->workspaceFiles.size() + newFiles.size());
+
+                        for (auto &[fref, file] : newFiles) {
+                            auto newFref = this->gs->enterFile(std::move(file));
+
+                            // This property relies on `LSPIndexer::commitEdit` never rolling back the effects of
+                            // `GlobalState::enterFile` on the indexer's global state, and LSPFileUpdate values never
+                            // being dropped or truncated.
+                            //
+                            // The first assumption is valid as the indexer only grows its file table and never rolls
+                            // back to a previous state.
+                            //
+                            // The second is valid because the consumer of LSPFileUpdate values from
+                            // `LSPIndexer::commitEdit` is SorbetWorkspaceEdit, and that task will either be a new edit,
+                            // or a merged combination of other edits that have accumulated up to that point. If the
+                            // slow path is cancelled we'll roll back the changes to the file table, but the updates
+                            // themselves will be merged into the next edit, ensuring that we do ultimately insert those
+                            // new files.
+                            if (fref != newFref) {
+                                ENFORCE(false);
+
+                                config->logger->error("Mismatched ref on new file path=\"{}\" expected={} actual={}",
+                                                      file->path(), fref.id(), newFref.id());
+                            }
+
+                            this->workspaceFiles.emplace_back(newFref);
+                        }
+                    }
+
+                    for (auto fref : updates.updatedFileRefs) {
                         // Not all files present in the update set will be from open files--some could be watchman
                         // update events, and others will be the result of a `textDocument/didClose` notification.
                         // As a result, we may need to remove entries from the set that was eagerly cloned from
@@ -430,6 +477,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
                         }
                     }
 
+                    updates.updatedFileRefs.clear();
                     updates.updatedFiles.clear();
                 }
 

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -756,6 +756,7 @@ unique_ptr<LSPFileUpdates> LSPTypechecker::getNoopUpdate(absl::Span<const core::
     noop.typecheckingPath = TypecheckingPath::Fast;
     // Epoch isn't important for this update.
     noop.epoch = 0;
+    noop.updatedFileRefs = vector(frefs.begin(), frefs.end());
     for (auto fref : frefs) {
         ENFORCE(fref.exists());
         noop.updatedFiles.push_back(gs->getFiles()[fref.id()]);

--- a/main/lsp/test/lsp_file_updates_test.cc
+++ b/main/lsp/test/lsp_file_updates_test.cc
@@ -27,6 +27,7 @@ shared_ptr<core::File> makeFile(string path, string contents) {
 }
 
 void addFile(LSPFileUpdates &updates, core::FileRef fref, string path, string contents) {
+    updates.updatedFileRefs.push_back(fref);
     updates.updatedFiles.push_back(makeFile(move(path), move(contents)));
 }
 


### PR DESCRIPTION
Keeping the file refs in sync between the indexer and typechecker threads allows us to stop applying updates by looking file paths up in the typechecker thread. This is a small optimization, but once we start trying to figure out which stratum an edit can be checked at, it'll become more necessary for it to be quick to go from a file to its stratum quickly. As we already build a map from file ref to stratum when building the initial traversal, using that mapping would be the easiest path forward as long as the file refs match between the indexer and typechecker global states.


### Motivation
Prework for package-directed preemption.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests. I'm reasonably sure that our current model is that we would never lose an edit that would add a file, and that's the only situation that could cause these two to go out of sync.

I had Sorbet active through a massive rebase on Stripe's codebase, and none of the error logs that I added printed out.
