### PR TITLE
sorbet-runtime: Drastically improve type coverage

### DIFF
--- a/gems/sorbet-runtime/.watchmanconfig
+++ b/gems/sorbet-runtime/.watchmanconfig
@@ -1,0 +1,3 @@
+{
+  "root_files": [".watchmanconfig"]
+}

--- a/gems/sorbet-runtime/lib/sorbet-runtime.rb
+++ b/gems/sorbet-runtime/lib/sorbet-runtime.rb
@@ -9,6 +9,7 @@
 module T; end
 module T::Helpers; end
 module T::Private; end
+T::Private::IS_TYPECHECKING = false
 module T::Private::Abstract; end
 module T::Private::Types; end
 

--- a/gems/sorbet-runtime/lib/sorbet-runtime.rbi
+++ b/gems/sorbet-runtime/lib/sorbet-runtime.rbi
@@ -1,0 +1,5 @@
+# typed: strict
+
+module T::Private
+  IS_TYPECHECKING = T.let(false, T::Boolean)
+end

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -1,5 +1,5 @@
-# typed: true
 # frozen_string_literal: true
+# typed: true
 
 module T::Configuration
   # Announces to Sorbet that we are currently in a test environment, so it

--- a/gems/sorbet-runtime/lib/types/private/abstract/validate.rb
+++ b/gems/sorbet-runtime/lib/types/private/abstract/validate.rb
@@ -9,7 +9,7 @@ module T::Private::Abstract::Validate
 
   def self.validate_abstract_module(mod)
     type = Abstract::Data.get(mod, :abstract_type)
-    validate_interface(mod) if type == :interface
+    validate_interface(mod) if :interface == type
   end
 
   # Validates a class/module with an abstract class/module as an ancestor. This must be called

--- a/gems/sorbet-runtime/lib/types/private/abstract/validate.rb
+++ b/gems/sorbet-runtime/lib/types/private/abstract/validate.rb
@@ -56,7 +56,7 @@ module T::Private::Abstract::Validate
       # signature and (b) methods from ancestors (note that these ancestors can come before or
       # after the abstract module in the inheritance chain -- the former coming from
       # walking `mod.ancestors` above).
-      abstract_signature = Methods.signature_for_method(abstract_method)
+      abstract_signature = Methods.signature_for_method(abstract_method) || raise("Method being abstract must imply it has a signature")
       # We allow implementation methods to be defined without a signature.
       # In that case, get its untyped signature.
       implementation_signature ||= Methods::Signature.new_untyped(

--- a/gems/sorbet-runtime/lib/types/private/abstract/validate.rb
+++ b/gems/sorbet-runtime/lib/types/private/abstract/validate.rb
@@ -111,8 +111,8 @@ module T::Private::Abstract::Validate
   end
 
   private_class_method def self.describe_method(method, show_owner: true)
-    loc = if method.source_location
-      method.source_location.join(':')
+    loc = if (source_loc = method.source_location)
+      source_loc.join(':')
     else
       "<unknown location>"
     end

--- a/gems/sorbet-runtime/lib/types/private/abstract/validate.rbi
+++ b/gems/sorbet-runtime/lib/types/private/abstract/validate.rbi
@@ -1,0 +1,21 @@
+# typed: true
+
+module T::Private::Abstract::Validate
+  sig { params(mod: Module).void }
+  def self.validate_abstract_module(mod); end
+
+  sig { params(mod: Module).void }
+  def self.validate_subclass(mod); end
+
+  sig { params(mod: Module, method_names: T::Array[Symbol]).void }
+  private_class_method def self.validate_interface_all_abstract(mod, method_names); end
+
+  sig { params(mod: Module).void }
+  private_class_method def self.validate_interface(mod); end
+
+  sig { params(mod: Module, method_names: T::Array[Symbol]).void }
+  private_class_method def self.validate_interface_all_public(mod, method_names); end
+
+  sig { params(method: UnboundMethod, show_owner: T::Boolean).returns(String) }
+  private_class_method def self.describe_method(method, show_owner: true); end
+end

--- a/gems/sorbet-runtime/lib/types/private/caller_utils.rbi
+++ b/gems/sorbet-runtime/lib/types/private/caller_utils.rbi
@@ -1,0 +1,11 @@
+# typed: true
+
+module T::Private::CallerUtils
+  sig do
+    params(
+      blk: T.proc.params(arg0: Thread::Backtrace::Location).returns(T::Boolean)
+    )
+      .returns(T.nilable(Thread::Backtrace::Location))
+  end
+  def self.find_caller(&blk); end
+end

--- a/gems/sorbet-runtime/lib/types/private/casts.rb
+++ b/gems/sorbet-runtime/lib/types/private/casts.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# typed: false
+# typed: true
 
 module T::Private
   module Casts

--- a/gems/sorbet-runtime/lib/types/private/class_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/class_utils.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# typed: false
+# typed: true
 
 # Cut down version of Chalk::Tools::ClassUtils with only :replace_method functionality.
 # Extracted to a separate namespace so the type system can be used standalone.

--- a/gems/sorbet-runtime/lib/types/private/class_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/class_utils.rb
@@ -22,6 +22,9 @@ module T::Private::ClassUtils
       # of these errors changed across Ruby VM versions, in ways that would sometimes
       # cause tests to fail if they were dependent on hard coding errors).
       mod.method(name)
+      # This is just to prove to Sorbet that this method raises.
+      # This line should be unreachable in practice due to the above call.
+      raise NameError.new("undefined method `#{name}' for class `#{mod}'")
     end
   end
 

--- a/gems/sorbet-runtime/lib/types/private/class_utils.rbi
+++ b/gems/sorbet-runtime/lib/types/private/class_utils.rbi
@@ -1,0 +1,31 @@
+# typed: true
+
+
+module T::Private::ClassUtils
+  sig {params(mod: Module, name: Symbol).returns(Symbol)}
+  def self.visibility_method_name(mod, name); end
+
+  sig do
+    params(
+      mod: Module,
+      name: Symbol,
+      visibility: Symbol,
+      method: T.nilable(T.any(Proc, Method, UnboundMethod)),
+      block: T.nilable(Proc)
+    )
+      .returns(NilClass)
+  end
+  def self.def_with_visibility(mod, name, visibility, method=nil, &block)
+  end
+
+  sig do
+    params(
+      original_method: UnboundMethod,
+      mod: Module,
+      name: Symbol,
+      blk: T.untyped
+    )
+      .returns(NilClass)
+  end
+  def self.replace_method(original_method, mod, name, &blk); end
+end

--- a/gems/sorbet-runtime/lib/types/private/decl_state.rbi
+++ b/gems/sorbet-runtime/lib/types/private/decl_state.rbi
@@ -1,0 +1,34 @@
+# typed: strict
+
+class T::Private::DeclState
+  sig {returns(T::Private::DeclState)}
+  def self.current; end
+
+  sig {params(other: T::Private::DeclState).returns(T::Private::DeclState)}
+  def self.current=(other); end
+
+  sig {returns(T.nilable(T::Private::Methods::DeclarationBlock))}
+  def active_declaration; end
+
+  sig do
+    params(active_declaration: T.nilable(T::Private::Methods::DeclarationBlock))
+      .returns(T.nilable(T::Private::Methods::DeclarationBlock))
+  end
+  def active_declaration=(active_declaration); end
+
+  sig {returns(T.nilable(TrueClass))}
+  def skip_on_method_added; end
+
+  sig {params(skip_on_method_added: T.nilable(TrueClass)).returns(T.nilable(TrueClass))}
+  def skip_on_method_added=(skip_on_method_added); end
+
+  sig {void}
+  def reset!; end
+
+  sig do
+    type_parameters(:U)
+      .params(blk: T.proc.returns(T.type_parameter(:U)))
+      .returns(T.type_parameter(:U))
+  end
+  def without_on_method_added(&blk); end
+end

--- a/gems/sorbet-runtime/lib/types/private/final.rb
+++ b/gems/sorbet-runtime/lib/types/private/final.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# typed: false
+# typed: true
 
 module T::Private::Final
   module NoInherit

--- a/gems/sorbet-runtime/lib/types/private/final.rb
+++ b/gems/sorbet-runtime/lib/types/private/final.rb
@@ -5,19 +5,19 @@ module T::Private::Final
   module NoInherit
     def inherited(arg)
       super(arg)
-      raise "#{self} was declared as final and cannot be inherited"
+      Kernel.raise "#{self} was declared as final and cannot be inherited"
     end
   end
 
   module NoIncludeExtend
     def included(arg)
       super(arg)
-      raise "#{self} was declared as final and cannot be included"
+      Kernel.raise "#{self} was declared as final and cannot be included"
     end
 
     def extended(arg)
       super(arg)
-      raise "#{self} was declared as final and cannot be extended"
+      Kernel.raise "#{self} was declared as final and cannot be extended"
     end
   end
 

--- a/gems/sorbet-runtime/lib/types/private/final.rbi
+++ b/gems/sorbet-runtime/lib/types/private/final.rbi
@@ -1,0 +1,6 @@
+# typed: true
+
+module T::Private::Final
+  sig {params(mod: Module).returns(T::Boolean)}
+  def self.final_module?(mod); end
+end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -32,12 +32,15 @@ module T::Private::Methods
   # in installed_hooks.
   @old_hooks = nil
 
+  # These names are for backwards compatibility from when these were `Object.new` instances
+  # rubocop:disable Naming/ClassAndModuleCamelCase
   module ARG_NOT_PROVIDED
     freeze
   end
   module PROC_TYPE
     freeze
   end
+  # rubocop:enable Naming/ClassAndModuleCamelCase
 
   # blk_or_decl:
   # - It's a `Proc` if we haven't forced the thunk yet.

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -565,14 +565,14 @@ module T::Private::Methods
 
   module MethodHooks
     def method_added(name)
-      ::T::Private::Methods._on_method_added(self, self, name)
+      ::T::Private::Methods._on_method_added(T.unsafe(self), T.unsafe(self), name)
       super(name)
     end
   end
 
   module SingletonMethodHooks
     def singleton_method_added(name)
-      ::T::Private::Methods._on_method_added(self, singleton_class, name)
+      ::T::Private::Methods._on_method_added(T.unsafe(self), singleton_class, name)
       super(name)
     end
   end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -50,7 +50,7 @@ module T::Private::Methods
 
   # See tests for how to use this.  But you shouldn't be using this.
   def self._declare_sig(mod, arg=nil, &blk)
-    _declare_sig_internal(mod, caller_locations(1, 1).first, arg, raw: true, &blk)
+    _declare_sig_internal(mod, caller_locations(1, 1)&.first, arg, raw: true, &blk)
   end
 
   private_class_method def self._declare_sig_internal(mod, loc, arg, raw: false, &blk)
@@ -158,7 +158,8 @@ module T::Private::Methods
           next if defining_ancestor_idx && source_ancestors[defining_ancestor_idx] == ancestor
         end
 
-        definition_file, definition_line = T::Private::Methods.signature_for_method(ancestor.instance_method(method_name)).method.source_location
+        final_sig = T::Private::Methods.signature_for_method(ancestor.instance_method(method_name))
+        definition_file, definition_line = final_sig&.method&.source_location
         is_redefined = target == ancestor
         caller_loc = T::Private::CallerUtils.find_caller { |loc| !loc.path.to_s.start_with?(SORBET_RUNTIME_LIB_PATH) }
         extra_info = "\n"
@@ -396,7 +397,7 @@ module T::Private::Methods
       SignatureValidation.validate(signature)
       signature
     rescue => e
-      super_method = original_method&.super_method
+      super_method = original_method.super_method
       super_signature = signature_for_method(super_method) if super_method
 
       T::Configuration.sig_validation_error_handler(

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -123,6 +123,10 @@ module T::Private::Methods
   # names that were declared final at one point.
   def self._check_final_ancestors(target, target_ancestors, source_method_names, source)
     source_ancestors = nil
+    if T::Private::IS_TYPECHECKING
+      # Need to avoid a pinning error, but don't want to use runtime types in _methods.rb
+      source_ancestors = T.let(nil, T.nilable(T::Array[T::Module[T.anything]]))
+    end
     # use reverse_each to check farther-up ancestors first, for better error messages.
     target_ancestors.reverse_each do |ancestor|
       final_methods = @modules_with_final.fetch(ancestor, nil)

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -32,8 +32,12 @@ module T::Private::Methods
   # in installed_hooks.
   @old_hooks = nil
 
-  ARG_NOT_PROVIDED = Object.new
-  PROC_TYPE = Object.new
+  module ARG_NOT_PROVIDED
+    freeze
+  end
+  module PROC_TYPE
+    freeze
+  end
 
   # blk_or_decl:
   # - It's a `Proc` if we haven't forced the thunk yet.

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# typed: false
+# typed: true
 
 module T::Private::Methods
   @installed_hooks = {}

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -112,7 +112,9 @@ module T::Private::Methods
 
   # Fetch the directory name of the file that defines the `T::Private` constant and
   # add a trailing slash to allow us to match it as a directory prefix.
-  SORBET_RUNTIME_LIB_PATH = File.dirname(T.const_source_location(:Private).first) + File::SEPARATOR
+  sorbet_runtime_loc = T.const_source_location(:Private)
+  raise "T::Private constant location not found" unless sorbet_runtime_loc
+  SORBET_RUNTIME_LIB_PATH = File.dirname(sorbet_runtime_loc.first) + File::SEPARATOR
   private_constant :SORBET_RUNTIME_LIB_PATH
 
   # when target includes a module with instance methods source_method_names, ensure there is zero intersection between
@@ -252,7 +254,7 @@ module T::Private::Methods
         method_sig ||= T::Private::Methods._handle_missing_method_signature(
           self,
           original_method,
-          __callee__,
+          __callee__ || raise("Unknown __callee__ for method without a signature"),
         )
 
         # Should be the same logic as CallValidation.wrap_method_if_needed but we

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -497,8 +497,9 @@ module T::Private::Methods
 
   def self.run_all_sig_blocks(force_type_init: true)
     loop do
-      break if @sig_wrappers.empty?
-      key, = @sig_wrappers.first
+      first_wrapper = @sig_wrappers.first
+      break unless first_wrapper
+      key, = first_wrapper
       run_sig_block_for_key(key, force_type_init: force_type_init)
     end
   end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -4,8 +4,9 @@
 module T::Private::Methods
   @installed_hooks = {}
   if defined?(Concurrent::Hash)
-    @signatures_by_method = Concurrent::Hash.new
-    @sig_wrappers = Concurrent::Hash.new
+    # Hide the Concurrent::Hash so that we get better typing by lying and saying it's a Hash
+    instance_variable_set(:@signatures_by_method, Concurrent::Hash.new)
+    instance_variable_set(:@sig_wrappers, Concurrent::Hash.new)
   else
     @signatures_by_method = {}
     @sig_wrappers = {}

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
@@ -1,0 +1,147 @@
+# typed: true
+
+module T::Private::Methods
+  class DeclarationBlock
+    sig {returns(Module)}
+    attr_accessor :mod
+
+    sig {returns(T.nilable(Thread::Backtrace::Location))}
+    attr_accessor :loc
+
+    sig {returns(T.nilable(T.any(T.proc.returns(DeclBuilder), Declaration)))}
+    attr_accessor :blk_or_decl
+
+    sig {returns(T::Boolean)}
+    attr_accessor :final
+
+    sig {returns(T::Boolean)}
+    attr_accessor :raw
+
+    sig do
+      params(
+        mod: Module,
+        loc: T.nilable(Thread::Backtrace::Location),
+        blk: Proc,
+        final: T::Boolean,
+        raw: T::Boolean
+      )
+        .void
+    end
+    def initialize(mod, loc, blk, final, raw); end
+  end
+
+  @installed_hooks = T.let({}, T::Hash[Module, TrueClass])
+  @modules_with_final = T.let({}, T::Hash[Module, T::Hash[Symbol, TrueClass]])
+  @was_ever_final_names = T.let({}, T::Hash[Symbol, TrueClass])
+  @sig_wrappers = T.let({}, T::Hash[String, T.proc.returns(Signature)])
+  @signatures_by_method = T.let({}, T::Hash[String, Signature])
+  @sigs_that_raised = T.let({}, T::Hash[String, TrueClass])
+  @old_hooks = T.let(nil, T.nilable([UnboundMethod, UnboundMethod, UnboundMethod]))
+
+  sig {params(mod: Module, loc: T.nilable(Thread::Backtrace::Location), arg: T.nilable(Symbol), blk: T.untyped).returns(NilClass)}
+  def self.declare_sig(mod, loc, arg, &blk); end
+
+  sig {params(mod: Module, arg: T.nilable(Symbol), blk: T.untyped).returns(DeclarationBlock)}
+  def self._declare_sig(mod, arg=nil, &blk); end
+
+  sig {params(mod: Module, declblock: T.nilable(DeclarationBlock), blk: T.untyped).void}
+  def self._with_declared_signature(mod, declblock, &blk); end
+
+  sig {returns(T::Private::Methods::DeclBuilder)}
+  def self.start_proc; end
+
+  sig {params(decl: T::Private::Methods::Declaration).returns(T::Types::Proc)}
+  def self.finalize_proc(decl); end
+
+  SORBET_RUNTIME_LIB_PATH = T.let("", String)
+
+  IS_TYPECHECKING = T.let(false, T::Boolean)
+
+  sig {params(target: Module, target_ancestors: T::Array[Module], source_method_names: T::Array[Symbol], source: T.nilable(Module)).void}
+  def self._check_final_ancestors(target, target_ancestors, source_method_names, source); end
+
+  sig {params(mod: Module, method_name: Symbol).returns(NilClass)}
+  def self.add_module_with_final_method(mod, method_name); end
+
+  sig {params(mod: Module).void}
+  def self.note_module_deals_with_final(mod); end
+
+  sig {params(hook_mod: Module, mod: Module, method_name: Symbol).void}
+  def self._on_method_added(hook_mod, mod, method_name); end
+
+  sig {params(receiver: Object, original_method: UnboundMethod, callee: Symbol).returns(T::Private::Methods::Signature)}
+  def self._handle_missing_method_signature(receiver, original_method, callee); end
+
+  sig {params(hook_mod: Module, method_name: Symbol, original_method: UnboundMethod, declaration_block: DeclarationBlock).returns(T::Private::Methods::Signature)}
+  def self.run_sig(hook_mod, method_name, original_method, declaration_block); end
+
+  sig {params(declaration_block: DeclarationBlock).returns(T::Private::Methods::Declaration)}
+  def self.run_builder(declaration_block); end
+
+  sig {params(hook_mod: Module, method_name: Symbol, original_method: UnboundMethod, current_declaration: T::Private::Methods::Declaration).returns(T::Private::Methods::Signature)}
+  def self.build_sig(hook_mod, method_name, original_method, current_declaration); end
+
+  sig {params(method: T.any(Method, UnboundMethod)).returns(T.nilable(T::Private::Methods::Signature))}
+  def self.signature_for_method(method); end
+
+  sig {params(mod: Module, signature: T::Private::Methods::Signature, original_method: UnboundMethod).void}
+  def self.unwrap_method(mod, signature, original_method); end
+
+  sig {params(method: UnboundMethod).returns(T::Boolean)}
+  def self.has_sig_block_for_method(method); end
+
+  sig {params(method: UnboundMethod).returns(T.nilable(T::Private::Methods::Signature))}
+  def self.maybe_run_sig_block_for_method(method); end
+
+  sig {params(key: String).returns(T.nilable(T::Private::Methods::Signature))}
+  def self.maybe_run_sig_block_for_key(key); end
+
+  sig {params(method: UnboundMethod).returns(T::Private::Methods::Signature)}
+  def self.run_sig_block_for_method(method); end
+
+  sig {params(force_type_init: T::Boolean).void}
+  def self.run_all_sig_blocks(force_type_init: true); end
+
+  sig {returns(T::Array[T::Private::Methods::Signature])}
+  def self.all_checked_tests_sigs; end
+
+  sig {params(target: Module, singleton_class: T::Boolean, source: Module).void}
+  def self._hook_impl(target, singleton_class, source); end
+
+  sig {params(enable: T::Boolean).void}
+  def self.set_final_checks_on_hooks(enable); end
+
+  sig {params(mod: T::Module[T.anything]).void}
+  def self.install_hooks(mod); end
+
+  sig {params(mod: Module, loc: T.nilable(Thread::Backtrace::Location), arg: T.nilable(Symbol), raw: T::Boolean, blk: Proc).returns(DeclarationBlock)}
+  private_class_method def self._declare_sig_internal(mod, loc, arg, raw: false, &blk); end
+
+  sig {params(key: String).returns(T.nilable(T::Private::Methods::Signature))}
+  private_class_method def self.signature_for_key(key); end
+
+  sig {params(key: String).returns(T::Boolean)}
+  private_class_method def self.has_sig_block_for_key(key); end
+
+  sig {params(owner: Module, name: T.any(Symbol, String)).returns(String)}
+  private_class_method def self.method_owner_and_name_to_key(owner, name); end
+
+  sig {params(method: T.any(Method, UnboundMethod)).returns(String)}
+  private_class_method def self.method_to_key(method); end
+
+  sig {params(key: String, force_type_init: T::Boolean).returns(T::Private::Methods::Signature)}
+  private_class_method def self.run_sig_block_for_key(key, force_type_init: false); end
+
+  module MethodHooks
+    sig {params(name: Symbol).void}
+    def method_added(name); end
+  end
+
+  module SingletonMethodHooks
+    sig {returns(Class)}
+    def singleton_class; end
+
+    sig {params(name: Symbol).void}
+    def singleton_method_added(name); end
+  end
+end

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# typed: false
+# typed: true
 
 module T::Private::Methods::CallValidation
   CallValidation = T::Private::Methods::CallValidation

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -139,7 +139,7 @@ module T::Private::Methods::CallValidation
     # reduce number of allocations that happen here.
 
     if method_sig.bind
-      message = method_sig.bind.error_message_for_obj(instance)
+      message = method_sig.bind&.error_message_for_obj(instance)
       if message
         CallValidation.report_error(
           method_sig,
@@ -338,7 +338,7 @@ module T::Private::Methods::CallValidation
       end
 
     pretty_message = "#{kind}#{name ? " '#{name}'" : ''}: #{error_message}\n" \
-      "Caller: #{caller_loc.path}:#{caller_loc.lineno}\n" \
+      "Caller: #{caller_loc&.path}:#{caller_loc&.lineno}\n" \
       "Definition: #{definition_file}:#{definition_line} (#{pretty_method_name})"
 
     T::Configuration.call_validation_error_handler(

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rbi
@@ -1,0 +1,68 @@
+# typed: true
+
+module T::Private::Methods
+  module CallValidation
+    sig do
+      params(
+        mod: Module,
+        method_sig: Signature,
+        original_method: UnboundMethod
+      )
+        .returns(UnboundMethod)
+    end
+    def self.wrap_method_if_needed(mod, method_sig, original_method); end
+
+    @is_allowed_to_have_fast_path = T.let(true, T::Boolean)
+
+    sig { returns(T::Boolean) }
+    def self.is_allowed_to_have_fast_path; end
+
+    sig { void }
+    def self.disable_fast_path; end
+
+    sig do
+      params(
+        mod: Module,
+        method_sig: Signature,
+        original_method: UnboundMethod,
+        original_visibility: Symbol
+      )
+        .void
+    end
+    def self.create_abstract_wrapper(mod, method_sig, original_method, original_visibility); end
+
+    sig do
+      params(
+        mod: Module,
+        original_method: UnboundMethod,
+        method_sig: Signature,
+        original_visibility: Symbol
+      )
+        .void
+    end
+    def self.create_validator_method(mod, original_method, method_sig, original_visibility); end
+
+    sig do
+      params(
+        mod: Module,
+        original_method: UnboundMethod,
+        method_sig: Signature,
+        original_visibility: Symbol
+      )
+        .void
+    end
+    def self.create_validator_slow_skip_block_type(mod, original_method, method_sig, original_visibility); end
+
+    sig do
+      params(
+        instance: T.untyped,
+        original_method: UnboundMethod,
+        method_sig: Signature,
+        args: T::Array[Kernel],
+        blk: Proc
+      )
+        .void
+    end
+    def self.validate_call_skip_block_type(instance, original_method, method_sig, args, blk); end
+  end
+end

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -237,7 +237,7 @@ module T::Private::Methods
         decl.params = FROZEN_HASH
       end
       if decl.type_parameters.equal?(ARG_NOT_PROVIDED)
-        decl.type_parameters = FROZEN_HASH
+        decl.type_parameters = FROZEN_ARRAY
       end
 
       decl.finalized = true
@@ -246,5 +246,6 @@ module T::Private::Methods
     end
 
     FROZEN_HASH = {}.freeze
+    FROZEN_ARRAY = [].freeze
   end
 end

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -208,7 +208,7 @@ module T::Private::Methods
       check_live!
 
       names.each do |name|
-        raise BuilderError.new("not a symbol: #{name}") unless name.is_a?(Symbol)
+        raise BuilderError.new("not a symbol: #{name}") unless Symbol === name
       end
 
       if !decl.type_parameters.equal?(ARG_NOT_PROVIDED)

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rbi
@@ -1,0 +1,91 @@
+# typed: true
+
+module T::Private::Methods
+  class Declaration
+    # TODO(jez) Can get the rest of these once ARG_NOT_PROVIDED is a module type
+
+    sig { returns(Module) }
+    attr_accessor :mod
+
+    sig {returns(T::Hash[Symbol, T.untyped])}
+    attr_accessor :params
+
+    sig {returns(Object)}
+    attr_accessor :returns
+
+    sig {returns(BasicObject)}
+    attr_accessor :bind
+
+    sig {returns(String)}
+    attr_accessor :mode
+
+    sig {returns(T.nilable(Symbol))}
+    attr_accessor :checked
+
+    sig {returns(T::Boolean)}
+    attr_accessor :finalized
+
+    sig {returns(T.nilable(T::Array[T.untyped]))}
+    attr_accessor :on_failure
+
+    sig {returns(T.any(T::Boolean, Symbol))}
+    attr_accessor :override_allow_incompatible
+
+    sig {returns(T.any(T::Array[Symbol], T.class_of(ARG_NOT_PROVIDED)))}
+    attr_accessor :type_parameters
+
+    sig {returns(T::Boolean)}
+    attr_accessor :raw
+
+    sig do
+      params(
+        mod: Module,
+        params: Object,
+        returns: Object,
+        bind: T.untyped,
+        mode: String,
+        checked: T.nilable(Symbol),
+        finalized: T::Boolean,
+        on_failure: T.any(T::Array[T.untyped], T.class_of(ARG_NOT_PROVIDED)),
+        override_allow_incompatible: T.any(T::Boolean, Symbol),
+        type_parameters: T.any(T::Array[Symbol], T.class_of(ARG_NOT_PROVIDED)),
+        raw: T::Boolean,
+      )
+        .void
+    end
+    def initialize(
+      mod,
+      params,
+      returns,
+      bind,
+      mode,
+      checked,
+      finalized,
+      on_failure,
+      override_allow_incompatible,
+      type_parameters,
+      raw
+    ); end
+  end
+
+  # NOTE:
+  # Most of the DeclBuilder methods are in rbi/sorbet/builder.rbi,
+  # because this is nominally a "public" API, via sigs.
+  #
+  # The ones that are here are the "private" ones used only for the implementation
+  class DeclBuilder
+    sig {returns(Declaration)}
+    def decl; end
+
+    sig {params(mod: Module, raw: T::Boolean).void}
+    def initialize(mod, raw)
+      @decl = T.let(nil, Declaration)
+    end
+
+    sig {returns(DeclBuilder)}
+    def finalize!; end
+
+    FROZEN_HASH = T.let({}, T::Hash[T.untyped, T.untyped])
+    FROZEN_ARRAY = T.let([], T::Array[T.untyped])
+  end
+end

--- a/gems/sorbet-runtime/lib/types/private/methods/modes.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/modes.rbi
@@ -1,0 +1,26 @@
+# typed: strict
+
+module T::Private::Methods::Modes
+  sig {returns(String)}
+  def self.standard; end
+
+  sig {returns(String)}
+  def self.abstract; end
+
+  sig {returns(String)}
+  def self.overridable; end
+
+  sig {returns(String)}
+  def self.override; end
+
+  sig {returns(String)}
+  def self.overridable_override; end
+
+  sig {returns(String)}
+  def self.untyped; end
+
+  MODES = T.let([], T::Array[String])
+  OVERRIDABLE_MODES = T.let([], T::Array[String])
+  OVERRIDE_MODES = T.let([], T::Array[String])
+  NON_OVERRIDE_MODES = T.let([], T::Array[String])
+end

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -67,10 +67,15 @@ class T::Private::Methods::Signature
     @defined_raw = defined_raw
 
     # Use T.untyped in lieu of T.nilable to try to avoid unnecessary allocations.
-    arg_types = T.let(nil, T.untyped)
-    kwarg_types = T.let(nil, T.untyped)
+    arg_types = nil
+    kwarg_types = nil
+    req_kwarg_names = nil
+    if T::Private::IS_TYPECHECKING
+      arg_types = T.let(nil, T.nilable(T::Array[[Symbol, T::Types::Base]]))
+      kwarg_types = T.let(nil, T.nilable(T::Hash[Symbol, T::Types::Base]))
+      req_kwarg_names = T.let(nil, T.nilable(T::Array[Symbol]))
+    end
     req_arg_count = 0
-    req_kwarg_names = T.let(nil, T.untyped)
 
     # If sig params are declared but there is a single parameter with a missing name
     # **and** the method ends with a "=", assume it is a writer method generated

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -52,7 +52,7 @@ class T::Private::Methods::Signature
     else
       @return_type
     end
-    @bind = bind ? T::Utils.coerce(bind) : bind
+    @bind = NilClass.===(bind) ? bind : T::Utils.coerce(bind)
     @mode = mode
     @check_level = check_level
     @parameters = parameters

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -8,7 +8,13 @@ class T::Private::Methods::Signature
               :check_level, :parameters, :on_failure, :override_allow_incompatible,
               :defined_raw
 
-  UNNAMED_REQUIRED_PARAMETERS = [[:req]].freeze
+  # T.unsafe: `UnboundMethod#parameters` lies and says `T::Array[[Symbol, Symbol]]`.
+  # Sorbet can't lub tuple types, meaning that `T.any([Symbol], [Symbol,
+  # Symbol])` would just be `T::Array[T.untyped]`. But Sorbet can see that
+  # UNNAMED_REQUIRED_PARAMETERS, which is an array of 1-tuples, can never
+  # equal an array of 2-tuples, and calls the code dead. There's no good
+  # option, let's just unsafe until tuples are better and we can fix the sig.
+  UNNAMED_REQUIRED_PARAMETERS = T.unsafe([[:req]].freeze)
 
   def self.new_untyped(method:, mode: T::Private::Methods::Modes.untyped, parameters: method.parameters)
     # Using `NotTyped` ensures we'll get an error if we ever try validation on these.
@@ -16,7 +22,7 @@ class T::Private::Methods::Signature
     raw_return_type = not_typed
     # Map missing parameter names to "argN" positionally
     parameters = parameters.each_with_index.map do |(param_kind, param_name), index|
-      [param_kind, param_name || "arg#{index}"]
+      [param_kind, T.unsafe(param_name) || "arg#{index}".to_sym]
     end
     raw_arg_types = {}
     parameters.each do |_, param_name|
@@ -91,7 +97,7 @@ class T::Private::Methods::Signature
     end
     i = 0
     raw_arg_types.each do |type_name, raw_type|
-      param_kind, param_name = parameters[i]
+      param_kind, param_name = parameters.fetch(i)
 
       if type_name != param_name
         hint = ""
@@ -107,7 +113,7 @@ class T::Private::Methods::Signature
 
         raise "Parameter `#{type_name}` is declared out of order (declared as arg number " \
               "#{i + 1}, defined in the method as arg number " \
-              "#{parameters.index { |_, name| name == type_name } + 1}).#{hint}\nMethod: #{method_desc}"
+              "#{T.must(parameters.index { |_, name| name == type_name }) + 1}).#{hint}\nMethod: #{method_desc}"
       end
 
       type = T::Utils.coerce(raw_type)

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rbi
@@ -1,0 +1,114 @@
+# typed: true
+
+class T::Private::Methods::Signature
+  sig {returns(UnboundMethod)}
+  attr_reader :method
+  sig {returns(Symbol)}
+  attr_reader :method_name
+  sig {returns(T::Array[[Symbol, T::Types::Base]])}
+  attr_reader :arg_types
+  sig {returns(T::Hash[Symbol, T::Types::Base])}
+  attr_reader :kwarg_types
+  sig {returns(T.nilable(T::Types::Base))}
+  attr_reader :block_type
+  sig {returns(T.nilable(Symbol))}
+  attr_reader :block_name
+  sig {returns(T.nilable(T::Types::Base))}
+  attr_reader :rest_type
+  sig {returns(T.nilable(Symbol))}
+  attr_reader :rest_name
+  sig {returns(T.nilable(T::Types::Base))}
+  attr_reader :keyrest_type
+  sig {returns(T.nilable(Symbol))}
+  attr_reader :keyrest_name
+  sig {returns(T.nilable(T::Types::Base))}
+  attr_reader :bind
+  sig {returns(T::Types::Base)}
+  attr_reader :effective_return_type
+  sig {returns(T::Types::Base)}
+  attr_reader :return_type
+  sig {returns(String)}
+  attr_reader :mode
+  sig {returns(Integer)}
+  attr_reader :req_arg_count
+  sig {returns(T::Array[Symbol])}
+  attr_reader :req_kwarg_names
+  sig {returns(Symbol)}
+  attr_reader :check_level
+  sig {returns(T.untyped)}
+  attr_reader :parameters
+  sig {returns(T.nilable(T::Array[T.untyped]))}
+  attr_reader :on_failure
+  sig {returns(T.nilable(T.any(TrueClass, FalseClass, Symbol)))}
+  attr_reader :override_allow_incompatible
+  sig {returns(T::Boolean)}
+  attr_reader :defined_raw
+
+  sig {params(method: UnboundMethod, mode: String, parameters: T.untyped).returns(T.attached_class)}
+  def self.new_untyped(method:, mode: T::Private::Methods::Modes.untyped, parameters: method.parameters); end
+
+  sig do
+    params(
+      method: UnboundMethod,
+      method_name: Symbol,
+      raw_arg_types: T::Hash[T.nilable(Symbol), T.untyped],
+      raw_return_type: T.untyped,
+      bind: T.untyped,
+      mode: String,
+      check_level: T.nilable(Symbol),
+      on_failure: T.nilable(T::Array[T.untyped]),
+      parameters: T.untyped,
+      override_allow_incompatible: T.any(TrueClass, FalseClass, Symbol),
+      defined_raw: T::Boolean,
+    ).void
+  end
+  def initialize(method:, method_name:, raw_arg_types:, raw_return_type:, bind:, mode:, check_level:, on_failure:, parameters: method.parameters, override_allow_incompatible: false, defined_raw: false)
+    @method = T.let(method, UnboundMethod)
+    @method_name = T.let(method_name, Symbol)
+    @block_type = T.let(nil, T.nilable(T::Types::Base))
+    @block_name = T.let(nil, T.nilable(Symbol))
+    @rest_type = T.let(nil, T.nilable(T::Types::Base))
+    @rest_name = T.let(nil, T.nilable(Symbol))
+    @keyrest_type = T.let(nil, T.nilable(T::Types::Base))
+    @keyrest_name = T.let(nil, T.nilable(Symbol))
+    @return_type = T.let(raw_return_type, T::Types::Base)
+    @effective_return_type = T.let(raw_return_type, T::Types::Base)
+    @bind = T.let(nil, T.nilable(T::Types::Base))
+    @mode = T.let(mode, String)
+    @check_level = T.let(check_level, Symbol)
+    @parameters = T.let(parameters, T.untyped)
+    @on_failure = T.let(on_failure, T.nilable(T::Array[T.untyped]))
+    @override_allow_incompatible = T.let(override_allow_incompatible, T.any(T::Boolean, Symbol))
+    @defined_raw = T.let(defined_raw, T::Boolean)
+  end
+
+  sig { params(method_name: Symbol).returns(Symbol) }
+  attr_writer :method_name
+
+  sig {params(alias_name: Symbol).returns(T::Private::Methods::Signature)}
+  def as_alias(alias_name); end
+
+  sig {returns(Integer)}
+  def arg_count; end
+
+  sig {returns(T::Array[Symbol])}
+  def kwarg_names; end
+
+  sig {returns(Module)}
+  def owner; end
+
+  sig {returns(String)}
+  def dsl_method; end
+
+  sig {params(args: T::Array[Kernel], blk: T.proc.params(name: T.untyped, val: T.untyped, type: T::Types::Base).void).void}
+  def each_args_value_type(args, &blk); end
+
+  sig {returns(String)}
+  def method_desc; end
+
+  sig {void}
+  def force_type_init; end
+
+  EMPTY_LIST = T.let(T.unsafe(nil), T::Array[T.untyped])
+  EMPTY_HASH = T.let(T.unsafe(nil), T::Hash[T.untyped, T.untyped])
+end

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rbi
@@ -89,6 +89,10 @@ class T::Private::Methods::Signature
     @on_failure = T.let(on_failure, T.nilable(T::Array[T.untyped]))
     @override_allow_incompatible = T.let(override_allow_incompatible, T.any(T::Boolean, Symbol))
     @defined_raw = T.let(defined_raw, T::Boolean)
+    @arg_types = T.let([], T::Array[[Symbol, T::Types::Base]])
+    @kwarg_types = T.let([], T::Hash[Symbol, T::Types::Base])
+    @req_arg_count = T.let(0, Integer)
+    @req_kwarg_names = T.let([], T::Array[Symbol])
   end
 
   sig { params(method_name: Symbol).returns(Symbol) }

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rbi
@@ -35,7 +35,7 @@ class T::Private::Methods::Signature
   attr_reader :req_kwarg_names
   sig {returns(Symbol)}
   attr_reader :check_level
-  sig {returns(T.untyped)}
+  sig {returns(T::Array[[Symbol, Symbol]])}
   attr_reader :parameters
   sig {returns(T.nilable(T::Array[T.untyped]))}
   attr_reader :on_failure
@@ -44,7 +44,16 @@ class T::Private::Methods::Signature
   sig {returns(T::Boolean)}
   attr_reader :defined_raw
 
-  sig {params(method: UnboundMethod, mode: String, parameters: T.untyped).returns(T.attached_class)}
+  sig do
+    params(
+      method: UnboundMethod,
+      mode: String,
+      # This is a lie: it would be better to say T.any([Symbol], [Symbol, Symbol])
+      # but Sorbet can't lub unequal tuples rught now (leads to T::Array[T.untyped])
+      parameters: T::Array[[Symbol, Symbol]]
+    )
+      .returns(T.attached_class)
+  end
   def self.new_untyped(method:, mode: T::Private::Methods::Modes.untyped, parameters: method.parameters); end
 
   sig do
@@ -57,7 +66,7 @@ class T::Private::Methods::Signature
       mode: String,
       check_level: T.nilable(Symbol),
       on_failure: T.nilable(T::Array[T.untyped]),
-      parameters: T.untyped,
+      parameters: T::Array[[Symbol, Symbol]],
       override_allow_incompatible: T.any(TrueClass, FalseClass, Symbol),
       defined_raw: T::Boolean,
     ).void
@@ -76,7 +85,7 @@ class T::Private::Methods::Signature
     @bind = T.let(nil, T.nilable(T::Types::Base))
     @mode = T.let(mode, String)
     @check_level = T.let(check_level, Symbol)
-    @parameters = T.let(parameters, T.untyped)
+    @parameters = T.let(parameters, T::Array[[Symbol, Symbol]])
     @on_failure = T.let(on_failure, T.nilable(T::Array[T.untyped]))
     @override_allow_incompatible = T.let(override_allow_incompatible, T.any(T::Boolean, Symbol))
     @defined_raw = T.let(defined_raw, T::Boolean)

--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
@@ -168,7 +168,7 @@ module T::Private::Methods::SignatureValidation
     # for any class.
     owner = signature.method.owner
     if (signature.mode == Modes.abstract || Modes::OVERRIDABLE_MODES.include?(signature.mode)) &&
-        owner.singleton_class? && owner.superclass == Module
+        owner.singleton_class? && Class === owner && owner.superclass == Module
       raise "Defining an overridable class method (via #{pretty_mode(signature)}) " \
             "on a module is not allowed. Class methods on " \
             "modules do not get inherited and thus cannot be overridden."

--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
@@ -312,7 +312,7 @@ module T::Private::Methods::SignatureValidation
   private_constant :METHOD_VISIBILITIES
 
   private_class_method def self.visibility_strength(vis)
-    METHOD_VISIBILITIES.find_index(vis)
+    METHOD_VISIBILITIES.find_index(vis) || raise("Unexpected visibility `#{vis}`")
   end
 
   private_class_method def self.base_override_loc_str(signature, super_signature)

--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rbi
@@ -1,0 +1,35 @@
+# typed: true
+
+module T::Private::Methods
+  module SignatureValidation
+    sig {params(signature: Signature).void}
+    def self.validate(signature); end
+
+    sig {params(signature: Signature).returns(String)}
+    private_class_method def self.pretty_mode(signature); end
+
+    sig {params(signature: Signature, super_signature: Signature).void}
+    def self.validate_override_mode(signature, super_signature); end
+
+    sig {params(signature: Signature).void}
+    def self.validate_non_override_mode(signature); end
+
+    sig {params(signature: Signature, super_signature: Signature).void}
+    def self.validate_override_shape(signature, super_signature); end
+
+    sig {params(signature: Signature, super_signature: Signature).void}
+    def self.validate_override_types(signature, super_signature); end
+
+    sig {params(signature: Signature, super_signature: Signature).void}
+    def self.validate_override_visibility(signature, super_signature); end
+
+    sig {params(method: UnboundMethod).returns(Symbol)}
+    private_class_method def self.method_visibility(method); end
+
+    sig {params(vis: Symbol).returns(Integer)}
+    private_class_method def self.visibility_strength(vis); end
+
+    sig {params(signature: Signature, super_signature: Signature).void}
+    private_class_method def self.base_override_loc_str(signature, super_signature); end
+  end
+end

--- a/gems/sorbet-runtime/lib/types/private/runtime_levels.rb
+++ b/gems/sorbet-runtime/lib/types/private/runtime_levels.rb
@@ -32,7 +32,7 @@ module T::Private::RuntimeLevels
   def self.enable_checking_in_tests
     if !@check_tests && @wrapped_tests_with_validation
       all_checked_tests_sigs = T::Private::Methods.all_checked_tests_sigs
-      locations = all_checked_tests_sigs.map { |sig| sig.method.source_location.join(':') }.join("\n- ")
+      locations = all_checked_tests_sigs.map { |sig| sig.method.source_location&.join(':') }.join("\n- ")
       raise "Toggle `:tests`-level runtime type checking earlier. " \
         "There are already some methods wrapped with `sig.checked(:tests)`:\n" \
         "- #{locations}"

--- a/gems/sorbet-runtime/lib/types/private/runtime_levels.rbi
+++ b/gems/sorbet-runtime/lib/types/private/runtime_levels.rbi
@@ -1,0 +1,23 @@
+# typed: true
+
+module T::Private::RuntimeLevels
+  @check_tests = T.let(false, T::Boolean)
+  @wrapped_tests_with_validation = T.let(false, T::Boolean)
+  @has_read_default_checked_level = T.let(false, T::Boolean)
+  @default_checked_level = T.let(:always, Symbol)
+
+  sig {returns(T::Boolean)}
+  def self.check_tests?; end
+
+  sig { void }
+  def self.enable_checking_in_tests; end
+
+  sig {returns(Symbol)}
+  def self.default_checked_level; end
+
+  sig {params(level: Symbol).returns(Symbol)}
+  def self.default_checked_level=(level); end
+
+  sig { params(checked: T::Boolean).void }
+  def self._toggle_checking_tests(checked); end
+end

--- a/gems/sorbet-runtime/lib/types/private/sealed.rb
+++ b/gems/sorbet-runtime/lib/types/private/sealed.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# typed: false
+# typed: true
 
 module T::Private::Sealed
   module NoInherit

--- a/gems/sorbet-runtime/lib/types/private/sealed.rb
+++ b/gems/sorbet-runtime/lib/types/private/sealed.rb
@@ -13,7 +13,7 @@ module T::Private::Sealed
     def sealed_subclasses
       @sorbet_sealed_module_all_subclasses_set ||= # rubocop:disable Naming/MemoizedInstanceVariableName
         begin
-          require 'set'
+          Kernel.require 'set'
           Set.new(@sorbet_sealed_module_all_subclasses).freeze
         end
     end
@@ -40,7 +40,7 @@ module T::Private::Sealed
       # else will add to it
       @sorbet_sealed_module_all_subclasses_set ||= # rubocop:disable Naming/MemoizedInstanceVariableName
         begin
-          require 'set'
+          Kernel.require 'set'
           Set.new(@sorbet_sealed_module_all_subclasses).freeze
         end
     end

--- a/gems/sorbet-runtime/lib/types/sig.rb
+++ b/gems/sorbet-runtime/lib/types/sig.rb
@@ -25,6 +25,6 @@ module T::Sig
   # {T::Helpers}
   T::Sig::WithoutRuntime.sig { params(arg0: T.nilable(Symbol), blk: T.proc.bind(T::Private::Methods::DeclBuilder).void).void }
   def sig(arg0=nil, &blk)
-    T::Private::Methods.declare_sig(self, Kernel.caller_locations(1, 1)&.first, arg0, &blk)
+    T::Private::Methods.declare_sig(T.unsafe(self), Kernel.caller_locations(1, 1)&.first, arg0, &blk)
   end
 end

--- a/gems/sorbet-runtime/lib/types/types/fixed_array.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_array.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 # https://jira.corp.stripe.com/browse/RUBYPLAT-1107
-# typed: false
+# typed: true
 
 module T::Types
   # Takes a list of types. Validates each item in an array using the type in the same position

--- a/gems/sorbet-runtime/lib/types/types/fixed_array.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_array.rb
@@ -29,7 +29,7 @@ module T::Types
       if obj.is_a?(Array) && obj.length == types.length
         i = 0
         while i < types.length
-          if !types[i].recursively_valid?(obj[i])
+          if !types.fetch(i).recursively_valid?(obj[i])
             return false
           end
           i += 1
@@ -45,7 +45,7 @@ module T::Types
       if obj.is_a?(Array) && obj.length == types.length
         i = 0
         while i < types.length
-          if !types[i].valid?(obj[i])
+          if !types.fetch(i).valid?(obj[i])
             return false
           end
           i += 1

--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -91,17 +91,17 @@ module T::Types
           return cached if cached
 
           type = if mod == ::Array
-            T::Array[T.untyped]
+            TypedArray::Untyped::Private::INSTANCE
           elsif mod == ::Hash
-            T::Hash[T.untyped, T.untyped]
+            TypedHash::Untyped.new
           elsif mod == ::Enumerable
-            T::Enumerable[T.untyped]
+            TypedEnumerable::Untyped.new
           elsif mod == ::Enumerator
-            T::Enumerator[T.untyped]
+            TypedEnumerator::Untyped.new
           elsif mod == ::Range
-            T::Range[T.untyped]
+            TypedRange.new(type)
           elsif !Object.autoload?(:Set) && Object.const_defined?(:Set) && mod == ::Set
-            T::Set[T.untyped]
+            TypedSet::Untyped.new
           else
             # ideally we would have a case mapping from ::Class -> T::Class and
             # ::Module -> T::Module here but for backwards compatibility we

--- a/gems/sorbet-runtime/lib/types/types/simple.rbi
+++ b/gems/sorbet-runtime/lib/types/types/simple.rbi
@@ -1,0 +1,28 @@
+# typed: true
+
+module T::Types
+  class Simple < Base
+    NAME_METHOD = T.let(nil, UnboundMethod)
+
+    def initialize(raw_type)
+      @raw_type = T.let(raw_type, Module)
+      @name = T.let(nil, T.nilable(String))
+      @nilable = T.let(nil, T.nilable(T::Private::Types::SimplePairUnion))
+    end
+
+    sig { params(obj: Kernel).returns(String) }
+    private def error_message(obj); end
+
+    module Private
+      module Pool
+        CACHE_FROZEN_OBJECTS = T.let(true, T::Boolean)
+
+        @cache = T.let(nil, ObjectSpace::WeakMap)
+
+        sig { params(mod: Module).returns(Base) }
+        def self.type_for_module(mod)
+        end
+      end
+    end
+  end
+end

--- a/gems/sorbet-runtime/lib/types/types/typed_array.rbi
+++ b/gems/sorbet-runtime/lib/types/types/typed_array.rbi
@@ -1,0 +1,16 @@
+# typed: true
+
+module T::Types
+  class TypedArray < TypedEnumerable
+    module Private
+      module Pool
+      end
+    end
+
+    class Untyped < TypedArray
+      module Private
+        INSTANCE = T.let(Untyped.new.freeze, Untyped)
+      end
+    end
+  end
+end

--- a/gems/sorbet-runtime/lib/types/types/typed_enumerable.rbi
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerable.rbi
@@ -1,0 +1,10 @@
+# typed: true
+
+module T::Types
+  class TypedEnumerable < Base
+    def initialize(type)
+      @inner_type = T.let(type, T.anything)
+      @type = T.let(nil, T.nilable(T::Types::Base))
+    end
+  end
+end

--- a/gems/sorbet-runtime/lib/types/types/union.rb
+++ b/gems/sorbet-runtime/lib/types/types/union.rb
@@ -39,7 +39,7 @@ module T::Types
         # evades Sorbet's static check and we end up on the slow path, or if someone
         # is using the T:Types::Union constructor directly (the latter possibility
         # is why we don't just move the `uniq` into `Private::Pool.union_of_types`).
-        return types[0].name
+        return types.fetch(0).name
       end
       nilable = T::Utils.coerce(NilClass)
       trueclass = T::Utils.coerce(TrueClass)

--- a/gems/sorbet-runtime/lib/types/types/union.rbi
+++ b/gems/sorbet-runtime/lib/types/types/union.rbi
@@ -1,0 +1,13 @@
+# typed: true
+
+module T::Types
+  class Union < Base
+    def initialize(types)
+      @inner_types = T.let(types, T::Array[Kernel])
+      @types = T.let(types, T.nilable(T::Array[Base]))
+    end
+
+    sig { params(types: T::Array[Base]).returns(String) }
+    private def type_shortcuts(types); end
+  end
+end

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -133,7 +133,7 @@ module T::Utils
   # @return [String]
   #
   def self.string_truncate_middle(str, start_len, end_len, ellipsis='...')
-    return unless str
+    return str unless str
 
     raise ArgumentError.new('must provide start_len') unless start_len
     raise ArgumentError.new('must provide end_len') unless end_len

--- a/gems/sorbet-runtime/lib/types/utils.rbi
+++ b/gems/sorbet-runtime/lib/types/utils.rbi
@@ -1,0 +1,54 @@
+# typed: true
+
+module T::Utils
+  # Only one caller--move into abstract validate, instead of typing externally
+  sig { params(mod: Module).returns(T::Array[Symbol]) }
+  def self.methods_excluding_object(mod)
+  end
+
+  # Should be in rbi/sorbet/t.rbi, but should this accept arbitrary type
+  # syntax? Unclear, leaving the type private for now.
+  sig { params(type: T.any(Module, T::Types::Base)).returns(T::Types::Base) }
+  def self.resolve_alias(type); end
+
+  # Should be in rbi/sorbet/t.rbi, but that would require exposing
+  # T::Private::Methods::Signature, which is bigger than I want to tackle rn
+  sig { params(method: UnboundMethod).returns(T.nilable(T::Private::Methods::Signature)) }
+  def self.signature_for_method(method); end
+
+  # Should be in rbi/sorbet/t.rbi, but that would require exposing
+  # T::Private::Methods::Signature, which is bigger than I want to tackle rn
+  sig do
+    params(
+      mod: T::Module[T.anything],
+      method_name: Symbol
+    )
+      .returns(T.nilable(T::Private::Methods::Signature))
+  end
+  def self.signature_for_instance_method(mod, method_name); end
+
+  sig do
+    params(
+      mod: T::Module[T.anything],
+      method_sig: T::Private::Methods::Signature,
+      original_method: UnboundMethod
+    )
+      .returns(UnboundMethod)
+  end
+  def self.wrap_method_with_call_validation_if_needed(mod, method_sig, original_method); end
+
+  # TODO(jez) If we were to move this to the public rbi/ folder, we would
+  # probably want the types to all be non-nil. Maybe we should just make this a
+  # private helper.
+  sig do
+    type_parameters(:U)
+      .params(
+        str: T.any(T.all(T.type_parameter(:U), NilClass), String),
+        start_len: T.nilable(Integer),
+        end_len: T.nilable(Integer),
+        ellipsis: String
+      )
+      .returns(T.any(T.all(T.type_parameter(:U), NilClass), String))
+  end
+  def self.string_truncate_middle(str, start_len, end_len, ellipsis='...'); end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I've been making some changes in various files like `_methods.rb` recently, and it would be really nice to have Sorbet.

It's a little tricky to get this typechecked, because this is the code that implements `sorbet-runtime` signatures, so we can't use runtime signatures (it would be a runtime cycle). Instead, I've added a bunch of RBI files.

This is almost entirely an RBI change, but in some places the runtime changes, too. They should be benign, and I'm going to call out any weird ones.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

We have a bazel target that typechecks the runtime.
