### PR TITLE
`--gen-packages` strict mode: imports

### DIFF
--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -713,7 +713,7 @@ std::optional<core::AutocorrectSuggestion> PackageInfo::aggregateMissingVisibleT
     return core::AutocorrectSuggestion{fmt::format("Add missing `{}`", "visible_to"), std::move(allEdits)};
 }
 
-std::string PackageInfo::renderPackageRbContents(const core::GlobalState &gs,
+std::string PackageInfo::renderPackageRbContents(const core::GlobalState &gs, vector<Import> newImports,
                                                  std::vector<core::SymbolRef> newExports) const {
     fmt::memory_buffer result;
 
@@ -778,8 +778,14 @@ std::string PackageInfo::renderPackageRbContents(const core::GlobalState &gs,
           {StrictDependenciesLevel::Dag, "  # strict_dependencies 'dag':\n"}}},
     };
 
-    // NOTE: this loop assumes importedPackageNames are already sorted by orderImports
-    // TODO(neil): sort the imports
+    fast_sort(newImports, [&](const auto &a, const auto &b) {
+        auto &aPkgInfo = gs.packageDB().getPackageInfo(a.mangledName);
+        auto &bPkgInfo = gs.packageDB().getPackageInfo(b.mangledName);
+        ENFORCE(aPkgInfo.exists());
+        ENFORCE(bPkgInfo.exists());
+        return orderImports(gs, aPkgInfo, a.isTestImport(), bPkgInfo, b.isTestImport()) < 0;
+    });
+
     bool layeringViolationsHeaderShown = false;
     bool testImportNewLineAdded = false;
 
@@ -787,12 +793,10 @@ std::string PackageInfo::renderPackageRbContents(const core::GlobalState &gs,
             "should not happen, was a new StrictDependenciesLevel added?");
     auto &headers = headerMap.find(strictDependenciesLevel)->second;
     auto headersIt = headers.begin();
-    for (auto &import : importedPackageNames) {
+    for (auto &import : newImports) {
         auto impPackageName = import.mangledName.owner.show(gs);
         auto &impPkgInfo = gs.packageDB().getPackageInfo(import.mangledName);
-        if (!impPkgInfo.exists()) {
-            continue;
-        }
+        ENFORCE(impPkgInfo.exists());
 
         if (gs.packageDB().enforceLayering() && import.type == ImportType::Normal) {
             if (!layeringViolationsHeaderShown && causesLayeringViolation(gs.packageDB(), impPkgInfo)) {
@@ -824,14 +828,16 @@ std::string PackageInfo::renderPackageRbContents(const core::GlobalState &gs,
         }
 
         switch (import.type) {
-            case ImportType::Normal:
-                if (import.usesInternals) {
+            case ImportType::Normal: {
+                auto *existingImport = importsPackage(import.mangledName);
+                if (existingImport != nullptr && existingImport->usesInternals) {
                     ENFORCE(gs.packageDB().testPackages());
                     fmt::format_to(std::back_inserter(result), "  import {}, uses_internals: true\n", impPackageName);
                 } else {
                     fmt::format_to(std::back_inserter(result), "  import {}\n", impPackageName);
                 }
                 break;
+            }
             case ImportType::TestHelper:
                 ENFORCE(!gs.packageDB().testPackages());
                 fmt::format_to(std::back_inserter(result), "  test_import {}\n", impPackageName);

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -338,7 +338,8 @@ public:
     aggregateMissingVisibleTo(const core::GlobalState &gs, std::vector<core::packages::MangledName> &visibleTos,
                               bool visibleToTests) const;
 
-    std::string renderPackageRbContents(const core::GlobalState &gs, std::vector<core::SymbolRef> newExports) const;
+    std::string renderPackageRbContents(const core::GlobalState &gs, std::vector<Import> newImports,
+                                        std::vector<core::SymbolRef> newExports) const;
 };
 CheckSize(PackageInfo, 256, 8);
 

--- a/packager/GenPackages.cc
+++ b/packager/GenPackages.cc
@@ -93,7 +93,8 @@ vector<core::packages::Import> computeNewImports(const core::GlobalState &gs,
     for (auto &import : pkgInfo.importedPackageNames) {
         auto &impPkgInfo = gs.packageDB().getPackageInfo(import.mangledName);
         if (impPkgInfo.exists() && impPkgInfo.isPreludePackage()) {
-            // Imports to prelude packages should not be removed, even if they're not referenced anywhere.
+            // If the `__package.rb` already imports a prelude package, we should keep that import, even if it's not
+            // referenced anywhere.
             importMap[import.mangledName] = import.type;
         }
     }

--- a/packager/GenPackages.cc
+++ b/packager/GenPackages.cc
@@ -110,15 +110,13 @@ vector<core::packages::Import> computeNewImports(const core::GlobalState &gs,
             if (!pkgInfo.exists()) {
                 continue;
             }
-            // TODO(neil): this ignores strict dependencies violations and unconditionally adds an import.
-            // Should we skip imports that would cause a strict dependencies error instead?
-            auto it = importMap.find(packageName);
-            if (it != importMap.end()) {
+            // TODO(neil): this ignores strict dependencies/visibility violations and unconditionally adds an import.
+            // Should we skip imports that would cause a strict dependencies/visibility error instead?
+            auto [it, inserted] = importMap.insert({packageName, importType});
+            if (!inserted) {
                 if (importType < it->second) {
                     it->second = importType;
                 }
-            } else {
-                importMap[packageName] = importType;
             }
         }
     }

--- a/packager/GenPackages.cc
+++ b/packager/GenPackages.cc
@@ -87,6 +87,50 @@ void exportField(const core::GlobalState &gs,
     }
 }
 
+vector<core::packages::Import> computeNewImports(const core::GlobalState &gs,
+                                                 const core::packages::PackageInfo &pkgInfo) {
+    UnorderedMap<core::packages::MangledName, core::packages::ImportType> importMap;
+    for (auto &import : pkgInfo.importedPackageNames) {
+        auto &impPkgInfo = gs.packageDB().getPackageInfo(import.mangledName);
+        if (impPkgInfo.exists() && impPkgInfo.isPreludePackage()) {
+            // Imports to prelude packages should not be removed, even if they're not referenced anywhere.
+            importMap[import.mangledName] = import.type;
+        }
+    }
+
+    // TODO(neil): this loop is very similar to the loop in aggregateMissingImports, should find a way to deduplicate.
+    // Can't deduplicate trivially because the loop in aggregateMissingImports skips entries where
+    // !packageReferenceInfo.importNeeded or packageReferenceInfo.causesModularityError, as well if the import would
+    // cause a visibility error. Maybe the common helper could take a function that filters?
+    for (auto &[file, referencedPackages] : pkgInfo.packagesReferencedByFile) {
+        auto importType = core::packages::PackageInfo::fileToImportType(gs, file);
+        for (auto &[packageName, packageReferenceInfo] : referencedPackages) {
+            auto &pkgInfo = gs.packageDB().getPackageInfo(packageName);
+            if (!pkgInfo.exists()) {
+                continue;
+            }
+            // TODO(neil): this ignores strict dependencies violations and unconditionally adds an import.
+            // Should we skip imports that would cause a strict dependencies error instead?
+            auto it = importMap.find(packageName);
+            if (it != importMap.end()) {
+                if (importType < it->second) {
+                    it->second = importType;
+                }
+            } else {
+                importMap[packageName] = importType;
+            }
+        }
+    }
+
+    vector<core::packages::Import> newImports;
+    newImports.reserve(importMap.size());
+    for (auto &[mangledName, importType] : importMap) {
+        newImports.emplace_back(mangledName, importType, core::LocOffsets::none());
+    }
+
+    return newImports;
+}
+
 UnorderedMap<core::SymbolRef, vector<core::FileRef>> computeReferencingFiles(const core::GlobalState &gs) {
     auto referencingFiles = UnorderedMap<core::SymbolRef, vector<core::FileRef>>{};
     // symbolsReferencedByFile is a map from file -> [symbol] referenced in that file
@@ -257,7 +301,7 @@ void GenPackages::runStrict(core::GlobalState &gs) {
         auto existingContents = existingContentsLoc.source(gs);
         ENFORCE(existingContents.has_value());
 
-        auto newContents = pkgInfo.renderPackageRbContents(gs, move(toExport[pkgName]));
+        auto newContents = pkgInfo.renderPackageRbContents(gs, computeNewImports(gs, pkgInfo), move(toExport[pkgName]));
 
         if (existingContents.value() != newContents) {
             if (auto e = gs.beginError(pkgInfo.declLoc(), core::errors::Packager::IncorrectPackageRB)) {

--- a/test/cli/package-gen-packages-strict/A/__package.rb
+++ b/test/cli/package-gen-packages-strict/A/__package.rb
@@ -8,5 +8,7 @@ class A < PackageSpec
 
   export A::CONSTANT_FROM_A
 
+  import Prelude
+
   test_import B
 end

--- a/test/cli/package-gen-packages-strict/A/test/helper.rb
+++ b/test/cli/package-gen-packages-strict/A/test/helper.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+class Test::A::Helper
+  def foo
+    puts B::CONSTANT_FROM_B
+  end
+end

--- a/test/cli/package-gen-packages-strict/B/__package.rb
+++ b/test/cli/package-gen-packages-strict/B/__package.rb
@@ -4,8 +4,8 @@ class B < PackageSpec
   layer 'util'
   strict_dependencies 'false'
 
-  import A
   import C
+  import A
 
   export B::CONSTANT_FROM_B
   export B::ANOTHER_CONSTANT_FROM_B

--- a/test/cli/package-gen-packages-strict/B/__package.rb
+++ b/test/cli/package-gen-packages-strict/B/__package.rb
@@ -4,6 +4,7 @@ class B < PackageSpec
   layer 'util'
   strict_dependencies 'false'
 
+  import D
   import C
   import A
 

--- a/test/cli/package-gen-packages-strict/B/constants.rb
+++ b/test/cli/package-gen-packages-strict/B/constants.rb
@@ -5,4 +5,5 @@ module B
   ANOTHER_CONSTANT_FROM_B = "Hello from Package B"
   puts A::CONSTANT_FROM_A
   puts C::CONSTANT_FROM_C
+  puts D::CONSTANT_FROM_D
 end

--- a/test/cli/package-gen-packages-strict/B/constants.rb
+++ b/test/cli/package-gen-packages-strict/B/constants.rb
@@ -3,4 +3,6 @@
 module B
   CONSTANT_FROM_B = "Hello from Package B"
   ANOTHER_CONSTANT_FROM_B = "Hello from Package B"
+  puts A::CONSTANT_FROM_A
+  puts C::CONSTANT_FROM_C
 end

--- a/test/cli/package-gen-packages-strict/B/test/constants.test.rb
+++ b/test/cli/package-gen-packages-strict/B/test/constants.test.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module Test::B
+  puts C::CONSTANT_FROM_C
+end

--- a/test/cli/package-gen-packages-strict/C/constants.rb
+++ b/test/cli/package-gen-packages-strict/C/constants.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+module C
+  CONSTANT_FROM_C = "Hello from Package C"
+  puts B::CONSTANT_FROM_B
+end

--- a/test/cli/package-gen-packages-strict/D/__package.rb
+++ b/test/cli/package-gen-packages-strict/D/__package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+class D < PackageSpec
+  layer 'util'
+  strict_dependencies 'dag'
+
+  export_all!
+end

--- a/test/cli/package-gen-packages-strict/D/constants.rb
+++ b/test/cli/package-gen-packages-strict/D/constants.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module D
+  CONSTANT_FROM_D = "Hello from Package D"
+end

--- a/test/cli/package-gen-packages-strict/prelude/__package.rb
+++ b/test/cli/package-gen-packages-strict/prelude/__package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+class Prelude < PackageSpec
+  prelude_package
+
+  layer 'app'
+  strict_dependencies 'dag'
+end

--- a/test/cli/package-gen-packages-strict/test.out
+++ b/test/cli/package-gen-packages-strict/test.out
@@ -7,6 +7,11 @@ A/__package.rb:3: `A` has changes https://srb.help/3734
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
 
+B/__package.rb:3: `B` has changes https://srb.help/3734
+     3 |class B < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+
 C/__package.rb:8: Strict dependencies violation: All of `C`'s `import`s must be `dag` or higher https://srb.help/3727
      8 |  import B
           ^^^^^^^^
@@ -28,11 +33,6 @@ C/__package.rb:8: Package `B` includes explicit visibility modifiers and cannot 
           ^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `B`
-
-B/__package.rb:3: `B` has changes https://srb.help/3734
-     3 |class B < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
 Errors: 5
 
 ###### cat A/__package.rb ######
@@ -64,6 +64,7 @@ class B < PackageSpec
 
   # strict_dependencies 'layered' or more strict:
   import C
+  import D
 
   export B::ANOTHER_CONSTANT_FROM_B
   export B::CONSTANT_FROM_B

--- a/test/cli/package-gen-packages-strict/test.out
+++ b/test/cli/package-gen-packages-strict/test.out
@@ -43,8 +43,10 @@ class A < PackageSpec
   layer 'app'
   strict_dependencies 'false'
 
-  test_import B
+  # strict_dependencies 'false':
+  import B
 
+  export A::CONSTANT_FROM_A
 end
 
 ###### cat B/__package.rb ######

--- a/test/cli/package-gen-packages-strict/test.out
+++ b/test/cli/package-gen-packages-strict/test.out
@@ -46,6 +46,9 @@ class A < PackageSpec
   # strict_dependencies 'false':
   import B
 
+  # strict_dependencies 'layered' or more strict:
+  import Prelude
+
   export A::CONSTANT_FROM_A
 end
 

--- a/test/cli/package-gen-packages-strict/test.out
+++ b/test/cli/package-gen-packages-strict/test.out
@@ -65,3 +65,16 @@ class B < PackageSpec
 
   visible_to A
 end
+
+###### cat C/__package.rb ######
+# typed: strict
+
+class C < PackageSpec
+  layer 'util'
+  strict_dependencies 'dag'
+
+  # strict_dependencies 'false', 'layered', or 'layered_dag':
+  import B
+
+  export_all!
+end

--- a/test/cli/package-gen-packages-strict/test.sh
+++ b/test/cli/package-gen-packages-strict/test.sh
@@ -27,3 +27,7 @@ cat A/__package.rb
 echo
 echo "###### cat B/__package.rb ######"
 cat B/__package.rb
+
+echo
+echo "###### cat C/__package.rb ######"
+cat C/__package.rb


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Depends on #9978. That PR just writes the `importedPackageNames` in `PackageInfo` as-is. This PR changes that to instead use the information from `packagesReferencedByFile ` that's used for the non-strict mode. This means that unused imports will get deleted, and missing imports will get added.

Similar to #10066 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Move tooling for working with packages into Sorbet.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
