### PR TITLE
sorbet-runtime: Two typing changes to ClassUtils

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/class_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/class_utils.rb
@@ -76,7 +76,6 @@ module T::Private::ClassUtils
       end
     end
 
-    overwritten = original_owner == mod
     T::Configuration.without_ruby_warnings do
       T::Private::DeclState.current.without_on_method_added do
         def_with_visibility(mod, name, original_visibility, &blk)

--- a/gems/sorbet-runtime/lib/types/private/class_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/class_utils.rb
@@ -3,59 +3,12 @@
 
 # Cut down version of Chalk::Tools::ClassUtils with only :replace_method functionality.
 # Extracted to a separate namespace so the type system can be used standalone.
+#
+# Note: the functionality to "restore" a method was removed, because it is no
+# longer being used by sorbet-runtime. Restoring a method requires care--if you
+# need to reintroduce this functionality, consult the git history for how to do
+# it safely.
 module T::Private::ClassUtils
-  class ReplacedMethod
-    def initialize(mod, old_method, new_method, overwritten, visibility)
-      if old_method.name != new_method.name
-        raise "Method names must match. old=#{old_method.name} new=#{new_method.name}"
-      end
-      @mod = mod
-      @old_method = old_method
-      @new_method = new_method
-      @overwritten = overwritten
-      @name = old_method.name
-      @visibility = visibility
-      @restored = false
-    end
-
-    def restore
-      # The check below would also catch this, but this makes the failure mode much clearer
-      if @restored
-        raise "Method '#{@name}' on '#{@mod}' was already restored"
-      end
-
-      if @mod.instance_method(@name) != @new_method
-        raise "Trying to restore #{@mod}##{@name} but the method has changed since the call to replace_method"
-      end
-
-      @restored = true
-
-      if @overwritten
-        # The original method was overwritten. Overwrite again to restore it.
-        T::Configuration.without_ruby_warnings do
-          @mod.send(:define_method, @old_method.name, @old_method)
-        end
-      else
-        # The original method was in an ancestor. Restore it by removing the overriding method.
-        @mod.send(:remove_method, @old_method.name)
-      end
-
-      # Restore the visibility. Note that we need to do this even when we call remove_method
-      # above, because the module may have set custom visibility for a method it inherited.
-      @mod.send(@visibility, @old_method.name)
-
-      nil
-    end
-
-    def bind(obj)
-      @old_method.bind(obj)
-    end
-
-    def to_s
-      @old_method.to_s
-    end
-  end
-
   # `name` must be an instance method (for class methods, pass in mod.singleton_class)
   def self.visibility_method_name(mod, name)
     if mod.public_method_defined?(name)
@@ -93,15 +46,18 @@ module T::Private::ClassUtils
     end
   end
 
-  # Replaces a method, either by overwriting it (if it is defined directly on `mod`) or by
-  # overriding it (if it is defined by one of mod's ancestors).  If `original_only` is
-  # false, returns a ReplacedMethod instance on which you can call `bind(...).call(...)`
-  # to call the original method, or `restore` to restore the original method (by
-  # overwriting or removing the override).
+  # Replaces a method, either by overwriting it (if it is defined directly on
+  # `mod`) or by overriding it (if it is defined by one of mod's ancestors).
   #
-  # If `original_only` is true, return the `UnboundMethod` representing the original method.
-  def self.replace_method(mod, name, original_only=false, &blk)
-    original_method = mod.instance_method(name)
+  # Takes the `original_method` as a parameter, so it does not return anything.
+  #
+  # Can also avoid `T.let` pinning errors by letting the caller pre-compute the
+  # `original_method`, so it knows that it will always be defined (because it
+  # doesn't know that the block will always run once)
+  #
+  # Does not share code with `replace_method_with_handle`, for performance (do
+  # not want to increase the call stack, as this is a very sensitive code path).
+  def self.replace_method(original_method, mod, name, &blk)
     original_visibility = visibility_method_name(mod, name)
     original_owner = original_method.owner
 
@@ -127,11 +83,6 @@ module T::Private::ClassUtils
       end
     end
 
-    if original_only
-      original_method
-    else
-      new_method = mod.instance_method(name)
-      ReplacedMethod.new(mod, original_method, new_method, overwritten, original_visibility)
-    end
+    nil
   end
 end

--- a/gems/sorbet-runtime/lib/types/private/class_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/class_utils.rb
@@ -57,7 +57,7 @@ module T::Private::ClassUtils
   end
 
   # `name` must be an instance method (for class methods, pass in mod.singleton_class)
-  private_class_method def self.visibility_method_name(mod, name)
+  def self.visibility_method_name(mod, name)
     if mod.public_method_defined?(name)
       :public
     elsif mod.protected_method_defined?(name)
@@ -65,7 +65,10 @@ module T::Private::ClassUtils
     elsif mod.private_method_defined?(name)
       :private
     else
-      mod.method(name) # Raises
+      # Raises a NameError formatted like the Ruby VM would (the exact text formatting
+      # of these errors changed across Ruby VM versions, in ways that would sometimes
+      # cause tests to fail if they were dependent on hard coding errors).
+      mod.method(name)
     end
   end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -242,7 +242,7 @@ module T::Private::Methods
     # (or unwrap back to the original method).
     key = method_owner_and_name_to_key(mod, method_name)
     unless current_declaration.raw
-      T::Private::ClassUtils.replace_method(mod, method_name, true) do |*args, &blk|
+      T::Private::ClassUtils.replace_method(original_method, mod, method_name) do |*args, &blk|
         method_sig = T::Private::Methods.maybe_run_sig_block_for_key(key)
         method_sig ||= T::Private::Methods._handle_missing_method_signature(
           self,
@@ -541,15 +541,21 @@ module T::Private::Methods
       end
       @old_hooks = nil
     else
-      old_included = T::Private::ClassUtils.replace_method(Module, :included, true) do |arg|
+      # Grab the original methods before replacing them, so that each block
+      # closure can reference a variable that is already assigned.
+      # (Do this directly, to avoid pinning errors)
+      old_included = Module.instance_method(:included)
+      T::Private::ClassUtils.replace_method(old_included, Module, :included) do |arg|
         old_included.bind_call(self, arg)
         ::T::Private::Methods._hook_impl(arg, false, self)
       end
-      old_extended = T::Private::ClassUtils.replace_method(Module, :extended, true) do |arg|
+      old_extended = Module.instance_method(:extended)
+      T::Private::ClassUtils.replace_method(old_extended, Module, :extended) do |arg|
         old_extended.bind_call(self, arg)
         ::T::Private::Methods._hook_impl(arg, true, self)
       end
-      old_inherited = T::Private::ClassUtils.replace_method(Class, :inherited, true) do |arg|
+      old_inherited = Class.instance_method(:inherited)
+      T::Private::ClassUtils.replace_method(old_inherited, Class, :inherited) do |arg|
         old_inherited.bind_call(self, arg)
         ::T::Private::Methods._hook_impl(arg, false, self)
       end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -602,22 +602,6 @@ module T::Private::Methods
     end
     mod.extend(SingletonMethodHooks)
   end
-
-  # `name` must be an instance method (for class methods, pass in mod.singleton_class)
-  def self.visibility_method_name(mod, name)
-    if mod.public_method_defined?(name)
-      :public
-    elsif mod.protected_method_defined?(name)
-      :protected
-    elsif mod.private_method_defined?(name)
-      :private
-    else
-      # Raises a NameError formatted like the Ruby VM would (the exact text formatting
-      # of these errors changed across Ruby VM versions, in ways that would sometimes
-      # cause tests to fail if they were dependent on hard coding errors).
-      mod.method(name)
-    end
-  end
 end
 
 # This has to be here, and can't be nested inside `T::Private::Methods`,

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -16,7 +16,7 @@ module T::Private::Methods::CallValidation
   # @param method_sig [T::Private::Methods::Signature]
   # @return [UnboundMethod] the new wrapper method (or the original one if we didn't wrap it)
   def self.wrap_method_if_needed(mod, method_sig, original_method)
-    original_visibility = T::Private::Methods.visibility_method_name(mod, method_sig.method_name)
+    original_visibility = T::Private::ClassUtils.visibility_method_name(mod, method_sig.method_name)
     if method_sig.mode == T::Private::Methods::Modes.abstract
       create_abstract_wrapper(mod, method_sig, original_method, original_visibility)
     # Do nothing in this case; this method was not wrapped in _on_method_added.

--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
@@ -304,7 +304,7 @@ module T::Private::Methods::SignatureValidation
   end
 
   private_class_method def self.method_visibility(method)
-    T::Private::Methods.visibility_method_name(method.owner, method.name)
+    T::Private::ClassUtils.visibility_method_name(method.owner, method.name)
   end
 
   # Higher = more restrictive.

--- a/gems/sorbet-runtime/lib/types/struct.rb
+++ b/gems/sorbet-runtime/lib/types/struct.rb
@@ -10,7 +10,8 @@ end
 class T::Struct < T::InexactStruct
   def self.inherited(subclass)
     super(subclass)
-    T::Private::ClassUtils.replace_method(subclass.singleton_class, :inherited, true) do |s|
+    original_method = subclass.singleton_class.instance_method(:inherited)
+    T::Private::ClassUtils.replace_method(original_method, subclass.singleton_class, :inherited) do |s|
       super(s)
       raise "#{self.name} is a subclass of T::Struct and cannot be subclassed"
     end
@@ -23,7 +24,8 @@ class T::ImmutableStruct < T::InexactStruct
   def self.inherited(subclass)
     super(subclass)
 
-    T::Private::ClassUtils.replace_method(subclass.singleton_class, :inherited, true) do |s|
+    original_method = subclass.singleton_class.instance_method(:inherited)
+    T::Private::ClassUtils.replace_method(original_method, subclass.singleton_class, :inherited) do |s|
       super(s)
       raise "#{self.name} is a subclass of T::ImmutableStruct and cannot be subclassed"
     end

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -923,7 +923,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     klass = Class.new do
       define_singleton_method(:method_added) do |name|
         # Reaching into a private method for testing purposes
-        visibility = T::Private::ClassUtils.send(:visibility_method_name, self, name)
+        visibility = T::Private::ClassUtils.visibility_method_name(self, name)
 
         method_redefinitions << [name, visibility]
 

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -898,9 +898,11 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     begin
       barrier = Concurrent::CyclicBarrier.new(2)
       mutex = Mutex.new
-      replaced = T::Private::ClassUtils.replace_method(T::Private::Methods.singleton_class, :run_sig_block_for_method) do |*args|
+      mod = T::Private::Methods.singleton_class
+      original_method = mod.instance_method(:run_sig_block_for_method)
+      T::Private::ClassUtils.replace_method(original_method, mod, :run_sig_block_for_method) do |*args|
         barrier.wait
-        mutex.synchronize { replaced.bind_call(T::Private::Methods, *args) }
+        mutex.synchronize { original_method.bind_call(T::Private::Methods, *args) }
       end
 
       klass = Class.new do
@@ -913,7 +915,15 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
       klass.hello
     ensure
       thread&.join
-      replaced&.restore
+
+      # We can directly restore this by redefining the method because we know
+      # that `run_sig_block_for_method` was defined on
+      # `T::Private::Methods.singleton_class`, not an ancestor.
+      #
+      # (If that weren't the case, we'd have to restore via `remove_method`)
+      T::Configuration.without_ruby_warnings do
+        mod.send(:define_method, original_method.name, original_method)
+      end
     end
   end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm working on getting better types for `gems/sorbet-runtime/`.

One of the errors that I came across was that the fact that `replace_method`
would return the `original_method` from before it replaces is caused a pinning
error. Fixing that pinning error evolved into a realization that things would be
simpler if we just overhauled that whole API, to no longer return the original
method but rather to accept the original method. This avoids the pinning errors.

In the process, I realized that some other code was either redundant or only
used once, so I deleted it.

The diff is big, but the net effect is small. Review each commit.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests