### PR TITLE
Handle RSpec.local_context blocks and dynamic include_examples args

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -293,6 +293,7 @@ NameDef names[] = {
     {"includeExamples", "include_examples"},
     {"includeContext", "include_context"},
     {"itBehavesLike", "it_behaves_like"},
+    {"localContext", "local_context"},
     {"RSpec", "RSpec", true},
     {"Core", "Core", true},
     {"ExampleGroup", "ExampleGroup", true},

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -991,8 +991,11 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::
 
             // Only rewrite when the argument is a string/symbol literal. If it's a variable
             // (e.g. a shared_examples block param), we can't resolve it at compile time.
+            // Return EmptyTree to silently drop the call rather than leaving a raw
+            // `include_examples(variable)` in the class body which would produce a
+            // method-not-found error.
             if (!ast::isa_tree<ast::Literal>(send->getPosArg(0))) {
-                return nullptr;
+                return ast::MK::EmptyTree();
             }
 
             auto name = makeSharedExamplesConstant(ctx, send->getPosArg(0));
@@ -1054,6 +1057,8 @@ vector<ast::ExpressionPtr> Minitest::run(core::MutableContext ctx, bool isClass,
         ctx.state.cacheSensitiveOptions.rspecRewriterEnabled) {
         auto *block = send->block();
 
+        // Note: only direct Send children of the block body are scanned.
+        // Shared examples nested inside conditionals or other blocks are not hoisted.
         auto processStmt = [&](ast::ExpressionPtr &stmt) {
             if (auto bodySend = ast::cast_tree<ast::Send>(stmt)) {
                 auto result = runSingle(ctx, /* isClass */ false, /* maybeSharedExamplesName */ nullptr, bodySend,

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -510,7 +510,7 @@ ast::ExpressionPtr runUnderParameterized(core::MutableContext ctx, core::NameRef
             // When called with the RSpec. prefix (e.g. `RSpec.shared_context 'name' do`),
             // these are standalone global definitions independent of the block params.
             // Delegate to runSingle so they get registered as root-scoped constants.
-            if (isRSpec(ctx, send->recv)) {
+            if (ctx.state.cacheSensitiveOptions.rspecRewriterEnabled && isRSpec(ctx, send->recv)) {
                 auto result =
                     runSingle(ctx, /* isClass */ false, /* maybeSharedExamplesName */ nullptr, send, insideDescribe);
                 if (result != nullptr) {

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -408,7 +408,11 @@ ast::ExpressionPtr runUnderParameterized(core::MutableContext ctx, core::NameRef
     }
 
     if (send->hasBlock() && send->block()->params.size() != 0) {
-        return invalidUnderParameterizedBody(ctx, eachName, move(stmt));
+        // Allow RSpec.shared_examples/shared_context with block params to pass through to the
+        // switch below, where they'll be handled by runSingle if the receiver is RSpec.
+        if (!isSharedExamplesName(send->fun) || !isRSpec(ctx, send->recv)) {
+            return invalidUnderParameterizedBody(ctx, eachName, move(stmt));
+        }
     }
 
     // test_each is a Sorbet-specific DSL, not RSpec, so use minitest-style strict arity
@@ -513,6 +517,15 @@ ast::ExpressionPtr runUnderParameterized(core::MutableContext ctx, core::NameRef
             if (!ctx.state.cacheSensitiveOptions.rspecRewriterEnabled || send->hasBlock() || !insideDescribe ||
                 send->numPosArgs() < 1) {
                 break;
+            }
+
+            // Only rewrite when the argument is a string/symbol literal. If it's a variable
+            // (e.g. a shared_examples block param), we can't resolve it at compile time.
+            // Return EmptyTree to silently drop the call rather than leaving a raw
+            // `include_examples(variable)` in the class body which would produce a
+            // method-not-found error.
+            if (!ast::isa_tree<ast::Literal>(send->getPosArg(0))) {
+                return ast::MK::EmptyTree();
             }
 
             auto name = makeSharedExamplesConstant(ctx, send->getPosArg(0));
@@ -976,6 +989,12 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::
                 return nullptr;
             }
 
+            // Only rewrite when the argument is a string/symbol literal. If it's a variable
+            // (e.g. a shared_examples block param), we can't resolve it at compile time.
+            if (!ast::isa_tree<ast::Literal>(send->getPosArg(0))) {
+                return nullptr;
+            }
+
             auto name = makeSharedExamplesConstant(ctx, send->getPosArg(0));
             return ast::MK::Send1(send->loc, move(send->recv), core::Names::include(), send->funLoc, move(name));
         }
@@ -1025,6 +1044,34 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::
 vector<ast::ExpressionPtr> Minitest::run(core::MutableContext ctx, bool isClass, ast::Send *send) {
     vector<ast::ExpressionPtr> stats;
     if (ctx.state.cacheSensitiveOptions.runningUnderAutogen) {
+        return stats;
+    }
+
+    // Handle RSpec.local_context do ... end: scan the body for RSpec.shared_examples /
+    // shared_context / shared_examples_for calls and hoist them to the top-level scope,
+    // making them resolvable via include_examples / include_context in any describe block.
+    if (send->fun == core::Names::localContext() && isRSpec(ctx, send->recv) && send->hasBlock() &&
+        ctx.state.cacheSensitiveOptions.rspecRewriterEnabled) {
+        auto *block = send->block();
+
+        auto processStmt = [&](ast::ExpressionPtr &stmt) {
+            if (auto bodySend = ast::cast_tree<ast::Send>(stmt)) {
+                auto result = runSingle(ctx, /* isClass */ false, /* maybeSharedExamplesName */ nullptr, bodySend,
+                                        /* insideDescribe */ false);
+                if (result != nullptr) {
+                    stats.emplace_back(std::move(result));
+                }
+            }
+        };
+
+        if (auto bodySeq = ast::cast_tree<ast::InsSeq>(block->body)) {
+            for (auto &exp : bodySeq->stats) {
+                processStmt(exp);
+            }
+            processStmt(bodySeq->expr);
+        } else {
+            processStmt(block->body);
+        }
         return stats;
     }
 

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -369,6 +369,7 @@ bool isSharedExamplesName(core::NameRef name) {
 // silently drop the call if the argument is not a string/symbol literal (e.g. a block parameter
 // that can't be resolved at compile time). Must only be called after a numPosArgs >= 1 check.
 ast::ExpressionPtr rewriteIncludeExamples(core::MutableContext ctx, ast::Send *send) {
+    ENFORCE(send->numPosArgs() > 0);
     if (!ast::isa_tree<ast::Literal>(send->getPosArg(0))) {
         return ast::MK::EmptyTree();
     }
@@ -1044,8 +1045,8 @@ vector<ast::ExpressionPtr> Minitest::run(core::MutableContext ctx, bool isClass,
     // Handle RSpec.local_context do ... end: scan the body for RSpec.shared_examples /
     // shared_context / shared_examples_for calls and hoist them to the top-level scope,
     // making them resolvable via include_examples / include_context in any describe block.
-    if (send->fun == core::Names::localContext() && isRSpec(ctx, send->recv) && send->hasBlock() &&
-        ctx.state.cacheSensitiveOptions.rspecRewriterEnabled) {
+    if (ctx.state.cacheSensitiveOptions.rspecRewriterEnabled && send->fun == core::Names::localContext() &&
+        isRSpec(ctx, send->recv) && send->hasBlock()) {
         auto *block = send->block();
 
         // Note: only direct Send children of the block body are scanned.

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -370,6 +370,9 @@ ast::ExpressionPtr prepareParameterizedBody(core::MutableContext ctx, core::Name
                                             absl::Span<const ast::ExpressionPtr> destructuringStmts,
                                             ast::ExpressionPtr &iteratee, bool insideDescribe);
 
+ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::ExpressionPtr &maybeSharedExamplesName,
+                             ast::Send *send, bool insideDescribe);
+
 ast::ExpressionPtr invalidUnderParameterizedBody(core::MutableContext ctx, core::NameRef eachName,
                                                  ast::ExpressionPtr stmt) {
     if (isSharedExamplesName(eachName)) {
@@ -488,8 +491,18 @@ ast::ExpressionPtr runUnderParameterized(core::MutableContext ctx, core::NameRef
         case core::Names::sharedExamples().rawId():
         case core::Names::sharedContext().rawId():
         case core::Names::sharedExamplesFor().rawId(): {
-            // We don't handle RSpec's SharedExampleGroup inside test_each, because it's not clear
-            // what that should do and whether anyone actually uses it.
+            // When called with the RSpec. prefix (e.g. `RSpec.shared_context 'name' do`),
+            // these are standalone global definitions independent of the block params.
+            // Delegate to runSingle so they get registered as root-scoped constants.
+            if (isRSpec(ctx, send->recv)) {
+                auto result =
+                    runSingle(ctx, /* isClass */ false, /* maybeSharedExamplesName */ nullptr, send, insideDescribe);
+                if (result != nullptr) {
+                    return result;
+                }
+            }
+            // For bare shared_examples inside parameterized blocks we don't handle them,
+            // because it's not clear what that should do and whether anyone actually uses it.
             //
             // We can revisit this choice if people complain about Sorbet lacking support for this.
             break;
@@ -585,9 +598,6 @@ ast::ExpressionPtr prepareParameterizedBody(core::MutableContext ctx, core::Name
 
     return body;
 }
-
-ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::ExpressionPtr &maybeSharedExamplesName,
-                             ast::Send *send, bool insideDescribe);
 
 ast::ExpressionPtr tryRunSingleOnSend(core::MutableContext ctx, bool isClass,
                                       const ast::ExpressionPtr &maybeSharedExamplesName, ast::ExpressionPtr body,

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -365,6 +365,17 @@ bool isSharedExamplesName(core::NameRef name) {
     }
 }
 
+// Rewrites include_examples/include_context to include(ConstantName), or returns EmptyTree to
+// silently drop the call if the argument is not a string/symbol literal (e.g. a block parameter
+// that can't be resolved at compile time). Must only be called after a numPosArgs >= 1 check.
+ast::ExpressionPtr rewriteIncludeExamples(core::MutableContext ctx, ast::Send *send) {
+    if (!ast::isa_tree<ast::Literal>(send->getPosArg(0))) {
+        return ast::MK::EmptyTree();
+    }
+    auto name = makeSharedExamplesConstant(ctx, send->getPosArg(0));
+    return ast::MK::Send1(send->loc, move(send->recv), core::Names::include(), send->funLoc, move(name));
+}
+
 ast::ExpressionPtr prepareParameterizedBody(core::MutableContext ctx, core::NameRef eachName, ast::ExpressionPtr body,
                                             const ast::MethodDef::PARAMS_store &args,
                                             absl::Span<const ast::ExpressionPtr> destructuringStmts,
@@ -519,17 +530,7 @@ ast::ExpressionPtr runUnderParameterized(core::MutableContext ctx, core::NameRef
                 break;
             }
 
-            // Only rewrite when the argument is a string/symbol literal. If it's a variable
-            // (e.g. a shared_examples block param), we can't resolve it at compile time.
-            // Return EmptyTree to silently drop the call rather than leaving a raw
-            // `include_examples(variable)` in the class body which would produce a
-            // method-not-found error.
-            if (!ast::isa_tree<ast::Literal>(send->getPosArg(0))) {
-                return ast::MK::EmptyTree();
-            }
-
-            auto name = makeSharedExamplesConstant(ctx, send->getPosArg(0));
-            return ast::MK::Send1(send->loc, move(send->recv), core::Names::include(), send->funLoc, move(name));
+            return rewriteIncludeExamples(ctx, send);
         }
     }
 
@@ -989,17 +990,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::
                 return nullptr;
             }
 
-            // Only rewrite when the argument is a string/symbol literal. If it's a variable
-            // (e.g. a shared_examples block param), we can't resolve it at compile time.
-            // Return EmptyTree to silently drop the call rather than leaving a raw
-            // `include_examples(variable)` in the class body which would produce a
-            // method-not-found error.
-            if (!ast::isa_tree<ast::Literal>(send->getPosArg(0))) {
-                return ast::MK::EmptyTree();
-            }
-
-            auto name = makeSharedExamplesConstant(ctx, send->getPosArg(0));
-            return ast::MK::Send1(send->loc, move(send->recv), core::Names::include(), send->funLoc, move(name));
+            return rewriteIncludeExamples(ctx, send);
         }
 
         case core::Names::itBehavesLike().rawId(): {

--- a/test/testdata/rewriter/rspec_include_examples_dynamic_arg.rb
+++ b/test/testdata/rewriter/rspec_include_examples_dynamic_arg.rb
@@ -40,3 +40,13 @@ RSpec.describe 'consumer' do
   include_examples 'suite alpha'
   include_examples 'suite beta'
 end
+
+# Dynamic arg in a non-parameterized describe block (exercises the runSingle path).
+# The call should be silently dropped rather than producing a spurious error.
+def suite_helper
+  'suite alpha'
+end
+
+RSpec.describe 'top-level dynamic' do
+  include_examples suite_helper
+end

--- a/test/testdata/rewriter/rspec_include_examples_dynamic_arg.rb
+++ b/test/testdata/rewriter/rspec_include_examples_dynamic_arg.rb
@@ -1,0 +1,42 @@
+# typed: true
+# enable-experimental-rspec: true
+# enable-experimental-requires-ancestor: true
+
+module RSpec
+  module Core
+    class ExampleGroup
+    end
+  end
+end
+
+# When include_examples / include_context is called with a non-literal argument
+# (e.g. a block parameter passed through from a parameterized shared_examples),
+# the rewriter must NOT attempt to rewrite it to `include(ConstantName)` because
+# the name cannot be resolved at compile time.  Previously this produced a
+# spurious "Unable to resolve constant <shared_examples 'foo'>" error.
+
+RSpec.shared_examples 'suite alpha' do
+  it 'passes' do
+  end
+end
+
+RSpec.shared_examples 'suite beta' do
+  it 'also passes' do
+  end
+end
+
+# Parameterized shared_examples that accepts the name of another shared_examples
+# as a block argument and forwards it via include_examples.
+RSpec.shared_examples 'runner' do |suite_name|
+  include_examples suite_name
+
+  context 'nested' do
+    include_examples suite_name
+  end
+end
+
+RSpec.describe 'consumer' do
+  # Literal argument — still works as before.
+  include_examples 'suite alpha'
+  include_examples 'suite beta'
+end

--- a/test/testdata/rewriter/rspec_include_examples_dynamic_arg.rb
+++ b/test/testdata/rewriter/rspec_include_examples_dynamic_arg.rb
@@ -1,6 +1,5 @@
 # typed: true
 # enable-experimental-rspec: true
-# enable-experimental-requires-ancestor: true
 
 module RSpec
   module Core

--- a/test/testdata/rewriter/rspec_include_examples_dynamic_arg.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_include_examples_dynamic_arg.rb.rewrite-tree.exp
@@ -1,0 +1,38 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  def suite_helper<<todo method>>(&<blk>)
+    "suite alpha"
+  end
+
+  module <emptyTree>::<C RSpec><<C <todo sym>>> < ()
+    module <emptyTree>::<C Core><<C <todo sym>>> < ()
+      class <emptyTree>::<C ExampleGroup><<C <todo sym>>> < (::<todo sym>)
+      end
+    end
+  end
+
+  module ::<root>::<C <shared_examples 'suite alpha'>><<C <todo sym>>> < ()
+    def <it 'passes'><<todo method>>(&<blk>)
+      <emptyTree>
+    end
+  end
+
+  module ::<root>::<C <shared_examples 'suite beta'>><<C <todo sym>>> < ()
+    def <it 'also passes'><<todo method>>(&<blk>)
+      <emptyTree>
+    end
+  end
+
+  module ::<root>::<C <shared_examples 'runner'>><<C <todo sym>>> < ()
+  end
+
+  class <emptyTree>::<C <describe 'consumer'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+    <self>.include(::<root>::<C <shared_examples 'suite alpha'>>)
+
+    <self>.include(::<root>::<C <shared_examples 'suite beta'>>)
+  end
+
+  <runtime method definition of suite_helper>
+
+  class <emptyTree>::<C <describe 'top-level dynamic'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+  end
+end

--- a/test/testdata/rewriter/rspec_shared_examples_in_local_context.rb
+++ b/test/testdata/rewriter/rspec_shared_examples_in_local_context.rb
@@ -1,0 +1,35 @@
+# typed: true
+# enable-experimental-rspec: true
+# enable-experimental-requires-ancestor: true
+
+module RSpec
+  module Core
+    class ExampleGroup
+    end
+  end
+end
+
+# RSpec.shared_examples/shared_context/shared_examples_for defined inside a
+# RSpec.local_context block should be registered as root-scoped constants and
+# be resolvable via include_context / include_examples in any describe block.
+RSpec.local_context do
+  RSpec.shared_context 'nested context inside local context' do
+    let(:value) { 42 }
+  end
+
+  RSpec.shared_examples 'nested examples inside local context' do
+    it 'works' do
+    end
+  end
+
+  RSpec.shared_examples_for 'nested examples_for inside local context' do
+    it 'also works' do
+    end
+  end
+end
+
+RSpec.describe 'consumer' do
+  include_context 'nested context inside local context'
+  include_examples 'nested examples inside local context'
+  include_examples 'nested examples_for inside local context'
+end

--- a/test/testdata/rewriter/rspec_shared_examples_in_local_context.rb
+++ b/test/testdata/rewriter/rspec_shared_examples_in_local_context.rb
@@ -1,6 +1,5 @@
 # typed: true
 # enable-experimental-rspec: true
-# enable-experimental-requires-ancestor: true
 
 module RSpec
   module Core

--- a/test/testdata/rewriter/rspec_shared_examples_in_local_context.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_shared_examples_in_local_context.rb.rewrite-tree.exp
@@ -1,0 +1,36 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C RSpec><<C <todo sym>>> < ()
+    module <emptyTree>::<C Core><<C <todo sym>>> < ()
+      class <emptyTree>::<C ExampleGroup><<C <todo sym>>> < (::<todo sym>)
+      end
+    end
+  end
+
+  module ::<root>::<C <shared_examples 'nested context inside local context'>><<C <todo sym>>> < ()
+    def value<<todo method>>(&<blk>)
+      42
+    end
+
+    <runtime method definition of value>
+  end
+
+  module ::<root>::<C <shared_examples 'nested examples inside local context'>><<C <todo sym>>> < ()
+    def <it 'works'><<todo method>>(&<blk>)
+      <emptyTree>
+    end
+  end
+
+  module ::<root>::<C <shared_examples 'nested examples_for inside local context'>><<C <todo sym>>> < ()
+    def <it 'also works'><<todo method>>(&<blk>)
+      <emptyTree>
+    end
+  end
+
+  class <emptyTree>::<C <describe 'consumer'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+    <self>.include(::<root>::<C <shared_examples 'nested context inside local context'>>)
+
+    <self>.include(::<root>::<C <shared_examples 'nested examples inside local context'>>)
+
+    <self>.include(::<root>::<C <shared_examples 'nested examples_for inside local context'>>)
+  end
+end

--- a/test/testdata/rewriter/rspec_shared_examples_in_parameterized_context.rb
+++ b/test/testdata/rewriter/rspec_shared_examples_in_parameterized_context.rb
@@ -1,0 +1,36 @@
+# typed: true
+# enable-experimental-rspec: true
+# enable-experimental-requires-ancestor: true
+
+module RSpec
+  module Core
+    class ExampleGroup
+    end
+  end
+end
+
+# `RSpec.shared_context` / `RSpec.shared_examples` defined inside a parameterized
+# shared context (one with block params) should be registered as root-scoped
+# constants and be resolvable via `include_context` / `include_examples`.
+RSpec.shared_context 'outer parameterized context' do |setup_version: 'v1'|
+  RSpec.shared_context 'nested context inside parameterized' do
+    let(:value) { 42 }
+  end
+
+  RSpec.shared_examples 'nested examples inside parameterized' do
+    it 'works' do
+    end
+  end
+
+  RSpec.shared_examples_for 'nested examples_for inside parameterized' do
+    it 'also works' do
+    end
+  end
+end
+
+RSpec.describe 'consumer' do
+  include_context 'outer parameterized context'
+  include_context 'nested context inside parameterized'
+  include_examples 'nested examples inside parameterized'
+  include_examples 'nested examples_for inside parameterized'
+end

--- a/test/testdata/rewriter/rspec_shared_examples_in_parameterized_context.rb
+++ b/test/testdata/rewriter/rspec_shared_examples_in_parameterized_context.rb
@@ -1,6 +1,5 @@
 # typed: true
 # enable-experimental-rspec: true
-# enable-experimental-requires-ancestor: true
 
 module RSpec
   module Core

--- a/test/testdata/rewriter/rspec_shared_examples_in_parameterized_context.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_shared_examples_in_parameterized_context.rb.rewrite-tree.exp
@@ -1,0 +1,40 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C RSpec><<C <todo sym>>> < ()
+    module <emptyTree>::<C Core><<C <todo sym>>> < ()
+      class <emptyTree>::<C ExampleGroup><<C <todo sym>>> < (::<todo sym>)
+      end
+    end
+  end
+
+  module ::<root>::<C <shared_examples 'outer parameterized context'>><<C <todo sym>>> < ()
+    module ::<root>::<C <shared_examples 'nested context inside parameterized'>><<C <todo sym>>> < ()
+      def value<<todo method>>(&<blk>)
+        42
+      end
+
+      <runtime method definition of value>
+    end
+
+    module ::<root>::<C <shared_examples 'nested examples inside parameterized'>><<C <todo sym>>> < ()
+      def <it 'works'><<todo method>>(&<blk>)
+        <emptyTree>
+      end
+    end
+
+    module ::<root>::<C <shared_examples 'nested examples_for inside parameterized'>><<C <todo sym>>> < ()
+      def <it 'also works'><<todo method>>(&<blk>)
+        <emptyTree>
+      end
+    end
+  end
+
+  class <emptyTree>::<C <describe 'consumer'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+    <self>.include(::<root>::<C <shared_examples 'outer parameterized context'>>)
+
+    <self>.include(::<root>::<C <shared_examples 'nested context inside parameterized'>>)
+
+    <self>.include(::<root>::<C <shared_examples 'nested examples inside parameterized'>>)
+
+    <self>.include(::<root>::<C <shared_examples 'nested examples_for inside parameterized'>>)
+  end
+end


### PR DESCRIPTION
Two related fixes for the RSpec rewriter that address patterns where shared examples are defined or referenced in non-obvious scopes.

### Fix 1: RSpec.local_context support

`RSpec.local_context` is an `instance_eval`-based DSL pattern where a block is stored and later evaluated in the context of a describe group. Any `RSpec.shared_examples/shared_context` defined inside such a block is registered globally at runtime, but the sorbet rewriter never saw these definitions because it didn't recognize `local_context` as a container to scan.

The fix registers `local_context` as a known name and adds handling in `Minitest::run`: when `RSpec.local_context do ... end` is encountered with `--enable-experimental-rspec`, the block body is scanned (one level deep — direct Send children only) and any `RSpec.shared_examples/shared_context/shared_examples_for` calls are hoisted to the top-level scope as module definitions.

### Fix 2: Dynamic include_examples arguments

When `include_examples` or `include_context` is called with a non-literal argument — e.g. a block parameter forwarded from a parameterized `shared_examples`:

```ruby
RSpec.shared_examples 'runner' do |suite_name|
  include_examples suite_name
end
```

...the rewriter was synthesizing a constant `<shared_examples 'suite_name'>` (using the variable name as the literal), which then failed to resolve. The fix adds a literal guard in both `runUnderParameterized` and `runSingle`: if the argument is not a string/symbol literal, the call is silently dropped (`EmptyTree` in both paths) rather than producing a spurious constant resolution error.

### Motivation

Both issues were discovered while running this version of sorbet against a large Rails monorepo. The combination produced hundreds of false-positive type errors that obscured real issues.

### Test plan

See included automated tests.

- `rspec_shared_examples_in_local_context.rb` — verifies `shared_context`, `shared_examples`, and `shared_examples_for` defined inside `RSpec.local_context` are resolvable via `include_context`/`include_examples`.
- `rspec_include_examples_dynamic_arg.rb` — verifies that `include_examples suite_name` where `suite_name` is a block parameter produces no errors (exercises `runUnderParameterized` path), and that a dynamic arg in a non-parameterized `describe` block is also silently dropped (exercises `runSingle` path).
- `rspec_shared_examples_in_parameterized_context.rb` — verifies `RSpec.shared_context`/`shared_examples` defined inside a parameterized shared context are resolvable from outside.

-----------------

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
