### PR TITLE
tidy up `Types::alignBaseTypeArgs`

### DIFF
--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -677,21 +677,18 @@ InlinedVector<TypeMemberRef, 4> Types::alignBaseTypeArgs(const GlobalState &gs, 
         auto members = what.data(gs)->typeMembers();
         currentAlignment.assign(members.begin(), members.end());
     } else {
+        auto members = what.data(gs)->typeMembers();
         currentAlignment.reserve(asIf.data(gs)->typeMembers().size());
-        for (auto originalTp : asIf.data(gs)->typeMembers()) {
-            auto name = originalTp.data(gs)->name;
-            SymbolRef align;
-            for (auto x : what.data(gs)->typeMembers()) {
-                if (x.data(gs)->name == name) {
-                    align = x;
-                    currentAlignment.emplace_back(x);
-                    break;
-                }
-            }
-            if (!align.exists()) {
-                currentAlignment.emplace_back(Symbols::noTypeMember());
-            }
-        }
+        absl::c_transform(asIf.data(gs)->typeMembers(), back_inserter(currentAlignment),
+                          [&gs, members](auto originalTp) -> TypeMemberRef {
+                              auto name = originalTp.data(gs)->name;
+                              auto it = absl::c_find_if(
+                                  members, [&gs, name](auto x) -> bool { return x.data(gs)->name == name; });
+                              if (it == members.end()) {
+                                  return Symbols::noTypeMember();
+                              }
+                              return *it;
+                          });
     }
     return currentAlignment;
 }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I found the use of `align` to indicate the doneness of the loop a little confusing, and I think the `<algorithm>`-inspired code makes everything a little easier to follow -- despite clang-format's insistence on the massive indent.  This might also be epsilon more efficient.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.