### PR TITLE
Some more typing refactors

### DIFF
--- a/gems/sorbet-runtime/BUILD
+++ b/gems/sorbet-runtime/BUILD
@@ -24,7 +24,9 @@ filegroup(
     srcs = glob([
         "lib/**/*.rbi",
         "sorbet/rbi/**/*.rbi",
-    ]),
+    ]) + [
+        "sorbet/config",
+    ],
 )
 
 sh_test(

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -22,10 +22,10 @@ module T::Private::Methods
         ARG_NOT_PROVIDED, # returns
         ARG_NOT_PROVIDED, # bind
         Modes.standard, # mode
-        ARG_NOT_PROVIDED, # checked
+        nil, # checked
         false, # finalized
         ARG_NOT_PROVIDED, # on_failure
-        nil, # override_allow_incompatible
+        false, # override_allow_incompatible
         ARG_NOT_PROVIDED, # type_parameters
         raw
       )
@@ -98,10 +98,10 @@ module T::Private::Methods
     def checked(level)
       check_live!
 
-      if !decl.checked.equal?(ARG_NOT_PROVIDED)
+      if !decl.checked.nil?
         raise BuilderError.new("You can't call .checked multiple times in a signature.")
       end
-      if level == :never && !decl.on_failure.equal?(ARG_NOT_PROVIDED)
+      if :never == level && !decl.on_failure.equal?(ARG_NOT_PROVIDED)
         raise BuilderError.new("You can't use .checked(:#{level}) with .on_failure because .on_failure will have no effect.")
       end
       if !T::Private::RuntimeLevels::LEVELS.include?(level)
@@ -119,8 +119,13 @@ module T::Private::Methods
       if !decl.on_failure.equal?(ARG_NOT_PROVIDED)
         raise BuilderError.new("You can't call .on_failure multiple times in a signature.")
       end
-      if decl.checked == :never
-        raise BuilderError.new("You can't use .on_failure with .checked(:#{decl.checked}) because .on_failure will have no effect.")
+      effective_checked = decl.checked.nil? ? T::Private::RuntimeLevels.default_checked_level : decl.checked
+      if effective_checked == :never
+        if decl.checked.nil?
+          raise BuilderError.new("To use .on_failure you must additionally call .checked(:tests) or .checked(:always), otherwise, the .on_failure has no effect.")
+        else
+          raise BuilderError.new("You can't use .on_failure with .checked(:#{effective_checked}) because .on_failure will have no effect.")
+        end
       end
 
       decl.on_failure = args
@@ -224,13 +229,6 @@ module T::Private::Methods
 
       if decl.bind.equal?(ARG_NOT_PROVIDED)
         decl.bind = nil
-      end
-      if decl.checked.equal?(ARG_NOT_PROVIDED)
-        default_checked_level = T::Private::RuntimeLevels.default_checked_level
-        if default_checked_level == :never && !decl.on_failure.equal?(ARG_NOT_PROVIDED)
-          raise BuilderError.new("To use .on_failure you must additionally call .checked(:tests) or .checked(:always), otherwise, the .on_failure has no effect.")
-        end
-        decl.checked = default_checked_level
       end
       if decl.on_failure.equal?(ARG_NOT_PROVIDED)
         decl.on_failure = nil

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -242,12 +242,12 @@ class T::Private::Methods::Signature
   end
 
   def method_desc
-    loc = if @method.source_location
-      @method.source_location.join(':')
+    loc = if (source_loc = @method.source_location)
+      source_loc.join(':')
     else
       "<unknown location>"
     end
-    "#{@method} at #{loc}"
+    "#{@method.owner}##{@method_name} at #{loc}"
   end
 
   def force_type_init

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -37,6 +37,7 @@ class T::Private::Methods::Signature
   end
 
   def initialize(method:, method_name:, raw_arg_types:, raw_return_type:, bind:, mode:, check_level:, on_failure:, parameters: method.parameters, override_allow_incompatible: false, defined_raw: false)
+    check_level = check_level.nil? ? T::Private::RuntimeLevels.default_checked_level : check_level
     @method = method
     @method_name = method_name
     @block_type = nil

--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
@@ -126,12 +126,12 @@ module T::Private::Methods::SignatureValidation
         # Peaceful
       elsif super_signature.mode == Modes.abstract
         raise "You must use `.override` when overriding the abstract method `#{signature.method_name}`.\n" \
-              "  Abstract definition: #{method_loc_str(super_signature.method)}\n" \
-              "  Implementation definition: #{method_loc_str(signature.method)}\n"
+              "  Abstract definition: #{super_signature.method_desc}\n" \
+              "  Implementation definition: #{signature.method_desc}\n"
       elsif super_signature.mode != Modes.untyped
         raise "You must use `.override` when overriding the existing method `#{signature.method_name}`.\n" \
-              "  Parent definition: #{method_loc_str(super_signature.method)}\n" \
-              "  Child definition:  #{method_loc_str(signature.method)}\n"
+              "  Parent definition: #{super_signature.method_desc}\n" \
+              "  Child definition:  #{signature.method_desc}\n"
       end
     else
       raise "Unexpected mode: #{signature.mode}. Please report this bug at https://github.com/sorbet/sorbet/issues"
@@ -153,7 +153,7 @@ module T::Private::Methods::SignatureValidation
       else
         raise "You marked `#{signature.method_name}` as #{pretty_mode(signature)}, but that method doesn't already exist in this class/module to be overridden.\n" \
           "  Either check for typos and for missing includes or super classes to make the parent method shows up\n" \
-          "  ... or remove #{pretty_mode(signature)} here: #{method_loc_str(signature.method)}\n"
+          "  ... or remove #{pretty_mode(signature)} here: #{signature.method_desc}\n"
       end
     when Modes.standard, *Modes::NON_OVERRIDE_MODES
       # Peaceful
@@ -244,8 +244,8 @@ module T::Private::Methods::SignatureValidation
       if !super_type.subtype_of?(type)
         raise "Incompatible type for arg ##{index + 1} (`#{name}`) in signature for #{mode_noun} of method " \
               "`#{signature.method_name}`:\n" \
-              "* Base: `#{super_type}` (in #{method_loc_str(super_signature.method)})\n" \
-              "* #{mode_noun.capitalize}: `#{type}` (in #{method_loc_str(signature.method)})\n" \
+              "* Base: `#{super_type}` (in #{super_signature.method_desc})\n" \
+              "* #{mode_noun.capitalize}: `#{type}` (in #{signature.method_desc})\n" \
               "(The types must be contravariant.)"
       end
     end
@@ -255,8 +255,8 @@ module T::Private::Methods::SignatureValidation
       type = signature.kwarg_types[name]
       if !super_type.subtype_of?(type)
         raise "Incompatible type for arg `#{name}` in signature for #{mode_noun} of method `#{signature.method_name}`:\n" \
-              "* Base: `#{super_type}` (in #{method_loc_str(super_signature.method)})\n" \
-              "* #{mode_noun.capitalize}: `#{type}` (in #{method_loc_str(signature.method)})\n" \
+              "* Base: `#{super_type}` (in #{super_signature.method_desc})\n" \
+              "* #{mode_noun.capitalize}: `#{type}` (in #{signature.method_desc})\n" \
               "(The types must be contravariant.)"
       end
     end
@@ -271,8 +271,8 @@ module T::Private::Methods::SignatureValidation
 
     if !signature.effective_return_type.subtype_of?(super_signature_return_type)
       raise "Incompatible return type in signature for #{mode_noun} of method `#{signature.method_name}`:\n" \
-            "* Base: `#{super_signature.effective_return_type}` (in #{method_loc_str(super_signature.method)})\n" \
-            "* #{mode_noun.capitalize}: `#{signature.effective_return_type}` (in #{method_loc_str(signature.method)})\n" \
+            "* Base: `#{super_signature.effective_return_type}` (in #{super_signature.method_desc})\n" \
+            "* #{mode_noun.capitalize}: `#{signature.effective_return_type}` (in #{signature.method_desc})\n" \
             "(The types must be covariant.)"
     end
   end
@@ -297,8 +297,8 @@ module T::Private::Methods::SignatureValidation
 
     if visibility_strength(vis) > visibility_strength(super_vis)
       raise "Incompatible visibility for #{mode_noun} of method #{method.name}\n" \
-            "* Base: #{super_vis} (in #{method_loc_str(super_method)})\n" \
-            "* #{mode_noun.capitalize}: #{vis} (in #{method_loc_str(method)})\n" \
+            "* Base: #{super_vis} (in #{super_signature.method_desc})\n" \
+            "* #{mode_noun.capitalize}: #{vis} (in #{signature.method_desc})\n" \
             "(The override must be at least as permissive as the supermethod)" \
     end
   end
@@ -317,16 +317,7 @@ module T::Private::Methods::SignatureValidation
 
   private_class_method def self.base_override_loc_str(signature, super_signature)
     mode_noun = super_signature.mode == Modes.abstract ? 'Implementation' : 'Override'
-    "\n * Base definition: in #{method_loc_str(super_signature.method)}" \
-    "\n * #{mode_noun}: in #{method_loc_str(signature.method)}"
-  end
-
-  private_class_method def self.method_loc_str(method)
-    loc = if method.source_location
-      method.source_location.join(':')
-    else
-      "<unknown location>"
-    end
-    "#{method.owner} at #{loc}"
+    "\n * Base definition: in #{super_signature.method_desc}" \
+    "\n * #{mode_noun}: in #{signature.method_desc}"
   end
 end

--- a/gems/sorbet-runtime/sorbet/config
+++ b/gems/sorbet-runtime/sorbet/config
@@ -1,5 +1,6 @@
 --dir=.
 --ignore=bench
---ignore=test/types
---ignore=test/wholesome
+--ignore=test
 --ignore=vendor
+# suppress splats to avoid some `T.unsafe`
+--suppress-error-code=7019

--- a/gems/sorbet-runtime/test/typecheck-runtime.sh
+++ b/gems/sorbet-runtime/test/typecheck-runtime.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-main/sorbet "$@"
+cd gems/sorbet-runtime
+# Inherits arguments from sorbet/config
+../../main/sorbet

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -26,7 +26,7 @@ module Opus::Types::Test
       assert_equal(mod, builder.decl.mod)
       assert_equal({x: Integer}, builder.decl.params)
       assert_equal(String, builder.decl.returns)
-      assert_equal(:always, builder.decl.checked)
+      assert_nil(builder.decl.checked)
       assert_equal('standard', builder.decl.mode)
       assert_equal(true, builder.decl.finalized)
     end

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -891,7 +891,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     e = assert_raises { instance.foo }
     assert_equal("foo", e.message)
     e = assert_raises { instance.foo }
-    assert_match(/A previous invocation of #<UnboundMethod: /, e.message)
+    assert_match(/A previous invocation of #<Class:/, e.message)
   end
 
   it 'does not crash when two threads call the same wrapper' do

--- a/gems/sorbet-runtime/test/types/method_modes.rb
+++ b/gems/sorbet-runtime/test/types/method_modes.rb
@@ -164,7 +164,7 @@ class Opus::Types::Test::MethodModesTest < Critic::Unit::UnitTest
       assert_includes(
         err.message,
         "You must use `.override` when overriding the abstract method `foo`.\n" \
-        "  Abstract definition: #{AbstractMixin} at #{__FILE__}"
+        "  Abstract definition: #{AbstractMixin}#foo at #{__FILE__}"
       )
     end
   end

--- a/gems/sorbet-runtime/test/types/validate_override_shape.rb
+++ b/gems/sorbet-runtime/test/types/validate_override_shape.rb
@@ -107,7 +107,7 @@ module Opus::Types::Test
       )
       assert_includes(
         err.message,
-        "in #{Base} at #{__FILE__}"
+        "in #{Base}#foo at #{__FILE__}"
       )
     end
 
@@ -130,7 +130,7 @@ module Opus::Types::Test
       )
       assert_includes(
         err.message,
-        "in #{Base} at #{__FILE__}"
+        "in #{Base}#foo at #{__FILE__}"
       )
     end
 
@@ -153,7 +153,7 @@ module Opus::Types::Test
       )
       assert_includes(
         err.message,
-        "in #{Base} at #{__FILE__}"
+        "in #{Base}#foo at #{__FILE__}"
       )
     end
 
@@ -176,7 +176,7 @@ module Opus::Types::Test
       )
       assert_includes(
         err.message,
-        "in #{Base} at #{__FILE__}"
+        "in #{Base}#foo at #{__FILE__}"
       )
     end
 
@@ -199,7 +199,7 @@ module Opus::Types::Test
       )
       assert_includes(
         err.message,
-        "in #{Base} at #{__FILE__}"
+        "in #{Base}#foo at #{__FILE__}"
       )
     end
 


### PR DESCRIPTION
This contains two main changes to the externally-visible runtime behavior of
sorbet-runtime which I need to add better typing for `_methods.rb`.

I think they're pretty benign, but I wanted to pull them out into their own PR
so that they don't get wrapped up with all the other, trivial typing changes to
come in a future PR.

### Commit summary

- **Refactor `checked` in `Declaration` and `Signature`** (2fb0b92a77)

  This makes `Declaration#checked` always store a `T.nilable(Symbol)` and
  makes `Signature#check_level` always store a `Symbol`.

  This technically is user-visible if people are introspecting private state,
  but I don't think people are in practice. However, getting this wrong could
  cause e.g. `default_checked_level` to fail to have an effect, so better to
  have it in its own change.

- **Consolidate on one method printing helper** (3e9b7dda6f)

  There was `method_loc_str` and `method_desc` that did mostly the same
  thing but slightly differently. One was defined for just `UnboundMethod`
  objects, the other is for `Signature` objects. But every time we used
  the former, we also had a `Signature` on hand, so we can just
  consolidate on the `Signature#method_desc` helper.

  (This was causing a typing error because the `source_location` method
  call was happening twice, leading to a spurious `nil` type error.)

- **Some adjustments to the harness** (95c4a961a8)

  This way, any options in the `sorbet/config` file stay in sync with the
  bazel target.



<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Typing sorbet-runtime implementation.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests