### PR TITLE
Declare constructors using `initialize`, not `self.new`

### DIFF
--- a/rbi/core/encoding.rbi
+++ b/rbi/core/encoding.rbi
@@ -947,7 +947,7 @@ class Encoding::Converter < Data
   #               #    [#<Encoding:EUC-JP>, #<Encoding:UTF-8>],
   #               #    [#<Encoding:UTF-8>, #<Encoding:UTF-16BE>]]
   # ```
-  def self.new(*_); end
+  def initialize(*_); end
 
   def ==(_); end
 

--- a/rbi/core/enumerator.rbi
+++ b/rbi/core/enumerator.rbi
@@ -592,7 +592,7 @@ class Enumerator::Lazy < Enumerator
   # filter_map(1..Float::INFINITY) {|i| i*i if i.even?}.first(5)
   # #=> [4, 16, 36, 64, 100]
   # ```
-  def self.new(*_); end
+  def initialize(*_); end
 
   # Like
   # [`Enumerable#chunk`](https://docs.ruby-lang.org/en/2.7.0/Enumerable.html#method-i-chunk),

--- a/rbi/core/errors.rbi
+++ b/rbi/core/errors.rbi
@@ -275,7 +275,7 @@ class NameError < StandardError
   # [1, 2, 3].method(:rject) # NameError with name "rject" and receiver: Array
   # [1, 2, 3].singleton_method(:rject) # NameError with name "rject" and receiver: [1, 2, 3]
   # ```
-  def self.new(*_); end
+  def initialize(*_); end
 
   # Return a list of the local variable names defined where this
   # [`NameError`](https://docs.ruby-lang.org/en/2.7.0/NameError.html) exception
@@ -320,7 +320,7 @@ class NoMethodError < NameError
   # call in private context, and can be accessed with `#private_call?` method.
   #
   # *receiver* argument stores an object whose method was called.
-  def self.new(*_); end
+  def initialize(*_); end
 
   # Return the arguments passed in as the third parameter to the constructor.
   def args; end
@@ -424,7 +424,7 @@ class SignalException < Exception
   # Construct a new
   # [`SignalException`](https://docs.ruby-lang.org/en/2.7.0/SignalException.html)
   # object. `sig_name` should be a known signal name.
-  def self.new(*_); end
+  def initialize(*_); end
 
   def signm; end
 
@@ -545,9 +545,9 @@ class SystemCallError < StandardError
   # object. The error number is subsequently available via the
   # [`errno`](https://docs.ruby-lang.org/en/2.7.0/SystemCallError.html#method-i-errno)
   # method.
-  sig { params(arg0: T.any(String, T.nilable(Integer))).returns(SystemCallError) }
-  sig { params(arg0: String, errno: T.nilable(Integer), func: T.nilable(Object)).returns(SystemCallError) }
-  def self.new(arg0, errno = nil, func = nil); end
+  sig { params(arg0: T.any(String, T.nilable(Integer))).void }
+  sig { params(arg0: String, errno: T.nilable(Integer), func: T.nilable(Object)).void }
+  def initialize(arg0, errno = nil, func = nil); end
 
   # Return this SystemCallError's error number.
   sig { returns(T.nilable(Integer)) }
@@ -563,7 +563,7 @@ end
 class SystemExit < Exception
   # Create a new `SystemExit` exception with the given status and message.
   # Status is true, false, or an integer. If status is not given, true is used.
-  def self.new(*_); end
+  def initialize(*_); end
 
   # Return the status value associated with this system exit.
   def status; end
@@ -648,7 +648,7 @@ class UncaughtThrowError < ArgumentError
   # ```
   # UncaughtThrowError: uncaught throw "foo"
   # ```
-  def self.new(*_); end
+  def initialize(*_); end
 
   # Return the tag object which was called for.
   def tag; end

--- a/rbi/core/monitor.rbi
+++ b/rbi/core/monitor.rbi
@@ -104,7 +104,7 @@ module MonitorMixin
   # Use `extend MonitorMixin` or `include MonitorMixin` instead of this
   # constructor. Have look at the examples above to understand how to use this
   # module.
-  def self.new(*args); end
+  def initialize(*args); end
 
   # Enters exclusive section.
   def mon_enter; end
@@ -159,7 +159,7 @@ end
 # and the example above calls while\_wait and signal, this class should be
 # documented.
 class MonitorMixin::ConditionVariable
-  def self.new(monitor); end
+  def initialize(monitor); end
 
   # Wakes up all threads waiting for this lock.
   def broadcast; end

--- a/rbi/core/process.rbi
+++ b/rbi/core/process.rbi
@@ -2100,7 +2100,7 @@ class Process::Tms < Struct
 
   def self.members; end
 
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 class Process::Waiter < Thread

--- a/rbi/core/ruby_vm.rbi
+++ b/rbi/core/ruby_vm.rbi
@@ -749,7 +749,7 @@ class RubyVM::InstructionSequence < Object
   # RubyVM::InstructionSequence.compile(File.read(path), path, path)
   # #=> <RubyVM::InstructionSequence:<compiled>@/absolute/path/to/test.rb:1>
   # ```
-  def self.new(*_); end
+  def initialize(*_); end
 
   # Returns the instruction sequence containing the given proc or method.
   #

--- a/rbi/gems/msgpack.rbi
+++ b/rbi/gems/msgpack.rbi
@@ -185,9 +185,9 @@ class MessagePack::ExtensionValue < Struct
     params(
       arg0: ::T.untyped,
     )
-    .returns(::T.untyped)
+    .void
   end
-  def self.new(*arg0); end
+  def initialize(*arg0); end
 end
 
 class MessagePack::Factory

--- a/rbi/stdlib/bundler.rbi
+++ b/rbi/stdlib/bundler.rbi
@@ -4382,9 +4382,9 @@ class Bundler::GemHelpers::PlatformMatch < Struct
     params(
       _: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
-  def self.new(*_); end
+  def initialize(*_); end
 
   sig do
     params(
@@ -4871,9 +4871,9 @@ class Bundler::LazySpecification::Identifier < Struct
     params(
       _: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 class Bundler::LockfileError < Bundler::BundlerError
@@ -5649,9 +5649,9 @@ class Bundler::Molinillo::DependencyGraph::Edge < Struct
     params(
       _: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 # A log for dependency graph actions
@@ -6273,9 +6273,9 @@ class Bundler::Molinillo::ResolutionState < Struct
     params(
       _: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 # This class encapsulates a dependency resolver. The resolver is responsible for
@@ -6531,9 +6531,9 @@ class Bundler::Molinillo::Resolver::Resolution::Conflict < Struct
     params(
       _: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 class Bundler::Molinillo::Resolver::Resolution::PossibilitySet < Struct
@@ -6586,9 +6586,9 @@ class Bundler::Molinillo::Resolver::Resolution::PossibilitySet < Struct
     params(
       _: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 class Bundler::Molinillo::Resolver::Resolution::UnwindDetails < Struct
@@ -6731,9 +6731,9 @@ class Bundler::Molinillo::Resolver::Resolution::UnwindDetails < Struct
     params(
       _: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 # An error that occurred during the resolution process
@@ -8867,9 +8867,9 @@ class Bundler::Settings::Path < Struct
     params(
       _: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 module Bundler::SharedHelpers

--- a/rbi/stdlib/csv.rbi
+++ b/rbi/stdlib/csv.rbi
@@ -1214,8 +1214,8 @@ class CSV::Table < Object
   # *   empty?()
   # *   length()
   # *   size()
-  sig { params(array_of_rows: T::Array[CSV::Row], headers: T::Array[BasicObject]).returns(CSV::Table) }
-  def self.new(array_of_rows, headers: nil); end
+  sig { params(array_of_rows: T::Array[CSV::Row], headers: T::Array[BasicObject]).void }
+  def initialize(array_of_rows, headers: nil); end
 
   # Adds a new row to the bottom end of this table. You can provide an
   # [`Array`](https://docs.ruby-lang.org/en/2.7.0/Array.html), which will be

--- a/rbi/stdlib/dbm.rbi
+++ b/rbi/stdlib/dbm.rbi
@@ -245,7 +245,7 @@ class DBM
   # [`WRITER`](https://docs.ruby-lang.org/en/2.7.0/DBM.html#WRITER),
   # [`WRCREAT`](https://docs.ruby-lang.org/en/2.7.0/DBM.html#WRCREAT) or
   # [`NEWDB`](https://docs.ruby-lang.org/en/2.7.0/DBM.html#NEWDB).
-  def self.new(*_); end
+  def initialize(*_); end
 
   # Open a dbm database and yields it if a block is given. See also `DBM.new`.
   def self.open(*_); end

--- a/rbi/stdlib/drb.rbi
+++ b/rbi/stdlib/drb.rbi
@@ -637,8 +637,8 @@ class DRb::DRbObject
   # `obj` is the (local) object we want to create a stub for. Normally this is
   # `nil`. `uri` is the [`URI`](https://docs.ruby-lang.org/en/2.6.0/URI.html) of
   # the remote object that this will be a stub for.
-  sig { params(obj: T.nilable(Object), uri: String).returns(DRb::DRbObject) }
-  def self.new(obj, uri = _); end
+  sig { params(obj: T.nilable(Object), uri: String).void }
+  def initialize(obj, uri = _); end
 
   # Creates a
   # [`DRb::DRbObject`](https://docs.ruby-lang.org/en/2.6.0/DRb/DRbObject.html)
@@ -818,8 +818,8 @@ class DRb::DRbRemoteError < ::DRb::DRbError
 
   # Creates a new remote error that wraps the
   # [`Exception`](https://docs.ruby-lang.org/en/2.6.0/Exception.html) `error`
-  sig { params(error: Exception).returns(DRb::DRbRemoteError) }
-  def self.new(error); end
+  sig { params(error: Exception).void }
+  def initialize(error); end
 end
 
 # [`Class`](https://docs.ruby-lang.org/en/2.6.0/Class.html) representing a drb
@@ -1007,9 +1007,9 @@ class DRb::DRbServer
       uri: String,
       front: T.nilable(Object),
       config_or_acl: T.nilable(Object)
-    ).returns(DRb::DRbServer)
+    ).void
   end
-  def self.new(uri, front, config_or_acl); end
+  def initialize(uri, front, config_or_acl); end
 
   # Get the default value of the :verbose option.
   sig { returns(T::Boolean) }
@@ -1113,6 +1113,6 @@ class DRb::DRbUnknownError < ::DRb::DRbError
   # for the
   # [`DRb::DRbUnknown`](https://docs.ruby-lang.org/en/2.6.0/DRb/DRbUnknown.html)
   # object `unknown`
-  sig { params(unknown: DRb::DRbUnknown).returns(DRb::DRbUnknownError) }
-  def self.new(unknown); end
+  sig { params(unknown: DRb::DRbUnknown).void }
+  def initialize(unknown); end
 end

--- a/rbi/stdlib/ip_addr.rbi
+++ b/rbi/stdlib/ip_addr.rbi
@@ -68,7 +68,7 @@ class IPAddr
   # [`in_addr`](https://docs.ruby-lang.org/en/2.7.0/IPAddr.html#method-i-in_addr)
   # value instead of an
   # [`IPAddr`](https://docs.ruby-lang.org/en/2.7.0/IPAddr.html) object.
-  def self.new(addr = _, family = _); end
+  def initialize(addr = _, family = _); end
 
   # Returns a new ipaddr built by bitwise AND.
   def &(other); end

--- a/rbi/stdlib/irb.rbi
+++ b/rbi/stdlib/irb.rbi
@@ -483,7 +483,7 @@ class IRB::Context
   # :   uses a [`File`](https://docs.ruby-lang.org/en/2.7.0/File.html)
   # `other`
   # :   uses this as InputMethod
-  def self.new(irb, workspace = _, input_method = _, output_method = _); end
+  def initialize(irb, workspace = _, input_method = _, output_method = _); end
 
   # A copy of the default `IRB.conf[:AP_NAME]`
   def ap_name; end
@@ -1073,7 +1073,7 @@ end
 # [`IO`](https://docs.ruby-lang.org/en/2.7.0/IO.html) with irb, see InputMethod
 class IRB::FileInputMethod < ::IRB::InputMethod
   # Creates a new input method object
-  def self.new(file); end
+  def initialize(file); end
 
   # The external encoding for standard input.
   def encoding; end
@@ -1097,7 +1097,7 @@ end
 
 class IRB::InputMethod
   # Creates a new input method object
-  def self.new(file = _); end
+  def initialize(file = _); end
 
   # The file name of this input method, usually given during initialization.
   def file_name; end
@@ -1157,7 +1157,7 @@ class IRB::Inspector
 
   # Creates a new inspector object, using the given `inspect_proc` when output
   # return values in irb.
-  def self.new(inspect_proc, init_proc = _); end
+  def initialize(inspect_proc, init_proc = _); end
 
   # [`Proc`](https://docs.ruby-lang.org/en/2.7.0/Proc.html) to call when the
   # inspector is activated, good for requiring dependent libraries.
@@ -1188,7 +1188,7 @@ class IRB::Irb
   ATTR_TTY = T.let(T.unsafe(nil), String)
 
   # Creates a new irb session
-  def self.new(workspace = _, input_method = _, output_method = _); end
+  def initialize(workspace = _, input_method = _, output_method = _); end
 
   # Returns the current context of this irb session
   def context; end
@@ -1299,7 +1299,7 @@ end
 class IRB::Notifier::AbstractNotifier
   # Creates a new
   # [`Notifier`](https://docs.ruby-lang.org/en/2.7.0/IRB/Notifier.html) object
-  def self.new(prefix, base_notifier); end
+  def initialize(prefix, base_notifier); end
 
   # Execute the given block if notifications are enabled.
   def exec_if; end
@@ -1358,7 +1358,7 @@ end
 class IRB::Notifier::CompositeNotifier < ::IRB::Notifier::AbstractNotifier
   # Create a new composite notifier object with the given `prefix`, and
   # `base_notifier` to use for output.
-  def self.new(prefix, base_notifier); end
+  def initialize(prefix, base_notifier); end
 
   # Creates a new LeveledNotifier in the composite
   # [`notifiers`](https://docs.ruby-lang.org/en/2.7.0/IRB/Notifier/CompositeNotifier.html#attribute-i-notifiers)
@@ -1428,7 +1428,7 @@ class IRB::Notifier::LeveledNotifier < ::IRB::Notifier::AbstractNotifier
   #
   # The given `level` is used to compare other leveled notifiers in the
   # CompositeNotifier group to determine whether or not to output notifications.
-  def self.new(base, level, prefix); end
+  def initialize(base, level, prefix); end
 
   # Compares the level of this notifier object with the given `other` notifier.
   #
@@ -1452,7 +1452,7 @@ end
 # CompositeNotifier#notifiers, and will not output messages of any sort.
 class IRB::Notifier::NoMsgNotifier < ::IRB::Notifier::LeveledNotifier
   # Creates a new notifier that should not be used to output messages.
-  def self.new; end
+  def initialize; end
 
   # Ensures notifications are ignored, see AbstractNotifier#notify? for more
   # information.
@@ -1541,7 +1541,7 @@ class IRB::RelineInputMethod < ::IRB::InputMethod
 
   # Creates a new input method object using
   # [`Reline`](https://docs.ruby-lang.org/en/3.1.0/Reline.html)
-  def self.new; end
+  def initialize; end
 
   # The external encoding for standard input.
   def encoding; end
@@ -1577,7 +1577,7 @@ class IRB::ReadlineInputMethod < ::IRB::InputMethod
 
   # Creates a new input method object using
   # [`Readline`](https://docs.ruby-lang.org/en/2.7.0/Readline.html)
-  def self.new; end
+  def initialize; end
 
   # The external encoding for standard input.
   def encoding; end
@@ -1617,7 +1617,7 @@ end
 
 class IRB::StdioInputMethod < ::IRB::InputMethod
   # Creates a new input method object
-  def self.new; end
+  def initialize; end
 
   # The external encoding for standard input.
   def encoding; end
@@ -1668,7 +1668,7 @@ class IRB::WorkSpace
   #
   # set self to main if specified, otherwise inherit main from
   # TOPLEVEL\_BINDING.
-  def self.new(*main); end
+  def initialize(*main); end
 
   # The [`Binding`](https://docs.ruby-lang.org/en/2.7.0/Binding.html) of this
   # workspace

--- a/rbi/stdlib/matrix.rbi
+++ b/rbi/stdlib/matrix.rbi
@@ -82,7 +82,7 @@ class Vector
   # is private; use Vector[] or
   # [`Vector.elements`](https://docs.ruby-lang.org/en/2.7.0/Vector.html#method-c-elements)
   # to create.
-  def self.new(array); end
+  def initialize(array); end
 
   # Creates a [`Vector`](https://docs.ruby-lang.org/en/2.7.0/Vector.html) from a
   # list of elements.
@@ -348,7 +348,7 @@ class Matrix
   # is private; use
   # [`Matrix.rows`](https://docs.ruby-lang.org/en/2.7.0/Matrix.html#method-c-rows),
   # columns, [], etc... to create.
-  def self.new(rows, column_count = rows[0].size); end
+  def initialize(rows, column_count = rows[0].size); end
 
   # Alias for:
   # [`identity`](https://docs.ruby-lang.org/en/2.7.0/Matrix.html#method-c-identity)
@@ -525,7 +525,7 @@ end
 # If A is symmetric, then V is orthogonal and thus A = V\*D\*V.t
 class Matrix::EigenvalueDecomposition
   # Constructs the eigenvalue decomposition for a square matrix `A`
-  def self.new(a); end
+  def initialize(a); end
 
   # Alias for:
   # [`eigenvalue_matrix`](https://docs.ruby-lang.org/en/2.7.0/Matrix/EigenvalueDecomposition.html#method-i-eigenvalue_matrix)

--- a/rbi/stdlib/net.rbi
+++ b/rbi/stdlib/net.rbi
@@ -383,7 +383,7 @@ class Net::DNS::RR
 
   def value(); end
 
-  def self.new(*args); end
+  def initialize(*args); end
 
   def self.parse(data); end
 
@@ -2336,7 +2336,7 @@ class Net::HTTP < Net::Protocol
   # the specified server address, without opening the TCP connection or
   # initializing the [`HTTP`](https://docs.ruby-lang.org/en/2.7.0/Net/HTTP.html)
   # session. The `address` should be a DNS hostname or IP address.
-  def self.new(address, port=T.unsafe(nil), p_addr=T.unsafe(nil), p_port=T.unsafe(nil), p_user=T.unsafe(nil), p_pass=T.unsafe(nil)); end
+  def initialize(address, port=T.unsafe(nil), p_addr=T.unsafe(nil), p_port=T.unsafe(nil), p_user=T.unsafe(nil), p_pass=T.unsafe(nil)); end
 
   # Alias for:
   # [`new`](https://docs.ruby-lang.org/en/2.7.0/Net/HTTP.html#method-c-new)
@@ -4355,7 +4355,7 @@ class Net::IMAP::Address < Struct
 
   def self.members(); end
 
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 class Net::IMAP::DataLite < Data
@@ -4809,7 +4809,7 @@ class Net::IMAP::ContentDisposition < Struct
 
   def self.members(); end
 
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 # [`Net::IMAP::ContinuationRequest`](https://docs.ruby-lang.org/en/2.7.0/Net/IMAP.html#ContinuationRequest)
@@ -4847,7 +4847,7 @@ class Net::IMAP::ContinuationRequest < Struct
 
   def self.members(); end
 
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 # Authenticator for the "CRAM-MD5" authentication type. See authenticate().
@@ -4965,7 +4965,7 @@ class Net::IMAP::Envelope < Struct
 
   def self.members(); end
 
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 # Superclass of [`IMAP`](https://docs.ruby-lang.org/en/2.7.0/Net/IMAP.html)
@@ -5033,7 +5033,7 @@ class Net::IMAP::FetchData < Struct
 
   def self.members(); end
 
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 # [`Error`](https://docs.ruby-lang.org/en/2.7.0/Error.html) raised when too many
@@ -5097,7 +5097,7 @@ class Net::IMAP::MailboxACLItem < Struct
 
   def self.members(); end
 
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 # [`Net::IMAP::MailboxList`](https://docs.ruby-lang.org/en/2.7.0/Net/IMAP.html#MailboxList)
@@ -5141,7 +5141,7 @@ class Net::IMAP::MailboxList < Struct
 
   def self.members(); end
 
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 # [`Net::IMAP::MailboxQuota`](https://docs.ruby-lang.org/en/2.7.0/Net/IMAP.html#MailboxQuota)
@@ -5186,7 +5186,7 @@ class Net::IMAP::MailboxQuota < Struct
 
   def self.members(); end
 
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 # [`Net::IMAP::MailboxQuotaRoot`](https://docs.ruby-lang.org/en/2.7.0/Net/IMAP.html#MailboxQuotaRoot)
@@ -5219,7 +5219,7 @@ class Net::IMAP::MailboxQuotaRoot < Struct
 
   def self.members(); end
 
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 class Net::IMAP::MessageSet < Net::IMAP::CommandData
@@ -5308,7 +5308,7 @@ class Net::IMAP::ResponseCode < Struct
 
   def self.members(); end
 
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 # Superclass of all errors used to encapsulate "fail" responses from the server.
@@ -5380,7 +5380,7 @@ class Net::IMAP::ResponseParser::Token < Struct
 
   def self.members(); end
 
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 # [`Net::IMAP::ResponseText`](https://docs.ruby-lang.org/en/2.7.0/Net/IMAP.html#ResponseText)
@@ -5413,7 +5413,7 @@ class Net::IMAP::ResponseText < Struct
 
   def self.members(); end
 
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 # [`Net::IMAP::StatusData`](https://docs.ruby-lang.org/en/2.7.0/Net/IMAP.html#StatusData)
@@ -5442,7 +5442,7 @@ class Net::IMAP::StatusData < Struct
 
   def self.members(); end
 
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 # [`Net::IMAP::TaggedResponse`](https://docs.ruby-lang.org/en/2.7.0/Net/IMAP.html#TaggedResponse)
@@ -5496,7 +5496,7 @@ class Net::IMAP::TaggedResponse < Struct
 
   def self.members(); end
 
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 # [`Net::IMAP::ThreadMember`](https://docs.ruby-lang.org/en/2.7.0/Net/IMAP.html#ThreadMember)
@@ -5527,7 +5527,7 @@ class Net::IMAP::ThreadMember < Struct
 
   def self.members(); end
 
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 # [`Net::IMAP::UntaggedResponse`](https://docs.ruby-lang.org/en/2.7.0/Net/IMAP.html#UntaggedResponse)
@@ -5573,7 +5573,7 @@ class Net::IMAP::UntaggedResponse < Struct
 
   def self.members(); end
 
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 class Net::InternetMessageIO < Net::BufferedIO

--- a/rbi/stdlib/net.rbi
+++ b/rbi/stdlib/net.rbi
@@ -383,8 +383,6 @@ class Net::DNS::RR
 
   def value(); end
 
-  def initialize(*args); end
-
   def self.parse(data); end
 
   def self.parse_packet(data, offset); end
@@ -1829,8 +1827,6 @@ class Net::HTTP < Net::Protocol
   # Alias for:
   # [`request_head`](https://docs.ruby-lang.org/en/2.7.0/Net/HTTP.html#method-i-request_head)
   def head2(path, initheader=T.unsafe(nil), &block); end
-
-  def initialize(address, port=T.unsafe(nil)); end
 
   def inspect(); end
 

--- a/rbi/stdlib/open_uri.rbi
+++ b/rbi/stdlib/open_uri.rbi
@@ -94,14 +94,14 @@ end
 class OpenURI::HTTPError < ::StandardError
   def io; end
 
-  def self.new(message, io); end
+  def initialize(message, io); end
 end
 
 # Raised on redirection, only occurs when `redirect` option for HTTP is `false`.
 class OpenURI::HTTPRedirect < ::OpenURI::HTTPError
   def uri; end
 
-  def self.new(message, io, uri); end
+  def initialize(message, io, uri); end
 end
 
 # Mixin for holding meta-information.

--- a/rbi/stdlib/prime.rbi
+++ b/rbi/stdlib/prime.rbi
@@ -255,7 +255,7 @@ class Prime::EratosthenesGenerator < ::Prime::PseudoPrimeGenerator
   # [`next`](https://docs.ruby-lang.org/en/2.7.0/Prime/EratosthenesGenerator.html#method-i-next)
   def succ; end
 
-  def self.new; end
+  def initialize; end
 end
 
 # Internal use. An implementation of Eratosthenes' sieve
@@ -265,7 +265,7 @@ class Prime::EratosthenesSieve
 
   def get_nth_prime(n); end
 
-  def self.new; end
+  def initialize; end
 end
 
 # Generates all integers which are greater than 2 and are not divisible by
@@ -286,7 +286,7 @@ class Prime::Generator23 < ::Prime::PseudoPrimeGenerator
   # [`next`](https://docs.ruby-lang.org/en/2.7.0/Prime/Generator23.html#method-i-next)
   def succ; end
 
-  def self.new; end
+  def initialize; end
 end
 
 # An abstract class for enumerating pseudo-prime numbers.
@@ -326,7 +326,7 @@ class Prime::PseudoPrimeGenerator
   # see `Enumerator`#with\_object.
   def with_object(obj); end
 
-  def self.new(ubound = nil); end
+  def initialize(ubound = nil); end
 end
 
 # Internal use. An implementation of prime table by trial division method.
@@ -339,7 +339,7 @@ class Prime::TrialDivision
   # `index` is a 0-based index.
   def [](index); end
 
-  def self.new; end
+  def initialize; end
 end
 
 # An implementation of `PseudoPrimeGenerator` which uses a prime table generated
@@ -357,5 +357,5 @@ class Prime::TrialDivisionGenerator < ::Prime::PseudoPrimeGenerator
   # [`next`](https://docs.ruby-lang.org/en/2.7.0/Prime/TrialDivisionGenerator.html#method-i-next)
   def succ; end
 
-  def self.new; end
+  def initialize; end
 end

--- a/rbi/stdlib/pstore.rbi
+++ b/rbi/stdlib/pstore.rbi
@@ -292,7 +292,7 @@ class PStore
   # [`PStore`](https://docs.ruby-lang.org/en/2.7.0/PStore.html) objects are
   # always reentrant. But if *thread\_safe* is set to true, then it will become
   # thread-safe at the cost of a minor performance hit.
-  def self.new(file, thread_safe = false); end
+  def initialize(file, thread_safe = false); end
 end
 
 # The error type thrown by all

--- a/rbi/stdlib/rdoc.rbi
+++ b/rbi/stdlib/rdoc.rbi
@@ -118,7 +118,7 @@ class RDoc::Alias < ::RDoc::CodeObject
   # Creates a new [`Alias`](https://docs.ruby-lang.org/en/2.7.0/RDoc/Alias.html)
   # with a token stream of `text` that aliases `old_name` to `new_name`, has
   # `comment` and is a `singleton` context.
-  def self.new(text, old_name, new_name, comment, singleton = _); end
+  def initialize(text, old_name, new_name, comment, singleton = _); end
 
   # Order by
   # [`singleton`](https://docs.ruby-lang.org/en/2.7.0/RDoc/Alias.html#attribute-i-singleton)
@@ -194,7 +194,7 @@ class RDoc::AnyMethod < ::RDoc::MethodAttr
   # Creates a new
   # [`AnyMethod`](https://docs.ruby-lang.org/en/2.7.0/RDoc/AnyMethod.html) with
   # a token stream `text` and `name`
-  def self.new(text, name); end
+  def initialize(text, name); end
 
   # Adds `an_alias` as an alias for this method in `context`.
   def add_alias(an_alias, context = _); end
@@ -291,7 +291,7 @@ class RDoc::Attr < ::RDoc::MethodAttr
   # Creates a new [`Attr`](https://docs.ruby-lang.org/en/2.7.0/RDoc/Attr.html)
   # with body `text`, `name`, read/write status `rw` and `comment`. `singleton`
   # marks this as a class attribute.
-  def self.new(text, name, rw, comment, singleton = _); end
+  def initialize(text, name, rw, comment, singleton = _); end
 
   # Attributes are equal when their names, singleton and rw are identical
   def ==(other); end
@@ -348,7 +348,7 @@ class RDoc::ClassModule < ::RDoc::Context
   # with `name` with optional `superclass`
   #
   # This is a constructor for subclasses, and must never be called directly.
-  def self.new(name, superclass = _); end
+  def initialize(name, superclass = _); end
 
   # Adds `comment` to this ClassModule's list of comments at `location`. This
   # method is preferred over
@@ -599,7 +599,7 @@ class RDoc::CodeObject
   # Creates a new
   # [`CodeObject`](https://docs.ruby-lang.org/en/2.7.0/RDoc/CodeObject.html)
   # that will document itself and its children
-  def self.new; end
+  def initialize; end
 
   # Our comment
   def comment; end
@@ -831,7 +831,7 @@ class RDoc::Comment
   # Creates a new comment with `text` that is found in the
   # [`RDoc::TopLevel`](https://docs.ruby-lang.org/en/2.7.0/RDoc/TopLevel.html)
   # `location`.
-  def self.new(text = _, location = _); end
+  def initialize(text = _, location = _); end
 
   def ==(other); end
 
@@ -933,7 +933,7 @@ class RDoc::Constant < ::RDoc::CodeObject
   ::RDoc::Constant::MARSHAL_VERSION = T.let(T.unsafe(nil), Integer)
 
   # Creates a new constant with `name`, `value` and `comment`
-  def self.new(name, value, comment); end
+  def initialize(name, value, comment); end
 
   # Constants are ordered by name
   def <=>(other); end
@@ -1019,7 +1019,7 @@ class RDoc::Context < ::RDoc::CodeObject
   TYPES = T.let(T.unsafe(nil), T::Array[T.untyped])
 
   # Creates an unnamed empty context with public current visibility
-  def self.new; end
+  def initialize; end
 
   # Contexts are sorted by
   # [`full_name`](https://docs.ruby-lang.org/en/2.7.0/RDoc/Context.html#method-i-full_name)
@@ -1434,7 +1434,7 @@ class RDoc::Context::Section
   MARSHAL_VERSION = T.let(T.unsafe(nil), Integer)
 
   # Creates a new section with `title` and `comment`
-  def self.new(parent, title, comment); end
+  def initialize(parent, title, comment); end
 
   # Sections are equal when they have the same
   # [`title`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Context/Section.html#attribute-i-title)
@@ -1544,7 +1544,7 @@ class RDoc::CrossReference
 
   # Allows cross-references to be created based on the given `context`
   # ([`RDoc::Context`](https://docs.ruby-lang.org/en/2.7.0/RDoc/Context.html)).
-  def self.new(context); end
+  def initialize(context); end
 
   # Returns a reference to `name`.
   #
@@ -1579,7 +1579,7 @@ end
 # Note that binding must enclose the io you wish to output on.
 class RDoc::ERBIO < ::ERB
   # Defaults `eoutvar` to 'io', otherwise is identical to ERB's initialize
-  def self.new(str, safe_level = _, trim_mode = _, eoutvar = _); end
+  def initialize(str, safe_level = _, trim_mode = _, eoutvar = _); end
 
   # Instructs `compiler` how to write to `io_variable`
   def set_eoutvar(compiler, io_variable); end
@@ -1767,7 +1767,7 @@ class RDoc::Generator::Darkfish
   VERSION = T.let(T.unsafe(nil), String)
 
   # Initialize a few instance variables before we start
-  def self.new(store, options); end
+  def initialize(store, options); end
 
   # Creates a template from its components and the `body_file`.
   #
@@ -2011,7 +2011,7 @@ class RDoc::Generator::JsonIndex
   # of links in the output index.
   #
   # `options` are the same options passed to the parent generator.
-  def self.new(parent_generator, options); end
+  def initialize(parent_generator, options); end
 
   # Builds the [`JSON`](https://docs.ruby-lang.org/en/2.6.0/JSON.html) index as
   # a [`Hash`](https://docs.ruby-lang.org/en/2.6.0/Hash.html).
@@ -2140,7 +2140,7 @@ class RDoc::Generator::POT
   # Description of this generator
   DESCRIPTION = T.let(T.unsafe(nil), String)
 
-  def self.new(store, options); end
+  def initialize(store, options); end
 
   def class_dir; end
 
@@ -2152,7 +2152,7 @@ end
 # [`RDoc::Store`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Store.html)
 class RDoc::Generator::POT::MessageExtractor
   # Creates a message extractor for `store`.
-  def self.new(store); end
+  def initialize(store); end
 
   # Extracts messages from `store`, stores them into
   # [`RDoc::Generator::POT::PO`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Generator/POT/PO.html)
@@ -2167,7 +2167,7 @@ class RDoc::Generator::POT::PO
   # Creates an object that represents
   # [`PO`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Generator/POT/PO.html)
   # format.
-  def self.new; end
+  def initialize; end
 
   # Adds a
   # [`PO`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Generator/POT/PO.html) entry
@@ -2185,7 +2185,7 @@ end
 # A PO entry in PO
 class RDoc::Generator::POT::POEntry
   # Creates a PO entry for `msgid`. Other values can be specified by `options`.
-  def self.new(msgid, options = _); end
+  def initialize(msgid, options = _); end
 
   # The comment content extracted from source file
   def extracted_comment; end
@@ -2217,7 +2217,7 @@ class RDoc::Generator::RI
   # Description of this generator
   DESCRIPTION = T.let(T.unsafe(nil), String)
 
-  def self.new(store, options); end
+  def initialize(store, options); end
 
   # Writes the parsed data store to disk for use by ri.
   def generate; end
@@ -2241,7 +2241,7 @@ module RDoc::I18n; end
 class RDoc::I18n::Locale
   # Creates a new locale object for `name` locale. `name` must follow IETF
   # language tag format.
-  def self.new(name); end
+  def initialize(name); end
 
   # Loads translation messages from `locale_directory`/+@name+/rdoc.po or
   # `locale_directory`/+@name+.po. The former has high priority.
@@ -2288,7 +2288,7 @@ end
 # [`Array`](https://docs.ruby-lang.org/en/2.6.0/Array.html) of them.
 class RDoc::I18n::Text
   # Creates a new i18n supported text for `raw` text.
-  def self.new(raw); end
+  def initialize(raw); end
 
   # Extracts translation target messages and yields each message.
   #
@@ -2554,7 +2554,7 @@ class RDoc::Markdown
   # Creates a new markdown parser that enables the given `extensions`.
   #
   # Also aliased as: orig\_initialize
-  def self.new(extensions = _, debug = _); end
+  def initialize(extensions = _, debug = _); end
 
   def _Alphanumeric; end
 
@@ -3203,7 +3203,7 @@ class RDoc::Markdown
 end
 
 class RDoc::Markdown::Literals
-  def self.new(str, debug = _); end
+  def initialize(str, debug = _); end
 
   def _Alphanumeric; end
 
@@ -3281,7 +3281,7 @@ class RDoc::Markdown::Literals
 end
 
 class RDoc::Markdown::Literals::MemoEntry
-  def self.new(ans, pos); end
+  def initialize(ans, pos); end
 
   def ans; end
 
@@ -3301,7 +3301,7 @@ end
 class RDoc::Markdown::Literals::ParseError < ::RuntimeError; end
 
 class RDoc::Markdown::Literals::RuleInfo
-  def self.new(name, rendered); end
+  def initialize(name, rendered); end
 
   def name; end
 
@@ -3311,7 +3311,7 @@ end
 RDoc::Markdown::Literals::Rules = T.let(T.unsafe(nil), T::Hash[T.untyped, T.untyped])
 
 class RDoc::Markdown::MemoEntry
-  def self.new(ans, pos); end
+  def initialize(ans, pos); end
 
   def ans; end
 
@@ -3331,7 +3331,7 @@ end
 class RDoc::Markdown::ParseError < ::RuntimeError; end
 
 class RDoc::Markdown::RuleInfo
-  def self.new(name, rendered); end
+  def initialize(name, rendered); end
 
   def name; end
 
@@ -4199,7 +4199,7 @@ class RDoc::Markup
   # Take a block of text and use various heuristics to determine its structure
   # (paragraphs, lists, and so on). Invoke an event handler as we identify
   # significant chunks.
-  def self.new(attribute_manager = _); end
+  def initialize(attribute_manager = _); end
 
   # Add to the sequences recognized as general markup.
   def add_html(tag, name); end
@@ -4247,7 +4247,7 @@ class RDoc::Markup::AttrChanger < ::Struct
 
   def self.members; end
 
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 # An array of attributes which parallels the characters in a string.
@@ -4255,7 +4255,7 @@ class RDoc::Markup::AttrSpan
   # Creates a new
   # [`AttrSpan`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Markup/AttrSpan.html)
   # for `length` characters
-  def self.new(length); end
+  def initialize(length); end
 
   # Accesses flags for character `n`
   def [](n); end
@@ -4275,7 +4275,7 @@ class RDoc::Markup::AttributeManager
 
   # Creates a new attribute manager that understands bold, emphasized and
   # teletype text.
-  def self.new; end
+  def initialize; end
 
   # Adds a markup class with `name` for words surrounded by HTML tag `tag`. To
   # process emphasis tags:
@@ -4360,7 +4360,7 @@ end
 # value.
 class RDoc::Markup::Attributes
   # Creates a new attributes set.
-  def self.new; end
+  def initialize; end
 
   # Returns a string representation of `bitmap`
   def as_string(bitmap); end
@@ -4383,7 +4383,7 @@ class RDoc::Markup::BlankLine < ::RDoc::Markup::Element
 
   # [`RDoc::Markup::BlankLine`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Markup/BlankLine.html)
   # is a singleton
-  def self.new; end
+  def initialize; end
 end
 
 # A quoted section which contains markup items.
@@ -4409,7 +4409,7 @@ class RDoc::Markup::Document
   # Creates a new
   # [`Document`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Markup/Document.html)
   # with `parts`
-  def self.new(*parts); end
+  def initialize(*parts); end
 
   # Appends `part` to the document
   def <<(part); end
@@ -4496,7 +4496,7 @@ end
 class RDoc::Markup::Formatter
   # Creates a new
   # [`Formatter`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Markup/Formatter.html)
-  def self.new(options, markup = _); end
+  def initialize(options, markup = _); end
 
   # Adds `document` to the output
   def accept_document(document); end
@@ -4575,7 +4575,7 @@ class RDoc::Markup::Formatter::InlineTag < ::Struct
 
   def self.members; end
 
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 # A hard-break in the middle of a paragraph.
@@ -4589,7 +4589,7 @@ class RDoc::Markup::HardBreak < ::RDoc::Markup::Element
 
   # [`RDoc::Markup::HardBreak`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Markup/HardBreak.html)
   # is a singleton
-  def self.new; end
+  def initialize; end
 end
 
 class RDoc::Markup::Heading < ::RDoc::Markup::Element
@@ -4619,7 +4619,7 @@ class RDoc::Markup::Heading < ::RDoc::Markup::Element
 
   def self.members; end
 
-  def self.new(*_); end
+  def initialize(*_); end
 
   def self.to_html; end
 
@@ -4633,7 +4633,7 @@ end
 # This implementation in incomplete.
 class RDoc::Markup::Include
   # Creates a new include that will import `file` from `include_path`
-  def self.new(file, include_path); end
+  def initialize(file, include_path); end
 
   def ==(other); end
 
@@ -4652,7 +4652,7 @@ class RDoc::Markup::IndentedParagraph < ::RDoc::Markup::Raw
   # Creates a new
   # [`IndentedParagraph`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Markup/IndentedParagraph.html)
   # containing `parts` indented with `indent` spaces
-  def self.new(indent, *parts); end
+  def initialize(indent, *parts); end
 
   def ==(other); end
 
@@ -4697,7 +4697,7 @@ end
 class RDoc::Markup::List
   # Creates a new list of `type` with `items`. Valid list types are: `:BULLET`,
   # `:LABEL`, `:LALPHA`, `:NOTE`, `:NUMBER`, `:UALPHA`
-  def self.new(type = _, *items); end
+  def initialize(type = _, *items); end
 
   # Appends `item` to the list
   def <<(item); end
@@ -4744,7 +4744,7 @@ class RDoc::Markup::ListItem
   # Creates a new
   # [`ListItem`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Markup/ListItem.html)
   # with an optional `label` containing `parts`
-  def self.new(label = _, *parts); end
+  def initialize(label = _, *parts); end
 
   # Appends `part` to the
   # [`ListItem`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Markup/ListItem.html)
@@ -4825,7 +4825,7 @@ class RDoc::Markup::Parser
   # [`Parser`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Markup/Parser.html). See
   # also
   # [`::parse`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Markup/Parser.html#method-c-parse)
-  def self.new; end
+  def initialize; end
 
   # Builds a Heading of `level`
   def build_heading(level); end
@@ -4929,7 +4929,7 @@ class RDoc::Markup::Parser::ParseError < ::RDoc::Markup::Parser::Error; end
 class RDoc::Markup::PreProcess
   # Creates a new pre-processor for `input_file_name` that will look for
   # included files in `include_path`
-  def self.new(input_file_name, include_path); end
+  def initialize(input_file_name, include_path); end
 
   # Look for the given file in the directory containing the current file, and
   # then in each of the directories specified in the RDOC\_INCLUDE path
@@ -5018,7 +5018,7 @@ class RDoc::Markup::Raw
   # Creates a new
   # [`Raw`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Markup/Raw.html) containing
   # `parts`
-  def self.new(*parts); end
+  def initialize(*parts); end
 
   # Appends `text`
   def <<(text); end
@@ -5054,7 +5054,7 @@ class RDoc::Markup::Rule < ::Struct
 end
 
 class RDoc::Markup::Special
-  def self.new(type, text); end
+  def initialize(type, text); end
 
   def ==(o); end
 
@@ -5075,7 +5075,7 @@ class RDoc::Markup::ToAnsi < ::RDoc::Markup::ToRdoc
   # Creates a new
   # [`ToAnsi`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Markup/ToAnsi.html)
   # visitor that is ready to output vibrant ANSI color!
-  def self.new(markup = _); end
+  def initialize(markup = _); end
 
   # Overrides indent width to ensure output lines up correctly.
   def accept_list_item_end(list_item); end
@@ -5100,7 +5100,7 @@ class RDoc::Markup::ToBs < ::RDoc::Markup::ToRdoc
   # Returns a new
   # [`ToBs`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Markup/ToBs.html) that is
   # ready for hot backspace action!
-  def self.new(markup = _); end
+  def initialize(markup = _); end
 
   # Makes heading text bold.
   def accept_heading(heading); end
@@ -5129,7 +5129,7 @@ class RDoc::Markup::ToHtml < ::RDoc::Markup::Formatter
   LIST_TYPE_TO_HTML = T.let(T.unsafe(nil), T::Hash[T.untyped, T.untyped])
 
   # Creates a new formatter that will output HTML
-  def self.new(options, markup = _); end
+  def initialize(options, markup = _); end
 
   # Adds `blank_line` to the output
   def accept_blank_line(blank_line); end
@@ -5252,7 +5252,7 @@ class RDoc::Markup::ToHtmlCrossref < ::RDoc::Markup::ToHtml
   # which lives at `from_path` in the generated files. '#' characters on
   # references are removed unless `show_hash` is true. Only method names
   # preceded by '#' or '::' are linked, unless `hyperlink_all` is true.
-  def self.new(options, from_path, context, markup = _); end
+  def initialize(options, from_path, context, markup = _); end
 
   # [`RDoc::CodeObject`](https://docs.ruby-lang.org/en/2.6.0/RDoc/CodeObject.html)
   # for generating references
@@ -5294,7 +5294,7 @@ class RDoc::Markup::ToHtmlSnippet < ::RDoc::Markup::ToHtml
   # [`ToHtmlSnippet`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Markup/ToHtmlSnippet.html)
   # formatter that will cut off the input on the next word boundary after the
   # given number of `characters` or `paragraphs` of text have been encountered.
-  def self.new(options, characters = _, paragraphs = _, markup = _); end
+  def initialize(options, characters = _, paragraphs = _, markup = _); end
 
   # Adds `heading` to the output as a paragraph
   def accept_heading(heading); end
@@ -5380,7 +5380,7 @@ end
 # This formatter only works on Paragraph instances. Attempting to process other
 # markup syntax items will not work.
 class RDoc::Markup::ToJoinedParagraph < ::RDoc::Markup::Formatter
-  def self.new; end
+  def initialize; end
 
   def accept_block_quote(*node); end
 
@@ -5413,7 +5413,7 @@ end
 # marks removed (\SomeClass is converted to SomeClass).
 class RDoc::Markup::ToLabel < ::RDoc::Markup::Formatter
   # Creates a new formatter that will output HTML-safe labels
-  def self.new(markup = _); end
+  def initialize(markup = _); end
 
   def accept_blank_line(*node); end
 
@@ -5456,7 +5456,7 @@ end
 # Outputs parsed markup as Markdown
 class RDoc::Markup::ToMarkdown < ::RDoc::Markup::ToRdoc
   # Creates a new formatter that will output Markdown format text
-  def self.new(markup = _); end
+  def initialize(markup = _); end
 
   # Finishes consumption of `list`
   def accept_list_end(list); end
@@ -5497,7 +5497,7 @@ end
 class RDoc::Markup::ToRdoc < ::RDoc::Markup::Formatter
   # Creates a new formatter that will output (mostly)
   # [`RDoc`](https://docs.ruby-lang.org/en/2.6.0/RDoc.html) markup
-  def self.new(markup = _); end
+  def initialize(markup = _); end
 
   # Adds `blank_line` to the output
   def accept_blank_line(blank_line); end
@@ -5593,7 +5593,7 @@ end
 # [`RDoc::Markup::Document`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Markup/Document.html)
 # to help build a table of contents
 class RDoc::Markup::ToTableOfContents < ::RDoc::Markup::Formatter
-  def self.new; end
+  def initialize; end
 
   def accept_blank_line(*node); end
 
@@ -5677,7 +5677,7 @@ end
 # undocumented parameters.
 class RDoc::Markup::ToTtOnly < ::RDoc::Markup::Formatter
   # Creates a new tt-only formatter.
-  def self.new(markup = _); end
+  def initialize(markup = _); end
 
   # Alias for:
   # [`do_nothing`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Markup/ToTtOnly.html#method-i-do_nothing)
@@ -5750,7 +5750,7 @@ end
 
 # A section of verbatim text
 class RDoc::Markup::Verbatim < ::RDoc::Markup::Raw
-  def self.new(*parts); end
+  def initialize(*parts); end
 
   def ==(other); end
 
@@ -5788,7 +5788,7 @@ class RDoc::MethodAttr < ::RDoc::CodeObject
   # from token stream `text` and method or attribute name `name`.
   #
   # Usually this is called by super from a subclass.
-  def self.new(text, name); end
+  def initialize(text, name); end
 
   # Order by
   # [`singleton`](https://docs.ruby-lang.org/en/2.7.0/RDoc/MethodAttr.html#attribute-i-singleton)
@@ -5971,7 +5971,7 @@ end
 class RDoc::Mixin < ::RDoc::CodeObject
   # Creates a new [`Mixin`](https://docs.ruby-lang.org/en/2.7.0/RDoc/Mixin.html)
   # for `name` with `comment`
-  def self.new(name, comment); end
+  def initialize(name, comment); end
 
   # Mixins are sorted by name
   def <=>(other); end
@@ -6185,7 +6185,7 @@ class RDoc::Options
   # `"rdoc/generator/template/#{template_name}"`
   Template = T.let(T.unsafe(nil), Object)
 
-  def self.new; end
+  def initialize; end
 
   def ==(other); end
 
@@ -6572,7 +6572,7 @@ class RDoc::Parser
   # `top_level`, `file_name`, `content`, `options` and `stats` in instance
   # variables. In +@preprocess+ an RDoc::Markup::PreProcess object is created
   # which allows processing of directives.
-  def self.new(top_level, file_name, content, options, stats); end
+  def initialize(top_level, file_name, content, options, stats); end
 
   # The name of the file being parsed
   def file_name; end
@@ -6778,7 +6778,7 @@ class RDoc::Parser::C < ::RDoc::Parser
   # Prepares for parsing a
   # [`C`](https://docs.ruby-lang.org/en/2.7.0/RDoc/Parser/C.html) file. See
   # RDoc::Parser#initialize for details on the arguments.
-  def self.new(top_level, file_name, content, options, stats); end
+  def initialize(top_level, file_name, content, options, stats); end
 
   # Maps [`C`](https://docs.ruby-lang.org/en/2.7.0/RDoc/Parser/C.html) variable
   # names to names of Ruby classes or modules
@@ -7152,7 +7152,7 @@ class RDoc::Parser::Ruby < ::RDoc::Parser
 
   # Creates a new
   # [`Ruby`](https://docs.ruby-lang.org/en/2.7.0/RDoc/Parser/Ruby.html) parser.
-  def self.new(top_level, file_name, content, options, stats); end
+  def initialize(top_level, file_name, content, options, stats); end
 
   # Look for the first comment in a file that isn't a shebang line.
   def collect_first_comment; end
@@ -7474,7 +7474,7 @@ class RDoc::Parser::Simple < ::RDoc::Parser
   include(::RDoc::Parser::Text)
 
   # Prepare to parse a plain file
-  def self.new(top_level, file_name, content, options, stats); end
+  def initialize(top_level, file_name, content, options, stats); end
 
   def content; end
 
@@ -7595,7 +7595,7 @@ class RDoc::RD::BlockParser < ::Racc::Parser
   # Use
   # [`parse`](https://docs.ruby-lang.org/en/2.6.0/RDoc/RD/BlockParser.html#method-i-parse)
   # to parse an rd-format document.
-  def self.new; end
+  def initialize; end
 
   def _reduce_1(val, _values, result); end
 
@@ -7788,7 +7788,7 @@ class RDoc::RD::Inline
   # [`Inline`](https://docs.ruby-lang.org/en/2.6.0/RDoc/RD/Inline.html) or a
   # [`String`](https://docs.ruby-lang.org/en/2.6.0/String.html). If `reference`
   # is not given it will use the text from `rdoc`.
-  def self.new(rdoc, reference = _); end
+  def initialize(rdoc, reference = _); end
 end
 
 # [`RD`](https://docs.ruby-lang.org/en/2.6.0/RDoc/RD.html) format parser for
@@ -7886,7 +7886,7 @@ class RDoc::RD::InlineParser < ::Racc::Parser
 
   # Creates a new parser for inline markup in the rd format. The `block_parser`
   # is used to for footnotes and labels in the inline text.
-  def self.new(block_parser); end
+  def initialize(block_parser); end
 
   def _reduce_101(val, _values, result); end
 
@@ -8040,7 +8040,7 @@ class RDoc::RDoc
   # Creates a new
   # [`RDoc::RDoc`](https://docs.ruby-lang.org/en/2.7.0/RDoc/RDoc.html) instance.
   # Call document to parse files and generate documentation.
-  def self.new; end
+  def initialize; end
 
   # Generates documentation or a coverage report depending upon the settings in
   # `options`.
@@ -8199,7 +8199,7 @@ module RDoc::RI; end
 class RDoc::RI::Driver
   # Creates a new driver using `initial_options` from
   # [`::process_args`](https://docs.ruby-lang.org/en/2.6.0/RDoc/RI/Driver.html#method-c-process_args)
-  def self.new(initial_options = _); end
+  def initialize(initial_options = _); end
 
   # Adds paths for undocumented classes `also_in` to `out`
   def add_also_in(out, also_in); end
@@ -8445,7 +8445,7 @@ class RDoc::RI::Driver::Error < ::RDoc::RI::Error; end
 
 # Raised when a name isn't found in the ri data stores
 class RDoc::RI::Driver::NotFoundError < ::RDoc::RI::Driver::Error
-  def self.new(klass, suggestions = _); end
+  def initialize(klass, suggestions = _); end
 
   def message; end
 
@@ -8541,7 +8541,7 @@ class RDoc::Require < ::RDoc::CodeObject
   # Creates a new
   # [`Require`](https://docs.ruby-lang.org/en/2.7.0/RDoc/Require.html) that
   # loads `name` with `comment`
-  def self.new(name, comment); end
+  def initialize(name, comment); end
 
   def inspect; end
 
@@ -8598,7 +8598,7 @@ class RDoc::RipperStateLex
 
   RIPPER_HAS_LEX_STATE = T.let(T.unsafe(nil), TrueClass)
 
-  def self.new(code); end
+  def initialize(code); end
 
   def get_squashed_tk; end
 
@@ -8608,7 +8608,7 @@ class RDoc::RipperStateLex
 end
 
 class RDoc::RipperStateLex::InnerStateLex < ::Ripper::Filter
-  def self.new(code); end
+  def initialize(code); end
 
   def each(&block); end
 
@@ -8650,7 +8650,7 @@ class RDoc::Servlet < ::WEBrick::HTTPServlet::AbstractServlet
   # `server` is provided automatically by
   # [`WEBrick`](https://docs.ruby-lang.org/en/2.7.0/WEBrick.html) when mounting.
   # `stores` and `cache` are provided automatically by the servlet.
-  def self.new(server, stores, cache, mount_path = _, extra_doc_dirs = _); end
+  def initialize(server, stores, cache, mount_path = _, extra_doc_dirs = _); end
 
   # Serves the asset at the path in `req` for `generator_name` via `res`.
   def asset(generator_name, req, res); end
@@ -8748,7 +8748,7 @@ class RDoc::Stats
   # Creates a new [`Stats`](https://docs.ruby-lang.org/en/2.7.0/RDoc/Stats.html)
   # that will have `num_files`. `verbosity` defaults to 1 which will create an
   # RDoc::Stats::Normal outputter.
-  def self.new(store, num_files, verbosity = _); end
+  def initialize(store, num_files, verbosity = _); end
 
   # Records the parsing of an alias `as`.
   def add_alias(as); end
@@ -8856,7 +8856,7 @@ class RDoc::Stats::Quiet
   # Creates a new
   # [`Quiet`](https://docs.ruby-lang.org/en/2.6.0/RDoc/Stats/Quiet.html) that
   # will print nothing
-  def self.new(num_files); end
+  def initialize(num_files); end
 
   # Prints a message at the beginning of parsing
   def begin_adding(*_); end
@@ -8934,7 +8934,7 @@ end
 class RDoc::Store
   # Creates a new [`Store`](https://docs.ruby-lang.org/en/2.7.0/RDoc/Store.html)
   # of `type` that will load or save to `path`
-  def self.new(path = _, type = _); end
+  def initialize(path = _, type = _); end
 
   # Adds `module` as an enclosure (namespace) for the given `variable` for C
   # files.
@@ -9244,7 +9244,7 @@ class RDoc::Store::MissingFileError < ::RDoc::Store::Error
   # [`MissingFileError`](https://docs.ruby-lang.org/en/2.7.0/RDoc/Store/MissingFileError.html)
   # for the missing `file` for the given `name` that should have been in the
   # `store`.
-  def self.new(store, file, name); end
+  def initialize(store, file, name); end
 
   # The file the
   # [`name`](https://docs.ruby-lang.org/en/2.7.0/RDoc/Store/MissingFileError.html#attribute-i-name)
@@ -9589,7 +9589,7 @@ class RDoc::TomDoc < ::RDoc::Markup::Parser
   # [`TomDoc`](https://docs.ruby-lang.org/en/2.7.0/RDoc/TomDoc.html) parser. See
   # also
   # [`RDoc::Markup::parse`](https://docs.ruby-lang.org/en/2.7.0/RDoc/Markup.html#method-c-parse)
-  def self.new; end
+  def initialize; end
 
   # Builds a heading from the token stream
   #
@@ -9695,7 +9695,7 @@ class RDoc::TopLevel < ::RDoc::Context
   # [`TopLevel`](https://docs.ruby-lang.org/en/2.7.0/RDoc/TopLevel.html) for the
   # file at `absolute_name`. If documentation is being generated outside the
   # source dir `relative_name` is relative to the source directory.
-  def self.new(absolute_name, relative_name = _); end
+  def initialize(absolute_name, relative_name = _); end
 
   # An
   # [`RDoc::TopLevel`](https://docs.ruby-lang.org/en/2.7.0/RDoc/TopLevel.html)

--- a/rbi/stdlib/reline.rbi
+++ b/rbi/stdlib/reline.rbi
@@ -205,7 +205,7 @@ class Reline::KillRing::RingPoint < Struct
   def self.inspect; end
   def self.keyword_init?; end
   def self.members; end
-  def self.new(*arg0); end
+  def initialize(*arg0); end
   def str; end
   def str=(_); end
   Elem = type_member(:out) {{fixed: T.untyped}}
@@ -455,7 +455,7 @@ class Struct::CompletionJourneyData < Struct
   def self.inspect; end
   def self.keyword_init?; end
   def self.members; end
-  def self.new(*arg0); end
+  def initialize(*arg0); end
   Elem = type_member(:out) {{fixed: T.untyped}}
 end
 class Struct::MenuInfo < Struct
@@ -465,7 +465,7 @@ class Struct::MenuInfo < Struct
   def self.inspect; end
   def self.keyword_init?; end
   def self.members; end
-  def self.new(*arg0); end
+  def initialize(*arg0); end
   def target; end
   def target=(_); end
   Elem = type_member(:out) {{fixed: T.untyped}}
@@ -616,7 +616,7 @@ class Struct::Key < Struct
   def self.inspect; end
   def self.keyword_init?; end
   def self.members; end
-  def self.new(*arg0); end
+  def initialize(*arg0); end
   def with_meta; end
   def with_meta=(_); end
   Elem = type_member(:out) {{fixed: T.untyped}}
@@ -626,7 +626,7 @@ class Reline::CursorPos < Struct
   def self.inspect; end
   def self.keyword_init?; end
   def self.members; end
-  def self.new(*arg0); end
+  def initialize(*arg0); end
   def x; end
   def x=(_); end
   def y; end
@@ -648,7 +648,7 @@ class Reline::DialogRenderInfo < Struct
   def self.inspect; end
   def self.keyword_init?; end
   def self.members; end
-  def self.new(*arg0); end
+  def initialize(*arg0); end
   def width; end
   def width=(_); end
   Elem = type_member(:out) {{fixed: T.untyped}}
@@ -723,6 +723,6 @@ class Reline::Core::DialogProc < Struct
   def self.inspect; end
   def self.keyword_init?; end
   def self.members; end
-  def self.new(*arg0); end
+  def initialize(*arg0); end
   Elem = type_member(:out) {{fixed: T.untyped}}
 end

--- a/rbi/stdlib/reline.rbi
+++ b/rbi/stdlib/reline.rbi
@@ -205,7 +205,6 @@ class Reline::KillRing::RingPoint < Struct
   def self.inspect; end
   def self.keyword_init?; end
   def self.members; end
-  def initialize(*arg0); end
   def str; end
   def str=(_); end
   Elem = type_member(:out) {{fixed: T.untyped}}

--- a/rbi/stdlib/resolv.rbi
+++ b/rbi/stdlib/resolv.rbi
@@ -367,7 +367,7 @@ end
 class Resolv::DNS::Config
   InitialTimeout = T.let(T.unsafe(nil), Integer)
 
-  def self.new(config_info = _); end
+  def initialize(config_info = _); end
 
   def generate_candidates(name); end
 
@@ -409,7 +409,7 @@ module Resolv::DNS::Label
 end
 
 class Resolv::DNS::Label::Str
-  def self.new(string); end
+  def initialize(string); end
 
   def ==(other); end
 
@@ -427,7 +427,7 @@ class Resolv::DNS::Label::Str
 end
 
 class Resolv::DNS::Message
-  def self.new(id = _); end
+  def initialize(id = _); end
 
   def ==(other); end
 
@@ -495,7 +495,7 @@ class Resolv::DNS::Message
 end
 
 class Resolv::DNS::Message::MessageDecoder
-  def self.new(data); end
+  def initialize(data); end
 
   def get_bytes(len = _); end
 
@@ -521,7 +521,7 @@ class Resolv::DNS::Message::MessageDecoder
 end
 
 class Resolv::DNS::Message::MessageEncoder
-  def self.new; end
+  def initialize; end
 
   def put_bytes(d); end
 
@@ -666,7 +666,7 @@ module Resolv::DNS::RCode
 end
 
 class Resolv::DNS::Requester
-  def self.new; end
+  def initialize; end
 
   def close; end
 
@@ -676,7 +676,7 @@ class Resolv::DNS::Requester
 end
 
 class Resolv::DNS::Requester::ConnectedUDP < ::Resolv::DNS::Requester
-  def self.new(host, port = _); end
+  def initialize(host, port = _); end
 
   def close; end
 
@@ -702,11 +702,11 @@ end
 class Resolv::DNS::Requester::RequestError < ::StandardError; end
 
 class Resolv::DNS::Requester::Sender
-  def self.new(msg, data, sock); end
+  def initialize(msg, data, sock); end
 end
 
 class Resolv::DNS::Requester::TCP < ::Resolv::DNS::Requester
-  def self.new(host, port = _); end
+  def initialize(host, port = _); end
 
   def close; end
 
@@ -722,7 +722,7 @@ class Resolv::DNS::Requester::TCP::Sender < ::Resolv::DNS::Requester::Sender
 end
 
 class Resolv::DNS::Requester::UnconnectedUDP < ::Resolv::DNS::Requester
-  def self.new(*nameserver_port); end
+  def initialize(*nameserver_port); end
 
   def close; end
 
@@ -732,7 +732,7 @@ class Resolv::DNS::Requester::UnconnectedUDP < ::Resolv::DNS::Requester
 end
 
 class Resolv::DNS::Requester::UnconnectedUDP::Sender < ::Resolv::DNS::Requester::Sender
-  def self.new(msg, data, sock, host, port); end
+  def initialize(msg, data, sock, host, port); end
 
   def data; end
 
@@ -1050,7 +1050,7 @@ end
 class Resolv::DNS::Resource::LOC < ::Resolv::DNS::Resource
   TypeValue = T.let(T.unsafe(nil), Integer)
 
-  def self.new(version, ssize, hprecision, vprecision, latitude, longitude, altitude); end
+  def initialize(version, ssize, hprecision, vprecision, latitude, longitude, altitude); end
 
   # The altitude of the
   # [`LOC`](https://docs.ruby-lang.org/en/2.7.0/Resolv/DNS/Resource/LOC.html)

--- a/rbi/stdlib/rexml.rbi
+++ b/rbi/stdlib/rexml.rbi
@@ -80,7 +80,7 @@ class REXML::AttlistDecl < ::REXML::Child
   # parse it. Sorry, but for the foreseeable future, DTD support in
   # [`REXML`](https://docs.ruby-lang.org/en/2.7.0/REXML.html) is pretty weak on
   # convenience. Have I mentioned how much I hate DTDs?
-  def self.new(source); end
+  def initialize(source); end
 
   # Access the attlist attribute/value pairs.
   #
@@ -162,7 +162,7 @@ class REXML::Attribute
   # Attribute.new( "attr", "attr_value" )
   # Attribute.new( "attr", "attr_value", parent_element )
   # ```
-  def self.new(first, second = _, parent = _); end
+  def initialize(first, second = _, parent = _); end
 
   # Returns true if other is an
   # [`Attribute`](https://docs.ruby-lang.org/en/2.7.0/REXML/Attribute.html) and
@@ -277,7 +277,7 @@ class REXML::Attributes < ::Hash
   # Constructor
   # element
   # :   the Element of which this is an Attribute
-  def self.new(element); end
+  def initialize(element); end
 
   # Alias for:
   # [`add`](https://docs.ruby-lang.org/en/2.7.0/REXML/Attributes.html#method-i-add)
@@ -452,7 +452,7 @@ class REXML::CData < ::REXML::Text
   # CData.new( "Here is some CDATA" )
   # CData.new( "Some unprocessed data", respect_whitespace_TF, parent_element )
   # ```
-  def self.new(first, whitespace = _, parent = _); end
+  def initialize(first, whitespace = _, parent = _); end
 
   # Make a copy of this object
   #
@@ -514,7 +514,7 @@ class REXML::Child
   # parent
   # :   if supplied, the parent of this child will be set to the supplied value,
   #     and self will be added to the parent
-  def self.new(parent = _); end
+  def initialize(parent = _); end
 
   # This doesn't yet handle encodings
   def bytes; end
@@ -596,7 +596,7 @@ class REXML::Comment < ::REXML::Child
   # argument is duplicated. If Source, the argument is scanned for a comment.
   # @param second If the first argument is a Source, this argument should be
   # nil, not supplied, or a Parent to be set as the parent of this object
-  def self.new(first, second = _); end
+  def initialize(first, second = _); end
 
   # Compares this
   # [`Comment`](https://docs.ruby-lang.org/en/2.7.0/REXML/Comment.html) to
@@ -641,7 +641,7 @@ end
 # This is an abstract class. You never use this directly; it serves as a parent
 # class for the specific declarations.
 class REXML::Declaration < ::REXML::Child
-  def self.new(src); end
+  def initialize(src); end
 
   def to_s; end
 
@@ -686,7 +686,7 @@ class REXML::DocType < ::REXML::Parent
   # ```
   #
   # is *deprecated*. Do not use it. It will probably disappear.
-  def self.new(first, parent = _); end
+  def initialize(first, parent = _); end
 
   def add(child); end
 
@@ -790,7 +790,7 @@ class REXML::Document < ::REXML::Element
   # [`XML`](https://docs.ruby-lang.org/en/2.7.0/XML.html) documents. @param
   # context if supplied, contains the context of the document; this should be a
   # [`Hash`](https://docs.ruby-lang.org/en/2.7.0/Hash.html).
-  def self.new(source = _, context = _); end
+  def initialize(source = _, context = _); end
 
   # Alias for:
   # [`add`](https://docs.ruby-lang.org/en/2.7.0/REXML/Document.html#method-i-add)
@@ -996,7 +996,7 @@ class REXML::Element < ::REXML::Parent
   # *   `:raw` can be :`all`, or an array of strings being the names of the
   #     elements to process in raw mode. In raw mode, special characters in text
   #     is not converted to or from entities.
-  def self.new(arg = _, parent = _, context = _); end
+  def initialize(arg = _, parent = _, context = _); end
 
   # Fetches an attribute value or a child.
   #
@@ -1503,7 +1503,7 @@ class REXML::Element < ::REXML::Parent
 end
 
 class REXML::ElementDecl < ::REXML::Declaration
-  def self.new(src); end
+  def initialize(src); end
 end
 
 # A class which provides filtering of children for
@@ -1519,7 +1519,7 @@ class REXML::Elements
   # Constructor
   # parent
   # :   the parent Element
-  def self.new(parent); end
+  def initialize(parent); end
 
   # Alias for:
   # [`add`](https://docs.ruby-lang.org/en/2.7.0/REXML/Elements.html#method-i-add)
@@ -1741,7 +1741,7 @@ class REXML::Entity < ::REXML::Child
   # ```ruby
   # e = Entity.new( 'amp', '&' )
   # ```
-  def self.new(stream, value = _, parent = _, reference = _); end
+  def initialize(stream, value = _, parent = _, reference = _); end
 
   def external; end
 
@@ -1818,7 +1818,7 @@ module REXML::EntityConst
 end
 
 class REXML::ExternalEntity < ::REXML::Child
-  def self.new(src); end
+  def initialize(src); end
 
   def to_s; end
 
@@ -1836,7 +1836,7 @@ class REXML::Formatters::Default
   #     tag, so that IE's bad
   #     [`XML`](https://docs.ruby-lang.org/en/2.7.0/XML.html) parser doesn't
   #     choke.
-  def self.new(ie_hack = _); end
+  def initialize(ie_hack = _); end
 
   # Writes the node to some output.
   #
@@ -1883,7 +1883,7 @@ class REXML::Formatters::Pretty < ::REXML::Formatters::Default
   #     thereby allowing Internet Explorer's
   #     [`XML`](https://docs.ruby-lang.org/en/2.7.0/XML.html) parser to
   #     function. Defaults to false.
-  def self.new(indentation = _, ie_hack = _); end
+  def initialize(indentation = _, ie_hack = _); end
 
   # If compact is set to true, then the formatter will attempt to use as little
   # space as possible
@@ -2077,7 +2077,7 @@ end
 # See the Source class for method documentation
 class REXML::IOSource < ::REXML::Source
   # block\_size has been deprecated
-  def self.new(arg, block_size = _, encoding = _); end
+  def initialize(arg, block_size = _, encoding = _); end
 
   def consume(pattern); end
 
@@ -2116,7 +2116,7 @@ class REXML::Instruction < ::REXML::Child
   # Parent. Can only be a Parent if the target argument is a Source. Otherwise,
   # this [`String`](https://docs.ruby-lang.org/en/2.7.0/String.html) is set as
   # the content of this instruction.
-  def self.new(target, content = _); end
+  def initialize(target, content = _); end
 
   # @return true if other is an
   # [`Instruction`](https://docs.ruby-lang.org/en/2.7.0/REXML/Instruction.html),
@@ -2220,7 +2220,7 @@ module REXML::Node
 end
 
 class REXML::NotationDecl < ::REXML::Child
-  def self.new(name, middle, pub, sys); end
+  def initialize(name, middle, pub, sys); end
 
   # This method retrieves the name of the notation.
   #
@@ -2244,7 +2244,7 @@ end
 class REXML::Output
   include(::REXML::Encoding)
 
-  def self.new(real_IO, encd = _); end
+  def initialize(real_IO, encd = _); end
 
   def <<(content); end
 
@@ -2263,7 +2263,7 @@ class REXML::Parent < ::REXML::Child
 
   # Constructor @param parent if supplied, will be set as the parent of this
   # object
-  def self.new(parent = _); end
+  def initialize(parent = _); end
 
   # Alias for:
   # [`push`](https://docs.ruby-lang.org/en/2.7.0/REXML/Parent.html#method-i-push)
@@ -2363,7 +2363,7 @@ class REXML::Parent < ::REXML::Child
 end
 
 class REXML::ParseException < ::RuntimeError
-  def self.new(message, source = _, parser = _, exception = _); end
+  def initialize(message, source = _, parser = _, exception = _); end
 
   def context; end
 
@@ -2548,7 +2548,7 @@ class REXML::Parsers::BaseParser
 
   XMLDECL_START = T.let(T.unsafe(nil), Regexp)
 
-  def self.new(source); end
+  def initialize(source); end
 
   def add_listener(listener); end
 
@@ -2589,7 +2589,7 @@ class REXML::Parsers::BaseParser
 end
 
 class REXML::Parsers::StreamParser
-  def self.new(source, listener); end
+  def initialize(source, listener); end
 
   def add_listener(listener); end
 
@@ -2597,7 +2597,7 @@ class REXML::Parsers::StreamParser
 end
 
 class REXML::Parsers::TreeParser
-  def self.new(source, build_context = _); end
+  def initialize(source, build_context = _); end
 
   def add_listener(listener); end
 
@@ -2838,7 +2838,7 @@ class REXML::Source
   # valid [`XML`](https://docs.ruby-lang.org/en/2.7.0/XML.html) document @param
   # encoding if non-null, sets the encoding of the source to this value,
   # overriding all encoding detection
-  def self.new(arg, encoding = _); end
+  def initialize(arg, encoding = _); end
 
   # The current buffer (what we're going to read next)
   def buffer; end
@@ -2998,7 +2998,7 @@ class REXML::SyncEnumerator
   # [`SyncEnumerator`](https://docs.ruby-lang.org/en/2.6.0/REXML/SyncEnumerator.html)
   # which enumerates rows of given
   # [`Enumerable`](https://docs.ruby-lang.org/en/2.6.0/Enumerable.html) objects.
-  def self.new(*enums); end
+  def initialize(*enums); end
 
   # Enumerates rows of the
   # [`Enumerable`](https://docs.ruby-lang.org/en/2.6.0/Enumerable.html) objects.
@@ -3088,7 +3088,7 @@ class REXML::Text < ::REXML::Child
   # In the last example, the `entity_filter` argument is ignored.
   #
   # `illegal` INTERNAL USE ONLY
-  def self.new(arg, respect_whitespace = _, parent = _, raw = _, entity_filter = _, illegal = _); end
+  def initialize(arg, respect_whitespace = _, parent = _, raw = _, entity_filter = _, illegal = _); end
 
   # Appends text to this text node. The text is appended in the `raw` mode of
   # this text node.
@@ -3219,13 +3219,13 @@ class REXML::Text < ::REXML::Child
 end
 
 class REXML::UndefinedNamespaceException < ::REXML::ParseException
-  def self.new(prefix, source, parser); end
+  def initialize(prefix, source, parser); end
 end
 
 module REXML::Validation; end
 
 class REXML::Validation::ValidationException < ::RuntimeError
-  def self.new(msg); end
+  def initialize(msg); end
 end
 
 REXML::Version = T.let(T.unsafe(nil), String)
@@ -3244,7 +3244,7 @@ class REXML::XMLDecl < ::REXML::Child
 
   STOP = T.let(T.unsafe(nil), String)
 
-  def self.new(version = _, encoding = _, standalone = _); end
+  def initialize(version = _, encoding = _, standalone = _); end
 
   def ==(other); end
 
@@ -3431,7 +3431,7 @@ class REXML::XPathParser
 
   LITERAL = T.let(T.unsafe(nil), Regexp)
 
-  def self.new; end
+  def initialize; end
 
   def []=(variable_name, value); end
 

--- a/rbi/stdlib/rinda.rbi
+++ b/rbi/stdlib/rinda.rbi
@@ -15,7 +15,7 @@ class Rinda::DRbObjectTemplate
   # Creates a new
   # [`DRbObjectTemplate`](https://docs.ruby-lang.org/en/2.7.0/Rinda/DRbObjectTemplate.html)
   # that will match against `uri` and `ref`.
-  def self.new(uri = _, ref = _); end
+  def initialize(uri = _, ref = _); end
 
   # This
   # [`DRbObjectTemplate`](https://docs.ruby-lang.org/en/2.7.0/Rinda/DRbObjectTemplate.html)
@@ -59,7 +59,7 @@ class Rinda::NotifyTemplateEntry < ::Rinda::TemplateEntry
   # Creates a new
   # [`NotifyTemplateEntry`](https://docs.ruby-lang.org/en/2.7.0/Rinda/NotifyTemplateEntry.html)
   # that watches `place` for +event+s that match `tuple`.
-  def self.new(place, event, tuple, expires = _); end
+  def initialize(place, event, tuple, expires = _); end
 
   # Yields event/tuple pairs until this
   # [`NotifyTemplateEntry`](https://docs.ruby-lang.org/en/2.7.0/Rinda/NotifyTemplateEntry.html)
@@ -139,7 +139,7 @@ class Rinda::RingFinger
   # be made using the given
   # [`multicast_hops`](https://docs.ruby-lang.org/en/2.7.0/Rinda/RingFinger.html#attribute-i-multicast_hops)
   # and multicast\_interface.
-  def self.new(broadcast_list = _, port = _); end
+  def initialize(broadcast_list = _, port = _); end
 
   # The list of addresses where
   # [`RingFinger`](https://docs.ruby-lang.org/en/2.7.0/Rinda/RingFinger.html)
@@ -228,7 +228,7 @@ class Rinda::RingProvider
   # [`RingProvider`](https://docs.ruby-lang.org/en/2.7.0/Rinda/RingProvider.html)
   # that will provide a `klass` service running on `front`, with a
   # `description`. `renewer` is optional.
-  def self.new(klass, front, desc, renewer = _); end
+  def initialize(klass, front, desc, renewer = _); end
 
   # Advertises this service on the primary remote TupleSpace.
   def provide; end
@@ -312,7 +312,7 @@ class Rinda::RingServer
   #
   # If the second is omitted then '::1' is used. If the third is omitted then 0
   # (default interface) is used.
-  def self.new(ts, addresses = _, port = _); end
+  def initialize(ts, addresses = _, port = _); end
 
   # Pulls lookup tuples out of the TupleSpace and sends their
   # [`DRb`](https://docs.ruby-lang.org/en/2.7.0/DRb.html) object the address of
@@ -354,7 +354,7 @@ end
 class Rinda::RingServer::Renewer
   include(::DRb::DRbUndumped)
 
-  def self.new; end
+  def initialize; end
 
   def renew; end
 
@@ -373,7 +373,7 @@ class Rinda::SimpleRenewer
   # Creates a new
   # [`SimpleRenewer`](https://docs.ruby-lang.org/en/2.7.0/Rinda/SimpleRenewer.html)
   # that keeps an object alive for another `sec` seconds.
-  def self.new(sec = _); end
+  def initialize(sec = _); end
 
   # Called by the TupleSpace to check if the object is still alive.
   def renew; end
@@ -435,7 +435,7 @@ class Rinda::Tuple
   # `ary_or_hash` which must be an
   # [`Array`](https://docs.ruby-lang.org/en/2.7.0/Array.html) or
   # [`Hash`](https://docs.ruby-lang.org/en/2.7.0/Hash.html).
-  def self.new(ary_or_hash); end
+  def initialize(ary_or_hash); end
 
   # Accessor method for elements of the tuple.
   def [](k); end
@@ -457,7 +457,7 @@ end
 # [`TupleBag`](https://docs.ruby-lang.org/en/2.7.0/Rinda/TupleBag.html) is an
 # unordered collection of tuples. It is the basis of Tuplespace.
 class Rinda::TupleBag
-  def self.new; end
+  def initialize; end
 
   # Removes `tuple` from the
   # [`TupleBag`](https://docs.ruby-lang.org/en/2.7.0/Rinda/TupleBag.html).
@@ -492,7 +492,7 @@ end
 class Rinda::TupleBag::TupleBin
   extend(::Forwardable)
 
-  def self.new; end
+  def initialize; end
 
   def add(tuple); end
 
@@ -522,7 +522,7 @@ class Rinda::TupleEntry
   # A renewer must implement the `renew` method which returns a
   # [`Numeric`](https://docs.ruby-lang.org/en/2.7.0/Numeric.html), nil, or true
   # to indicate when the tuple has expired.
-  def self.new(ary, sec = _); end
+  def initialize(ary, sec = _); end
 
   # Retrieves `key` from the tuple.
   def [](key); end
@@ -611,7 +611,7 @@ class Rinda::TupleSpace
   # the
   # [`TupleSpace`](https://docs.ruby-lang.org/en/2.7.0/Rinda/TupleSpace.html)
   # will stop looking for dead tuples.
-  def self.new(period = _); end
+  def initialize(period = _); end
 
   # Moves `tuple` to `port`.
   def move(port, tuple, sec = _); end
@@ -653,7 +653,7 @@ class Rinda::TupleSpaceProxy
   # Creates a new
   # [`TupleSpaceProxy`](https://docs.ruby-lang.org/en/2.7.0/Rinda/TupleSpaceProxy.html)
   # to wrap `ts`.
-  def self.new(ts); end
+  def initialize(ts); end
 
   # Registers for notifications of event `ev` on the proxied TupleSpace. See
   # TupleSpace#notify
@@ -674,7 +674,7 @@ class Rinda::TupleSpaceProxy
 end
 
 class Rinda::TupleSpaceProxy::Port
-  def self.new; end
+  def initialize; end
 
   def close; end
 
@@ -687,7 +687,7 @@ end
 
 # *Documentation?*
 class Rinda::WaitTemplateEntry < ::Rinda::TemplateEntry
-  def self.new(place, ary, expires = _); end
+  def initialize(place, ary, expires = _); end
 
   def cancel; end
 

--- a/rbi/stdlib/ripper.rbi
+++ b/rbi/stdlib/ripper.rbi
@@ -199,7 +199,7 @@ class Ripper::Filter
   # Ripper::Lexer.new
   #
   # The lexer is for internal use only.
-  def self.new(src, filename = '-', lineno = 1); end
+  def initialize(src, filename = '-', lineno = 1); end
 
   # The column number of the current token. This value starts from 0. This
   # method is valid only in event handlers.

--- a/rbi/stdlib/rubygems.rbi
+++ b/rbi/stdlib/rubygems.rbi
@@ -1123,7 +1123,7 @@ class Gem::Platform < Object
 
   def self.match(platform); end
 
-  def self.new(arch); end
+  def initialize(arch); end
 end
 
 # Generated when trying to lookup a gem to indicate that the gem was found, but
@@ -2751,9 +2751,9 @@ class Gem::Version < Object
         Gem::Version, # Will return the same version object
         NilClass # Deprecated, and will issue a warning
       )
-    ).returns(Gem::Version)
+    ).void
   end
-  def self.new(version); end
+  def initialize(version); end
 end
 
 class Gem::Package

--- a/rbi/stdlib/sdbm.rbi
+++ b/rbi/stdlib/sdbm.rbi
@@ -72,7 +72,7 @@ class SDBM
   #
   # If the file exists, it will be opened in read/write mode. If this fails, it
   # will be opened in read-only mode.
-  def self.new(*_); end
+  def initialize(*_); end
 
   # Returns the `value` in the database associated with the given `key` string.
   #

--- a/rbi/stdlib/strscan.rbi
+++ b/rbi/stdlib/strscan.rbi
@@ -128,9 +128,9 @@ class StringScanner < Object
         arg0: String,
         arg1: T::Boolean,
     )
-    .returns(StringScanner)
+    .void
   end
-  def self.new(arg0, arg1=T.unsafe(nil)); end
+  def initialize(arg0, arg1=T.unsafe(nil)); end
 
   # Appends `str` to the string being scanned. This method does not affect scan
   # pointer.

--- a/rbi/stdlib/syslog.rbi
+++ b/rbi/stdlib/syslog.rbi
@@ -306,7 +306,7 @@ class Syslog::Logger
   # may be set to specify the facility level which will be used.
   #
   # Due to the way syslog works, only one program name may be chosen.
-  def self.new(program_name = _, facility = _); end
+  def initialize(program_name = _, facility = _); end
 
   # Almost duplicates
   # [`Logger#add`](https://docs.ruby-lang.org/en/2.7.0/Logger.html#method-i-add).

--- a/rbi/stdlib/thwait.rbi
+++ b/rbi/stdlib/thwait.rbi
@@ -40,7 +40,7 @@ class ThreadsWait
   # Creates a
   # [`ThreadsWait`](https://docs.ruby-lang.org/en/2.6.0/ThreadsWait.html)
   # object, specifying the threads to wait on. Non-blocking.
-  def self.new(*threads); end
+  def initialize(*threads); end
 
   def Fail(err = _, *rest); end
 

--- a/rbi/stdlib/uri.rbi
+++ b/rbi/stdlib/uri.rbi
@@ -607,7 +607,7 @@ class URI::FTP < URI::Generic
   #
   # Arguments are `scheme`, `userinfo`, `host`, `port`, `registry`, `path`,
   # `opaque`, `query`, and `fragment`, in that order.
-  def self.new(scheme, userinfo, host, port, registry, path, opaque, query, fragment, parser = _, arg_check = _); end
+  def initialize(scheme, userinfo, host, port, registry, path, opaque, query, fragment, parser = _, arg_check = _); end
 
   def merge(oth); end
 
@@ -1840,7 +1840,7 @@ class URI::LDAPS < URI::LDAP
   #
   # See also
   # [`URI::Generic.new`](https://docs.ruby-lang.org/en/2.6.0/URI/Generic.html#method-c-new).
-  def self.new(*arg); end
+  def initialize(*arg); end
 
   # Returns attributes.
   def attributes; end
@@ -1971,7 +1971,7 @@ class URI::MailTo < URI::Generic
   # This method is usually called from
   # [`URI::parse`](https://docs.ruby-lang.org/en/2.7.0/URI.html#method-c-parse),
   # which checks the validity of each component.
-  def self.new(*arg); end
+  def initialize(*arg); end
 
   # E-mail headers set by the URL, as an
   # [`Array`](https://docs.ruby-lang.org/en/2.7.0/Array.html) of Arrays.
@@ -2144,7 +2144,7 @@ class URI::RFC2396_Parser < Object
   # u1 == u2 #=> true
   # u1.eql?(u2) #=> false
   # ```
-  def self.new(opts = _); end
+  def initialize(opts = _); end
 
   # ## Args
   #

--- a/rbi/stdlib/weakref.rbi
+++ b/rbi/stdlib/weakref.rbi
@@ -24,7 +24,7 @@ class WeakRef < Delegator
   # [`Symbol`](https://docs.ruby-lang.org/en/2.7.0/Symbol.html),
   # [`Integer`](https://docs.ruby-lang.org/en/2.7.0/Integer.html), or
   # [`Float`](https://docs.ruby-lang.org/en/2.7.0/Float.html).
-  def self.new(orig); end
+  def initialize(orig); end
 
   # Returns true if the referenced object is still alive.
   def weakref_alive?; end

--- a/rbi/stdlib/webrick.rbi
+++ b/rbi/stdlib/webrick.rbi
@@ -1155,9 +1155,9 @@ class WEBrick::HTTPAuth::DigestAuth::OpaqueInfo < Struct
     params(
       _: T.untyped,
     )
-    .returns(T.untyped)
+    .void
   end
-  def self.new(*_); end
+  def initialize(*_); end
 end
 
 # [`Htdigest`](https://docs.ruby-lang.org/en/2.7.0/WEBrick/HTTPAuth/Htdigest.html)

--- a/rbi/stdlib/zlib.rbi
+++ b/rbi/stdlib/zlib.rbi
@@ -450,7 +450,7 @@ class Zlib::Deflate < ::Zlib::ZStream
   #
   # While this example will work, for best optimization review the flags for
   # your specific time, memory usage and output space requirements.
-  def self.new(*_); end
+  def initialize(*_); end
 
   # Inputs `string` into the deflate stream just like
   # [`Zlib::Deflate#deflate`](https://docs.ruby-lang.org/en/2.7.0/Zlib/Deflate.html#method-i-deflate),
@@ -950,7 +950,7 @@ class Zlib::GzipWriter < ::Zlib::GzipFile
   # The `options` hash may be used to set the encoding of the data.
   # `:external_encoding`, `:internal_encoding` and `:encoding` may be set as in
   # [`IO::new`](https://docs.ruby-lang.org/en/2.7.0/IO.html#method-c-new).
-  def self.new(*_); end
+  def initialize(*_); end
 
   # Same as [`IO`](https://docs.ruby-lang.org/en/2.7.0/IO.html).
   def <<(_); end
@@ -1061,7 +1061,7 @@ class Zlib::Inflate < ::Zlib::ZStream
   #   end
   # end
   # ```
-  def self.new(*_); end
+  def initialize(*_); end
 
   # Same as [`IO`](https://docs.ruby-lang.org/en/2.7.0/IO.html).
   def <<(_); end

--- a/test/testdata/rbi/exception.rb
+++ b/test/testdata/rbi/exception.rb
@@ -7,7 +7,7 @@ StandardError.new(:msg)
 ex = StandardError.new("bees")
 RuntimeError.new(ex)
 
-SystemCallError.new # error: Not enough arguments provided for method `SystemCallError.new (overload.1)`. Expected: `1`, got: `0`
+SystemCallError.new # error: Not enough arguments provided for method `SystemCallError#initialize (overload.1)`. Expected: `1`, got: `0`
 SystemCallError.new(1)
 SystemCallError.new(nil)
 SystemCallError.new("message")


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

If there's no definition for `def self.new`, Sorbet is able to see that
the dispatch goes up to `Class#new`, which returns `T.attached_class`
and allows inferring a type for the result based on the receiver.

When there is an override of `Class#new`, that type is used entirely. If
there is no sig, or a sig with `T.untyped` for the return type, then the
result of calling `klass.new` will be untyped.

It seems we have a lot of RBIs using `def self.new` to declare the type,
which clobbers Sorbet's ability to give good types for constructors.

Replacing these definitions with `def initialize` allows the definition
to specify the method arity and parameter types without interferring
with result type inference.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

RBI-change

Testing on Stripe's codebase.