### PR TITLE
Allow new slow path edits to cancel preemption

### DIFF
--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -12,6 +12,7 @@
 #include "main/lsp/LSPConfiguration.h"
 #include "main/lsp/ShowOperation.h"
 #include "main/lsp/json_types.h"
+#include "main/lsp/notifications/sorbet_workspace_edit.h"
 #include "main/pipeline/pipeline.h"
 #include "payload/payload.h"
 
@@ -455,7 +456,30 @@ void LSPIndexer::updateConfigAndGsFromOptions(const DidChangeConfigurationParams
 }
 
 bool LSPIndexer::preemptionPossible(const TaskQueue::QueueType &tasks) const {
-    return !tasks.empty() && tasks.front()->canPreempt(*this);
+    if (tasks.empty()) {
+        return false;
+    }
+
+    auto cannotPreempt =
+        absl::c_find_if_not(tasks, [&indexer = *this](auto &task) { return task->canPreempt(indexer); });
+
+    // No tasks can preempt
+    if (cannotPreempt == tasks.begin()) {
+        return false;
+    }
+
+    // All tasks can preempt
+    if (cannotPreempt == tasks.end()) {
+        return true;
+    }
+
+    // If the first task that can't preempt is a workspace edit, return that preemption is no longer possible so that
+    // the main thread will clean out any tasks that do support preemption in favor forcing the slow path cancellation.
+    if (dynamic_cast<SorbetWorkspaceEditTask *>(cannotPreempt->get())) {
+        return false;
+    }
+
+    return true;
 }
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -474,7 +474,7 @@ bool LSPIndexer::preemptionPossible(const TaskQueue::QueueType &tasks) const {
     }
 
     // If the first task that can't preempt is a workspace edit, return that preemption is no longer possible so that
-    // the main thread will clean out any tasks that do support preemption in favor forcing the slow path cancellation.
+    // the main thread will move the slow path edit to the front of the queue and force a slow path cancellation.
     if (dynamic_cast<SorbetWorkspaceEditTask *>(cannotPreempt->get())) {
         return false;
     }

--- a/main/lsp/LSPLoop.cc
+++ b/main/lsp/LSPLoop.cc
@@ -342,8 +342,8 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> inp
                         }
 
                         // If the first task that cannot preempt is not an edit, there are no tasks to move.
-                        auto cannotPreempt = absl::c_find_if_not(
-                            tasks, [&indexer = this->indexer](auto &task) { return task->canPreempt(indexer); });
+                        auto cannotPreempt = absl::c_find_if(
+                            tasks, [&indexer = this->indexer](auto &task) { return !task->canPreempt(indexer); });
                         if (cannotPreempt == tasks.end() ||
                             dynamic_cast<SorbetWorkspaceEditTask *>(cannotPreempt->get()) == nullptr) {
                             continue;
@@ -351,8 +351,9 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> inp
 
                         config->logger->debug("[Processing] Promoting slow path edits");
 
-                        // Migrate all the edit tasks to the beginning of the queue, but leave everything after
-                        // the first slow path edit alone.
+                        // As we might have more than one edit between the front of the queue and the slow path edit,
+                        // migrate all the edits to the front of the queue and preserve their order so that we can merge
+                        // them into a single edit.
                         auto firstNonEdit = std::stable_partition(tasks.begin(), cannotPreempt + 1, [](auto &task) {
                             return dynamic_cast<SorbetWorkspaceEditTask *>(task.get()) != nullptr;
                         });

--- a/main/lsp/LSPLoop.cc
+++ b/main/lsp/LSPLoop.cc
@@ -360,10 +360,12 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> inp
                         // If we only moved a single edit, we're done.
                         auto numEdits = std::distance(tasks.begin(), firstNonEdit);
                         if (numEdits <= 1) {
+                            prodCategoryCounterInc("lsp.preemption.cancelation", "single");
                             continue;
                         }
 
                         config->logger->debug("[Processing] Merging {} promoted edits", numEdits);
+                        prodCategoryCounterInc("lsp.preemption.cancelation", "merged");
 
                         // At this point, we can assume that the front of the queue is an edit. Merge all of the
                         // newer edits into it to ensure that the front of the queue is a single slow path edit.

--- a/main/lsp/LSPLoop.cc
+++ b/main/lsp/LSPLoop.cc
@@ -330,7 +330,54 @@ optional<unique_ptr<core::GlobalState>> LSPLoop::runLSP(shared_ptr<LSPInput> inp
                             logger->debug("[Processing] Canceled scheduled preemption for task {}", methodStr);
                         }
 
-                        // At this point, we are guaranteed that the scheduled task has run or has been canceled.
+                        // At this point, we know that the preemption task has either run or been cancelled. If it was
+                        // cancelled because we detected a new slow path edit in the queue, move all edits between the
+                        // front of the queue and the slow path edit to the front of the queue, and merge them together.
+                        auto &tasks = this->taskQueue->tasks();
+
+                        // If the front of the queue cannot preempt, then we ran to completion and there are no tasks to
+                        // move.
+                        if (tasks.empty() || !tasks.front()->canPreempt(indexer)) {
+                            continue;
+                        }
+
+                        // If the first task that cannot preempt is not an edit, there are no tasks to move.
+                        auto cannotPreempt = absl::c_find_if_not(
+                            tasks, [&indexer = this->indexer](auto &task) { return task->canPreempt(indexer); });
+                        if (cannotPreempt == tasks.end() ||
+                            dynamic_cast<SorbetWorkspaceEditTask *>(cannotPreempt->get()) == nullptr) {
+                            continue;
+                        }
+
+                        config->logger->debug("[Processing] Promoting slow path edits");
+
+                        // Migrate all the edit tasks to the beginning of the queue, but leave everything after
+                        // the first slow path edit alone.
+                        auto firstNonEdit = std::stable_partition(tasks.begin(), cannotPreempt + 1, [](auto &task) {
+                            return dynamic_cast<SorbetWorkspaceEditTask *>(task.get()) != nullptr;
+                        });
+
+                        // If we only moved a single edit, we're done.
+                        auto numEdits = std::distance(tasks.begin(), firstNonEdit);
+                        if (numEdits <= 1) {
+                            continue;
+                        }
+
+                        config->logger->debug("[Processing] Merging {} promoted edits", numEdits);
+
+                        // At this point, we can assume that the front of the queue is an edit. Merge all of the
+                        // newer edits into it to ensure that the front of the queue is a single slow path edit.
+                        auto *oldestEdit = dynamic_cast<SorbetWorkspaceEditTask *>(tasks.front().get());
+                        ENFORCE(oldestEdit != nullptr);
+
+                        auto second = tasks.begin() + 1;
+                        for (auto it = second; it != firstNonEdit; ++it) {
+                            auto *newerEdit = dynamic_cast<SorbetWorkspaceEditTask *>(it->get());
+                            oldestEdit->mergeNewer(*newerEdit);
+                        }
+
+                        tasks.erase(second, firstNonEdit);
+
                         continue;
                     }
                     // If preemption scheduling failed, then the slow path probably finished just now. Continue as

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -1028,7 +1028,7 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "PreemptionCanceledForSlowPathWorks
     }
 
     // Make a completion query in the queue so that we schedule preemption.
-    sendAsync(*completion("foo.rb", 5, 14));
+    sendAsync(*completion("foo.rb", 4, 14));
 
     // Send another update that finishes the include. This should cancel preemption
     sendAsync(*changeFile("foo.rb",
@@ -1084,6 +1084,192 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "PreemptionCanceledForSlowPathWorks
         auto counters = getCounters();
         CHECK_EQ(counters.getCategoryCounter("lsp.preemption.cancelation", "single"), 1);
         CHECK_EQ(counters.getCategoryCounter("lsp.preemption.cancelation", "merged"), 0);
+    }
+
+    // Make another slow path edit that deletes part of the module name
+    sendAsync(*changeFile("foo.rb",
+                          "# typed: true\n"
+                          "class Foo\n"
+                          "  module ModuleA; end\n"
+                          "  module ModuleB; end\n"
+                          "  include Modu\n"
+                          "end\n",
+                          5, false, 0));
+
+    // Wait for typechecking to start.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // An error will be raised for the include argument
+    {
+        vector<unique_ptr<LSPMessage>> msgs;
+        msgs.emplace_back(readAsync());
+        // TODO(trevor): why does this report the same error twice?
+        assertErrorDiagnostics(move(msgs), {{"foo.rb", 4, "Unable to resolve constant `Modu`"},
+                                            {"foo.rb", 4, "Unable to resolve constant `Modu`"}});
+    }
+
+    // And finally the slow path finishes
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Ended);
+    }
+}
+
+TEST_CASE_FIXTURE(MultithreadedProtocolTest, "PreemptionCanceledForSlowPathWorksWithDelete") {
+    auto initOptions = make_unique<SorbetInitializationOptions>();
+    initOptions->enableTypecheckInfo = true;
+    assertErrorDiagnostics(
+        initializeLSP(true /* supportsMarkdown */, true /* supportsCodeActionResolve */, move(initOptions)), {});
+
+    // Create a simple file.
+    assertErrorDiagnostics(send(*openFile("foo.rb", "")), {});
+    sendAsync(*changeFile("foo.rb",
+                          "# typed: true\n"
+                          "class Foo\n"
+                          "  module ModuleA; end\n"
+                          "  module ModuleB; end\n"
+                          "  include Foo::Bar::Baz::Foo\n"
+                          "end\n",
+                          2));
+
+    // Wait for initial typechecking to start.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // Wait for initial typechecking to finish, with errors.
+    {
+        auto msg = readAsync();
+        REQUIRE(msg->isNotification());
+        REQUIRE_EQ(msg->asNotification().method, LSPMethod::TextDocumentPublishDiagnostics);
+
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Ended);
+    }
+
+    // Clear counters
+    getCounters();
+
+    // Turn on slow path blocking, and send an edit that is going to cause a slow path.
+    setSlowPathBlocked(true);
+    sendAsync(*changeFile("foo.rb",
+                          "# typed: true\n"
+                          "class Foo\n"
+                          "  module ModuleA; end\n"
+                          "  module ModuleB; end\n"
+                          "  include Mod\n"
+                          "end\n",
+                          3, false, 0));
+
+    // Wait for typechecking to start.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // Make a completion query at the end of the old include into the queue so that we schedule preemption.
+    sendAsync(*completion("foo.rb", 4, 28));
+
+    // Send another update that finishes the include. This should cancel preemption
+    sendAsync(*changeFile("foo.rb",
+                          "# typed: true\n"
+                          "class Foo\n"
+                          "  module ModuleA; end\n"
+                          "  module ModuleB; end\n"
+                          "  include ModuleA\n"
+                          "end\n",
+                          4, false, 0));
+
+    // We expect the slow path to be blocked, so we want to make sure that we _don't_ receive any messages within a
+    // pretty long time frame---let's say 2000ms.
+    {
+        auto &wrapper = dynamic_cast<MultiThreadedLSPWrapper &>(*lspWrapper);
+        auto msg = wrapper.read(2000);
+        REQUIRE(msg == nullptr);
+    }
+
+    // Unblock the slow path.
+    setSlowPathBlocked(false);
+
+    // The slow path should now be unblocked, and will be canceled immediately.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Cancelled);
+    }
+
+    // Now we'll see the second slow path edit start
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // Then the response to the completion request
+    {
+        auto msg = readAsync();
+        REQUIRE(msg->isResponse());
+        REQUIRE_EQ(msg->asResponse().requestMethod, LSPMethod::TextDocumentCompletion);
+    }
+
+    // And finally the slow path finishes after reporting that there are no more errors.
+    {
+        std::vector<unique_ptr<LSPMessage>> msgs;
+        msgs.emplace_back(readAsync());
+        assertErrorDiagnostics(move(msgs), {});
+
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Ended);
+    }
+
+    // Verify the path that we took during cancellation.
+    {
+        auto counters = getCounters();
+        CHECK_EQ(counters.getCategoryCounter("lsp.preemption.cancelation", "single"), 1);
+        CHECK_EQ(counters.getCategoryCounter("lsp.preemption.cancelation", "merged"), 0);
+    }
+
+    // Make another slow path edit that deletes part of the module name
+    sendAsync(*changeFile("foo.rb",
+                          "# typed: true\n"
+                          "class Foo\n"
+                          "  module ModuleA; end\n"
+                          "  module ModuleB; end\n"
+                          "  include Modu\n"
+                          "end\n",
+                          5, false, 0));
+
+    // Wait for typechecking to start.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // An error will be raised for the include argument
+    {
+        vector<unique_ptr<LSPMessage>> msgs;
+        msgs.emplace_back(readAsync());
+        // TODO(trevor): why does this report the same error twice?
+        assertErrorDiagnostics(move(msgs), {{"foo.rb", 4, "Unable to resolve constant `Modu`"},
+                                            {"foo.rb", 4, "Unable to resolve constant `Modu`"}});
+    }
+
+    // And finally the slow path finishes
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Ended);
     }
 }
 
@@ -1157,7 +1343,7 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "MergingEditsWhenCancellingPreempti
                           4, false, 0));
 
     // Make a completion query in the queue so that we schedule preemption.
-    sendAsync(*completion("foo.rb", 5, 14));
+    sendAsync(*completion("foo.rb", 4, 14));
 
     // Send another update that finishes the include. This should cancel preemption
     sendAsync(*changeFile("foo.rb",

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -976,4 +976,246 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "StallInSlowPathWorks") {
     }
 }
 
+TEST_CASE_FIXTURE(MultithreadedProtocolTest, "PreemptionCanceledForSlowPathWorks") {
+    auto initOptions = make_unique<SorbetInitializationOptions>();
+    initOptions->enableTypecheckInfo = true;
+    assertErrorDiagnostics(
+        initializeLSP(true /* supportsMarkdown */, true /* supportsCodeActionResolve */, move(initOptions)), {});
+
+    // Create a simple file.
+    assertErrorDiagnostics(send(*openFile("foo.rb", "")), {});
+    sendAsync(*changeFile("foo.rb",
+                          "# typed: true\n"
+                          "class Foo\n"
+                          "  module ModuleA; end\n"
+                          "  module ModuleB; end\n"
+                          "end\n",
+                          2));
+
+    // Wait for initial typechecking to start.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // Wait for initial typechecking to finish.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Ended);
+    }
+
+    // Clear counters
+    getCounters();
+
+    // Turn on slow path blocking, and send an edit that is going to cause a slow path.
+    setSlowPathBlocked(true);
+    sendAsync(*changeFile("foo.rb",
+                          "# typed: true\n"
+                          "class Foo\n"
+                          "  module ModuleA; end\n"
+                          "  module ModuleB; end\n"
+                          "  include Mod\n"
+                          "end\n",
+                          3, false, 0));
+
+    // Wait for typechecking to start.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // Make a completion query in the queue so that we schedule preemption.
+    sendAsync(*completion("foo.rb", 5, 14));
+
+    // Send another update that finishes the include. This should cancel preemption
+    sendAsync(*changeFile("foo.rb",
+                          "# typed: true\n"
+                          "class Foo\n"
+                          "  module ModuleA; end\n"
+                          "  module ModuleB; end\n"
+                          "  include ModuleA\n"
+                          "end\n",
+                          4, false, 0));
+
+    // We expect the slow path to be blocked, so we want to make sure that we _don't_ receive any messages within a
+    // pretty long time frame---let's say 2000ms.
+    {
+        auto &wrapper = dynamic_cast<MultiThreadedLSPWrapper &>(*lspWrapper);
+        auto msg = wrapper.read(2000);
+        REQUIRE(msg == nullptr);
+    }
+
+    // Unblock the slow path.
+    setSlowPathBlocked(false);
+
+    // The slow path should now be unblocked, and will be canceled immediately.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Cancelled);
+    }
+
+    // Now we'll see the second slow path edit start
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // Then the response to the completion request
+    {
+        auto msg = readAsync();
+        REQUIRE(msg->isResponse());
+        REQUIRE_EQ(msg->asResponse().requestMethod, LSPMethod::TextDocumentCompletion);
+    }
+
+    // And finally the slow path finishes
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Ended);
+    }
+
+    // Verify the path that we took during cancellation.
+    {
+        auto counters = getCounters();
+        CHECK_EQ(counters.getCategoryCounter("lsp.preemption.cancelation", "single"), 1);
+        CHECK_EQ(counters.getCategoryCounter("lsp.preemption.cancelation", "merged"), 0);
+    }
+}
+
+TEST_CASE_FIXTURE(MultithreadedProtocolTest, "MergingEditsWhenCancellingPreemptionWorks") {
+    auto initOptions = make_unique<SorbetInitializationOptions>();
+    initOptions->enableTypecheckInfo = true;
+    assertErrorDiagnostics(
+        initializeLSP(true /* supportsMarkdown */, true /* supportsCodeActionResolve */, move(initOptions)), {});
+
+    // Create a simple file.
+    assertErrorDiagnostics(send(*openFile("foo.rb", "")), {});
+    sendAsync(*changeFile("foo.rb",
+                          "# typed: true\n"
+                          "class Foo\n"
+                          "  module ModuleA; end\n"
+                          "  module ModuleB; end\n"
+                          "\n"
+                          "  def foo\n"
+                          "  end\n"
+                          "end\n",
+                          2));
+
+    // Wait for initial typechecking to start.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // Wait for initial typechecking to finish.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Ended);
+    }
+
+    // Clear counters
+    getCounters();
+
+    // Turn on slow path blocking, and send an edit that is going to cause a slow path.
+    setSlowPathBlocked(true);
+    sendAsync(*changeFile("foo.rb",
+                          "# typed: true\n"
+                          "class Foo\n"
+                          "  module ModuleA; end\n"
+                          "  module ModuleB; end\n"
+                          "  include Mod\n"
+                          "  def foo\n"
+                          "  end\n"
+                          "end\n",
+                          3, false, 0));
+
+    // Wait for typechecking to start.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // Send another change that would take the fast path
+    sendAsync(*changeFile("foo.rb",
+                          "# typed: true\n"
+                          "class Foo\n"
+                          "  module ModuleA; end\n"
+                          "  module ModuleB; end\n"
+                          "  include Mod\n"
+                          "  def foo\n"
+                          "    puts :hi\n"
+                          "  end\n"
+                          "end\n",
+                          4, false, 0));
+
+    // Make a completion query in the queue so that we schedule preemption.
+    sendAsync(*completion("foo.rb", 5, 14));
+
+    // Send another update that finishes the include. This should cancel preemption
+    sendAsync(*changeFile("foo.rb",
+                          "# typed: true\n"
+                          "class Foo\n"
+                          "  module ModuleA; end\n"
+                          "  module ModuleB; end\n"
+                          "  include ModuleA\n"
+                          "  def foo\n"
+                          "    puts :hi\n"
+                          "  end\n"
+                          "end\n",
+                          5, false, 0));
+
+    // We expect the slow path to be blocked, so we want to make sure that we _don't_ receive any messages within a
+    // pretty long time frame---let's say 2000ms.
+    {
+        auto &wrapper = dynamic_cast<MultiThreadedLSPWrapper &>(*lspWrapper);
+        auto msg = wrapper.read(2000);
+        REQUIRE(msg == nullptr);
+    }
+
+    // Unblock the slow path.
+    setSlowPathBlocked(false);
+
+    // The slow path should now be unblocked, and will be canceled immediately.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Cancelled);
+    }
+
+    // Now we'll see the second slow path edit start
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // Then the response to the completion request
+    {
+        auto msg = readAsync();
+        REQUIRE(msg->isResponse());
+        REQUIRE_EQ(msg->asResponse().requestMethod, LSPMethod::TextDocumentCompletion);
+    }
+
+    // And finally the slow path finishes
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Ended);
+    }
+
+    // Verify the path that we took during cancellation.
+    {
+        auto counters = getCounters();
+        CHECK_EQ(counters.getCategoryCounter("lsp.preemption.cancelation", "single"), 0);
+        CHECK_EQ(counters.getCategoryCounter("lsp.preemption.cancelation", "merged"), 1);
+    }
+}
 } // namespace sorbet::test::lsp


### PR DESCRIPTION
When the slow path is running and we decide to schedule the preemption task, a new slow path edit arriving will be blocked from cancelling the slow path as long as preemptable tasks exist at the head of the queue. This will all resolve as soon as we start processing tasks during preemption (or those tasks at the head of the queue are cancelled by the client) but on large codebases that can be a bit of a wait.

This PR makes a change to how we decide to stop waiting for preemption from `LSPLoop`: if we detect a slow path edit is stuck behind other tasks that support preemption, we eagerly cancel preemption and bump all edits up to the newest slow path edit to the front of the queue. This enables us to cancel the existing slow path on the next iteration of the task processing loop, and avoid running preemption tasks off of stale versions of files being edited.

One drawback with this approach is that if the client doesn't cancel those preemption tasks, they may run on a newer version of the file's contents than when they were scheduled. This seems like an acceptable tradeoff, as in larger codebases where the time to preemption can grow long, it's better to restart the slow path faster in service of a more responsive editor experience.

### Motivation
Lowering slow path latency.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
