### PR TITLE
Add CLI tests for `--prism` and RBS options

### DIFF
--- a/test/cli/enable-experimental-rbs-comments/test.out
+++ b/test/cli/enable-experimental-rbs-comments/test.out
@@ -32,3 +32,29 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     ::<root>::<C T>.cast(x, <emptyTree>::<C String>)
   end
 end
+==== test deprecated '--enable-experimental-rbs-signatures' ====
+Options `--enable-experimental-rbs-signatures` and `--enable-experimental-rbs-assertions` have been combined into the `--enable-experimental-rbs-comments` option. Please update your Sorbet config to use `--enable-experimental-rbs-comments` instead.
+⚠️ Going forward, Sorbet will only support RBS mode when parsing with Prism.
+Please add `--parser=prism` to your Sorbet config. This will become an error at the end of May 2026.
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.params(:x, <emptyTree>::<C Object>).returns(<emptyTree>::<C Integer>)
+  end
+
+  def demo<<todo method>>(x, &<blk>)
+    ::<root>::<C T>.cast(x, <emptyTree>::<C String>)
+  end
+end
+==== test deprecated '--enable-experimental-rbs-assertions' ====
+Options `--enable-experimental-rbs-signatures` and `--enable-experimental-rbs-assertions` have been combined into the `--enable-experimental-rbs-comments` option. Please update your Sorbet config to use `--enable-experimental-rbs-comments` instead.
+⚠️ Going forward, Sorbet will only support RBS mode when parsing with Prism.
+Please add `--parser=prism` to your Sorbet config. This will become an error at the end of May 2026.
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.params(:x, <emptyTree>::<C Object>).returns(<emptyTree>::<C Integer>)
+  end
+
+  def demo<<todo method>>(x, &<blk>)
+    ::<root>::<C T>.cast(x, <emptyTree>::<C String>)
+  end
+end

--- a/test/cli/enable-experimental-rbs-comments/test.sh
+++ b/test/cli/enable-experimental-rbs-comments/test.sh
@@ -28,3 +28,9 @@ main/sorbet "${common_args[@]}" --enable-experimental-rbs-comments 2>&1
 echo "==== test deprecated use with original parser ===="
 main/sorbet "${common_args[@]}" --enable-experimental-rbs-comments --parser=original 2>&1
 
+echo "==== test deprecated '--enable-experimental-rbs-signatures' ===="
+main/sorbet "${common_args[@]}" --enable-experimental-rbs-signatures 2>&1
+
+echo "==== test deprecated '--enable-experimental-rbs-assertions' ===="
+main/sorbet "${common_args[@]}" --enable-experimental-rbs-assertions 2>&1
+

--- a/test/cli/parser/test.out
+++ b/test/cli/parser/test.out
@@ -1,0 +1,18 @@
+==== Original parser is the default ====
+Integer {
+  val = "123"
+}
+==== '--parser=original' ====
+Integer {
+  val = "123"
+}
+==== '--parser=prism' ====
+@ ProgramNode (location: (0,0)-(0,3))
++-- locals: []
++-- statements:
+    @ StatementsNode (location: (0,0)-(0,3))
+    +-- body: (length: 1)
+        +-- @ IntegerNode (location: (0,0)-(0,3))
+            +-- IntegerBaseFlags: decimal
+            +-- value: 123
+

--- a/test/cli/parser/test.sh
+++ b/test/cli/parser/test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+common_args=(
+  --silence-dev-message
+  --quiet
+  --no-error-count
+  --print=parse-tree
+  --stop-after=parser
+  -e "123"
+)
+
+echo "==== Original parser is the default ===="
+main/sorbet "${common_args[@]}" 2>&1
+
+echo "==== '--parser=original' ===="
+main/sorbet "${common_args[@]}" --parser=original 2>&1
+
+echo "==== '--parser=prism' ===="
+main/sorbet "${common_args[@]}" --parser=prism 2>&1

--- a/test/cli/rbs-print-rewrite-tree/test.sh
+++ b/test/cli/rbs-print-rewrite-tree/test.sh
@@ -1,20 +1,24 @@
 #!/bin/bash
 set -euo pipefail
 
+common_args=(
+  --silence-dev-message
+  --quiet
+  --no-error-count
+  --print=rbs-rewrite-tree
+  --stop-after=rbs
+  --parser=prism
+  test/cli/rbs-print-rewrite-tree/test.rb
+)
+
 main/sorbet \
-  --print=rbs-rewrite-tree \
+  "${common_args[@]}" \
   --enable-experimental-rbs-comments \
-  --parser=prism \
-  --silence-dev-message \
-  --no-error-count \
-  --quiet \
   test/cli/rbs-print-rewrite-tree/test.rb 2>&1
 
 echo --------------------------------------------------------------------------
 
+# intentionally not using `--enable-experimental-rbs-comments`
 main/sorbet \
-  --print=rbs-rewrite-tree \
-  --silence-dev-message \
-  --no-error-count \
-  --quiet \
+  "${common_args[@]}" \
   test/cli/rbs-print-rewrite-tree/test.rb 2>&1


### PR DESCRIPTION
### Motivation

Recently learned about CLI tests in #10069. Prism and RBS options should have them.

### Test plan

Adds new tests.
