### PR TITLE
Package-directed preemption support

### DIFF
--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -218,6 +218,10 @@ void LSPTask::preprocess(LSPPreprocessor &preprocessor) {}
 
 void LSPTask::index(LSPIndexer &indexer) {}
 
+core::packages::Stratum LSPTask::preemptionStratum(FileStratumMapping info) const {
+    return info.getLastStratum();
+}
+
 LSPRequestTask::LSPRequestTask(const LSPConfiguration &config, MessageId id, LSPMethod method)
     : LSPTask(config, method), id(move(id)) {}
 

--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -91,6 +91,10 @@ public:
     // Runs the task. Is only ever invoked from the typechecker thread. Since it is exceedingly rare for a request to
     // not need to interface with the typechecker, this method must be implemented by all subclasses.
     virtual void run(LSPTypecheckerDelegate &typechecker) = 0;
+
+    // The stratum that this task is runnable at, if running from the preemption scheduler. By default this returns the
+    // last stratum, which is a conservatively correct choice for any task that supports preemption.
+    virtual core::packages::Stratum preemptionStratum(FileStratumMapping info) const;
 };
 
 /**

--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -115,6 +115,8 @@ public:
     Phase finalPhase() const override;
 
     bool cancel(const MessageId &id) override;
+
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override = 0;
 };
 
 // Doubles as the `methodString` for a `TextDocumentCompletion` LSPTask and also as

--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -179,6 +179,15 @@ public:
                 if (!indexer.preemptionPossible(taskQueue.tasks())) {
                     break;
                 }
+
+                // If we haven't reached a stratum that's sufficient for running this task, indicate that preemption
+                // should be rescheduled for later.
+                auto neededStratum = taskQueue.tasks().front()->preemptionStratum(delegate.getFileStratumMapping());
+                if (currentStratum < neededStratum) {
+                    result.setRescheduledStratum(neededStratum);
+                    return result;
+                }
+
                 task = move(taskQueue.tasks().front());
                 taskQueue.tasks().pop_front();
 

--- a/main/lsp/notifications/did_change_configuration.cc
+++ b/main/lsp/notifications/did_change_configuration.cc
@@ -43,4 +43,9 @@ void DidChangeConfigurationTask::run(LSPTypecheckerDelegate &tc) {
     updates->epoch = epoch;
     tc.typecheckOnFastPath(std::move(updates), {});
 }
+
+core::packages::Stratum DidChangeConfigurationTask::preemptionStratum(FileStratumMapping info) const {
+    return info.getStratumForPaths(this->openFilePaths);
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/notifications/did_change_configuration.h
+++ b/main/lsp/notifications/did_change_configuration.h
@@ -19,6 +19,8 @@ public:
     void index(LSPIndexer &indexer) override;
 
     void run(LSPTypecheckerDelegate &tc) override;
+
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
 };
 } // namespace sorbet::realmain::lsp
 

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -1,4 +1,5 @@
 #include "main/lsp/notifications/sorbet_workspace_edit.h"
+#include "absl/algorithm/container.h"
 #include "core/lsp/TypecheckEpochManager.h"
 #include "main/lsp/LSPFileUpdates.h"
 #include "main/lsp/LSPIndexer.h"
@@ -159,6 +160,13 @@ bool SorbetWorkspaceEditTask::canPreempt(const LSPIndexer &index) const {
 
 const SorbetWorkspaceEditParams &SorbetWorkspaceEditTask::getParams() const {
     return *params;
+}
+
+core::packages::Stratum SorbetWorkspaceEditTask::preemptionStratum(FileStratumMapping info) const {
+    vector<string_view> paths;
+    paths.reserve(this->params->updates.size());
+    absl::c_transform(this->params->updates, back_inserter(paths), [](auto &file) { return file->path(); });
+    return info.getStratumForPaths(paths);
 }
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/notifications/sorbet_workspace_edit.h
+++ b/main/lsp/notifications/sorbet_workspace_edit.h
@@ -34,6 +34,7 @@ public:
     void run(LSPTypecheckerDelegate &typechecker) override;
     void runSpecial(LSPTypechecker &typechecker, WorkerPool &workers) override;
     void schedulerWaitUntilReady() override;
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
 
     bool canPreempt(const LSPIndexer &index) const override;
     TypecheckingPath getTypecheckingPath(const LSPIndexer &index) const;

--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -373,4 +373,8 @@ unique_ptr<ResponseMessage> CodeActionTask::runRequest(LSPTypecheckerDelegate &t
     return response;
 }
 
+core::packages::Stratum CodeActionTask::preemptionStratum(FileStratumMapping info) const {
+    return info.getStratumForUri(this->params->textDocument->uri);
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/code_action.h
+++ b/main/lsp/requests/code_action.h
@@ -13,6 +13,8 @@ public:
     CodeActionTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<CodeActionParams> params);
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/code_action_resolve.cc
+++ b/main/lsp/requests/code_action_resolve.cc
@@ -120,4 +120,12 @@ unique_ptr<ResponseMessage> CodeActionResolveTask::runRequest(LSPTypecheckerDele
     return response;
 }
 
+core::packages::Stratum CodeActionResolveTask::preemptionStratum(FileStratumMapping info) const {
+    if (auto &insertOverride = this->params->data.value()->insertOverride) {
+        return info.getStratumForUri(insertOverride.value()->textDocument->uri);
+    }
+
+    return info.getStratumForUri(this->params->data.value()->params->textDocument->uri);
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/code_action_resolve.h
+++ b/main/lsp/requests/code_action_resolve.h
@@ -12,6 +12,8 @@ public:
     CodeActionResolveTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<CodeAction> params);
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -1704,4 +1704,8 @@ unique_ptr<ResponseMessage> CompletionTask::runRequest(LSPTypecheckerDelegate &t
     return response;
 }
 
+core::packages::Stratum CompletionTask::preemptionStratum(FileStratumMapping info) const {
+    return info.getStratumForUri(this->params->textDocument->uri);
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/completion.h
+++ b/main/lsp/requests/completion.h
@@ -83,6 +83,10 @@ public:
     CompletionTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<CompletionParams> params);
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+
+    std::unique_ptr<ResponseMessage> serverCancel();
+
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/definition.cc
+++ b/main/lsp/requests/definition.cc
@@ -156,4 +156,8 @@ unique_ptr<ResponseMessage> DefinitionTask::runRequest(LSPTypecheckerDelegate &t
     return response;
 }
 
+core::packages::Stratum DefinitionTask::preemptionStratum(FileStratumMapping info) const {
+    return info.getStratumForUri(this->params->textDocument->uri);
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/definition.h
+++ b/main/lsp/requests/definition.h
@@ -12,6 +12,8 @@ public:
     DefinitionTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<TextDocumentPositionParams> params);
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/document_formatting.cc
+++ b/main/lsp/requests/document_formatting.cc
@@ -159,4 +159,9 @@ unique_ptr<ResponseMessage> DocumentFormattingTask::runRequest(LSPTypecheckerDel
     Exception::raise("Unimplemented and unused");
 }
 
+core::packages::Stratum DocumentFormattingTask::preemptionStratum(FileStratumMapping info) const {
+    ENFORCE(false, "Document formatting should be handled by the preprocessor");
+    return info.getLastStratum();
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/document_formatting.h
+++ b/main/lsp/requests/document_formatting.h
@@ -18,6 +18,8 @@ public:
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
 
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
+
 private:
     void displayError(std::string errorMessage, std::unique_ptr<ResponseMessage> &response);
 };

--- a/main/lsp/requests/document_highlight.cc
+++ b/main/lsp/requests/document_highlight.cc
@@ -113,4 +113,8 @@ unique_ptr<ResponseMessage> DocumentHighlightTask::runRequest(LSPTypecheckerDele
     return response;
 }
 
+core::packages::Stratum DocumentHighlightTask::preemptionStratum(FileStratumMapping info) const {
+    return info.getStratumForUri(this->params->textDocument->uri);
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/document_highlight.h
+++ b/main/lsp/requests/document_highlight.h
@@ -13,6 +13,8 @@ public:
                           std::unique_ptr<TextDocumentPositionParams> params);
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/document_symbol.cc
+++ b/main/lsp/requests/document_symbol.cc
@@ -212,4 +212,8 @@ unique_ptr<ResponseMessage> DocumentSymbolTask::runRequest(LSPTypecheckerDelegat
     return response;
 }
 
+core::packages::Stratum DocumentSymbolTask::preemptionStratum(FileStratumMapping info) const {
+    return info.getStratumForUri(this->params->textDocument->uri);
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/document_symbol.h
+++ b/main/lsp/requests/document_symbol.h
@@ -14,6 +14,8 @@ public:
     bool isDelayable() const override;
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/hover.cc
+++ b/main/lsp/requests/hover.cc
@@ -210,4 +210,8 @@ unique_ptr<ResponseMessage> HoverTask::runRequest(LSPTypecheckerDelegate &typech
     return response;
 }
 
+core::packages::Stratum HoverTask::preemptionStratum(FileStratumMapping info) const {
+    return info.getStratumForUri(this->params->textDocument->uri);
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/hover.h
+++ b/main/lsp/requests/hover.h
@@ -12,6 +12,8 @@ public:
     HoverTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<TextDocumentPositionParams> params);
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/implementation.cc
+++ b/main/lsp/requests/implementation.cc
@@ -146,4 +146,9 @@ unique_ptr<ResponseMessage> ImplementationTask::runRequest(LSPTypecheckerDelegat
     response->result = move(result);
     return response;
 }
+
+core::packages::Stratum ImplementationTask::preemptionStratum(FileStratumMapping info) const {
+    return info.getStratumForUri(this->params->textDocument->uri);
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/implementation.h
+++ b/main/lsp/requests/implementation.h
@@ -13,6 +13,8 @@ public:
     ImplementationTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<ImplementationParams> params);
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/initialize.cc
+++ b/main/lsp/requests/initialize.cc
@@ -55,4 +55,11 @@ unique_ptr<ResponseMessage> InitializeTask::runRequest(LSPTypecheckerDelegate &t
     response->result = make_unique<InitializeResult>(move(serverCap));
     return response;
 }
+
+core::packages::Stratum InitializeTask::preemptionStratum(FileStratumMapping info) const {
+    // Initialization will never happen from a preemption context.
+    ENFORCE(false, "Initialization should never happen from preemption");
+    return info.getLastStratum();
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/initialize.h
+++ b/main/lsp/requests/initialize.h
@@ -20,6 +20,8 @@ protected:
     void preprocess(LSPPreprocessor &preprocessor) override;
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &ts) override;
+
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
 };
 } // namespace sorbet::realmain::lsp
 

--- a/main/lsp/requests/prepare_rename.cc
+++ b/main/lsp/requests/prepare_rename.cc
@@ -132,4 +132,10 @@ unique_ptr<ResponseMessage> PrepareRenameTask::runRequest(LSPTypecheckerDelegate
     return response;
 }
 
+core::packages::Stratum PrepareRenameTask::preemptionStratum(FileStratumMapping info) const {
+    // We can't tell how far the rename will go, so we conservatively say that we can preempt at the end of the package
+    // graph.
+    return info.getLastStratum();
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/prepare_rename.h
+++ b/main/lsp/requests/prepare_rename.h
@@ -12,6 +12,8 @@ public:
     PrepareRenameTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<TextDocumentPositionParams> params);
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -292,4 +292,9 @@ unique_ptr<ResponseMessage> ReferencesTask::runRequest(LSPTypecheckerDelegate &t
     return response;
 }
 
+core::packages::Stratum ReferencesTask::preemptionStratum(FileStratumMapping info) const {
+    // We can't tell how much of the codebase we'd need to see, so we conservatively default to the whole thing.
+    return info.getLastStratum();
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/references.h
+++ b/main/lsp/requests/references.h
@@ -16,6 +16,8 @@ public:
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
 
     bool canPreempt(const LSPIndexer &indexer) const override;
+
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/rename.cc
+++ b/main/lsp/requests/rename.cc
@@ -384,4 +384,10 @@ unique_ptr<ResponseMessage> RenameTask::runRequest(LSPTypecheckerDelegate &typec
     return response;
 }
 
+core::packages::Stratum RenameTask::preemptionStratum(FileStratumMapping info) const {
+    // We can't tell how far the rename will go, so we conservatively say that we can preempt at the end of the package
+    // graph.
+    return info.getLastStratum();
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/rename.h
+++ b/main/lsp/requests/rename.h
@@ -13,6 +13,8 @@ public:
     RenameTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<RenameParams> params);
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/shutdown.cc
+++ b/main/lsp/requests/shutdown.cc
@@ -11,6 +11,10 @@ bool ShutdownTask::canPreempt(const LSPIndexer &indexer) const {
     return true;
 }
 
+core::packages::Stratum ShutdownTask::preemptionStratum(FileStratumMapping info) const {
+    return core::packages::Stratum(0);
+}
+
 unique_ptr<ResponseMessage> ShutdownTask::runRequest(LSPTypecheckerDelegate &ts) {
     auto response = make_unique<ResponseMessage>("2.0", id, LSPMethod::Shutdown);
     response->result = JSONNullObject();

--- a/main/lsp/requests/shutdown.h
+++ b/main/lsp/requests/shutdown.h
@@ -10,6 +10,8 @@ public:
 
     bool canPreempt(const LSPIndexer &indexer) const override;
 
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
+
 protected:
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &ts) override;
 };

--- a/main/lsp/requests/signature_help.cc
+++ b/main/lsp/requests/signature_help.cc
@@ -122,4 +122,9 @@ unique_ptr<ResponseMessage> SignatureHelpTask::runRequest(LSPTypecheckerDelegate
     response->result = move(sigHelp);
     return response;
 }
+
+core::packages::Stratum SignatureHelpTask::preemptionStratum(FileStratumMapping info) const {
+    return info.getStratumForUri(this->params->textDocument->uri);
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/signature_help.h
+++ b/main/lsp/requests/signature_help.h
@@ -12,6 +12,8 @@ public:
     SignatureHelpTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<TextDocumentPositionParams> params);
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/sorbet_read_file.cc
+++ b/main/lsp/requests/sorbet_read_file.cc
@@ -23,4 +23,9 @@ unique_ptr<ResponseMessage> SorbetReadFileTask::runRequest(LSPTypecheckerDelegat
     return response;
 }
 
+core::packages::Stratum SorbetReadFileTask::preemptionStratum(FileStratumMapping info) const {
+    // This task only interacts with the file table.
+    return core::packages::Stratum(0);
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/sorbet_read_file.h
+++ b/main/lsp/requests/sorbet_read_file.h
@@ -12,6 +12,8 @@ public:
     SorbetReadFileTask(const LSPConfiguration &config, MessageId id, std::unique_ptr<TextDocumentIdentifier> params);
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/sorbet_show_symbol.cc
+++ b/main/lsp/requests/sorbet_show_symbol.cc
@@ -87,4 +87,8 @@ unique_ptr<ResponseMessage> SorbetShowSymbolTask::runRequest(LSPTypecheckerDeleg
     return response;
 }
 
+core::packages::Stratum SorbetShowSymbolTask::preemptionStratum(FileStratumMapping info) const {
+    return info.getStratumForUri(this->params->textDocument->uri);
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/sorbet_show_symbol.h
+++ b/main/lsp/requests/sorbet_show_symbol.h
@@ -13,6 +13,8 @@ public:
                          std::unique_ptr<TextDocumentPositionParams> params);
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/type_definition.cc
+++ b/main/lsp/requests/type_definition.cc
@@ -146,4 +146,9 @@ unique_ptr<ResponseMessage> TypeDefinitionTask::runRequest(LSPTypecheckerDelegat
     response->result = move(locations);
     return response;
 }
+
+core::packages::Stratum TypeDefinitionTask::preemptionStratum(FileStratumMapping info) const {
+    return info.getStratumForUri(this->params->textDocument->uri);
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/type_definition.h
+++ b/main/lsp/requests/type_definition.h
@@ -13,6 +13,8 @@ public:
                        std::unique_ptr<TextDocumentPositionParams> params);
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/workspace_symbols.cc
+++ b/main/lsp/requests/workspace_symbols.cc
@@ -343,4 +343,10 @@ unique_ptr<ResponseMessage> WorkspaceSymbolsTask::runRequest(LSPTypecheckerDeleg
     response->result = matcher.doQuery(params->query);
     return response;
 }
+
+core::packages::Stratum WorkspaceSymbolsTask::preemptionStratum(FileStratumMapping info) const {
+    // This request requires the whole codebase, so we can only support preemption in the final stratum.
+    return info.getLastStratum();
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/workspace_symbols.h
+++ b/main/lsp/requests/workspace_symbols.h
@@ -14,6 +14,8 @@ public:
     bool isDelayable() const override;
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
+
+    core::packages::Stratum preemptionStratum(FileStratumMapping info) const override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -4,6 +4,7 @@
 #include "common/common.h"
 #include "common/sort/sort.h"
 #include "test/helpers/lsp.h"
+#include "test/helpers/packages.h"
 #include "test/lsp/ProtocolTest.h"
 
 using namespace std;
@@ -1451,4 +1452,317 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanPreemptDoesNotCrashOnEvictedFil
     // Drain the pipeline with a fence.
     assertErrorDiagnostics(send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20))), {});
 }
+
+// This case shows how preemption works when the preemption tasks occur in a stratum that's at or before the one that
+// contains the file that kicked off the slow path.
+TEST_CASE_FIXTURE(MultithreadedProtocolTest, "PackageDirectedPreemptionBeforeSlowPathStratum") {
+    auto opts = make_shared<realmain::options::Options>();
+    opts->cacheSensitiveOptions.sorbetPackages = true;
+    opts->packageDirected = true;
+    resetState(opts);
+
+    vector<pair<string, string>> files = {
+        {"__package.rb", PackageTextBuilder().withName("Root").withExports({"Root::A"}).build()},
+        {"a.rb", "# typed: true\n"
+                 "module Root\n"
+                 "  class A\n"
+                 "    def fun\n"
+                 "    end\n"
+                 "  end\n"
+                 "end\n"},
+        {"foo/__package.rb",
+         PackageTextBuilder().withName("Root::Foo").withExports({"Root::Foo::A"}).withImports({"Root"}).build()},
+        {"foo/a.rb", "# typed: true\n"
+                     "module Root::Foo\n"
+                     "  class A\n"
+                     "    def foo\n"
+                     "      Root::A.new()\n"
+                     "    end\n"
+                     "  end\n"
+                     "end\n"},
+    };
+
+    writeFilesToFS(files);
+
+    for (auto &[path, _] : files) {
+        this->lspWrapper->opts->inputFileNames.emplace_back(fmt::format("{}/{}", this->rootPath, path));
+    }
+
+    auto initOptions = make_unique<SorbetInitializationOptions>();
+    initOptions->enableTypecheckInfo = true;
+    assertErrorDiagnostics(
+        initializeLSP(true /* supportsMarkdown */, true /* supportsCodeActionResolve */, move(initOptions)), {});
+
+    assertErrorDiagnostics(send(*openFile("a.rb", files[1].second)), {});
+
+    assertErrorDiagnostics(send(*openFile("foo/b.rb", "# typed: true\n"
+                                                      "module Root::Foo\n"
+                                                      "  class Bar\n"
+                                                      "  end\n"
+                                                      "end\n")),
+                           {});
+
+    setSlowPathBlocked(true);
+
+    {
+        auto cancellationExpected = false;
+
+        // We're expecting one preemption from each of the following sub-cases.
+        auto preemptionsExpected = 1;
+
+        sendAsync(*changeFile("foo/b.rb",
+                              "# typed: true\n"
+                              "module Root::Foo\n"
+                              "  class Bar\n"
+                              "    class Inner\n"
+                              "      def bar\n"
+                              "        Root::A.n\n"
+                              "      end\n"
+                              "    end\n"
+                              "  end\n"
+                              "end\n",
+                              2, cancellationExpected, preemptionsExpected));
+    }
+
+    // Wait for typechecking to start.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    SUBCASE("completion") {
+        // Send a completion request at the end of `Root::A.`
+        sendAsync(*completion("foo/b.rb", 5, 16));
+
+        setSlowPathBlocked(false);
+
+        // This is the completion result
+        auto resp = readAsync();
+        REQUIRE(resp->isResponse());
+        CHECK_EQ(resp->asResponse().requestMethod, LSPMethod::TextDocumentCompletion);
+    }
+
+    SUBCASE("hover") {
+        // Send a hover request at the end of `Root::A.`
+        sendAsync(*hover("foo/b.rb", 5, 14));
+
+        setSlowPathBlocked(false);
+
+        // This is the hover result
+        auto resp = readAsync();
+        REQUIRE(resp->isResponse());
+        CHECK_EQ(resp->asResponse().requestMethod, LSPMethod::TextDocumentHover);
+    }
+
+    SUBCASE("fast_path_edit") {
+        // Make a fast-path edit to a.rb
+        sendAsync(*changeFile("a.rb",
+                              "# typed: true\n"
+                              "module Root\n"
+                              "  class A\n"
+                              "    def fun\n"
+                              "      A.new\n"
+                              "    end\n"
+                              "  end\n"
+                              "end\n",
+                              2));
+
+        setSlowPathBlocked(false);
+
+        // We should see a fast path start notification
+        {
+            auto diag = readAsync();
+            REQUIRE(diag->isNotification());
+            REQUIRE_EQ(diag->asNotification().method, LSPMethod::SorbetTypecheckRunInfo);
+            auto &runInfo = get<unique_ptr<SorbetTypecheckRunInfo>>(diag->asNotification().params);
+            CHECK_EQ(runInfo->typecheckingPath, TypecheckingPath::Fast);
+            CHECK_EQ(runInfo->status, SorbetTypecheckRunStatus::Started);
+            CHECK(runInfo->filesTypechecked.empty());
+        }
+
+        // And then a fast path end notification
+        {
+            auto diag = readAsync();
+            REQUIRE(diag->isNotification());
+            REQUIRE_EQ(diag->asNotification().method, LSPMethod::SorbetTypecheckRunInfo);
+            auto &runInfo = get<unique_ptr<SorbetTypecheckRunInfo>>(diag->asNotification().params);
+            CHECK_EQ(runInfo->typecheckingPath, TypecheckingPath::Fast);
+            CHECK_EQ(runInfo->status, SorbetTypecheckRunStatus::Ended);
+            REQUIRE_EQ(runInfo->filesTypechecked.size(), 1);
+            CHECK_EQ(runInfo->filesTypechecked.front(), fmt::format("{}/a.rb", this->rootPath));
+        }
+    }
+
+    // This is the slow path publishing a notification about the call to Roo::A.n
+    auto diag = readAsync();
+    REQUIRE(diag->isNotification());
+    CHECK_EQ(diag->asNotification().method, LSPMethod::TextDocumentPublishDiagnostics);
+
+    // Finally, we'll see the slow path end
+    {
+        auto diag = readAsync();
+        REQUIRE(diag->isNotification());
+        REQUIRE_EQ(diag->asNotification().method, LSPMethod::SorbetTypecheckRunInfo);
+        auto &runInfo = get<unique_ptr<SorbetTypecheckRunInfo>>(diag->asNotification().params);
+        CHECK_EQ(runInfo->typecheckingPath, TypecheckingPath::Slow);
+        CHECK_EQ(runInfo->status, SorbetTypecheckRunStatus::Ended);
+    }
+}
+
+// This case shows how preemption works when the preemption tasks occur in a stratum that's after the one that contains
+// the file that kicked off the slow path.
+TEST_CASE_FIXTURE(MultithreadedProtocolTest, "PackageDirectedPreemptionAfterSlowPathStratum") {
+    auto opts = make_shared<realmain::options::Options>();
+    opts->cacheSensitiveOptions.sorbetPackages = true;
+    opts->packageDirected = true;
+    resetState(opts);
+
+    vector<pair<string, string>> files = {
+        {"__package.rb", PackageTextBuilder().withName("Root").withExports({"Root::A"}).build()},
+        {"a.rb", "# typed: true\n"
+                 "module Root\n"
+                 "  class A\n"
+                 "    def fun\n"
+                 "    end\n"
+                 "  end\n"
+                 "end\n"},
+        {"foo/__package.rb",
+         PackageTextBuilder().withName("Root::Foo").withExports({"Root::Foo::A"}).withImports({"Root"}).build()},
+        {"foo/a.rb", "# typed: true\n"
+                     "module Root::Foo\n"
+                     "  class A\n"
+                     "    def foo\n"
+                     "      Root::A.new()\n"
+                     "    end\n"
+                     "  end\n"
+                     "end\n"},
+    };
+
+    writeFilesToFS(files);
+
+    for (auto &[path, _] : files) {
+        this->lspWrapper->opts->inputFileNames.emplace_back(fmt::format("{}/{}", this->rootPath, path));
+    }
+
+    auto initOptions = make_unique<SorbetInitializationOptions>();
+    initOptions->enableTypecheckInfo = true;
+    assertErrorDiagnostics(
+        initializeLSP(true /* supportsMarkdown */, true /* supportsCodeActionResolve */, move(initOptions)), {});
+
+    // Add a new file in the first stratum
+    assertErrorDiagnostics(send(*openFile("b.rb", "# typed: true\n"
+                                                  "module Root\n"
+                                                  "  class B\n"
+                                                  "  end\n"
+                                                  "end\n")),
+                           {});
+
+    assertErrorDiagnostics(send(*openFile("foo/a.rb", files[3].second)), {});
+
+    setSlowPathBlocked(true);
+
+    {
+        auto cancellationExpected = false;
+
+        // We're expecting one preemption from each of the following sub-cases.
+        auto preemptionsExpected = 1;
+
+        // We're modifying a file in the first stratum, and making preemption queries for files in the second.
+        sendAsync(*changeFile("b.rb",
+                              "# typed: true\n"
+                              "module Root\n"
+                              "  class B\n"
+                              "    class Inner\n"
+                              "      def bar\n"
+                              "        Root::A.n\n"
+                              "      end\n"
+                              "    end\n"
+                              "  end\n"
+                              "end\n",
+                              2, cancellationExpected, preemptionsExpected));
+    }
+
+    // Wait for typechecking to start.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    SUBCASE("hover") {
+        // Send a hover request at the end of `Root::A.`
+        sendAsync(*hover("foo/a.rb", 4, 12));
+
+        setSlowPathBlocked(false);
+
+        // This is the slow path publishing a notification about the call to Roo::A.n in b.rb, which happens on an
+        // earlier stratum than the hover in foo/a.rb.
+        auto diag = readAsync();
+        REQUIRE(diag->isNotification());
+        CHECK_EQ(diag->asNotification().method, LSPMethod::TextDocumentPublishDiagnostics);
+
+        // This is the hover result
+        auto resp = readAsync();
+        REQUIRE(resp->isResponse());
+        CHECK_EQ(resp->asResponse().requestMethod, LSPMethod::TextDocumentHover);
+    }
+
+    SUBCASE("fast_path_edit") {
+        // Make a fast-path edit to foo/a.rb
+        sendAsync(*changeFile("foo/a.rb",
+                              "# typed: true\n"
+                              "module Root::Foo\n"
+                              "  class A\n"
+                              "    def foo\n"
+                              "      Root::A.new()\n"
+                              "      puts :hi\n"
+                              "    end\n"
+                              "  end\n"
+                              "end\n",
+                              2));
+
+        setSlowPathBlocked(false);
+
+        // This is the slow path publishing a notification about the call to Roo::A.n in b.rb, which happens on an
+        // earlier stratum than the fast path edit to foo/a.rb
+        auto diag = readAsync();
+        REQUIRE(diag->isNotification());
+        CHECK_EQ(diag->asNotification().method, LSPMethod::TextDocumentPublishDiagnostics);
+
+        // We should see a fast path start notification
+        {
+            auto diag = readAsync();
+            REQUIRE(diag->isNotification());
+            REQUIRE_EQ(diag->asNotification().method, LSPMethod::SorbetTypecheckRunInfo);
+            auto &runInfo = get<unique_ptr<SorbetTypecheckRunInfo>>(diag->asNotification().params);
+            CHECK_EQ(runInfo->typecheckingPath, TypecheckingPath::Fast);
+            CHECK_EQ(runInfo->status, SorbetTypecheckRunStatus::Started);
+            CHECK(runInfo->filesTypechecked.empty());
+        }
+
+        // And then a fast path end notification
+        {
+            auto diag = readAsync();
+            REQUIRE(diag->isNotification());
+            REQUIRE_EQ(diag->asNotification().method, LSPMethod::SorbetTypecheckRunInfo);
+            auto &runInfo = get<unique_ptr<SorbetTypecheckRunInfo>>(diag->asNotification().params);
+            CHECK_EQ(runInfo->typecheckingPath, TypecheckingPath::Fast);
+            CHECK_EQ(runInfo->status, SorbetTypecheckRunStatus::Ended);
+            REQUIRE_EQ(runInfo->filesTypechecked.size(), 1);
+            CHECK_EQ(runInfo->filesTypechecked.front(), fmt::format("{}/foo/a.rb", this->rootPath));
+        }
+    }
+
+    // Finally, we'll see the slow path end
+    {
+        auto diag = readAsync();
+        REQUIRE(diag->isNotification());
+        REQUIRE_EQ(diag->asNotification().method, LSPMethod::SorbetTypecheckRunInfo);
+        auto &runInfo = get<unique_ptr<SorbetTypecheckRunInfo>>(diag->asNotification().params);
+        CHECK_EQ(runInfo->typecheckingPath, TypecheckingPath::Slow);
+        CHECK_EQ(runInfo->status, SorbetTypecheckRunStatus::Ended);
+    }
+}
+
 } // namespace sorbet::test::lsp


### PR DESCRIPTION
This PR implements support for preemption when LSP is running in package-directed mode. All tasks that support preemption are modified to have an overload of the new `preemptionStratum` method, that receives a `FileStratumMapping` argument to help determine an appropriate stratum for the task. The `PreemptionLoop` task's run method has been modified to use the rescheduling behavior added in #10170 when it determines that it can't run yet.

### Motivation
Stabilizing package-directed mode.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included tests.
