### PR TITLE
Add `benchmark` gem as explicit dev dependency

### DIFF
--- a/gems/sorbet-runtime/sorbet-runtime.gemspec
+++ b/gems/sorbet-runtime/sorbet-runtime.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ['>= 3.0.0']
 
+  s.add_development_dependency 'benchmark'
   s.add_development_dependency 'minitest', '~> 5.11'
   s.add_development_dependency 'mocha', '~> 2.1'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
### Motivation

Fixes this warning:

> /.../sorbet-runtime/bench/getters.rb:4: warning: benchmark used to be loaded from the standard library, but is not part of the default gems since Ruby 4.0.0.
You can add benchmark to your Gemfile or gemspec to fix this error.