### PR TITLE
sorbet-runtime: Remove `@has_rest`, `@has_keyrest` from `Signature`

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -68,7 +68,7 @@ module T::Private::Methods::CallValidation
   end
 
   def self.create_validator_method(mod, original_method, method_sig, original_visibility)
-    has_fixed_arity = method_sig.kwarg_types.empty? && !method_sig.has_rest && !method_sig.has_keyrest &&
+    has_fixed_arity = method_sig.kwarg_types.empty? && method_sig.rest_type.nil? && !method_sig.has_keyrest &&
       original_method.parameters.all? { |(kind, _name)| kind == :req || kind == :block }
     can_skip_block_type = method_sig.block_type.nil? || method_sig.block_type.valid?(nil)
     ok_for_fast_path = has_fixed_arity && can_skip_block_type && !method_sig.bind && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -68,7 +68,7 @@ module T::Private::Methods::CallValidation
   end
 
   def self.create_validator_method(mod, original_method, method_sig, original_visibility)
-    has_fixed_arity = method_sig.kwarg_types.empty? && method_sig.rest_type.nil? && !method_sig.has_keyrest &&
+    has_fixed_arity = method_sig.kwarg_types.empty? && method_sig.rest_type.nil? && method_sig.keyrest_type.nil? &&
       original_method.parameters.all? { |(kind, _name)| kind == :req || kind == :block }
     can_skip_block_type = method_sig.block_type.nil? || method_sig.block_type.valid?(nil)
     ok_for_fast_path = has_fixed_arity && can_skip_block_type && !method_sig.bind && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -4,7 +4,7 @@
 class T::Private::Methods::Signature
   attr_reader :method, :method_name, :arg_types, :kwarg_types, :block_type, :block_name,
               :rest_type, :rest_name, :keyrest_type, :keyrest_name, :bind, :effective_return_type,
-              :return_type, :mode, :req_arg_count, :req_kwarg_names, :has_keyrest,
+              :return_type, :mode, :req_arg_count, :req_kwarg_names,
               :check_level, :parameters, :on_failure, :override_allow_incompatible,
               :defined_raw
 
@@ -55,7 +55,6 @@ class T::Private::Methods::Signature
     @bind = bind ? T::Utils.coerce(bind) : bind
     @mode = mode
     @check_level = check_level
-    @has_keyrest = false
     @parameters = parameters
     @on_failure = on_failure
     @override_allow_incompatible = override_allow_incompatible
@@ -142,7 +141,6 @@ class T::Private::Methods::Signature
         @rest_name = param_name
         @rest_type = type
       when :keyrest
-        @has_keyrest = true
         @keyrest_name = param_name
         @keyrest_type = type
       else
@@ -193,7 +191,7 @@ class T::Private::Methods::Signature
     # causes forwarding **kwargs to do the wrong thing: see https://bugs.ruby-lang.org/issues/10708
     # and https://bugs.ruby-lang.org/issues/11860.
     args_length = args.length
-    if (args_length > @req_arg_count) && (!@kwarg_types.empty? || @has_keyrest) && args[-1].is_a?(Hash)
+    if (args_length > @req_arg_count) && (!@kwarg_types.empty? || !@keyrest_type.nil?) && args[-1].is_a?(Hash)
       kwargs = args[-1]
       args_length -= 1
     else
@@ -231,7 +229,7 @@ class T::Private::Methods::Signature
 
     kwargs.each do |name, val|
       type = @kwarg_types[name]
-      if !type && @has_keyrest
+      if !type && !@keyrest_type.nil?
         type = @keyrest_type
       end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -4,7 +4,7 @@
 class T::Private::Methods::Signature
   attr_reader :method, :method_name, :arg_types, :kwarg_types, :block_type, :block_name,
               :rest_type, :rest_name, :keyrest_type, :keyrest_name, :bind, :effective_return_type,
-              :return_type, :mode, :req_arg_count, :req_kwarg_names, :has_rest, :has_keyrest,
+              :return_type, :mode, :req_arg_count, :req_kwarg_names, :has_keyrest,
               :check_level, :parameters, :on_failure, :override_allow_incompatible,
               :defined_raw
 
@@ -55,7 +55,6 @@ class T::Private::Methods::Signature
     @bind = bind ? T::Utils.coerce(bind) : bind
     @mode = mode
     @check_level = check_level
-    @has_rest = false
     @has_keyrest = false
     @parameters = parameters
     @on_failure = on_failure
@@ -140,7 +139,6 @@ class T::Private::Methods::Signature
         @block_name = param_name
         @block_type = type
       when :rest
-        @has_rest = true
         @rest_name = param_name
         @rest_type = type
       when :keyrest
@@ -202,7 +200,7 @@ class T::Private::Methods::Signature
       kwargs = EMPTY_HASH
     end
 
-    if !@has_rest && ((args_length < @req_arg_count) || (args_length > @arg_types.length))
+    if @rest_type.nil? && ((args_length < @req_arg_count) || (args_length > @arg_types.length))
       expected_str = @req_arg_count.to_s
       if @arg_types.length != @req_arg_count
         expected_str += "..#{@arg_types.length}"
@@ -220,7 +218,7 @@ class T::Private::Methods::Signature
         it += 1
       end
 
-      if @has_rest
+      if !@rest_type.nil?
         rest_count = args_length - @arg_types.length
         rest_count = 0 if rest_count.negative?
 

--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
@@ -200,7 +200,7 @@ module T::Private::Methods::SignatureValidation
             "#{base_override_loc_str(signature, super_signature)}"
     end
 
-    if !signature.has_keyrest
+    if signature.keyrest_type.nil?
       # O(nm), but n and m are tiny here
       missing_kwargs = super_signature.kwarg_names - signature.kwarg_names
       if !missing_kwargs.empty?
@@ -210,7 +210,7 @@ module T::Private::Methods::SignatureValidation
       end
     end
 
-    if !signature.has_keyrest && super_signature.has_keyrest
+    if signature.keyrest_type.nil? && !super_signature.keyrest_type.nil?
       raise "Your definition of `#{method_name}` must have `**#{super_signature.keyrest_name}` " \
             "to be compatible with the method it #{mode_verb}: " \
             "#{base_override_loc_str(signature, super_signature)}"

--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
@@ -182,13 +182,13 @@ module T::Private::Methods::SignatureValidation
     method_name = signature.method_name
     mode_verb = super_signature.mode == Modes.abstract ? 'implements' : 'overrides'
 
-    if !signature.has_rest && signature.arg_count < super_signature.arg_count
+    if signature.rest_type.nil? && signature.arg_count < super_signature.arg_count
       raise "Your definition of `#{method_name}` must accept at least #{super_signature.arg_count} " \
             "positional arguments to be compatible with the method it #{mode_verb}: " \
             "#{base_override_loc_str(signature, super_signature)}"
     end
 
-    if !signature.has_rest && super_signature.has_rest
+    if signature.rest_type.nil? && !super_signature.rest_type.nil?
       raise "Your definition of `#{method_name}` must have `*#{super_signature.rest_name}` " \
             "to be compatible with the method it #{mode_verb}: " \
             "#{base_override_loc_str(signature, super_signature)}"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm working on typing `sorbet-runtime`. There are some places where we're
checking whether these ivar are `true`, and then using that to assume that
`@rest_type` or `@keyrest_type` is non-`nil`.

Alternatively, we can just check whether those ivars are non-`nil` directly, and
get rid of the extra ivars.

This actually gets us closer to being able to resurrect the idea in #9075: if we
can get to 15 ivars or fewer, we should realize some memory savings.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests, type checking on my WIP type checking branch (#10157), and
Stripe's codebase.