### PR TITLE
Update Kernel.require to allow Pathname arg

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -2101,23 +2101,23 @@ module Kernel
   # [`gem_original_require`](https://docs.ruby-lang.org/en/2.6.0/Kernel.html#method-i-gem_original_require)
   sig do
     params(
-        path: String,
+        path: T.any(String, Pathname),
     )
     .returns(T::Boolean)
   end
   def require(path); end
 
-  # Ruby tries to load the library named *string* relative to the requiring
+  # Ruby tries to load the library named *path* relative to the requiring
   # file's path. If the file's path cannot be determined a
   # [`LoadError`](https://docs.ruby-lang.org/en/2.7.0/LoadError.html) is raised.
   # If a file is loaded `true` is returned and false otherwise.
   sig do
     params(
-        feature: T.any(String, Pathname)
+        path: T.any(String, Pathname)
     )
     .returns(T::Boolean)
   end
-  def require_relative(feature); end
+  def require_relative(path); end
 
   # Calls select(2) system call. It monitors given arrays of
   # [`IO`](https://docs.ruby-lang.org/en/2.7.0/IO.html) objects, waits until one


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
`require` accepts Pathname instances

I've also updated the require_relative param name for clarity and consistency.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested with `ruby -e "require 'pathname'; require(Pathname('./foo.rb'))"`
