### PR TITLE
Deduplicate the preemption check

### DIFF
--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -454,4 +454,8 @@ void LSPIndexer::updateConfigAndGsFromOptions(const DidChangeConfigurationParams
     }
 }
 
+bool LSPIndexer::preemptionPossible(const TaskQueue::QueueType &tasks) const {
+    return !tasks.empty() && tasks.front()->canPreempt(*this);
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -111,6 +111,9 @@ public:
     void transferInitializeState(InitializedTask &task);
 
     void updateConfigAndGsFromOptions(const DidChangeConfigurationParams &options) const;
+
+    // Determines if it's possible for the head of the task queue to run during preemption.
+    bool preemptionPossible(const TaskQueue::QueueType &tasks) const;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPLoop.cc
+++ b/main/lsp/LSPLoop.cc
@@ -306,8 +306,9 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> inp
                         // thread if a fast path edit preempts, with the `canPreempt` checks of edits in this thread.
                         auto noPreemptionTasksRemain = [&indexer = this->indexer,
                                                         &tasks = this->taskQueue->tasks()]() -> bool {
-                            // Await always holds taskQueueMutex when calling this function, but absl doesn't know that.
-                            return tasks.empty() || !tasks.front()->canPreempt(indexer);
+                            // The capture of `tasks` here is safe because the only caller of this closure is the
+                            // `Await` below, which will lock the mutex that guards `tasks` for its duration.
+                            return !indexer.preemptionPossible(tasks);
                         };
                         // Wait until the head of the queue turns into a non-preemptible task to resume processing the
                         // queue.

--- a/main/lsp/LSPPreprocessor.h
+++ b/main/lsp/LSPPreprocessor.h
@@ -18,6 +18,10 @@ class WatchmanQueryResponse;
 class CancelParams;
 
 class TaskQueue final {
+public:
+    using QueueType = std::deque<std::unique_ptr<LSPTask>>;
+
+private:
     absl::Mutex stateMutex;
 
     std::deque<std::unique_ptr<LSPTask>> pendingTasks ABSL_GUARDED_BY(stateMutex);
@@ -49,8 +53,8 @@ public:
 
     CounterState &getCounters() ABSL_EXCLUSIVE_LOCKS_REQUIRED(stateMutex);
 
-    const std::deque<std::unique_ptr<LSPTask>> &tasks() const ABSL_SHARED_LOCKS_REQUIRED(stateMutex);
-    std::deque<std::unique_ptr<LSPTask>> &tasks() ABSL_EXCLUSIVE_LOCKS_REQUIRED(stateMutex);
+    const QueueType &tasks() const ABSL_SHARED_LOCKS_REQUIRED(stateMutex);
+    QueueType &tasks() ABSL_EXCLUSIVE_LOCKS_REQUIRED(stateMutex);
 
     absl::Mutex *getMutex() ABSL_LOCK_RETURNED(stateMutex);
 

--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -174,7 +174,7 @@ public:
             unique_ptr<LSPTask> task;
             {
                 absl::MutexLock lck(taskQueue.getMutex());
-                if (taskQueue.tasks().empty() || !taskQueue.tasks().front()->canPreempt(indexer)) {
+                if (!indexer.preemptionPossible(taskQueue.tasks())) {
                     break;
                 }
                 task = move(taskQueue.tasks().front());


### PR DESCRIPTION
This is a pretty important condition that keeps the main thread and the preemption loop in sync. Instead of duplicating it, let's make it a method on the indexer so that there's less possibility of drift between the two.

### Motivation
Clarity.

### Test plan

No changes expected, refactoring only.
