### PR TITLE
remove unused `NonRefcounted`

### DIFF
--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -14,8 +14,6 @@ class TypeConstraint;
 struct DispatchResult;
 struct DispatchArgs;
 
-class NonRefcounted {};
-
 class Refcounted {
     friend class TypePtrTestHelper;
     std::atomic<uint32_t> counter{0};


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It is unused.  I think this might have been an intermediate state when `TypePtr` was converted to use invasive refcounting.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

If it compiles, it works.