### PR TITLE
Refactor RBS APIs to return `void`

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -265,24 +265,21 @@ parser::Prism::ParseResult runPrismParser(core::GlobalState &gs, core::FileRef f
     return parser::Prism::Parser::run(ctx);
 }
 
-parser::Prism::ParseResult runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file,
-                                              parser::Prism::ParseResult parseResult, const options::Printers &print) {
+void runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file, parser::Prism::ParseResult &parseResult,
+                        const options::Printers &print) {
     if (gs.cacheSensitiveOptions.rbsEnabled) {
         Timer timeit(gs.tracer(), "runRBSRewrite", {{"file", string(file.data(gs).path())}});
         core::MutableContext ctx(gs, core::Symbols::root(), file);
         core::UnfreezeNameTable nameTableAccess(gs);
 
         auto &parser = parseResult.getParser();
-        auto node = rbs::runPrismRBSRewrite(gs, file, parseResult.getRawNodePointer(),
-                                            parseResult.getCommentLocations(), ctx, parser);
-        parseResult.replaceRootNode(node);
+        rbs::runPrismRBSRewrite(gs, file, parseResult.getRawNodePointer(), parseResult.getCommentLocations(), ctx,
+                                parser);
     }
 
     if (print.RBSRewriteTree.enabled) {
         print.RBSRewriteTree.fmt("{}\n", parseResult.prettyPrint());
     }
-
-    return parseResult;
 }
 
 unique_ptr<parser::Node> runRBSRewrite(core::GlobalState &gs, core::FileRef file, parser::ParseResult &&parseResult,
@@ -451,12 +448,12 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
                         return emptyParsedFile(file);
                     }
 
-                    auto rbsRewrittenParseResult = runPrismRBSRewrite(lgs, file, move(parseResult), print);
+                    runPrismRBSRewrite(lgs, file, parseResult, print);
                     if (opts.stopAfterPhase == options::Phase::RBS_REWRITER) {
                         return emptyParsedFile(file);
                     }
 
-                    tree = runPrismDesugar(lgs, file, move(rbsRewrittenParseResult), print);
+                    tree = runPrismDesugar(lgs, file, move(parseResult), print);
                     if (opts.stopAfterPhase == options::Phase::DESUGARER) {
                         return emptyParsedFile(file);
                     }

--- a/parser/prism/Parser.h
+++ b/parser/prism/Parser.h
@@ -122,12 +122,6 @@ public:
         return node;
     }
 
-    // Replace the root node, e.g. after RBS rewriting.
-    void replaceRootNode(pm_node_t *newNode) {
-        // Does not destroy the old node, since the rewriter mutates the tree in-place.
-        node = newNode;
-    }
-
     std::string prettyPrint() const {
         return parser->prettyPrint(node);
     }

--- a/rbs/prism/AssertionsRewriterPrism.cc
+++ b/rbs/prism/AssertionsRewriterPrism.cc
@@ -1136,9 +1136,9 @@ void AssertionsRewriterPrism::run(pm_node_t *node) {
     }
 
     // Calculate total number of comments for early termination.
-    totalComments = 0;
+    this->totalComments = 0;
     for (const auto &[_, comments] : commentsByNode) {
-        totalComments += comments.size();
+        this->totalComments += comments.size();
     }
 
     rewriteBody(node);

--- a/rbs/prism/AssertionsRewriterPrism.cc
+++ b/rbs/prism/AssertionsRewriterPrism.cc
@@ -588,8 +588,8 @@ pm_node_t *AssertionsRewriterPrism::rewriteBody(pm_node_t *node) {
     return rewriteNode(node);
 }
 
-pm_statements_node_t *AssertionsRewriterPrism::rewriteBody(pm_statements_node_t *stmts) {
-    return down_cast<pm_statements_node_t>(rewriteBody(up_cast(stmts)));
+void AssertionsRewriterPrism::rewriteBody(pm_statements_node_t *stmts) {
+    rewriteBody(up_cast(stmts));
 }
 
 /**
@@ -637,7 +637,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             auto *begin = down_cast<pm_begin_node_t>(node);
             node = maybeInsertCast(node);
             if (begin->statements) {
-                begin->statements = rewriteBody(begin->statements);
+                rewriteBody(begin->statements);
             }
             if (begin->rescue_clause) {
                 begin->rescue_clause = down_cast<pm_rescue_node_t>(rewriteNode(up_cast(begin->rescue_clause)));
@@ -880,7 +880,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             }
             wl->predicate = rewriteNode(wl->predicate);
             if (wl->statements) {
-                wl->statements = rewriteBody(wl->statements);
+                rewriteBody(wl->statements);
             }
             return node;
         }
@@ -893,7 +893,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             }
             until->predicate = rewriteNode(until->predicate);
             if (until->statements) {
-                until->statements = rewriteBody(until->statements);
+                rewriteBody(until->statements);
             }
             return node;
         }
@@ -903,7 +903,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             for_->index = rewriteNode(for_->index);
             for_->collection = rewriteNode(for_->collection);
             if (for_->statements) {
-                for_->statements = rewriteBody(for_->statements);
+                rewriteBody(for_->statements);
             }
             return node;
         }
@@ -940,7 +940,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             node = maybeInsertCast(node);
             if_->predicate = rewriteNode(if_->predicate);
             if (if_->statements) {
-                if_->statements = rewriteBody(if_->statements);
+                rewriteBody(if_->statements);
             }
             if (if_->subsequent) {
                 if_->subsequent = rewriteBody(if_->subsequent);
@@ -952,7 +952,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             node = maybeInsertCast(node);
             unless_->predicate = rewriteNode(unless_->predicate);
             if (unless_->statements) {
-                unless_->statements = rewriteBody(unless_->statements);
+                rewriteBody(unless_->statements);
             }
             if (unless_->else_clause) {
                 unless_->else_clause = down_cast<pm_else_node_t>(rewriteBody(up_cast(unless_->else_clause)));
@@ -972,7 +972,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
         case PM_WHEN_NODE: {
             auto *when = down_cast<pm_when_node_t>(node);
             if (when->statements) {
-                when->statements = rewriteBody(when->statements);
+                rewriteBody(when->statements);
             }
             return node;
         }
@@ -990,7 +990,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             auto *inPattern = down_cast<pm_in_node_t>(node);
             inPattern->pattern = rewriteNode(inPattern->pattern);
             if (inPattern->statements) {
-                inPattern->statements = down_cast<pm_statements_node_t>(rewriteBody(up_cast(inPattern->statements)));
+                rewriteBody(inPattern->statements);
             }
             return node;
         }
@@ -1006,7 +1006,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
         case PM_RESCUE_NODE: {
             auto *rescue = down_cast<pm_rescue_node_t>(node);
             if (rescue->statements) {
-                rescue->statements = rewriteBody(rescue->statements);
+                rewriteBody(rescue->statements);
             }
             if (rescue->subsequent) {
                 rescue->subsequent = down_cast<pm_rescue_node_t>(rewriteNode(up_cast(rescue->subsequent)));
@@ -1016,14 +1016,14 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
         case PM_ELSE_NODE: {
             auto *else_ = down_cast<pm_else_node_t>(node);
             if (else_->statements) {
-                else_->statements = rewriteBody(else_->statements);
+                rewriteBody(else_->statements);
             }
             return node;
         }
         case PM_ENSURE_NODE: {
             auto *ensure = down_cast<pm_ensure_node_t>(node);
             if (ensure->statements) {
-                ensure->statements = rewriteBody(ensure->statements);
+                rewriteBody(ensure->statements);
             }
             return node;
         }
@@ -1128,14 +1128,14 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
     }
 }
 
-pm_node_t *AssertionsRewriterPrism::run(pm_node_t *node) {
+void AssertionsRewriterPrism::run(pm_node_t *node) {
     if (node == nullptr) {
-        return node;
+        return;
     }
 
     // If there are no assertion comments to process we can skip entire tree walk.
     if (commentsByNode.empty()) {
-        return node;
+        return;
     }
 
     // Calculate total number of comments for early termination.
@@ -1144,7 +1144,7 @@ pm_node_t *AssertionsRewriterPrism::run(pm_node_t *node) {
         totalComments += comments.size();
     }
 
-    return rewriteBody(node);
+    rewriteBody(node);
 }
 
 } // namespace sorbet::rbs

--- a/rbs/prism/AssertionsRewriterPrism.cc
+++ b/rbs/prism/AssertionsRewriterPrism.cc
@@ -506,6 +506,10 @@ pm_node_t *AssertionsRewriterPrism::maybeInsertCast(pm_node_t *node) {
     return node;
 }
 
+void AssertionsRewriterPrism::rewriteStatements(pm_statements_node_t *stmts) {
+    rewriteNodes(stmts->body);
+}
+
 /**
  * Rewrite a collection of Prism nodes in place.
  */
@@ -551,45 +555,6 @@ void AssertionsRewriterPrism::rewriteNodesAsArray(pm_node_t *node, pm_node_list_
 }
 
 /**
- * Rewrite the body of a node (class, module, method, etc).
- *
- * This function handles ANY node type that can be a body:
- * 1. StatementsNode - iterates and rewrites each statement in its body array
- * 2. BeginNode, or any other node type - delegates to rewriteNode which handles all node types
- * 3. nullptr - returns nullptr
- *
- * The key insight: StatementsNode is the only node type with a flat array of statements
- * that we can iterate directly. All other compound nodes (BeginNode, IfNode, etc.) have
- * their own specific structure handled by rewriteNode.
- *
- * The returned node should be assigned back to the body field of the parent node.
- * For example: def->body = rewriteBody(def->body)
- */
-pm_node_t *AssertionsRewriterPrism::rewriteBody(pm_node_t *node) {
-    if (node == nullptr) {
-        return node;
-    }
-
-    // StatementsNode is special: it's a flat array of statements that we iterate directly
-    // This is the most common case for method/class/module bodies
-    if (PM_NODE_TYPE_P(node, PM_STATEMENTS_NODE)) {
-        auto *statements = down_cast<pm_statements_node_t>(node);
-
-        rewriteNodes(statements->body);
-
-        return node;
-    }
-
-    // For any other node type (BeginNode, single expressions, etc), delegate to rewriteNode
-    // rewriteNode has a comprehensive switch statement that handles all node types properly
-    return rewriteNode(node);
-}
-
-void AssertionsRewriterPrism::rewriteBody(pm_statements_node_t *stmts) {
-    rewriteBody(up_cast(stmts));
-}
-
-/**
  * Rewrite a node.
  */
 pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
@@ -606,25 +571,25 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
         // Scopes
         case PM_MODULE_NODE: {
             auto *module = down_cast<pm_module_node_t>(node);
-            module->body = rewriteBody(module->body);
+            module->body = rewriteNode(module->body);
             typeParams.clear();
             return node;
         }
         case PM_CLASS_NODE: {
             auto *klass = down_cast<pm_class_node_t>(node);
-            klass->body = rewriteBody(klass->body);
+            klass->body = rewriteNode(klass->body);
             typeParams.clear();
             return node;
         }
         case PM_SINGLETON_CLASS_NODE: {
             auto *sclass = down_cast<pm_singleton_class_node_t>(node);
-            sclass->body = rewriteBody(sclass->body);
+            sclass->body = rewriteNode(sclass->body);
             typeParams.clear();
             return node;
         }
         case PM_DEF_NODE: {
             auto *def = down_cast<pm_def_node_t>(node);
-            def->body = rewriteBody(def->body);
+            def->body = rewriteNode(def->body);
             typeParams.clear();
             return node;
         }
@@ -634,16 +599,16 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             auto *begin = down_cast<pm_begin_node_t>(node);
             node = maybeInsertCast(node);
             if (begin->statements) {
-                rewriteBody(begin->statements);
+                rewriteStatements(begin->statements);
             }
             if (begin->rescue_clause) {
-                begin->rescue_clause = down_cast<pm_rescue_node_t>(rewriteNode(up_cast(begin->rescue_clause)));
+                rewriteNode(up_cast(begin->rescue_clause));
             }
             if (begin->else_clause) {
-                begin->else_clause = down_cast<pm_else_node_t>(rewriteNode(up_cast(begin->else_clause)));
+                rewriteNode(up_cast(begin->else_clause));
             }
             if (begin->ensure_clause) {
-                begin->ensure_clause = down_cast<pm_ensure_node_t>(rewriteNode(up_cast(begin->ensure_clause)));
+                rewriteNode(up_cast(begin->ensure_clause));
             }
             return node;
         }
@@ -857,13 +822,13 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
         case PM_BLOCK_NODE: {
             auto *block = down_cast<pm_block_node_t>(node);
             node = maybeInsertCast(node);
-            block->body = rewriteBody(block->body);
+            block->body = rewriteNode(block->body);
             return node;
         }
         case PM_LAMBDA_NODE: {
             auto *lambda = down_cast<pm_lambda_node_t>(node);
             node = maybeInsertCast(node);
-            lambda->body = rewriteBody(lambda->body);
+            lambda->body = rewriteNode(lambda->body);
             return node;
         }
 
@@ -877,7 +842,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             }
             wl->predicate = rewriteNode(wl->predicate);
             if (wl->statements) {
-                rewriteBody(wl->statements);
+                rewriteStatements(wl->statements);
             }
             return node;
         }
@@ -890,7 +855,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             }
             until->predicate = rewriteNode(until->predicate);
             if (until->statements) {
-                rewriteBody(until->statements);
+                rewriteStatements(until->statements);
             }
             return node;
         }
@@ -900,7 +865,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             for_->index = rewriteNode(for_->index);
             for_->collection = rewriteNode(for_->collection);
             if (for_->statements) {
-                rewriteBody(for_->statements);
+                rewriteStatements(for_->statements);
             }
             return node;
         }
@@ -937,10 +902,10 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             node = maybeInsertCast(node);
             if_->predicate = rewriteNode(if_->predicate);
             if (if_->statements) {
-                rewriteBody(if_->statements);
+                rewriteStatements(if_->statements);
             }
             if (if_->subsequent) {
-                if_->subsequent = rewriteBody(if_->subsequent);
+                if_->subsequent = rewriteNode(if_->subsequent);
             }
             return node;
         }
@@ -949,10 +914,10 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             node = maybeInsertCast(node);
             unless_->predicate = rewriteNode(unless_->predicate);
             if (unless_->statements) {
-                rewriteBody(unless_->statements);
+                rewriteStatements(unless_->statements);
             }
             if (unless_->else_clause) {
-                unless_->else_clause = down_cast<pm_else_node_t>(rewriteBody(up_cast(unless_->else_clause)));
+                rewriteNode(up_cast(unless_->else_clause));
             }
             return node;
         }
@@ -962,14 +927,14 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             case_->predicate = rewriteNode(case_->predicate);
             rewriteNodes(case_->conditions);
             if (case_->else_clause) {
-                case_->else_clause = down_cast<pm_else_node_t>(rewriteBody(up_cast(case_->else_clause)));
+                rewriteNode(up_cast(case_->else_clause));
             }
             return node;
         }
         case PM_WHEN_NODE: {
             auto *when = down_cast<pm_when_node_t>(node);
             if (when->statements) {
-                rewriteBody(when->statements);
+                rewriteStatements(when->statements);
             }
             return node;
         }
@@ -979,7 +944,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             caseMatch->predicate = rewriteNode(caseMatch->predicate);
             rewriteNodes(caseMatch->conditions);
             if (caseMatch->else_clause) {
-                caseMatch->else_clause = down_cast<pm_else_node_t>(rewriteBody(up_cast(caseMatch->else_clause)));
+                rewriteNode(up_cast(caseMatch->else_clause));
             }
             return node;
         }
@@ -987,7 +952,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             auto *inPattern = down_cast<pm_in_node_t>(node);
             inPattern->pattern = rewriteNode(inPattern->pattern);
             if (inPattern->statements) {
-                rewriteBody(inPattern->statements);
+                rewriteStatements(inPattern->statements);
             }
             return node;
         }
@@ -1003,24 +968,24 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
         case PM_RESCUE_NODE: {
             auto *rescue = down_cast<pm_rescue_node_t>(node);
             if (rescue->statements) {
-                rewriteBody(rescue->statements);
+                rewriteStatements(rescue->statements);
             }
             if (rescue->subsequent) {
-                rescue->subsequent = down_cast<pm_rescue_node_t>(rewriteNode(up_cast(rescue->subsequent)));
+                rewriteNode(up_cast(rescue->subsequent));
             }
             return node;
         }
         case PM_ELSE_NODE: {
             auto *else_ = down_cast<pm_else_node_t>(node);
             if (else_->statements) {
-                rewriteBody(else_->statements);
+                rewriteStatements(else_->statements);
             }
             return node;
         }
         case PM_ENSURE_NODE: {
             auto *ensure = down_cast<pm_ensure_node_t>(node);
             if (ensure->statements) {
-                rewriteBody(ensure->statements);
+                rewriteStatements(ensure->statements);
             }
             return node;
         }
@@ -1090,7 +1055,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
         case PM_PROGRAM_NODE: {
             auto *program = down_cast<pm_program_node_t>(node);
             // Rewrite the top-level statements
-            rewriteBody(up_cast(program->statements));
+            rewriteStatements(program->statements);
             return node;
         }
 
@@ -1141,7 +1106,7 @@ void AssertionsRewriterPrism::run(pm_node_t *node) {
         this->totalComments += comments.size();
     }
 
-    rewriteBody(node);
+    rewriteNode(node);
 }
 
 } // namespace sorbet::rbs

--- a/rbs/prism/AssertionsRewriterPrism.cc
+++ b/rbs/prism/AssertionsRewriterPrism.cc
@@ -575,10 +575,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteBody(pm_node_t *node) {
     if (PM_NODE_TYPE_P(node, PM_STATEMENTS_NODE)) {
         auto *statements = down_cast<pm_statements_node_t>(node);
 
-        // Iterate over each statement and rewrite it in place
-        for (size_t i = 0; i < statements->body.size; i++) {
-            statements->body.nodes[i] = rewriteNode(statements->body.nodes[i]);
-        }
+        rewriteNodes(statements->body);
 
         return node;
     }

--- a/rbs/prism/AssertionsRewriterPrism.h
+++ b/rbs/prism/AssertionsRewriterPrism.h
@@ -49,8 +49,7 @@ private:
 
     core::LocOffsets translateLocation(pm_location_t location);
 
-    pm_node_t *rewriteBody(pm_node_t *tree);
-    void rewriteBody(pm_statements_node_t *stmts);
+    void rewriteStatements(pm_statements_node_t *stmts);
     pm_node_t *rewriteNode(pm_node_t *tree);
     void rewriteNodes(pm_node_list_t &nodes);
     void rewriteArgumentsNode(pm_arguments_node_t *args);

--- a/rbs/prism/AssertionsRewriterPrism.h
+++ b/rbs/prism/AssertionsRewriterPrism.h
@@ -31,7 +31,8 @@ public:
     AssertionsRewriterPrism(core::MutableContext ctx, parser::Prism::Parser &parser,
                             UnorderedMap<pm_node_t *, std::vector<CommentNodePrism>> &commentsByNode)
         : ctx(ctx), parser(parser), prism(parser), commentsByNode(commentsByNode){};
-    pm_node_t *run(pm_node_t *node);
+    // Rewrite the RBS assertions in the Prism AST, in-place.
+    void run(pm_node_t *node);
 
 private:
     core::MutableContext ctx;
@@ -49,7 +50,7 @@ private:
     core::LocOffsets translateLocation(pm_location_t location);
 
     pm_node_t *rewriteBody(pm_node_t *tree);
-    pm_statements_node_t *rewriteBody(pm_statements_node_t *stmts);
+    void rewriteBody(pm_statements_node_t *stmts);
     pm_node_t *rewriteNode(pm_node_t *tree);
     void rewriteNodes(pm_node_list_t &nodes);
     void rewriteArgumentsNode(pm_arguments_node_t *args);

--- a/rbs/prism/RBSRewriterPrism.cc
+++ b/rbs/prism/RBSRewriterPrism.cc
@@ -9,9 +9,9 @@ using namespace std;
 
 namespace sorbet::rbs {
 
-pm_node_t *runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file, pm_node_t *node,
-                              const vector<core::LocOffsets> &commentLocations, core::MutableContext &ctx,
-                              parser::Prism::Parser &parser) {
+void runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file, pm_node_t *node,
+                        const vector<core::LocOffsets> &commentLocations, core::MutableContext &ctx,
+                        parser::Prism::Parser &parser) {
     Timer timeit(gs.tracer(), "runPrismRBSRewrite", {{"file", string(file.data(gs).path())}});
 
     auto associator = CommentsAssociatorPrism(ctx, parser, commentLocations);
@@ -22,8 +22,6 @@ pm_node_t *runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file, pm_node
 
     auto assertionsRewriter = AssertionsRewriterPrism(ctx, parser, commentMap.assertionsForNode);
     assertionsRewriter.run(node);
-
-    return node;
 }
 
 } // namespace sorbet::rbs

--- a/rbs/prism/RBSRewriterPrism.cc
+++ b/rbs/prism/RBSRewriterPrism.cc
@@ -21,7 +21,7 @@ pm_node_t *runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file, pm_node
     sigsRewriter.run(node);
 
     auto assertionsRewriter = AssertionsRewriterPrism(ctx, parser, commentMap.assertionsForNode);
-    node = assertionsRewriter.run(node);
+    assertionsRewriter.run(node);
 
     return node;
 }

--- a/rbs/prism/RBSRewriterPrism.cc
+++ b/rbs/prism/RBSRewriterPrism.cc
@@ -18,7 +18,7 @@ pm_node_t *runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file, pm_node
     auto commentMap = associator.run(node);
 
     auto sigsRewriter = SigsRewriterPrism(ctx, parser, commentMap.signaturesForNode);
-    node = sigsRewriter.run(node);
+    sigsRewriter.run(node);
 
     auto assertionsRewriter = AssertionsRewriterPrism(ctx, parser, commentMap.assertionsForNode);
     node = assertionsRewriter.run(node);

--- a/rbs/prism/RBSRewriterPrism.h
+++ b/rbs/prism/RBSRewriterPrism.h
@@ -12,9 +12,9 @@ extern "C" {
 
 namespace sorbet::rbs {
 
-pm_node_t *runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file, pm_node_t *node,
-                              const std::vector<core::LocOffsets> &commentLocations, core::MutableContext &ctx,
-                              parser::Prism::Parser &parser);
+void runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file, pm_node_t *node,
+                        const std::vector<core::LocOffsets> &commentLocations, core::MutableContext &ctx,
+                        parser::Prism::Parser &parser);
 
 } // namespace sorbet::rbs
 

--- a/rbs/prism/SigsRewriterPrism.cc
+++ b/rbs/prism/SigsRewriterPrism.cc
@@ -445,8 +445,10 @@ pm_node_t *SigsRewriterPrism::rewriteBody(pm_node_t *node) {
                 }
             }
 
+            rewriteNode(stmt);
+
             // Add the rewritten statement
-            pm_node_list_append(&statements->body, rewriteNode(stmt));
+            pm_node_list_append(&statements->body, stmt);
         }
 
         // Free the old list structure (not the nodes themselves, as they were moved)
@@ -458,16 +460,20 @@ pm_node_t *SigsRewriterPrism::rewriteBody(pm_node_t *node) {
     // Handle single node that is a signature target
     if (canHaveSignature(node, parser)) {
         if (auto signatures = signaturesForNode(node)) {
+            rewriteNode(node);
+
             // Wrap in a statements node with signatures + node
-            return createStatementsWithSignatures(rewriteNode(node), move(signatures));
+            return createStatementsWithSignatures(node, move(signatures));
         }
     }
 
-    return rewriteNode(node);
+    rewriteNode(node);
+
+    return node;
 }
 
-pm_statements_node_t *SigsRewriterPrism::rewriteBody(pm_statements_node_t *stmts) {
-    return down_cast<pm_statements_node_t>(rewriteBody(up_cast(stmts)));
+void SigsRewriterPrism::rewriteBody(pm_statements_node_t *stmts) {
+    rewriteBody(up_cast(stmts));
 }
 
 void SigsRewriterPrism::processClassBody(pm_node_t *node, pm_node_t *&body, absl::Span<pm_node_t *const> helpers) {
@@ -482,16 +488,16 @@ void SigsRewriterPrism::processClassBody(pm_node_t *node, pm_node_t *&body, absl
     insertTypeParams(node, body);
 }
 
-pm_node_t *SigsRewriterPrism::rewriteClass(pm_node_t *node) {
+void SigsRewriterPrism::rewriteClass(pm_node_t *node) {
     if (node == nullptr) {
-        return node;
+        return;
     }
 
     auto comments = commentsForNode(node);
     auto helpers = extractHelpers(ctx, comments.annotations, parser);
 
     if (comments.signatures.empty() && helpers.empty()) {
-        return node;
+        return;
     }
 
     switch (PM_NODE_TYPE(node)) {
@@ -507,140 +513,142 @@ pm_node_t *SigsRewriterPrism::rewriteClass(pm_node_t *node) {
         default:
             Exception::raise("Unimplemented node type for rewriteClass: {}", (int)PM_NODE_TYPE(node));
     }
-
-    return node;
 }
 
-pm_node_t *SigsRewriterPrism::rewriteNode(pm_node_t *node) {
+void SigsRewriterPrism::rewriteNode(pm_node_t *node) {
     if (node == nullptr) {
-        return node;
+        return;
     }
 
     switch (PM_NODE_TYPE(node)) {
         case PM_BEGIN_NODE: {
             auto *begin = down_cast<pm_begin_node_t>(node);
-            begin->statements = down_cast<pm_statements_node_t>(rewriteNode(up_cast(begin->statements)));
-            begin->rescue_clause = down_cast<pm_rescue_node_t>(rewriteNode(up_cast(begin->rescue_clause)));
-            begin->else_clause = down_cast<pm_else_node_t>(rewriteNode(up_cast(begin->else_clause)));
-            begin->ensure_clause = down_cast<pm_ensure_node_t>(rewriteNode(up_cast(begin->ensure_clause)));
-            return node;
+            rewriteNode(up_cast(begin->statements));
+            rewriteNode(up_cast(begin->rescue_clause));
+            rewriteNode(up_cast(begin->else_clause));
+            rewriteNode(up_cast(begin->ensure_clause));
+            break;
         }
         case PM_BLOCK_NODE: {
             auto *block = down_cast<pm_block_node_t>(node);
             block->body = rewriteBody(block->body);
-            return node;
+            break;
         }
         case PM_LOCAL_VARIABLE_WRITE_NODE: {
             auto *n = down_cast<pm_local_variable_write_node_t>(node);
-            n->value = rewriteNode(n->value);
-            return node;
+            rewriteNode(n->value);
+            break;
+            break;
         }
         case PM_LOCAL_VARIABLE_AND_WRITE_NODE: {
             auto *n = down_cast<pm_local_variable_and_write_node_t>(node);
-            n->value = rewriteNode(n->value);
-            return node;
+            rewriteNode(n->value);
+            break;
         }
         case PM_LOCAL_VARIABLE_OR_WRITE_NODE: {
             auto *n = down_cast<pm_local_variable_or_write_node_t>(node);
-            n->value = rewriteNode(n->value);
-            return node;
+            rewriteNode(n->value);
+            break;
         }
         case PM_LOCAL_VARIABLE_OPERATOR_WRITE_NODE: {
             auto *n = down_cast<pm_local_variable_operator_write_node_t>(node);
-            n->value = rewriteNode(n->value);
-            return node;
+            rewriteNode(n->value);
+            break;
         }
         case PM_MODULE_NODE: {
             auto *mod = down_cast<pm_module_node_t>(node);
-            mod->body = rewriteBody(mod->body);
-            return rewriteClass(node);
+            rewriteBody(mod->body);
+            rewriteClass(node);
+            break;
         }
         case PM_CLASS_NODE: {
             auto *cls = down_cast<pm_class_node_t>(node);
-            cls->body = rewriteBody(cls->body);
-            return rewriteClass(node);
+            rewriteBody(cls->body);
+            rewriteClass(node);
+            break;
         }
         case PM_DEF_NODE: {
             auto *def = down_cast<pm_def_node_t>(node);
-            def->body = rewriteBody(def->body);
-            return node;
+            rewriteBody(def->body);
+            break;
         }
         case PM_SINGLETON_CLASS_NODE: {
             auto *sclass = down_cast<pm_singleton_class_node_t>(node);
-            sclass->body = rewriteBody(sclass->body);
-            return rewriteClass(node);
+            rewriteBody(sclass->body);
+            rewriteClass(node);
+            break;
         }
         case PM_FOR_NODE: {
             auto *for_ = down_cast<pm_for_node_t>(node);
             if (auto *stmts = for_->statements) {
-                for_->statements = rewriteBody(stmts);
+                rewriteBody(stmts);
             }
-            return node;
+            break;
         }
         case PM_ARRAY_NODE: {
             auto *array = down_cast<pm_array_node_t>(node);
             rewriteNodes(array->elements);
-            return node;
+            break;
         }
         case PM_HASH_NODE: {
             auto *hash = down_cast<pm_hash_node_t>(node);
             rewriteNodes(hash->elements);
-            return node;
+            break;
         }
         case PM_ASSOC_NODE: {
             auto *pair = down_cast<pm_assoc_node_t>(node);
-            pair->key = rewriteNode(pair->key);
-            pair->value = rewriteNode(pair->value);
-            return node;
+            rewriteNode(pair->key);
+            rewriteNode(pair->value);
+            break;
         }
         case PM_RESCUE_NODE: {
             auto *rescue = down_cast<pm_rescue_node_t>(node);
             if (auto *stmts = rescue->statements) {
-                rescue->statements = rewriteBody(stmts);
+                rewriteBody(stmts);
             }
             if (auto *subsequent = rescue->subsequent) {
-                rescue->subsequent = down_cast<pm_rescue_node_t>(rewriteNode(up_cast(subsequent)));
+                rewriteNode(up_cast(subsequent));
             }
-            return node;
+            break;
         }
         case PM_ELSE_NODE: {
             auto *else_ = down_cast<pm_else_node_t>(node);
             if (auto *stmts = else_->statements) {
-                else_->statements = rewriteBody(stmts);
+                rewriteBody(stmts);
             }
-            return node;
+            break;
         }
         case PM_ENSURE_NODE: {
             auto *ensure = down_cast<pm_ensure_node_t>(node);
             if (auto *stmts = ensure->statements) {
-                ensure->statements = rewriteBody(stmts);
+                rewriteBody(stmts);
             }
-            return node;
+            break;
         }
         case PM_IF_NODE: {
             auto *if_ = down_cast<pm_if_node_t>(node);
             if (auto *stmts = if_->statements) {
-                if_->statements = rewriteBody(stmts);
+                rewriteBody(stmts);
             }
             if (auto *subsequent = if_->subsequent) {
                 if_->subsequent = rewriteBody(subsequent);
             }
-            return node;
+            break;
         }
         case PM_UNLESS_NODE: {
             auto *unless_ = down_cast<pm_unless_node_t>(node);
             if (auto *stmts = unless_->statements) {
-                unless_->statements = rewriteBody(stmts);
+                rewriteBody(stmts);
             }
             if (auto *elseClause = unless_->else_clause) {
                 unless_->else_clause = down_cast<pm_else_node_t>(rewriteBody(up_cast(elseClause)));
             }
-            return node;
+            break;
         }
         case PM_MULTI_WRITE_NODE: {
             auto *masgn = down_cast<pm_multi_write_node_t>(node);
-            masgn->value = rewriteNode(masgn->value);
-            return node;
+            rewriteNode(masgn->value);
+            break;
         }
         case PM_CASE_NODE: {
             auto *case_ = down_cast<pm_case_node_t>(node);
@@ -648,7 +656,7 @@ pm_node_t *SigsRewriterPrism::rewriteNode(pm_node_t *node) {
             if (auto *elseClause = case_->else_clause) {
                 case_->else_clause = down_cast<pm_else_node_t>(rewriteBody(up_cast(elseClause)));
             }
-            return node;
+            break;
         }
         case PM_CASE_MATCH_NODE: {
             auto *case_ = down_cast<pm_case_match_node_t>(node);
@@ -656,47 +664,47 @@ pm_node_t *SigsRewriterPrism::rewriteNode(pm_node_t *node) {
             if (auto *elseClause = case_->else_clause) {
                 case_->else_clause = down_cast<pm_else_node_t>(rewriteBody(up_cast(elseClause)));
             }
-            return node;
+            break;
         }
         case PM_WHEN_NODE: {
             auto *when = down_cast<pm_when_node_t>(node);
             if (auto *stmts = when->statements) {
-                when->statements = rewriteBody(stmts);
+                rewriteBody(stmts);
             }
-            return node;
+            break;
         }
         case PM_CALL_NODE: {
             auto *call = down_cast<pm_call_node_t>(node);
             if (auto *block = call->block) {
-                call->block = rewriteNode(block);
+                rewriteNode(block);
             }
             rewriteArgumentsNode(call->arguments);
-            return node;
+            break;
         }
         case PM_SUPER_NODE: {
             auto *sup = down_cast<pm_super_node_t>(node);
             rewriteArgumentsNode(sup->arguments);
-            return node;
+            break;
         }
         case PM_RETURN_NODE: {
             auto *ret = down_cast<pm_return_node_t>(node);
             rewriteArgumentsNode(ret->arguments);
-            return node;
+            break;
         }
         case PM_NEXT_NODE: {
             auto *n = down_cast<pm_next_node_t>(node);
             rewriteArgumentsNode(n->arguments);
-            return node;
+            break;
         }
         case PM_BREAK_NODE: {
             auto *b = down_cast<pm_break_node_t>(node);
             rewriteArgumentsNode(b->arguments);
-            return node;
+            break;
         }
         case PM_SPLAT_NODE: {
             auto *s = down_cast<pm_splat_node_t>(node);
-            s->expression = rewriteNode(s->expression);
-            return node;
+            rewriteNode(s->expression);
+            break;
         }
         case PM_CONSTANT_WRITE_NODE: {
             auto *write = down_cast<pm_constant_write_node_t>(node);
@@ -707,34 +715,34 @@ pm_node_t *SigsRewriterPrism::rewriteNode(pm_node_t *node) {
                 if (constantRead->name == RBS_SYNTHETIC_TYPE_ALIAS_MARKER) {
                     // Replace the value with the T.type_alias call
                     write->value = replaceSyntheticTypeAlias(write->value);
-                    return node;
+                    return;
                 }
             }
-            write->value = rewriteNode(write->value);
-            return node;
+            rewriteNode(write->value);
+            break;
         }
         case PM_PROGRAM_NODE: {
             auto *program = down_cast<pm_program_node_t>(node);
             rewriteBody(up_cast(program->statements));
-            return node;
+            break;
         }
         case PM_STATEMENTS_NODE: {
             auto *statements = down_cast<pm_statements_node_t>(node);
             rewriteNodes(statements->body);
-            return node;
+            break;
         }
         default:
-            return node;
+            break;
     }
 }
 
-pm_node_t *SigsRewriterPrism::run(pm_node_t *node) {
+void SigsRewriterPrism::run(pm_node_t *node) {
     // If there are no signature comments to process, we can skip the entire tree walk.
     if (commentsByNode.empty()) {
-        return node;
+        return;
     }
 
-    return rewriteBody(node);
+    rewriteBody(node);
 }
 
 // Helper method to create statements nodes with signatures

--- a/rbs/prism/SigsRewriterPrism.h
+++ b/rbs/prism/SigsRewriterPrism.h
@@ -39,7 +39,9 @@ public:
     SigsRewriterPrism(core::MutableContext ctx, parser::Prism::Parser &parser,
                       UnorderedMap<pm_node_t *, std::vector<rbs::CommentNodePrism>> &commentsByNode)
         : ctx{ctx}, parser{parser}, prism{parser}, commentsByNode{commentsByNode} {}
-    pm_node_t *run(pm_node_t *node);
+
+    // Rewrite the RBS signatures in the Prism AST, in-place.
+    void run(pm_node_t *node);
 
 private:
     core::MutableContext ctx;
@@ -48,11 +50,11 @@ private:
     UnorderedMap<pm_node_t *, std::vector<rbs::CommentNodePrism>> &commentsByNode;
 
     pm_node_t *rewriteBody(pm_node_t *node);
-    pm_statements_node_t *rewriteBody(pm_statements_node_t *stmts);
-    pm_node_t *rewriteNode(pm_node_t *node);
+    void rewriteBody(pm_statements_node_t *stmts);
+    void rewriteNode(pm_node_t *node);
     void rewriteNodes(pm_node_list_t &nodes);
     void rewriteArgumentsNode(pm_arguments_node_t *args);
-    pm_node_t *rewriteClass(pm_node_t *node);
+    void rewriteClass(pm_node_t *node);
     std::unique_ptr<std::vector<pm_node_t *>> signaturesForNode(pm_node_t *node);
     CommentsPrism commentsForNode(pm_node_t *node);
     void insertTypeParams(pm_node_t *node, pm_node_t *body);

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -282,9 +282,8 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> f
 
                     if (gs.cacheSensitiveOptions.rbsEnabled) {
                         auto &prismParser = prismParseResult->getParser();
-                        auto node = rbs::runPrismRBSRewrite(gs, file, prismParseResult->getRawNodePointer(),
-                                                            prismParseResult->getCommentLocations(), ctx, prismParser);
-                        prismParseResult->replaceRootNode(node);
+                        rbs::runPrismRBSRewrite(gs, file, prismParseResult->getRawNodePointer(),
+                                                prismParseResult->getCommentLocations(), ctx, prismParser);
                         disableParserComparison = true;
 
                         handler.addObserved(gs, "rbs-rewrite-tree", [&]() { return prismParseResult->prettyPrint(); });
@@ -820,9 +819,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
                 // Run the Prism-level RBS rewriter
                 if (gs->cacheSensitiveOptions.rbsEnabled) {
                     auto &prismParser = prismResult.getParser();
-                    auto node = rbs::runPrismRBSRewrite(*gs, f, prismResult.getRawNodePointer(),
-                                                        prismResult.getCommentLocations(), ctx, prismParser);
-                    prismResult.replaceRootNode(node);
+                    rbs::runPrismRBSRewrite(*gs, f, prismResult.getRawNodePointer(), prismResult.getCommentLocations(),
+                                            ctx, prismParser);
 
                     handler.addObserved(*gs, "rbs-rewrite-tree", [&]() { return prismResult.prettyPrint(); });
                 }


### PR DESCRIPTION
### Motivation

Part of #9065. Fixes #9995. Easiest to review commit-by-commit

Most RBS rewriting is done in place, there's very few places where rewriting one node can result in a different node to be returned. None of those need to touch the public API, so we can just make all these `void`-returning.

### Test plan

Pure factor.