### PR TITLE
Add fallback for getting the names of Method owners

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -5,6 +5,10 @@ module T::Private::Methods::CallValidation
   CallValidation = T::Private::Methods::CallValidation
   Modes = T::Private::Methods::Modes
 
+  KERNEL_TO_S = Kernel.instance_method(:to_s)
+  MODULE_TO_S = Module.instance_method(:to_s)
+  private_constant(:KERNEL_TO_S, :MODULE_TO_S)
+
   # Wraps a method with a layer of validation for the given type signature.
   # This wrapper is meant to be fast, and is applied by a previous wrapper,
   # which was placed by `_on_method_added`.
@@ -301,6 +305,24 @@ module T::Private::Methods::CallValidation
     end
   end
 
+  # Get the name of a method owner via its `.to_s`, but fallback if its implementation raises or returns `nil`.
+  def self.safe_method_owner_to_s(method_owner)
+    result = begin
+      mod.to_s
+    rescue Exception # rubocop:disable Lint/RescueException
+      nil
+    end
+
+    return result if result
+
+    case method_owner
+    when Module # methods are usually owned by a Class or Module...
+      MODULE_TO_S.bind_call(method_owner)
+    else # ... but could be a singleton method on any kind of Object.
+      KERNEL_TO_S.bind_call(method_owner)
+    end
+  end
+
   def self.report_error(method_sig, error_message, kind, name, type, value, caller_offset: 0)
     caller_loc = T.must(caller_locations(3 + caller_offset, 1))[0]
     method = method_sig.method
@@ -310,9 +332,9 @@ module T::Private::Methods::CallValidation
     pretty_method_name =
       if owner.singleton_class? && owner.respond_to?(:attached_object)
         # attached_object is new in Ruby 3.2
-        "#{owner.attached_object}.#{method.name}"
+        "#{safe_method_owner_to_s(owner.attached_object)}.#{method.name}"
       else
-        "#{owner}##{method.name}"
+        "#{safe_method_owner_to_s(owner)}##{method.name}"
       end
 
     pretty_message = "#{kind}#{name ? " '#{name}'" : ''}: #{error_message}\n" \

--- a/gems/sorbet-runtime/test/types/method_validation.rb
+++ b/gems/sorbet-runtime/test/types/method_validation.rb
@@ -315,6 +315,58 @@ module Opus::Types::Test
         assert_empty(lines[3..-1])
       end
 
+      it "reports type errors on method's owner isn't a Class or Module" do
+        klass = Class.new do
+          extend T::Sig
+
+          sig { returns(Integer) }
+          def bad_method = "not an integer"
+        end
+
+        object = klass.new
+        def object.to_s = raise
+
+        err = assert_raises(TypeError) { klass.new.bad_method }
+
+        lines = err.message.split("\n")
+        assert_equal("Return value: Expected type Integer, got type String with value \"not an integer\"", lines[0])
+        assert_match(/\ADefinition: .+method_validation.rb:\d+ \(#<Class:0x\h+>#bad_method\)\z/, lines[2])
+      end
+
+      it "reports type errors even when the method owner's to_s returns nil" do
+        klass = Class.new do
+          extend T::Sig
+
+          def self.to_s = nil
+
+          sig { returns(Integer) }
+          def bad_method = "not an integer"
+        end
+
+        err = assert_raises(TypeError) { klass.new.bad_method }
+
+        lines = err.message.split("\n")
+        assert_equal("Return value: Expected type Integer, got type String with value \"not an integer\"", lines[0])
+        assert_match(/\ADefinition: .+method_validation.rb:\d+ \(#<Class:0x\h+>#bad_method\)\z/, lines[2])
+      end
+
+      it "reports type errors even when the method owner's to_s raises a non-StandardError" do
+        klass = Class.new do
+          extend T::Sig
+
+          def self.to_s = raise(Exception) # rubocop:disable Lint/RaiseException
+
+          sig { returns(Integer) }
+          def bad_method = "not an integer"
+        end
+
+        err = assert_raises(TypeError) { klass.new.bad_method }
+
+        lines = err.message.split("\n")
+        assert_equal("Return value: Expected type Integer, got type String with value \"not an integer\"", lines[0])
+        assert_match(/\ADefinition: .+method_validation.rb:\d+ \(#<Class:0x\h+>#bad_method\)\z/, lines[2])
+      end
+
       it "accepts T.proc" do
         @mod.sig { params(blk: T.proc.params(i: Integer).returns(Integer)).returns(Integer) }
         def @mod.foo(&blk)


### PR DESCRIPTION
### Motivation

Prevent crashing if a class/module has a bad `.to_s`:

```ruby
#!/usr/bin/ruby
require 'sorbet-runtime'

class DubiousCode
  extend T::Sig
  
  def self.to_s = raise
  
  sig { returns(Integer) }
  def bad_method = "not an integer" # triggers report_error, which calls DubiousCode.to_s
end

puts DubiousCode.new.bad_method
```


### Test plan