### PR TITLE
Add a test that shows some circular load behavior

### DIFF
--- a/gems/sorbet-runtime/test/types/circular_load.rb
+++ b/gems/sorbet-runtime/test/types/circular_load.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+module Opus::Types::Test
+  class CircularLoadTest < Critic::Unit::UnitTest
+    it "allows a method to be called while its sig is loading" do
+      require_relative './fixtures/circular_load/_impl'
+
+      Fixtures::CircularLoad::Child1.new
+
+      assert_equal(
+        [Fixtures::CircularLoad::Child2, Fixtures::CircularLoad::Child1],
+        Fixtures::CircularLoad::Parent.foo_invocations
+      )
+    end
+  end
+end

--- a/gems/sorbet-runtime/test/types/fixtures/circular_load/_impl.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/circular_load/_impl.rb
@@ -1,0 +1,13 @@
+# typed: true
+require_relative '../../../test_helper'
+
+module Opus::Types::Test
+  module Fixtures
+    module CircularLoad
+      autoload :Parent,   "#{__dir__}/parent.rb"
+      autoload :OneOrTwo, "#{__dir__}/one_or_two.rb"
+      autoload :Child1,   "#{__dir__}/child1.rb"
+      autoload :Child2,   "#{__dir__}/child2.rb"
+    end
+  end
+end

--- a/gems/sorbet-runtime/test/types/fixtures/circular_load/child1.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/circular_load/child1.rb
@@ -2,6 +2,6 @@
 
 module Opus::Types::Test::Fixtures::CircularLoad
   class Child1 < Parent
-    foo(self)
+    Parent.foo(self)
   end
 end

--- a/gems/sorbet-runtime/test/types/fixtures/circular_load/child1.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/circular_load/child1.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+module Opus::Types::Test::Fixtures::CircularLoad
+  class Child1 < Parent
+    foo(self)
+  end
+end

--- a/gems/sorbet-runtime/test/types/fixtures/circular_load/child2.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/circular_load/child2.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+module Opus::Types::Test::Fixtures::CircularLoad
+  class Child2 < Parent
+    foo(self)
+  end
+end

--- a/gems/sorbet-runtime/test/types/fixtures/circular_load/child2.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/circular_load/child2.rb
@@ -2,6 +2,6 @@
 
 module Opus::Types::Test::Fixtures::CircularLoad
   class Child2 < Parent
-    foo(self)
+    Parent.foo(self)
   end
 end

--- a/gems/sorbet-runtime/test/types/fixtures/circular_load/one_or_two.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/circular_load/one_or_two.rb
@@ -1,0 +1,10 @@
+# typed: true
+
+module Opus::Types::Test::Fixtures::CircularLoad
+  OneOrTwo = T.type_alias do
+    T.any(
+      T.class_of(Child1),
+      T.class_of(Child2)
+    )
+  end
+end

--- a/gems/sorbet-runtime/test/types/fixtures/circular_load/parent.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/circular_load/parent.rb
@@ -1,0 +1,14 @@
+# typed: true
+
+module Opus::Types::Test::Fixtures::CircularLoad
+  class Parent
+    extend T::Sig
+    sig { params(x: OneOrTwo).void }
+    def self.foo(x)
+      @@foo_invocations ||= []
+      @@foo_invocations << x
+    end
+
+    def self.foo_invocations = @@foo_invocations
+  end
+end

--- a/gems/sorbet-runtime/test/types/fixtures/circular_load/parent.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/circular_load/parent.rb
@@ -5,10 +5,12 @@ module Opus::Types::Test::Fixtures::CircularLoad
     extend T::Sig
     sig { params(x: OneOrTwo).void }
     def self.foo(x)
-      @@foo_invocations ||= []
-      @@foo_invocations << x
+      @foo_invocations ||= []
+      @foo_invocations << x
     end
 
-    def self.foo_invocations = @@foo_invocations
+    class << self
+      attr_reader :foo_invocations
+    end
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm working on a sorbet-runtime feature, and it exposed that we don't have any tests for circular load-time behavior like this.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Test-only change.

I encountered this case while working on another change, and I verified that it was enough to fail in the same way as Stripe's codebase would fail.
