### PR TITLE
Add Set::SubclassCompatible to stdlib set RBI

### DIFF
--- a/rbi/stdlib/set.rbi
+++ b/rbi/stdlib/set.rbi
@@ -1065,6 +1065,7 @@ class Set < Object
   # Source: https://github.com/ruby/ruby/blob/master/lib/set/subclass_compatible.rb
   module SubclassCompatible
     module ClassMethods; end
+    private_constant :SubclassCompatible
   end
 end
 

--- a/rbi/stdlib/set.rbi
+++ b/rbi/stdlib/set.rbi
@@ -1065,8 +1065,8 @@ class Set < Object
   # Source: https://github.com/ruby/ruby/blob/master/lib/set/subclass_compatible.rb
   module SubclassCompatible
     module ClassMethods; end
-    private_constant :SubclassCompatible
   end
+  private_constant :SubclassCompatible
 end
 
 # [`SortedSet`](https://docs.ruby-lang.org/en/2.7.0/SortedSet.html) implements a

--- a/rbi/stdlib/set.rbi
+++ b/rbi/stdlib/set.rbi
@@ -1057,6 +1057,15 @@ class Set < Object
   # Clone internal hash.
   sig { params(orig: T::Set[Elem], options: T.untyped).returns(T::Set[Elem]) }
   def initialize_clone(orig, **options); end
+
+  # Provides backwards compatibility for subclasses of Set with the pure-Ruby
+  # Set implementation used before Ruby 4. Automatically included in Set
+  # subclasses.
+  #
+  # Source: https://github.com/ruby/ruby/blob/master/lib/set/subclass_compatible.rb
+  module SubclassCompatible
+    module ClassMethods; end
+  end
 end
 
 # [`SortedSet`](https://docs.ruby-lang.org/en/2.7.0/SortedSet.html) implements a


### PR DESCRIPTION
## Summary

`Set::SubclassCompatible` is a module introduced in Ruby 4 that is automatically included in subclasses of `Set` to maintain backwards compatibility with the pure-Ruby implementation used before Ruby 4 (see [`lib/set/subclass_compatible.rb`](https://github.com/ruby/ruby/blob/master/lib/set/subclass_compatible.rb)).

Gems that subclass `Set` (e.g. `concurrent-ruby`, which defines `CRubySet < ::Set`) will have `Set::SubclassCompatible` included in those subclasses at runtime on Ruby 4. When tapioca introspects those classes and generates RBIs, it faithfully emits the `include`/`extend` calls:

```
include ::Set::SubclassCompatible
extend  ::Set::SubclassCompatible::ClassMethods
```

Without this definition in the stdlib RBI, Sorbet reports unresolved constant errors on those generated RBIs.

This PR adds the namespace stubs for `Set::SubclassCompatible` and `Set::SubclassCompatible::ClassMethods` so Sorbet can resolve those constants.