### PR TITLE
add a `ZipSpans` function so we get free type derivation

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -1111,12 +1111,11 @@ public:
     bool prismDesugarEqual(const core::GlobalState &gs, const ExpressionPtr &other, const core::FileRef file) const;
 
     core::ZippedPairSpan<ExpressionPtr, ExpressionPtr> kviter() {
-        return core::ZippedPairSpan<ExpressionPtr, ExpressionPtr>{absl::MakeSpan(keys), absl::MakeSpan(values)};
+        return core::ZipSpans(absl::MakeSpan(keys), absl::MakeSpan(values));
     }
 
     core::ZippedPairSpan<const ExpressionPtr, const ExpressionPtr> kviter() const {
-        return core::ZippedPairSpan<const ExpressionPtr, const ExpressionPtr>{absl::MakeSpan(keys),
-                                                                              absl::MakeSpan(values)};
+        return core::ZipSpans(absl::MakeSpan(keys), absl::MakeSpan(values));
     }
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;

--- a/core/Types.h
+++ b/core/Types.h
@@ -897,10 +897,10 @@ public:
     bool derivesFrom(const GlobalState &gs, core::ClassOrModuleRef klass) const;
 
     ZippedPairSpan<TypePtr, TypePtr> kviter() {
-        return ZippedPairSpan<TypePtr, TypePtr>{absl::MakeSpan(keys), absl::MakeSpan(values)};
+        return ZipSpans(absl::MakeSpan(keys), absl::MakeSpan(values));
     }
     ZippedPairSpan<const TypePtr, const TypePtr> kviter() const {
-        return ZippedPairSpan<const TypePtr, const TypePtr>{absl::MakeSpan(keys), absl::MakeSpan(values)};
+        return ZipSpans(absl::MakeSpan(keys), absl::MakeSpan(values));
     }
 
     std::optional<size_t> indexForKey(const TypePtr &t) const;

--- a/core/ZippedPair.h
+++ b/core/ZippedPair.h
@@ -72,6 +72,11 @@ template <typename KeyT, typename ValueT> struct ZippedPairSpan {
     }
 };
 
+template <typename KeyT, typename ValueT>
+ZippedPairSpan<KeyT, ValueT> ZipSpans(absl::Span<KeyT> keys, absl::Span<ValueT> values) {
+    return ZippedPairSpan<KeyT, ValueT>{keys, values};
+}
+
 } // namespace sorbet::core
 
 #endif // SORBET_ZIPPED_PAIR_H


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This just reduces the amount of typing that you have to do when using `ZippedPairSpan`, since functions infer types for template parameters, but constructing objects does not.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.