### PR TITLE
Skip unnecessary null checks in RBS rewriters

### DIFF
--- a/rbs/prism/AssertionsRewriterPrism.cc
+++ b/rbs/prism/AssertionsRewriterPrism.cc
@@ -557,11 +557,15 @@ void AssertionsRewriterPrism::rewriteNodesAsArray(pm_node_t *node, pm_node_list_
 /**
  * Rewrite a node.
  */
-pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
+inline pm_node_t *AssertionsRewriterPrism::rewriteNullableNode(pm_node_t *node) {
     if (node == nullptr) {
         return node;
     }
 
+    return rewriteNode(node);
+}
+
+pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
     // If all comments have been consumed, we can skip the rest of the tree.
     if (consumedComments.size() >= totalComments) {
         return node;
@@ -571,25 +575,25 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
         // Scopes
         case PM_MODULE_NODE: {
             auto *module = down_cast<pm_module_node_t>(node);
-            module->body = rewriteNode(module->body);
+            module->body = rewriteNullableNode(module->body);
             typeParams.clear();
             return node;
         }
         case PM_CLASS_NODE: {
             auto *klass = down_cast<pm_class_node_t>(node);
-            klass->body = rewriteNode(klass->body);
+            klass->body = rewriteNullableNode(klass->body);
             typeParams.clear();
             return node;
         }
         case PM_SINGLETON_CLASS_NODE: {
             auto *sclass = down_cast<pm_singleton_class_node_t>(node);
-            sclass->body = rewriteNode(sclass->body);
+            sclass->body = rewriteNullableNode(sclass->body);
             typeParams.clear();
             return node;
         }
         case PM_DEF_NODE: {
             auto *def = down_cast<pm_def_node_t>(node);
-            def->body = rewriteNode(def->body);
+            def->body = rewriteNullableNode(def->body);
             typeParams.clear();
             return node;
         }
@@ -598,18 +602,10 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
         case PM_BEGIN_NODE: {
             auto *begin = down_cast<pm_begin_node_t>(node);
             node = maybeInsertCast(node);
-            if (begin->statements) {
-                rewriteStatements(begin->statements);
-            }
-            if (begin->rescue_clause) {
-                rewriteNode(up_cast(begin->rescue_clause));
-            }
-            if (begin->else_clause) {
-                rewriteNode(up_cast(begin->else_clause));
-            }
-            if (begin->ensure_clause) {
-                rewriteNode(up_cast(begin->ensure_clause));
-            }
+            rewriteNullableNode(up_cast(begin->statements));
+            rewriteNullableNode(up_cast(begin->rescue_clause));
+            rewriteNullableNode(up_cast(begin->else_clause));
+            rewriteNullableNode(up_cast(begin->ensure_clause));
             return node;
         }
 
@@ -811,10 +807,10 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
                 // parameters from the method signature.
                 return node;
             }
-            call->receiver = rewriteNode(call->receiver);
+            call->receiver = rewriteNullableNode(call->receiver);
             node = maybeInsertCast(node);
             rewriteArgumentsNode(call->arguments);
-            call->block = rewriteNode(call->block);
+            call->block = rewriteNullableNode(call->block);
             return node;
         }
 
@@ -822,13 +818,13 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
         case PM_BLOCK_NODE: {
             auto *block = down_cast<pm_block_node_t>(node);
             node = maybeInsertCast(node);
-            block->body = rewriteNode(block->body);
+            block->body = rewriteNullableNode(block->body);
             return node;
         }
         case PM_LAMBDA_NODE: {
             auto *lambda = down_cast<pm_lambda_node_t>(node);
             node = maybeInsertCast(node);
-            lambda->body = rewriteNode(lambda->body);
+            lambda->body = rewriteNullableNode(lambda->body);
             return node;
         }
 
@@ -904,9 +900,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             if (if_->statements) {
                 rewriteStatements(if_->statements);
             }
-            if (if_->subsequent) {
-                if_->subsequent = rewriteNode(if_->subsequent);
-            }
+            if_->subsequent = rewriteNullableNode(if_->subsequent);
             return node;
         }
         case PM_UNLESS_NODE: {
@@ -916,19 +910,15 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             if (unless_->statements) {
                 rewriteStatements(unless_->statements);
             }
-            if (unless_->else_clause) {
-                rewriteNode(up_cast(unless_->else_clause));
-            }
+            rewriteNullableNode(up_cast(unless_->else_clause));
             return node;
         }
         case PM_CASE_NODE: {
             auto *case_ = down_cast<pm_case_node_t>(node);
             node = maybeInsertCast(node);
-            case_->predicate = rewriteNode(case_->predicate);
+            case_->predicate = rewriteNullableNode(case_->predicate);
             rewriteNodes(case_->conditions);
-            if (case_->else_clause) {
-                rewriteNode(up_cast(case_->else_clause));
-            }
+            rewriteNullableNode(up_cast(case_->else_clause));
             return node;
         }
         case PM_WHEN_NODE: {
@@ -943,9 +933,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             node = maybeInsertCast(node);
             caseMatch->predicate = rewriteNode(caseMatch->predicate);
             rewriteNodes(caseMatch->conditions);
-            if (caseMatch->else_clause) {
-                rewriteNode(up_cast(caseMatch->else_clause));
-            }
+            rewriteNullableNode(up_cast(caseMatch->else_clause));
             return node;
         }
         case PM_IN_NODE: {
@@ -970,9 +958,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
             if (rescue->statements) {
                 rewriteStatements(rescue->statements);
             }
-            if (rescue->subsequent) {
-                rewriteNode(up_cast(rescue->subsequent));
-            }
+            rewriteNullableNode(up_cast(rescue->subsequent));
             return node;
         }
         case PM_ELSE_NODE: {
@@ -1034,7 +1020,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
         // Splat
         case PM_SPLAT_NODE: {
             auto *splat = down_cast<pm_splat_node_t>(node);
-            splat->expression = rewriteNode(splat->expression);
+            splat->expression = rewriteNullableNode(splat->expression);
             return node;
         }
         case PM_ASSOC_SPLAT_NODE: {
@@ -1062,7 +1048,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
         case PM_PARENTHESES_NODE: {
             auto *paren = down_cast<pm_parentheses_node_t>(node);
             node = maybeInsertCast(node);
-            paren->body = rewriteNode(paren->body);
+            paren->body = rewriteNullableNode(paren->body);
             return node;
         }
 

--- a/rbs/prism/AssertionsRewriterPrism.h
+++ b/rbs/prism/AssertionsRewriterPrism.h
@@ -51,6 +51,7 @@ private:
 
     void rewriteStatements(pm_statements_node_t *stmts);
     pm_node_t *rewriteNode(pm_node_t *tree);
+    pm_node_t *rewriteNullableNode(pm_node_t *tree);
     void rewriteNodes(pm_node_list_t &nodes);
     void rewriteArgumentsNode(pm_arguments_node_t *args);
     void rewriteNodesAsArray(pm_node_t *node, pm_node_list_t &nodes);

--- a/rbs/prism/SigsRewriterPrism.cc
+++ b/rbs/prism/SigsRewriterPrism.cc
@@ -515,18 +515,20 @@ void SigsRewriterPrism::rewriteClass(pm_node_t *node) {
     }
 }
 
-void SigsRewriterPrism::rewriteNode(pm_node_t *node) {
-    if (node == nullptr) {
-        return;
+inline void SigsRewriterPrism::rewriteNullableNode(pm_node_t *node) {
+    if (node != nullptr) {
+        rewriteNode(node);
     }
+}
 
+void SigsRewriterPrism::rewriteNode(pm_node_t *node) {
     switch (PM_NODE_TYPE(node)) {
         case PM_BEGIN_NODE: {
             auto *begin = down_cast<pm_begin_node_t>(node);
-            rewriteNode(up_cast(begin->statements));
-            rewriteNode(up_cast(begin->rescue_clause));
-            rewriteNode(up_cast(begin->else_clause));
-            rewriteNode(up_cast(begin->ensure_clause));
+            rewriteNullableNode(up_cast(begin->statements));
+            rewriteNullableNode(up_cast(begin->rescue_clause));
+            rewriteNullableNode(up_cast(begin->else_clause));
+            rewriteNullableNode(up_cast(begin->ensure_clause));
             break;
         }
         case PM_BLOCK_NODE: {
@@ -703,7 +705,7 @@ void SigsRewriterPrism::rewriteNode(pm_node_t *node) {
         }
         case PM_SPLAT_NODE: {
             auto *s = down_cast<pm_splat_node_t>(node);
-            rewriteNode(s->expression);
+            rewriteNullableNode(s->expression);
             break;
         }
         case PM_CONSTANT_WRITE_NODE: {

--- a/rbs/prism/SigsRewriterPrism.h
+++ b/rbs/prism/SigsRewriterPrism.h
@@ -52,6 +52,7 @@ private:
     pm_node_t *rewriteBody(pm_node_t *node);
     void rewriteBody(pm_statements_node_t *stmts);
     void rewriteNode(pm_node_t *node);
+    void rewriteNullableNode(pm_node_t *node);
     void rewriteNodes(pm_node_list_t &nodes);
     void rewriteArgumentsNode(pm_arguments_node_t *args);
     void rewriteClass(pm_node_t *node);


### PR DESCRIPTION
### Motivation

Follow the same pattern as the Prism desugar (`desugar()` vs `desugarNullable()`), which lets us skip null checks in places where null isn't a possible value (the majority).

When tested against our core monolith, this saves around 0.175 ms (~3.3% of the time up to `--stop-after=rbs`, statistically significant)

| Comparison           | Time  | Δ       |
|----------------------|---------|------:|
| `master`             | 5.323 s |     - |
| This PR w/o `inline` | 5.186 s | -2.5% |
| This PR w/ `inline`  | 5.148 s | -3.3% |

```sh
$ hyperfine --warmup 10 --runs 100 \
  -n before '~/sorbet-before --no-config --cache-dir= --parser=prism --quiet --stop-after=rbs .' \
  -n after  '~/sorbet-after  --no-config --cache-dir= --parser=prism --quiet --stop-after=rbs .' \
∙ -n inline '~/sorbet-inline  --no-config --cache-dir= --parser=prism --quiet --stop-after=rbs .'
Benchmark 1: before
  Time (mean ± σ):      5.323 s ±  0.515 s    [User: 12.706 s, System: 16.136 s]
  Range (min … max):    5.103 s … 10.196 s    100 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark 2: after
  Time (mean ± σ):      5.186 s ±  0.283 s    [User: 12.140 s, System: 15.613 s]
  Range (min … max):    5.006 s …  7.548 s    100 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark 3: inline
  Time (mean ± σ):      5.148 s ±  0.274 s    [User: 11.947 s, System: 15.253 s]
  Range (min … max):    4.901 s …  7.526 s    100 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
```

### Test plan

Pure refactor.