### PR TITLE
Allow preemption tasks to reschedule

### DIFF
--- a/core/lsp/PreemptionTask.h
+++ b/core/lsp/PreemptionTask.h
@@ -15,8 +15,8 @@ public:
     // be done until the stratum indicated.
     virtual std::optional<uint16_t> run(uint16_t currentStratum) = 0;
 
-    // Optional hook called when the task has been run to completion. Any notification to unblock other threads sould be
-    // done here to avoid accidentally unblocking work that could interact with the preemption scheduler.
+    // Optional hook called when the task has been run to completion. Any notification to unblock other threads should
+    // be done here to avoid accidentally unblocking work that could interact with the preemption scheduler.
     virtual void finish() {}
 
     // Disallow copy/move to force management through smart pointers.

--- a/core/lsp/PreemptionTask.h
+++ b/core/lsp/PreemptionTask.h
@@ -1,6 +1,8 @@
 #ifndef SORBET_LSP_PREEMPTION_TASK_H
 #define SORBET_LSP_PREEMPTION_TASK_H
 
+#include <cstdint>
+
 namespace sorbet::core::lsp {
 // Generic interface for tasks that can run at preemption points.
 class PreemptionTask {
@@ -8,7 +10,7 @@ public:
     PreemptionTask() = default;
     virtual ~PreemptionTask() = default;
 
-    virtual void run() = 0;
+    virtual void run(uint16_t currentStratum) = 0;
 
     // Disallow copy/move to force management through smart pointers.
     PreemptionTask(PreemptionTask &) = delete;

--- a/core/lsp/PreemptionTask.h
+++ b/core/lsp/PreemptionTask.h
@@ -2,6 +2,7 @@
 #define SORBET_LSP_PREEMPTION_TASK_H
 
 #include <cstdint>
+#include <optional>
 
 namespace sorbet::core::lsp {
 // Generic interface for tasks that can run at preemption points.
@@ -10,7 +11,13 @@ public:
     PreemptionTask() = default;
     virtual ~PreemptionTask() = default;
 
-    virtual void run(uint16_t currentStratum) = 0;
+    // Run the preemption task. Returning a non-empty result indicates that there is more work to do, and that it can't
+    // be done until the stratum indicated.
+    virtual std::optional<uint16_t> run(uint16_t currentStratum) = 0;
+
+    // Optional hook called when the task has been run to completion. Any notification to unblock other threads sould be
+    // done here to avoid accidentally unblocking work that could interact with the preemption scheduler.
+    virtual void finish() {}
 
     // Disallow copy/move to force management through smart pointers.
     PreemptionTask(PreemptionTask &) = delete;

--- a/core/lsp/PreemptionTaskManager.cc
+++ b/core/lsp/PreemptionTaskManager.cc
@@ -34,9 +34,18 @@ bool PreemptionTaskManager::trySchedulePreemptionTask(shared_ptr<PreemptionTask>
     return success;
 }
 
-bool PreemptionTaskManager::tryRunScheduledPreemptionTask(const core::GlobalState &gs) {
+bool PreemptionTaskManager::tryRunScheduledPreemptionTask(const core::GlobalState &gs, bool allowReschedule) {
     TypecheckEpochManager::assertConsistentThread(
         typecheckingThreadId, "PreemptionTaskManager::tryRunScheduledPreemptionTask", "typechecking thread");
+
+    auto currentStratum = this->preemptionStratum.load();
+    auto runnableStratum = this->runnableAt.load();
+    // We can early-exit if we know that it's not possible to run preemption yet, but if we know that rescheduling is
+    // not possible, we should run to completion.
+    if (allowReschedule && currentStratum < runnableStratum) {
+        return false;
+    }
+
     auto preemptTask = atomic_load(&this->preemptTask);
     if (preemptTask != nullptr &&
         atomic_compare_exchange_strong(&this->preemptTask, &preemptTask, shared_ptr<PreemptionTask>(nullptr))) {
@@ -50,7 +59,22 @@ bool PreemptionTaskManager::tryRunScheduledPreemptionTask(const core::GlobalStat
         gs.errorQueue = make_shared<core::ErrorQueue>(previousErrorQueue->logger, previousErrorQueue->tracer,
                                                       make_shared<core::NullFlusher>());
         gs.tracer().debug("[Typechecker] Beginning preemption task.");
-        preemptTask->run(this->getPreemptionStratum());
+        auto result = preemptTask->run(currentStratum);
+        if (allowReschedule && result.has_value()) {
+            // In this case the task has indicated that there's more work to do, but that it can't occur until the
+            // stratum named in `result`. We re-queue the task, and remember the stratum that we can run at so that we
+            // can early exit in future calls to `tryRunScheduledPreemptionTask`.
+            this->runnableAt.store(*result);
+
+            // As we haven't called `finish` yet, we're assuming unique access to the preemptTask slot: LSPLoop should
+            // be blocked as the PreemptionLoop won't have notified it yet.
+            auto existingTask = atomic_load(&this->preemptTask);
+            ENFORCE(existingTask == nullptr);
+            auto success = atomic_compare_exchange_strong(&this->preemptTask, &existingTask, preemptTask);
+            ENFORCE(success);
+        } else {
+            preemptTask->finish();
+        }
         gs.tracer().debug("[Typechecker] Preemption task complete.");
         gs.errorQueue = move(previousErrorQueue);
         return true;

--- a/core/lsp/PreemptionTaskManager.cc
+++ b/core/lsp/PreemptionTaskManager.cc
@@ -34,11 +34,11 @@ bool PreemptionTaskManager::trySchedulePreemptionTask(shared_ptr<PreemptionTask>
     return success;
 }
 
-bool PreemptionTaskManager::tryRunScheduledPreemptionTask(const core::GlobalState &gs, bool allowReschedule) {
+bool PreemptionTaskManager::tryRunScheduledPreemptionTask(const core::GlobalState &gs, uint16_t currentStratum,
+                                                          bool allowReschedule) {
     TypecheckEpochManager::assertConsistentThread(
         typecheckingThreadId, "PreemptionTaskManager::tryRunScheduledPreemptionTask", "typechecking thread");
 
-    auto currentStratum = this->preemptionStratum.load();
     auto runnableStratum = this->runnableAt.load();
     // We can early-exit if we know that it's not possible to run preemption yet, but if we know that rescheduling is
     // not possible, we should run to completion.

--- a/core/lsp/PreemptionTaskManager.cc
+++ b/core/lsp/PreemptionTaskManager.cc
@@ -78,10 +78,12 @@ bool PreemptionTaskManager::tryRunScheduledPreemptionTask(const core::GlobalStat
             ENFORCE(existingTask == nullptr);
             auto success = atomic_compare_exchange_strong(&this->preemptTask, &existingTask, preemptTask);
             ENFORCE(success);
+
+            gs.tracer().debug("[Typechecker] Preemption task deferred.");
         } else {
             preemptTask->finish();
+            gs.tracer().debug("[Typechecker] Preemption task complete.");
         }
-        gs.tracer().debug("[Typechecker] Preemption task complete.");
         gs.errorQueue = move(previousErrorQueue);
         return true;
     }

--- a/core/lsp/PreemptionTaskManager.cc
+++ b/core/lsp/PreemptionTaskManager.cc
@@ -50,7 +50,7 @@ bool PreemptionTaskManager::tryRunScheduledPreemptionTask(const core::GlobalStat
         gs.errorQueue = make_shared<core::ErrorQueue>(previousErrorQueue->logger, previousErrorQueue->tracer,
                                                       make_shared<core::NullFlusher>());
         gs.tracer().debug("[Typechecker] Beginning preemption task.");
-        preemptTask->run();
+        preemptTask->run(this->getPreemptionStratum());
         gs.tracer().debug("[Typechecker] Preemption task complete.");
         gs.errorQueue = move(previousErrorQueue);
         return true;

--- a/core/lsp/PreemptionTaskManager.cc
+++ b/core/lsp/PreemptionTaskManager.cc
@@ -17,19 +17,26 @@ bool PreemptionTaskManager::trySchedulePreemptionTask(shared_ptr<PreemptionTask>
     bool success = false;
     // Need to grab epoch lock so we have accurate information w.r.t. if typechecking is happening / if typechecking was
     // canceled. Avoids races with typechecking thread.
-    this->epochManager->withEpochLock(
-        [&preemptTask = this->preemptTask, &task, &success](TypecheckEpochManager::TypecheckingStatus status) -> void {
-            // The code should only ever set one preempt function.
-            auto existingTask = atomic_load(&preemptTask);
-            ENFORCE(existingTask == nullptr);
-            if (!status.slowPathRunning || status.slowPathWasCanceled || existingTask != nullptr) {
-                // No slow path running, typechecking was canceled so we can't preempt the canceled slow path, or a task
-                // is already scheduled. The latter should _never_ occur, as the scheduled task should _block_ the
-                // thread that scheduled it.
-                return;
-            }
-            success = atomic_compare_exchange_strong(&preemptTask, &existingTask, move(task));
-        });
+    this->epochManager->withEpochLock([&preemptTask = this->preemptTask, &runnableAt = this->runnableAt, &task,
+                                       &success](TypecheckEpochManager::TypecheckingStatus status) -> void {
+        // The code should only ever set one preempt function.
+        auto existingTask = atomic_load(&preemptTask);
+        ENFORCE(existingTask == nullptr);
+        if (!status.slowPathRunning || status.slowPathWasCanceled || existingTask != nullptr) {
+            // No slow path running, typechecking was canceled so we can't preempt the canceled slow path, or a task
+            // is already scheduled. The latter should _never_ occur, as the scheduled task should _block_ the
+            // thread that scheduled it.
+            return;
+        }
+
+        // We preemptively reset the runnableStratum at this point. Because we are already assuming that the task
+        // slot is empty, this should not have any affect on an existing task. However, if there was somehow a task
+        // already scheduled that had set `runnableAt`, this would cause it to run again immediately and then
+        // potentially defer itself again.
+        runnableAt.store(0);
+
+        success = atomic_compare_exchange_strong(&preemptTask, &existingTask, move(task));
+    });
 
     return success;
 }
@@ -39,10 +46,9 @@ bool PreemptionTaskManager::tryRunScheduledPreemptionTask(const core::GlobalStat
     TypecheckEpochManager::assertConsistentThread(
         typecheckingThreadId, "PreemptionTaskManager::tryRunScheduledPreemptionTask", "typechecking thread");
 
-    auto runnableStratum = this->runnableAt.load();
     // We can early-exit if we know that it's not possible to run preemption yet, but if we know that rescheduling is
     // not possible, we should run to completion.
-    if (allowReschedule && currentStratum < runnableStratum) {
+    if (allowReschedule && currentStratum < this->runnableAt.load()) {
         return false;
     }
 
@@ -66,8 +72,8 @@ bool PreemptionTaskManager::tryRunScheduledPreemptionTask(const core::GlobalStat
             // can early exit in future calls to `tryRunScheduledPreemptionTask`.
             this->runnableAt.store(*result);
 
-            // As we haven't called `finish` yet, we're assuming unique access to the preemptTask slot: LSPLoop should
-            // be blocked as the PreemptionLoop won't have notified it yet.
+            // As we haven't called `finish` yet, we're assuming unique access to the preemptTask slot: LSPLoop will be
+            // blocked as the PreemptionLoop won't have notified it yet.
             auto existingTask = atomic_load(&this->preemptTask);
             ENFORCE(existingTask == nullptr);
             auto success = atomic_compare_exchange_strong(&this->preemptTask, &existingTask, preemptTask);

--- a/core/lsp/PreemptionTaskManager.h
+++ b/core/lsp/PreemptionTaskManager.h
@@ -23,6 +23,20 @@ private:
     std::optional<std::thread::id> processingThreadId;
 
     // If a preemption task has rescheduled itself, this is the stratum that it indicated it would be runnable at.
+    //
+    // This is written from two contexts:
+    // 1. `trySchedulePreemptionTask`, where it is reset to zero when preemption task scheduling is successful,
+    // 2. and `tryRunScheduledPreemptionTask`, where it's set if the task indicates that it can't run until some future
+    //    stratum N.
+    //
+    // These two writes are safe for the following reasons:
+    // 1. No other preemption task will be scheduled, when its set in `trySchedulePreemptionTask`, and the only
+    //    implementation of `PreemptionTask` that we run outside of tasks is `PreemptionLoop`, which blocks the main
+    //    thread while it's scheduled.
+    // 2. No other preemption task will be scheduled while we're running the current one, as the main thread will be
+    //    blocked waiting for a notification from the running task's `finish` method. Again, this logic is pretty
+    //    specific to the `PreemptionLoop` implementation, but that's also the only non-test implementation of
+    //    `PremeptionTask`.
     std::atomic<uint16_t> runnableAt = 0;
 
 public:
@@ -45,13 +59,6 @@ public:
     std::unique_ptr<absl::ReaderMutexLock> lockPreemption() const;
     // (For testing only) Assert that typecheckMutex is held.
     void assertTypecheckMutexHeld();
-
-    // Reset the preemption stratum back to the first stratum.
-    void resetPreemptionStratum() {
-        // The first time we run a preemption task, it won't know what stratum it needs to be run at, so we
-        // optimistically track this as stratum zero, with the assupmtion that rescheduling will be cheap.
-        this->runnableAt.store(0);
-    }
 };
 
 } // namespace sorbet::core::lsp

--- a/core/lsp/PreemptionTaskManager.h
+++ b/core/lsp/PreemptionTaskManager.h
@@ -22,10 +22,6 @@ private:
     // Thread ID of the processing thread. Lazily set.
     std::optional<std::thread::id> processingThreadId;
 
-    // The stratum that the typechecker is currently typechecking. Preemption is available for all strata whose id is
-    // less than or equal to this number.
-    std::atomic<uint16_t> preemptionStratum = 0;
-
     // If a preemption task has rescheduled itself, this is the stratum that it indicated it would be runnable at.
     std::atomic<uint16_t> runnableAt = 0;
 
@@ -41,7 +37,7 @@ public:
     // cleared out. Otherwise there is the possibility that it might get rescheduled, which would cause problems the
     // next time preemption was scheduled from the main thread. Handles running task with a fresh errorQueue, and
     // restoring previous errorQueue when done.
-    bool tryRunScheduledPreemptionTask(const core::GlobalState &gs, bool allowReschedule);
+    bool tryRunScheduledPreemptionTask(const core::GlobalState &gs, uint16_t currentStratum, bool allowReschedule);
     // Run only from processing thread.
     // Tries to cancel the scheduled preemption task. Returns true if it succeeds.
     bool tryCancelScheduledPreemptionTask(std::shared_ptr<PreemptionTask> &task);
@@ -52,24 +48,9 @@ public:
 
     // Reset the preemption stratum back to the first stratum.
     void resetPreemptionStratum() {
-        this->preemptionStratum.store(0);
-
         // The first time we run a preemption task, it won't know what stratum it needs to be run at, so we
         // optimistically track this as stratum zero, with the assupmtion that rescheduling will be cheap.
         this->runnableAt.store(0);
-    }
-
-    // Return the current stratum. All preemption tasks that are possible to run at a stratum that is less than or equal
-    // to this number are runnable at this point.
-    uint16_t getPreemptionStratum() {
-        return this->preemptionStratum.load();
-    }
-
-    // Increment the current preepmtion stratum. Used to indicate that we've started processing a new stratum in the
-    // condensation graph.
-    // Only called from the slow path.
-    void incrementPreemptionStratum() {
-        this->preemptionStratum.fetch_add(1);
     }
 };
 

--- a/core/lsp/PreemptionTaskManager.h
+++ b/core/lsp/PreemptionTaskManager.h
@@ -26,6 +26,9 @@ private:
     // less than or equal to this number.
     std::atomic<uint16_t> preemptionStratum = 0;
 
+    // If a preemption task has rescheduled itself, this is the stratum that it indicated it would be runnable at.
+    std::atomic<uint16_t> runnableAt = 0;
+
 public:
     PreemptionTaskManager(std::shared_ptr<TypecheckEpochManager> epochManager);
     // Run only from processing thread.
@@ -34,8 +37,11 @@ public:
     bool trySchedulePreemptionTask(std::shared_ptr<PreemptionTask> task);
     // Run only from the typechecking thread.
     // Runs the scheduled preemption task, if any.
-    // Handles running task with a fresh errorQueue, and restoring previous errorQueue when done.
-    bool tryRunScheduledPreemptionTask(const core::GlobalState &gs);
+    // Must be called with `allowReschedule` set to false on the last run to ensure that the preemption task gets
+    // cleared out. Otherwise there is the possibility that it might get rescheduled, which would cause problems the
+    // next time preemption was scheduled from the main thread. Handles running task with a fresh errorQueue, and
+    // restoring previous errorQueue when done.
+    bool tryRunScheduledPreemptionTask(const core::GlobalState &gs, bool allowReschedule);
     // Run only from processing thread.
     // Tries to cancel the scheduled preemption task. Returns true if it succeeds.
     bool tryCancelScheduledPreemptionTask(std::shared_ptr<PreemptionTask> &task);
@@ -47,6 +53,10 @@ public:
     // Reset the preemption stratum back to the first stratum.
     void resetPreemptionStratum() {
         this->preemptionStratum.store(0);
+
+        // The first time we run a preemption task, it won't know what stratum it needs to be run at, so we
+        // optimistically track this as stratum zero, with the assupmtion that rescheduling will be cheap.
+        this->runnableAt.store(0);
     }
 
     // Return the current stratum. All preemption tasks that are possible to run at a stratum that is less than or equal

--- a/core/lsp/PreemptionTaskManager.h
+++ b/core/lsp/PreemptionTaskManager.h
@@ -22,6 +22,10 @@ private:
     // Thread ID of the processing thread. Lazily set.
     std::optional<std::thread::id> processingThreadId;
 
+    // The stratum that the typechecker is currently typechecking. Preemption is available for all strata whose id is
+    // less than or equal to this number.
+    std::atomic<uint16_t> preemptionStratum = 0;
+
 public:
     PreemptionTaskManager(std::shared_ptr<TypecheckEpochManager> epochManager);
     // Run only from processing thread.
@@ -39,6 +43,24 @@ public:
     std::unique_ptr<absl::ReaderMutexLock> lockPreemption() const;
     // (For testing only) Assert that typecheckMutex is held.
     void assertTypecheckMutexHeld();
+
+    // Reset the preemption stratum back to the first stratum.
+    void resetPreemptionStratum() {
+        this->preemptionStratum.store(0);
+    }
+
+    // Return the current stratum. All preemption tasks that are possible to run at a stratum that is less than or equal
+    // to this number are runnable at this point.
+    uint16_t getPreemptionStratum() {
+        return this->preemptionStratum.load();
+    }
+
+    // Increment the current preepmtion stratum. Used to indicate that we've started processing a new stratum in the
+    // condensation graph.
+    // Only called from the slow path.
+    void incrementPreemptionStratum() {
+        this->preemptionStratum.fetch_add(1);
+    }
 };
 
 } // namespace sorbet::core::lsp

--- a/core/lsp/PreemptionTaskManager.h
+++ b/core/lsp/PreemptionTaskManager.h
@@ -36,7 +36,7 @@ private:
     // 2. No other preemption task will be scheduled while we're running the current one, as the main thread will be
     //    blocked waiting for a notification from the running task's `finish` method. Again, this logic is pretty
     //    specific to the `PreemptionLoop` implementation, but that's also the only non-test implementation of
-    //    `PremeptionTask`.
+    //    `PreemeptionTask`.
     std::atomic<uint16_t> runnableAt = 0;
 
 public:

--- a/core/lsp/TypecheckEpochManager.cc
+++ b/core/lsp/TypecheckEpochManager.cc
@@ -63,7 +63,7 @@ bool TypecheckEpochManager::tryCancelSlowPath(uint32_t newEpoch) {
 
 bool TypecheckEpochManager::tryCommitEpoch(core::GlobalState &gs, uint32_t epoch, bool isCancelable,
                                            shared_ptr<PreemptionTaskManager> preemptionManager,
-                                           function<void()> typecheck) {
+                                           function<uint16_t()> typecheck) {
     assertConsistentThread(typecheckingThreadId, "TypecheckEpochManager::tryCommitEpoch", "typechecking");
     if (!isCancelable) {
         typecheck();
@@ -74,7 +74,7 @@ bool TypecheckEpochManager::tryCommitEpoch(core::GlobalState &gs, uint32_t epoch
     ENFORCE(ABSL_TS_UNCHECKED_READ(currentlyProcessingLSPEpoch).load() == epoch);
     // Typechecking does not run under the mutex, as it would prevent another thread from running `tryCancelSlowPath`
     // during typechecking.
-    typecheck();
+    auto finalStratum = typecheck();
 
     bool committed = false;
     {
@@ -98,7 +98,7 @@ bool TypecheckEpochManager::tryCommitEpoch(core::GlobalState &gs, uint32_t epoch
     if (preemptionManager) {
         // Now that we are no longer running a slow path, run a preemption task that might have snuck in while we were
         // finishing up. No others can be scheduled.
-        preemptionManager->tryRunScheduledPreemptionTask(gs, /* allowReschedule */ false);
+        preemptionManager->tryRunScheduledPreemptionTask(gs, finalStratum, /* allowReschedule */ false);
     }
     return committed;
 }

--- a/core/lsp/TypecheckEpochManager.cc
+++ b/core/lsp/TypecheckEpochManager.cc
@@ -98,7 +98,7 @@ bool TypecheckEpochManager::tryCommitEpoch(core::GlobalState &gs, uint32_t epoch
     if (preemptionManager) {
         // Now that we are no longer running a slow path, run a preemption task that might have snuck in while we were
         // finishing up. No others can be scheduled.
-        preemptionManager->tryRunScheduledPreemptionTask(gs);
+        preemptionManager->tryRunScheduledPreemptionTask(gs, /* allowReschedule */ false);
     }
     return committed;
 }

--- a/core/lsp/TypecheckEpochManager.h
+++ b/core/lsp/TypecheckEpochManager.h
@@ -2,6 +2,7 @@
 #define SORBET_LSP_TYPECHECKEPOCHMANAGER_H
 
 #include "core/core.h"
+#include <cstdint>
 #include <memory>
 
 namespace sorbet::core::lsp {
@@ -53,7 +54,7 @@ public:
     // Tries to commit the given epoch. Returns true if the commit succeeded, or false if it was canceled.
     // The presence of PreemptionTaskManager determines if this commit is preemptible.
     bool tryCommitEpoch(core::GlobalState &gs, uint32_t epoch, bool isCancelable,
-                        std::shared_ptr<PreemptionTaskManager> preemptionManager, std::function<void()> typecheck);
+                        std::shared_ptr<PreemptionTaskManager> preemptionManager, std::function<uint16_t()> typecheck);
     // Grabs the epoch lock, and calls function with the current typechecking status.
     void withEpochLock(std::function<void(TypecheckingStatus)> lambda) const;
 };

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -326,7 +326,9 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
     auto sorted = sortParsedFiles(*gs, *errorReporter, move(resolved));
     const auto presorted = true;
     const auto cancelable = false;
-    pipeline::typecheck(*gs, move(sorted), config->opts, workers, cancelable, nullptr, presorted);
+    // TODO(trevor): ultimately this should be the maximum stratum, but for now this is acceptable.
+    const auto currentStratum = 0;
+    pipeline::typecheck(*gs, move(sorted), config->opts, workers, cancelable, currentStratum, nullptr, presorted);
     gs->lspTypecheckCount++;
 
     auto duration = timeit.setEndTime();
@@ -388,7 +390,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
     auto &epochManager = *this->gs->epochManager;
     // Note: Commits can only be canceled if this edit is cancelable, LSP is running across multiple threads, and the
     // cancelation feature is enabled.
-    auto committed = epochManager.tryCommitEpoch(*this->gs, epoch, cancelable, preemptManager, [&]() -> void {
+    auto committed = epochManager.tryCommitEpoch(*this->gs, epoch, cancelable, preemptManager, [&]() -> uint16_t {
         // Replace error queue with one that is owned by this thread.
         this->gs->errorQueue =
             make_shared<core::ErrorQueue>(this->gs->errorQueue->logger, this->gs->errorQueue->tracer, errorFlusher);
@@ -519,6 +521,11 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
         if (this->config->opts.cacheSensitiveOptions.sorbetPackages) {
             Timer timeit(this->config->logger, "buildPackageDB");
 
+            // This is a bit of a lie: we haven't gotten the first stratum to a state where we could run preemption
+            // tasks yet, but any errors raised by running a preemption action on this incomplete global state will be
+            // transient.
+            uint16_t firstStratum = 0;
+
             auto numPackageFiles = pipeline::partitionPackageFiles(*this->gs, workspaceFilesSpan);
             auto inputPackageFiles = workspaceFilesSpan.first(numPackageFiles);
             workspaceFilesSpan = workspaceFilesSpan.subspan(numPackageFiles);
@@ -528,7 +535,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
                     hashing::Hashing::indexAndComputeFileHashes(*this->gs, this->config->opts, *this->config->logger,
                                                                 inputPackageFiles, workers, ownedKvstore, cancelable);
                 if (!result.hasResult()) {
-                    return;
+                    return firstStratum;
                 }
                 packageIndexed = std::move(result.result());
             }
@@ -553,16 +560,23 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
                 pipeline::name(*this->gs, absl::MakeSpan(packageIndexed), this->config->opts, workers, foundHashes);
             if (cancelled) {
                 ast::ParsedFilesOrCancelled::cancel(move(packageIndexed), workers);
-                return;
+                return firstStratum;
             }
 
             pipeline::buildPackageDB(*this->gs, absl::MakeSpan(packageIndexed), workspaceFilesSpan, this->config->opts,
                                      workers);
         }
 
+        // This is cast to a uint16_t everywhere it's used. This seems bad, but it should be fine because:
+        // 1. we increment in the beginning of the loop before any use
+        // 2. overflowing a uint16_t would mean that we have a chain of depndencies that's >65535 packages long
+        int currentStratum = -1;
+
         auto strata = pipeline::computePackageStrata(*this->gs, packageIndexed, workspaceFilesSpan, this->config->opts);
         for (auto &stratum : strata.strata) {
             vector<ast::ParsedFile> stratumFiles, nonPackagedIndexed;
+
+            ++currentStratum;
 
             // When we unpartition the package and non-package files, we'll realloc stratumFiles to hold everything.
             stratumFiles.reserve(stratum.packageFiles.size() + stratum.sourceFiles.size());
@@ -589,7 +603,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
                         ownedKvstore, cancelable);
                     if (!result.hasResult()) {
                         ast::ParsedFilesOrCancelled::cancel(std::move(stratumFiles), workers);
-                        return;
+                        return currentStratum;
                     }
                     nonPackagedIndexed = std::move(result.result());
                     this->cacheUpdatedFiles(nonPackagedIndexed, openFiles);
@@ -621,7 +635,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
                 if (canceled) {
                     ast::ParsedFilesOrCancelled::cancel(move(stratumFiles), workers);
                     ast::ParsedFilesOrCancelled::cancel(move(nonPackagedIndexed), workers);
-                    return;
+                    return currentStratum;
                 }
                 pipeline::validatePackagedFiles(*this->gs, absl::MakeSpan(nonPackagedIndexed), this->config->opts,
                                                 workers);
@@ -633,14 +647,14 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
             indexingOp.reset();
 
             if (epochManager.wasTypecheckingCanceled()) {
-                return;
+                return currentStratum;
             }
 
             pipeline::unpartitionPackageFiles(stratumFiles, std::move(nonPackagedIndexed));
 
             auto maybeResolved = pipeline::resolve(*gs, move(stratumFiles), config->opts, workers);
             if (!maybeResolved.hasResult()) {
-                return;
+                return currentStratum;
             }
 
             if (gs->sleepInSlowPathSeconds.has_value()) {
@@ -668,7 +682,8 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
             while (updates.preemptionsExpected > 0) {
                 auto loopStartTime = Timer::clock_gettime_coarse();
                 auto coarseThreshold = Timer::get_clock_threshold_coarse();
-                while (!preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true)) {
+                while (
+                    !preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true)) {
                     auto curTime = Timer::clock_gettime_coarse();
                     if (curTime.usec - loopStartTime.usec > 20'000'000) {
                         Exception::raise("Slow path timed out waiting for preemption edit");
@@ -689,15 +704,16 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
                     }
                     Timer::timedSleep(coarseThreshold, *logger, "slow_path.expected_cancellation.sleep");
                 }
-                return;
+                return currentStratum;
             }
 
             auto sorted = sortParsedFiles(*gs, *errorReporter, move(maybeResolved.result()));
             const auto presorted = true;
-            pipeline::typecheck(*gs, move(sorted), config->opts, workers, cancelable, preemptManager, presorted);
-
-            this->preemptManager->incrementPreemptionStratum();
+            pipeline::typecheck(*gs, move(sorted), config->opts, workers, cancelable, currentStratum, preemptManager,
+                                presorted);
         }
+
+        return currentStratum;
     });
 
     gs->lspQuery = core::lsp::Query::noQuery();

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -384,8 +384,6 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
         timeit.setTag("cancelable", "false");
     }
 
-    this->preemptManager->resetPreemptionStratum();
-
     const uint32_t epoch = updates.epoch;
     auto &epochManager = *this->gs->epochManager;
     // Note: Commits can only be canceled if this edit is cancelable, LSP is running across multiple threads, and the

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -668,7 +668,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
             while (updates.preemptionsExpected > 0) {
                 auto loopStartTime = Timer::clock_gettime_coarse();
                 auto coarseThreshold = Timer::get_clock_threshold_coarse();
-                while (!preemptManager->tryRunScheduledPreemptionTask(*gs)) {
+                while (!preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true)) {
                     auto curTime = Timer::clock_gettime_coarse();
                     if (curTime.usec - loopStartTime.usec > 20'000'000) {
                         Exception::raise("Slow path timed out waiting for preemption edit");

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -567,7 +567,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
 
         // This is cast to a uint16_t everywhere it's used. This seems bad, but it should be fine because:
         // 1. we increment in the beginning of the loop before any use
-        // 2. overflowing a uint16_t would mean that we have a chain of depndencies that's >65535 packages long
+        // 2. overflowing a uint16_t would mean that we have a chain of dependencies that's >65535 packages long
         int currentStratum = -1;
 
         auto strata = pipeline::computePackageStrata(*this->gs, packageIndexed, workspaceFilesSpan, this->config->opts);

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -382,6 +382,8 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
         timeit.setTag("cancelable", "false");
     }
 
+    this->preemptManager->resetPreemptionStratum();
+
     const uint32_t epoch = updates.epoch;
     auto &epochManager = *this->gs->epochManager;
     // Note: Commits can only be canceled if this edit is cancelable, LSP is running across multiple threads, and the
@@ -693,6 +695,8 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
             auto sorted = sortParsedFiles(*gs, *errorReporter, move(maybeResolved.result()));
             const auto presorted = true;
             pipeline::typecheck(*gs, move(sorted), config->opts, workers, cancelable, preemptManager, presorted);
+
+            this->preemptManager->incrementPreemptionStratum();
         }
     });
 

--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -165,7 +165,7 @@ public:
         }
     }
 
-    void run(uint16_t currentStratum) override {
+    optional<uint16_t> run(uint16_t currentStratum) override {
         // Destruct timer, if specified. Causes metric to be reported.
         this->timeUntilRun = nullptr;
 
@@ -196,6 +196,11 @@ public:
             timeit.setTag("method", task->methodString());
             task->run(this->delegate);
         }
+
+        return nullopt;
+    }
+
+    void finish() override {
         finished.Notify();
     }
 };

--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -165,7 +165,7 @@ public:
         }
     }
 
-    void run() override {
+    void run(uint16_t currentStratum) override {
         // Destruct timer, if specified. Causes metric to be reported.
         this->timeUntilRun = nullptr;
 

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -115,13 +115,15 @@ public:
     CountingTask(shared_ptr<core::lsp::PreemptionTaskManager> preemptManager, core::GlobalState &gs)
         : preemptManager(move(preemptManager)), gs(gs) {}
 
-    void run(uint16_t currentStratum) override {
+    optional<uint16_t> run(uint16_t currentStratum) override {
         // The task should run with typecheck mutex held with a write lock.
         preemptManager->assertTypecheckMutexHeld();
         // Emulate behavior of most LSP Tasks and drain all diagnostics and query responses.
         // This should never drain error queue items from the preempted task.
         gs.errorQueue->flushAllErrors(gs);
         runCount++;
+
+        return nullopt;
     }
 };
 
@@ -344,7 +346,7 @@ TEST_CASE("PreemptionTasksWorkAsExpected") {
                                       vector<core::ErrorSection>(), vector<core::AutocorrectSuggestion>(), false));
 
     // No preemption task registered.
-    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs));
+    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true));
 
     auto task = make_shared<CountingTask>(preemptManager, *gs);
     // Should fail because a slow path is not running, so there's nothing to preempt.
@@ -360,7 +362,7 @@ TEST_CASE("PreemptionTasksWorkAsExpected") {
     CHECK(preemptManager->trySchedulePreemptionTask(task));
 
     // This should run + clear the scheduled task.
-    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs));
+    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true));
     CHECK_EQ(1, task->runCount);
 
     // Our error should still be there.
@@ -375,6 +377,118 @@ TEST_CASE("PreemptionTasksWorkAsExpected") {
 
     // We should not be able to schedule further tasks after cancelation.
     CHECK_FALSE(preemptManager->trySchedulePreemptionTask(task));
+}
+
+class ReschedulingTask : public core::lsp::PreemptionTask {
+public:
+    const uint16_t targetStratum;
+    int runCount = 0;
+
+    ReschedulingTask(uint16_t targetStratum) : targetStratum{targetStratum} {}
+
+    optional<uint16_t> run(uint16_t currentStratum) override {
+        this->runCount++;
+
+        if (this->targetStratum > currentStratum) {
+            return this->targetStratum;
+        }
+
+        return nullopt;
+    }
+};
+
+TEST_CASE("PreemptionReschedulingWorksAsExpected") {
+    auto errorCollector = make_shared<core::ErrorCollector>();
+    auto gs = makeGS(errorCollector);
+    // Note: needs to be > 0 otherwise an enforce triggers.
+    gs->lspTypecheckCount++;
+    auto preemptManager = make_shared<core::lsp::PreemptionTaskManager>(gs->epochManager);
+
+    // Put an error in the queue.
+    gs->errorQueue->pushError(
+        *gs, make_unique<core::Error>(core::Loc::none(), core::ErrorClass{1, core::StrictLevel::True}, "MyError",
+                                      vector<core::ErrorSection>(), vector<core::AutocorrectSuggestion>(), false));
+
+    // No preemption task registered.
+    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true));
+
+    auto task = make_shared<ReschedulingTask>(2);
+
+    // Signify to GlobalState that a slow path is beginning.
+    gs->epochManager->startCommitEpoch(2);
+    CHECK_FALSE(gs->epochManager->wasTypecheckingCanceled());
+
+    // Preempting should work now.
+    CHECK(preemptManager->trySchedulePreemptionTask(task));
+
+    // This should run scheduled task, but not clear it.
+    CHECK_EQ(0, preemptManager->getPreemptionStratum());
+    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true));
+    CHECK_EQ(1, task->runCount);
+
+    // This should not run the scheduled task, as we haven't made it to stratum 2 yet.
+    preemptManager->incrementPreemptionStratum();
+    CHECK_EQ(1, preemptManager->getPreemptionStratum());
+    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true));
+    CHECK_EQ(1, task->runCount);
+
+    // This should run and clear the task.
+    preemptManager->incrementPreemptionStratum();
+    CHECK_EQ(2, preemptManager->getPreemptionStratum());
+    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true));
+    CHECK_EQ(2, task->runCount);
+
+    // Running at stratum 3 should show no preemption tasks run
+    preemptManager->incrementPreemptionStratum();
+    CHECK_EQ(3, preemptManager->getPreemptionStratum());
+    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true));
+    CHECK_EQ(2, task->runCount);
+
+    // The preemption manager has dropped the task, so we should be the only remaining reference.
+    CHECK_EQ(1, task.use_count());
+
+    // Cancel the slow path
+    CHECK(gs->epochManager->tryCancelSlowPath(3));
+}
+
+TEST_CASE("RescheduledPreemptionTasksClearOnCancelation") {
+    auto errorCollector = make_shared<core::ErrorCollector>();
+    auto gs = makeGS(errorCollector);
+    // Note: needs to be > 0 otherwise an enforce triggers.
+    gs->lspTypecheckCount++;
+    auto preemptManager = make_shared<core::lsp::PreemptionTaskManager>(gs->epochManager);
+
+    // Put an error in the queue.
+    gs->errorQueue->pushError(
+        *gs, make_unique<core::Error>(core::Loc::none(), core::ErrorClass{1, core::StrictLevel::True}, "MyError",
+                                      vector<core::ErrorSection>(), vector<core::AutocorrectSuggestion>(), false));
+
+    // No preemption task registered.
+    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true));
+
+    auto task = make_shared<ReschedulingTask>(2);
+
+    // Signify to GlobalState that a slow path is beginning.
+    gs->epochManager->startCommitEpoch(2);
+    CHECK_FALSE(gs->epochManager->wasTypecheckingCanceled());
+
+    // Preempting should work now.
+    CHECK(preemptManager->trySchedulePreemptionTask(task));
+
+    // This should run scheduled task, but not clear it.
+    CHECK_EQ(0, preemptManager->getPreemptionStratum());
+    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true));
+    CHECK_EQ(1, task->runCount);
+
+    // If we cancel at this point and schedule a new task, that should be successful.
+    CHECK(gs->epochManager->tryCancelSlowPath(3));
+    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ false));
+
+    // Allow the task to be scheduled again, now that cancellation has run and we've cleared out the preemption task
+    // slot.
+    gs->epochManager->startCommitEpoch(3);
+    CHECK_FALSE(gs->epochManager->wasTypecheckingCanceled());
+    CHECK(preemptManager->trySchedulePreemptionTask(task));
 }
 
 } // namespace sorbet::realmain::lsp::test

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -384,15 +384,20 @@ class ReschedulingTask : public core::lsp::PreemptionTask {
 public:
     const uint16_t targetStratum;
     int runCount = 0;
+    bool successful = false;
 
     ReschedulingTask(uint16_t targetStratum) : targetStratum{targetStratum} {}
 
     optional<uint16_t> run(uint16_t currentStratum) override {
+        CHECK_FALSE(this->successful);
+
         this->runCount++;
 
         if (this->targetStratum > currentStratum) {
             return this->targetStratum;
         }
+
+        this->successful = true;
 
         return nullopt;
     }
@@ -441,6 +446,7 @@ TEST_CASE("PreemptionReschedulingWorksAsExpected") {
     ++currentStratum;
     CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
     CHECK_EQ(2, task->runCount);
+    CHECK(task->successful);
 
     // The preemption manager has dropped the task, so we should be the only remaining reference.
     CHECK_EQ(1, task.use_count());
@@ -486,7 +492,96 @@ TEST_CASE("RescheduledPreemptionTasksClearOnCancelation") {
     // slot.
     gs->epochManager->startCommitEpoch(3);
     CHECK_FALSE(gs->epochManager->wasTypecheckingCanceled());
+    CHECK_FALSE(task->successful);
+
+    // The preemption manager has dropped the task, so we should be the only remaining reference.
+    CHECK_EQ(1, task.use_count());
+
+    // Scheduling another task should work fine
+    task = make_shared<ReschedulingTask>(2);
     CHECK(preemptManager->trySchedulePreemptionTask(task));
+}
+
+TEST_CASE("RescheduledPreemptionTasksClearOnSuccess") {
+    auto errorCollector = make_shared<core::ErrorCollector>();
+    auto gs = makeGS(errorCollector);
+    // Note: needs to be > 0 otherwise an enforce triggers.
+    gs->lspTypecheckCount++;
+    auto preemptManager = make_shared<core::lsp::PreemptionTaskManager>(gs->epochManager);
+
+    // Put an error in the queue.
+    gs->errorQueue->pushError(
+        *gs, make_unique<core::Error>(core::Loc::none(), core::ErrorClass{1, core::StrictLevel::True}, "MyError",
+                                      vector<core::ErrorSection>(), vector<core::AutocorrectSuggestion>(), false));
+
+    // No preemption task registered.
+    uint16_t currentStratum = 0;
+    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
+
+    auto task = make_shared<ReschedulingTask>(2);
+
+    // Signify to GlobalState that a slow path is beginning.
+    gs->epochManager->startCommitEpoch(2);
+    CHECK_FALSE(gs->epochManager->wasTypecheckingCanceled());
+
+    // Preempting should work now.
+    CHECK(preemptManager->trySchedulePreemptionTask(task));
+
+    CHECK(gs->epochManager->tryCommitEpoch(*gs, 2, true, preemptManager, [&]() {
+        // This should run scheduled task, but not clear it.
+        CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
+        CHECK_EQ(1, task->runCount);
+        return 2;
+    }));
+
+    // tryCommitEpoch will be successful, and the task will have run to completion.
+    CHECK_FALSE(gs->epochManager->wasTypecheckingCanceled());
+    CHECK(task->successful);
+
+    // The preemption manager has dropped the task, so we should be the only remaining reference.
+    CHECK_EQ(1, task.use_count());
+}
+
+// Very similar to the previous test, but checks that the preemption task is given the final stratum reported by the
+// lambda given to `tryCommitEpoch`.
+TEST_CASE("RescheduledPreemptionTasksClearOnSuccessWrongStratum") {
+    auto errorCollector = make_shared<core::ErrorCollector>();
+    auto gs = makeGS(errorCollector);
+    // Note: needs to be > 0 otherwise an enforce triggers.
+    gs->lspTypecheckCount++;
+    auto preemptManager = make_shared<core::lsp::PreemptionTaskManager>(gs->epochManager);
+
+    // Put an error in the queue.
+    gs->errorQueue->pushError(
+        *gs, make_unique<core::Error>(core::Loc::none(), core::ErrorClass{1, core::StrictLevel::True}, "MyError",
+                                      vector<core::ErrorSection>(), vector<core::AutocorrectSuggestion>(), false));
+
+    // No preemption task registered.
+    uint16_t currentStratum = 0;
+    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
+
+    auto task = make_shared<ReschedulingTask>(2);
+
+    // Signify to GlobalState that a slow path is beginning.
+    gs->epochManager->startCommitEpoch(2);
+    CHECK_FALSE(gs->epochManager->wasTypecheckingCanceled());
+
+    // Preempting should work now.
+    CHECK(preemptManager->trySchedulePreemptionTask(task));
+
+    CHECK(gs->epochManager->tryCommitEpoch(*gs, 2, true, preemptManager, [&]() {
+        // This should run scheduled task, but not clear it.
+        CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
+        CHECK_EQ(1, task->runCount);
+        return 1;
+    }));
+
+    // tryCommitEpoch will be successful, but the task will not report success, as it can only run at stratum >= 2.
+    CHECK_FALSE(gs->epochManager->wasTypecheckingCanceled());
+    CHECK_FALSE(task->successful);
+
+    // The preemption manager has dropped the task, so we should be the only remaining reference.
+    CHECK_EQ(1, task.use_count());
 }
 
 } // namespace sorbet::realmain::lsp::test

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -346,7 +346,8 @@ TEST_CASE("PreemptionTasksWorkAsExpected") {
                                       vector<core::ErrorSection>(), vector<core::AutocorrectSuggestion>(), false));
 
     // No preemption task registered.
-    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true));
+    uint16_t currentStratum = 0;
+    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
 
     auto task = make_shared<CountingTask>(preemptManager, *gs);
     // Should fail because a slow path is not running, so there's nothing to preempt.
@@ -362,7 +363,7 @@ TEST_CASE("PreemptionTasksWorkAsExpected") {
     CHECK(preemptManager->trySchedulePreemptionTask(task));
 
     // This should run + clear the scheduled task.
-    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true));
+    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
     CHECK_EQ(1, task->runCount);
 
     // Our error should still be there.
@@ -410,7 +411,8 @@ TEST_CASE("PreemptionReschedulingWorksAsExpected") {
                                       vector<core::ErrorSection>(), vector<core::AutocorrectSuggestion>(), false));
 
     // No preemption task registered.
-    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true));
+    uint16_t currentStratum = 0;
+    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
 
     auto task = make_shared<ReschedulingTask>(2);
 
@@ -422,26 +424,22 @@ TEST_CASE("PreemptionReschedulingWorksAsExpected") {
     CHECK(preemptManager->trySchedulePreemptionTask(task));
 
     // This should run scheduled task, but not clear it.
-    CHECK_EQ(0, preemptManager->getPreemptionStratum());
-    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true));
+    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
     CHECK_EQ(1, task->runCount);
 
     // This should not run the scheduled task, as we haven't made it to stratum 2 yet.
-    preemptManager->incrementPreemptionStratum();
-    CHECK_EQ(1, preemptManager->getPreemptionStratum());
-    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true));
+    ++currentStratum;
+    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
     CHECK_EQ(1, task->runCount);
 
     // This should run and clear the task.
-    preemptManager->incrementPreemptionStratum();
-    CHECK_EQ(2, preemptManager->getPreemptionStratum());
-    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true));
+    ++currentStratum;
+    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
     CHECK_EQ(2, task->runCount);
 
     // Running at stratum 3 should show no preemption tasks run
-    preemptManager->incrementPreemptionStratum();
-    CHECK_EQ(3, preemptManager->getPreemptionStratum());
-    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true));
+    ++currentStratum;
+    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
     CHECK_EQ(2, task->runCount);
 
     // The preemption manager has dropped the task, so we should be the only remaining reference.
@@ -464,7 +462,8 @@ TEST_CASE("RescheduledPreemptionTasksClearOnCancelation") {
                                       vector<core::ErrorSection>(), vector<core::AutocorrectSuggestion>(), false));
 
     // No preemption task registered.
-    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true));
+    uint16_t currentStratum = 0;
+    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
 
     auto task = make_shared<ReschedulingTask>(2);
 
@@ -476,13 +475,12 @@ TEST_CASE("RescheduledPreemptionTasksClearOnCancelation") {
     CHECK(preemptManager->trySchedulePreemptionTask(task));
 
     // This should run scheduled task, but not clear it.
-    CHECK_EQ(0, preemptManager->getPreemptionStratum());
-    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ true));
+    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
     CHECK_EQ(1, task->runCount);
 
     // If we cancel at this point and schedule a new task, that should be successful.
     CHECK(gs->epochManager->tryCancelSlowPath(3));
-    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, /* allowReschedule */ false));
+    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ false));
 
     // Allow the task to be scheduled again, now that cancellation has run and we've cleared out the preemption task
     // slot.

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -115,7 +115,7 @@ public:
     CountingTask(shared_ptr<core::lsp::PreemptionTaskManager> preemptManager, core::GlobalState &gs)
         : preemptManager(move(preemptManager)), gs(gs) {}
 
-    void run() override {
+    void run(uint16_t currentStratum) override {
         // The task should run with typecheck mutex held with a write lock.
         preemptManager->assertTypecheckMutexHeld();
         // Emulate behavior of most LSP Tasks and drain all diagnostics and query responses.

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1482,8 +1482,9 @@ void typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Op
 } // namespace
 
 void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> what, const options::Options &opts,
-               WorkerPool &workers, bool cancelable, shared_ptr<core::lsp::PreemptionTaskManager> preemptionManager,
-               bool presorted, bool intentionallyLeakASTs) {
+               WorkerPool &workers, bool cancelable, uint16_t currentStratum,
+               shared_ptr<core::lsp::PreemptionTaskManager> preemptionManager, bool presorted,
+               bool intentionallyLeakASTs) {
     // Unless the error queue had a critical error, only typecheck should flush errors to the client, otherwise we will
     // drop errors in LSP mode.
     ENFORCE(gs.hadCriticalError() || gs.errorQueue->filesFlushedCount == 0);
@@ -1496,7 +1497,7 @@ void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> what, const 
         Timer timeit(gs.tracer(), "typecheck");
         if (preemptionManager) {
             // Before kicking off typechecking, check if we need to preempt.
-            preemptionManager->tryRunScheduledPreemptionTask(gs, /* allowReschedule */ true);
+            preemptionManager->tryRunScheduledPreemptionTask(gs, currentStratum, /* allowReschedule */ true);
         }
 
         auto fileq = make_shared<ConcurrentBoundedQueue<ast::ParsedFile>>(what.size());
@@ -1574,7 +1575,8 @@ void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> what, const 
                     cfgInferProgress.reportProgress(fileq->doneEstimate());
 
                     if (preemptionManager) {
-                        preemptionManager->tryRunScheduledPreemptionTask(gs, /* allowReschedule */ true);
+                        preemptionManager->tryRunScheduledPreemptionTask(gs, currentStratum,
+                                                                         /* allowReschedule */ true);
                     }
                 }
                 if (cancelable && epochManager.wasTypecheckingCanceled()) {

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1496,7 +1496,7 @@ void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> what, const 
         Timer timeit(gs.tracer(), "typecheck");
         if (preemptionManager) {
             // Before kicking off typechecking, check if we need to preempt.
-            preemptionManager->tryRunScheduledPreemptionTask(gs);
+            preemptionManager->tryRunScheduledPreemptionTask(gs, /* allowReschedule */ true);
         }
 
         auto fileq = make_shared<ConcurrentBoundedQueue<ast::ParsedFile>>(what.size());
@@ -1574,7 +1574,7 @@ void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> what, const 
                     cfgInferProgress.reportProgress(fileq->doneEstimate());
 
                     if (preemptionManager) {
-                        preemptionManager->tryRunScheduledPreemptionTask(gs);
+                        preemptionManager->tryRunScheduledPreemptionTask(gs, /* allowReschedule */ true);
                     }
                 }
                 if (cancelable && epochManager.wasTypecheckingCanceled()) {

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -106,7 +106,7 @@ std::vector<ast::ParsedFile> incrementalResolve(
 // If `intentionallyLeakASTs` is `true`, typecheck will leak the ASTs rather than pay the cost of deleting them
 // properly, which is a significant speedup on large codebases.
 void typecheck(const core::GlobalState &gs, std::vector<ast::ParsedFile> what, const options::Options &opts,
-               WorkerPool &workers, bool cancelable = false,
+               WorkerPool &workers, bool cancelable = false, uint16_t currentStratum = 0,
                std::shared_ptr<core::lsp::PreemptionTaskManager> preemptionManager = nullptr, bool presorted = false,
                bool intentionallyLeakASTs = false);
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -646,8 +646,11 @@ int realmain(int argc, char *argv[]) {
         // The rest of the pipeline proceeds by strata in the package condensation graph. When stripe-packages is not
         // enabled, everything ends up in one big stratum.
         vector<ast::ParsedFile> stratumFiles;
+        int currentStratum = -1;
         auto strata = pipeline::computePackageStrata(*gs, packageIndexed, inputFilesSpan, opts);
         for (auto &stratum : strata.strata) {
+            ++currentStratum;
+
             // We can unconditionally reset (to drop the vectors) instead of having to consult
             // intentionallyLeakASTs, because if intentionallyLeakASTs, then necessarily
             // packageDirected will be false, and thus this loop will only iterate once, and since
@@ -708,7 +711,7 @@ int realmain(int argc, char *argv[]) {
                 if (opts.genPackagesMode == core::packages::GenPackagesMode::Disabled) {
                     // In --gen-packages mode, we skip typecheck because we only want to show packaging related errors,
                     // and skipping typecheck saves a significant amount of time.
-                    pipeline::typecheck(*gs, move(stratumFiles), opts, *workers, /* cancelable */ false,
+                    pipeline::typecheck(*gs, move(stratumFiles), opts, *workers, /* cancelable */ false, currentStratum,
                                         /* preemptionManager */ nullptr, /* presorted */ false, intentionallyLeakASTs);
 
                     if (gs->hadCriticalError()) {


### PR DESCRIPTION
This PR adds support for preemption tasks to reschedule themselves to run at a later stratum. It's prework for supporting preemption in package-directed mode, and won't have any effect on the current implementation's behavior.

The big change here is to plumb through the index of the stratum currently being typechecked on the slow path to the scheduled preemption task. This gives the task the opportunity to determine if the slow path's `GlobalState` is populated enough for it to run successfully. If the slow path isn't far enough through the package graph strata to run successfully, it can now return a non-empty `optional<uint16_t>` which indicates the stratum that it will be able to run at.

The `PreemptionLoop` implementation is only updated enough to conform to the signature changes of `PreemptionTask::run`, so this change will not have any effect on existing uses of Sorbet's LSP. There is a new test added with a specialized subclass of `PreemptionTask` that shows how the new rescheduling logic works.

### Motivation
Stabilizing package-directed typechecking.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
