### PR TITLE
sorbet-runtime: Cache and then reset `declaration_block.blk`

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -337,10 +337,14 @@ module T::Private::Methods
         Signature.new_untyped(method: original_method)
       end
 
-    # Drop this declaration
+    unwrap_method(signature.method.owner, signature, original_method)
+
+    # Drop this declaration. Only drop it after we've actually wrapped the
+    # method and recorded the signature, because that might raise an exception,
+    # leaving the declaration in a weird state if the program rescues that
+    # exception and continues.
     declaration_block.blk_or_decl = nil
 
-    unwrap_method(signature.method.owner, signature, original_method)
     signature
   end
 
@@ -416,7 +420,7 @@ module T::Private::Methods
     @signatures_by_method[key]
   end
 
-  def self.unwrap_method(mod, signature, original_method)
+  private_class_method def self.unwrap_method(mod, signature, original_method)
     maybe_wrapped_method = CallValidation.wrap_method_if_needed(mod, signature, original_method)
     @signatures_by_method[method_to_key(maybe_wrapped_method)] = signature
   end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -327,6 +327,7 @@ module T::Private::Methods
         nil
       end
 
+    # Release location information sooner
     declaration_block.loc = nil
 
     signature =
@@ -336,16 +337,25 @@ module T::Private::Methods
         Signature.new_untyped(method: original_method)
       end
 
+    # Drop this declaration
+    declaration_block.blk_or_decl = nil
+
     unwrap_method(signature.method.owner, signature, original_method)
     signature
   end
 
   def self.run_builder(declaration_block)
+    blk_or_decl = declaration_block.blk_or_decl
+    return blk_or_decl if blk_or_decl.is_a?(Declaration)
+    if blk_or_decl.nil?
+      raise "DeclarationBlock for #{declaration_block.mod} at #{declaration_block.loc} should have already been unwrapped"
+    end
+
     builder = DeclBuilder.new(declaration_block.mod, declaration_block.raw)
-    builder
-      .instance_exec(&declaration_block.blk_or_decl)
-      .finalize!
-      .decl
+    decl = builder.instance_exec(&blk_or_decl).finalize!.decl
+    # Record that we've already run `blk` once and constructed a `Declaration`
+    declaration_block.blk_or_decl = decl
+    decl
   end
 
   def self.build_sig(hook_mod, method_name, original_method, current_declaration)

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -34,7 +34,13 @@ module T::Private::Methods
   ARG_NOT_PROVIDED = Object.new
   PROC_TYPE = Object.new
 
-  DeclarationBlock = Struct.new(:mod, :loc, :blk, :final, :raw)
+  # blk_or_decl:
+  # - It's a `Proc` if we haven't forced the thunk yet.
+  # - It's a `Declaration` if we have, but we haven't finished building the sig
+  #   (This can matter for circular load-time behavior, where a method is
+  #   called while its Signature is being built)
+  # - It's `nil` if we've finished building the sig
+  DeclarationBlock = Struct.new(:mod, :loc, :blk_or_decl, :final, :raw)
 
   def self.declare_sig(mod, loc, arg, &blk)
     T::Private::DeclState.current.active_declaration = _declare_sig_internal(mod, loc, arg, &blk)
@@ -337,7 +343,7 @@ module T::Private::Methods
   def self.run_builder(declaration_block)
     builder = DeclBuilder.new(declaration_block.mod, declaration_block.raw)
     builder
-      .instance_exec(&declaration_block.blk)
+      .instance_exec(&declaration_block.blk_or_decl)
       .finalize!
       .decl
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I want to be able to check whether the `blk` is `nil?` for the purpose of
implementing `abstract` and `override` as DSL methods. It should already be
the case that no one is depending on `blk` still being set after forcing
the block, and so I want to land that as its own change to prove that it's
the case.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests, and Stripe's codebase

I did all the testing for this in #10148 but when I tried restacking some PRs manually, I accidentally caused that PR to be closed in an un-reopenable state, so I've had to recreate it. All the test runs on Stripe's codebase can be seen in that PR.