### PR TITLE
sorbet-runtime: Remove `Signature#dsl_method`

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -181,10 +181,6 @@ class T::Private::Methods::Signature
     @method.owner
   end
 
-  def dsl_method
-    "#{@mode}_method"
-  end
-
   # @return [Hash] a mapping like `{arg_name: [val, type], ...}`, for only those args actually present.
   def each_args_value_type(args)
     # Manually split out args and kwargs based on ruby's behavior. Do not try to implement this by


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is a leftover from when `sig` was called `standard_method` and
`sig { override.void }` was `override_method`, etc.

There is some history about this in this blog post

<https://blog.jez.io/history-of-sorbet-syntax/#appetite-for-typing-at-stripe>



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

n/a