### PR TITLE
Add `T::Types::Base#build_type` abstract method

### DIFF
--- a/rbi/sorbet/ttypes.rbi
+++ b/rbi/sorbet/ttypes.rbi
@@ -14,6 +14,9 @@ class T::Types::Base
   sig { abstract.params(obj: Kernel).returns(T::Boolean) }
   def valid?(obj); end
 
+  sig { abstract.void }
+  def build_type; end
+
   def recursively_valid?(obj); end
 
   # Should return `String` but this is hard because technically


### PR DESCRIPTION
There are other methods following this pattern in `T::Types::Base`, like
`valid?`. The implementation in the source file itself is

    define_method(:build_type) do
      raise NotImplementedError
    end

To avoid needing to rely on `sig { abstract }` to raise the
`NotImplementedError` exception


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Typing `gems/sorbet-runtime/`. Some code won't typecheck until this is defined.

Trying to pull out the changes that could have external effects into their own
PRs.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

```
stog //gems/sorbet-runtime:runtime-typechecks
```