### PR TITLE
sorbet-runtime: More payload types for methods

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/abstract/hooks.rb
+++ b/gems/sorbet-runtime/lib/types/private/abstract/hooks.rb
@@ -27,7 +27,7 @@ module T::Private::Abstract::Hooks
     # `self` may not actually be abstract -- it could be a concrete class that inherited from an
     # abstract class. We only need to check this in `inherited` because, for modules being included
     # or extended, the concrete ones won't have these hooks at all. This is just an optimization.
-    return if !T::AbstractUtils.abstract_module?(self)
+    return if !T::AbstractUtils.abstract_module?(T.unsafe(self))
 
     T::Private::Abstract::Data.set(self, :last_used_by, other)
   end

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -437,6 +437,7 @@ module T::Configuration
 end
 
 module T::Utils
+  sig { params(method: T.any(Proc, UnboundMethod)).returns(Integer) }
   def self.arity(method); end
 
   # Converts Sorbet type syntax into a T::Types::Base instance to provide
@@ -445,12 +446,16 @@ module T::Utils
   def self.coerce(val); end
 
   def self.resolve_alias(type); end
+
+  sig { params(force_type_init: T::Boolean).void }
   def self.run_all_sig_blocks(force_type_init: true); end
   def self.signature_for_method(method); end
   def self.signature_for_instance_method(mod, method_name); end
+
   sig { params(type: T.anything).returns(T.nilable(T::Types::Base)) }
   def self.unwrap_nilable(type); end
   def self.wrap_method_with_call_validation_if_needed(mod, method_sig, original_method); end
+
   def self.check_type_recursive!(value, type); end
 
   # only one caller; delete
@@ -459,9 +464,16 @@ end
 
 
 module T::AbstractUtils
+  sig { params(method: UnboundMethod).returns(T::Boolean) }
   def self.abstract_method?(method); end
+
+  sig { params(mod: T::Module[T.anything]).returns(T::Array[UnboundMethod]) }
   def self.abstract_methods_for(mod); end
+
+  sig { params(mod: T::Module[T.anything]).returns(T::Boolean) }
   def self.abstract_module?(mod); end
+
+  sig { params(mod: T::Module[T.anything]).returns(T::Array[UnboundMethod]) }
   def self.declared_abstract_methods_for(mod); end
 end
 

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -437,7 +437,7 @@ module T::Configuration
 end
 
 module T::Utils
-  sig { params(method: T.any(Proc, UnboundMethod)).returns(Integer) }
+  sig { params(method: T.any(Proc, Method, UnboundMethod)).returns(Integer) }
   def self.arity(method); end
 
   # Converts Sorbet type syntax into a T::Types::Base instance to provide
@@ -464,13 +464,15 @@ end
 
 
 module T::AbstractUtils
-  sig { params(method: UnboundMethod).returns(T::Boolean) }
+  sig { params(method: T.any(Method, UnboundMethod)).returns(T::Boolean) }
   def self.abstract_method?(method); end
 
   sig { params(mod: T::Module[T.anything]).returns(T::Array[UnboundMethod]) }
   def self.abstract_methods_for(mod); end
 
-  sig { params(mod: T::Module[T.anything]).returns(T::Boolean) }
+  # This should have been limited to checking Module.
+  # Have to put it at `BasicObject` because callers assume they can pass anything
+  sig { params(mod: BasicObject).returns(T::Boolean) }
   def self.abstract_module?(mod); end
 
   sig { params(mod: T::Module[T.anything]).returns(T::Array[UnboundMethod]) }

--- a/rbi/sorbet/ttypes.rbi
+++ b/rbi/sorbet/ttypes.rbi
@@ -28,6 +28,7 @@ class T::Types::Base
   def subtype_of?(t2); end
   def to_s; end
   def describe_obj(obj); end
+  sig { params(obj: Kernel).returns(T.nilable(String)) }
   def error_message_for_obj(obj); end
   def error_message_for_obj_recursive(obj); end
   def validate!(obj); end
@@ -56,6 +57,9 @@ class T::Types::Simple < T::Types::Base
 
   sig { returns(T::Module[T.anything]) }
   def raw_type; end
+
+  sig { returns(T::Types::Union) }
+  def to_nilable; end
 end
 
 class T::Types::Union < T::Types::Base


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These are the type annotations required to get improved typing in
`gems/sorbet-runtime/` for definitions that are public or pseudo-public APIs in
Sorbet's payload.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Stripe's codebase