### PR TITLE
Add optional `inherit` argument to `protected_method_defined?` and `public_method_defined?`

### DIFF
--- a/rbi/core/module.rbi
+++ b/rbi/core/module.rbi
@@ -1531,10 +1531,11 @@ class Module < Object
   sig do
     params(
         arg0: T.any(Symbol, String),
+        inherit: T::Boolean,
     )
     .returns(T::Boolean)
   end
-  def protected_method_defined?(arg0); end
+  def protected_method_defined?(arg0, inherit=true); end
 
   # With no arguments, sets the default visibility for subsequently defined
   # methods to public. With arguments, sets the named methods to have public
@@ -1621,10 +1622,11 @@ class Module < Object
   sig do
     params(
         arg0: T.any(Symbol, String),
+        inherit: T::Boolean,
     )
     .returns(T::Boolean)
   end
-  def public_method_defined?(arg0); end
+  def public_method_defined?(arg0, inherit=true); end
 
   # Refine *mod* in the receiver.
   #


### PR DESCRIPTION
## Summary

- Add the optional second `inherit` argument to `Module#protected_method_defined?` (defaults to `true`)
- Add the optional second `inherit` argument to `Module#public_method_defined?` (defaults to `true`)

These match the signatures for `Module#method_defined?` and `Module#private_method_defined?`, which already include this parameter.

## References

- https://docs.ruby-lang.org/en/3.4/Module.html#method-i-protected_method_defined-3F
- https://docs.ruby-lang.org/en/3.4/Module.html#method-i-public_method_defined-3F