### PR TITLE
add a `sig` for `Enumerable#uniq`

### DIFF
--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -1793,6 +1793,11 @@ module Enumerable
   #
   # See also
   # [`Array#uniq`](https://docs.ruby-lang.org/en/2.7.0/Array.html#method-i-uniq).
+  sig do
+    params(
+      blk: T.nilable(T.proc.params(arg0: Elem).returns(T.anything))
+    ).returns(T::Array[Elem])
+  end
   def uniq(&blk); end
 
   # Iterates the given block for each slice of <n> elements. If no block is


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Saw `.uniq` on a `T::Set[X]` was returning untyped and didn't like it.

See the similar signature for `Array#uniq`:

https://github.com/sorbet/sorbet/blob/a64b588170750b87bd4b4d1b387e64e349188317/rbi/core/array.rbi#L2699-L2700

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests, testing on Stripe's codebase.
