### PR TITLE
Remove id2ref, because it's deprecated

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -439,12 +439,6 @@ module T::Private::Methods
     method_owner_and_name_to_key(method.owner, method.name)
   end
 
-  private_class_method def self.key_to_method(key)
-    id, name = key.split("#")
-    obj = ObjectSpace._id2ref(id.to_i)
-    obj.instance_method(name)
-  end
-
   private_class_method def self.run_sig_block_for_key(key, force_type_init: false)
     blk = @sig_wrappers[key]
     if !blk
@@ -453,7 +447,7 @@ module T::Private::Methods
         # We already ran the sig block, perhaps in another thread.
         return sig
       else
-        raise "No `sig` wrapper for #{key_to_method(key)}"
+        raise "No `sig` wrapper for #{key}. This is likely a bug in sorbet-runtime. If you can reproduce, please report an issue."
       end
     end
 
@@ -464,7 +458,7 @@ module T::Private::Methods
       raise
     end
     if @sigs_that_raised[key]
-      raise "A previous invocation of #{key_to_method(key)} raised, and the current one succeeded. Please don't do that."
+      raise "A previous invocation of #{sig.method_desc} raised, and the current one succeeded. Please don't do that."
     end
 
     @sig_wrappers.delete(key)


### PR DESCRIPTION
This was only used in error messages.

1.  The first usage is an untested, unknown class of issue in Sorbet.
    It's unclear what could cause it, and it's unclear what information
    might be present to help debug it. I think it's probably better to
    defer that until we have a case of someone running into this (e.g.,
    possibly the specific way that this manifests means that we actually
    have an `UnboundMethod` object in scope somewhere, and we could
    add debugging prints elsewhere to print it before the crash).

2.  The second usage is in a context where we already have the desired
    information because there's a reference to it in the `sig`, so we
    can just use that instead. I also took the opportunity to make the
    error slightly better by using `method_desc`, which will also show
    the location of the method, if it has one.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Supercedes the changes in #8788, because using a WeakMap was overkill for
something that is exceedingly rare.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

There is a test of (2) that still passes with these changes.

As far as I can tell, (1) is untested and would represent a bug in
sorbet-runtime if it were to happen.