### PR TITLE
Remove additional std::optional indirection

### DIFF
--- a/core/lsp/TypecheckEpochManager.cc
+++ b/core/lsp/TypecheckEpochManager.cc
@@ -62,7 +62,7 @@ bool TypecheckEpochManager::tryCancelSlowPath(uint32_t newEpoch) {
 }
 
 bool TypecheckEpochManager::tryCommitEpoch(core::GlobalState &gs, uint32_t epoch, bool isCancelable,
-                                           optional<shared_ptr<PreemptionTaskManager>> preemptionManager,
+                                           shared_ptr<PreemptionTaskManager> preemptionManager,
                                            function<void()> typecheck) {
     assertConsistentThread(typecheckingThreadId, "TypecheckEpochManager::tryCommitEpoch", "typechecking");
     if (!isCancelable) {
@@ -95,10 +95,10 @@ bool TypecheckEpochManager::tryCommitEpoch(core::GlobalState &gs, uint32_t epoch
         }
     }
 
-    if (preemptionManager.has_value()) {
+    if (preemptionManager) {
         // Now that we are no longer running a slow path, run a preemption task that might have snuck in while we were
         // finishing up. No others can be scheduled.
-        (*preemptionManager)->tryRunScheduledPreemptionTask(gs);
+        preemptionManager->tryRunScheduledPreemptionTask(gs);
     }
     return committed;
 }

--- a/core/lsp/TypecheckEpochManager.h
+++ b/core/lsp/TypecheckEpochManager.h
@@ -53,8 +53,7 @@ public:
     // Tries to commit the given epoch. Returns true if the commit succeeded, or false if it was canceled.
     // The presence of PreemptionTaskManager determines if this commit is preemptible.
     bool tryCommitEpoch(core::GlobalState &gs, uint32_t epoch, bool isCancelable,
-                        std::optional<std::shared_ptr<PreemptionTaskManager>> preemptionManager,
-                        std::function<void()> typecheck);
+                        std::shared_ptr<PreemptionTaskManager> preemptionManager, std::function<void()> typecheck);
     // Grabs the epoch lock, and calls function with the current typechecking status.
     void withEpochLock(std::function<void(TypecheckingStatus)> lambda) const;
 };


### PR DESCRIPTION
Remove one additional `std::optional<std::shared_ptr<...>>` that I missed in #10127.

### Motivation
Simplification.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavioral change expected, refactoring only.
