### PR TITLE
Expose the file->stratum mapping

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -376,8 +376,9 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
             openFiles.insert(entry.first);
         }
 
-        this->cancellationUndoState = make_unique<UndoState>(std::move(savedGS), std::move(this->indexedFinalGS),
-                                                             this->workspaceFiles, updates.epoch);
+        this->cancellationUndoState =
+            make_unique<UndoState>(std::move(savedGS), std::move(this->indexedFinalGS), move(this->fileToStratum),
+                                   this->lastStratum, this->workspaceFiles, updates.epoch);
     } else {
         timeit.setTag("cancelable", "false");
     }
@@ -559,6 +560,8 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
         }
 
         auto strata = pipeline::computePackageStrata(*this->gs, packageIndexed, workspaceFilesSpan, this->config->opts);
+        this->fileToStratum = move(strata.fileToStratum);
+        this->lastStratum = strata.strata.size() - 1;
         for (auto &stratum : strata.strata) {
             vector<ast::ParsedFile> stratumFiles, nonPackagedIndexed;
 
@@ -711,7 +714,8 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
         // Eagerly restore the state to how it was before this slow path, so that we're not holding the old state for an
         // arbitrarily long time. The next update will be responsible for freeing the underlying UndoState after it
         // makes use of the epoch field to determine additional files to include in the edit.
-        cancellationUndoState->restore(this->gs, this->indexedFinalGS, this->workspaceFiles);
+        cancellationUndoState->restore(this->gs, this->indexedFinalGS, this->fileToStratum, this->lastStratum,
+                                       this->workspaceFiles);
         logger->debug("[Typechecker] Typecheck run for epoch {} was canceled.", updates.epoch);
     }
 
@@ -819,6 +823,22 @@ vector<unique_ptr<core::Error>> LSPTypechecker::retypecheck(vector<core::FileRef
     runFastPath(*updates, workers, errorCollector, isNoopUpdateForRetypecheck);
 
     return errorCollector->drainErrors();
+}
+
+uint16_t LSPTypechecker::getStratumForEdit(absl::Span<const core::FileRef> edit) const {
+    uint16_t stratum = 0;
+
+    for (auto fref : edit) {
+        if (fref.id() >= this->fileToStratum.size()) {
+            // Indicate that this can only run at the end of the slow path, as we don't have any information about this
+            // file.
+            return this->lastStratum;
+        }
+
+        stratum = std::max(stratum, this->fileToStratum[fref.id()]);
+    }
+
+    return stratum;
 }
 
 ast::ExpressionPtr LSPTypechecker::getLocalVarTrees(core::FileRef fref) const {
@@ -986,6 +1006,10 @@ void LSPTypecheckerDelegate::updateConfigAndGsFromOptions(const DidChangeConfigu
 
 unique_ptr<LSPFileUpdates> LSPTypecheckerDelegate::getNoopUpdate(absl::Span<const core::FileRef> frefs) const {
     return typechecker.getNoopUpdate(frefs);
+}
+
+uint16_t LSPTypecheckerDelegate::getStratumForEdit(absl::Span<const core::FileRef> edit) const {
+    return typechecker.getStratumForEdit(edit);
 }
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -86,6 +86,10 @@ class LSPTypechecker final {
     bool slowPathBlocked ABSL_GUARDED_BY(slowPathBlockedMutex) = false;
     absl::Mutex slowPathBlockedMutex;
 
+    std::vector<uint16_t> fileToStratum;
+
+    uint16_t lastStratum = 0;
+
     enum class SlowPathMode {
         Init,
         Cancelable,
@@ -202,6 +206,25 @@ public:
      * doesn't actually change anything.
      */
     std::unique_ptr<LSPFileUpdates> getNoopUpdate(absl::Span<const core::FileRef> frefs) const;
+
+    /**
+     * Get the id of the stratum that an edit involving these files could be checked at.
+     */
+    uint16_t getStratumForEdit(absl::Span<const core::FileRef> edit) const;
+
+    /**
+     * Get the id of the stratum that an edit involving this file could be checked at.
+     */
+    uint16_t getStratumForUri(std::string_view uri) const {
+        return this->getStratumForEdit({this->config->uri2FileRef(*this->gs, uri)});
+    }
+
+    /**
+     * Get the id of the last stratum in the condensation graph.
+     */
+    uint16_t getLastStratum() const {
+        return this->lastStratum;
+    }
 };
 
 /**
@@ -247,6 +270,15 @@ public:
 
     void updateConfigAndGsFromOptions(const DidChangeConfigurationParams &options) const;
     std::unique_ptr<LSPFileUpdates> getNoopUpdate(absl::Span<const core::FileRef> frefs) const;
+    uint16_t getStratumForEdit(absl::Span<const core::FileRef> edit) const;
+
+    uint16_t getLastStratum() const {
+        return typechecker.getLastStratum();
+    }
+
+    uint16_t getStratumForUri(std::string_view uri) const {
+        return typechecker.getStratumForUri(uri);
+    }
 };
 } // namespace sorbet::realmain::lsp
 #endif

--- a/main/lsp/UndoState.cc
+++ b/main/lsp/UndoState.cc
@@ -9,15 +9,19 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 UndoState::UndoState(unique_ptr<core::GlobalState> evictedGs, UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS,
-                     const vector<core::FileRef> &workspaceFiles, uint32_t epoch)
-    : evictedGs(move(evictedGs)),
-      evictedIndexedFinalGS(std::move(evictedIndexedFinalGS)), initialWorkspaceFilesSize{workspaceFiles.size()},
+                     vector<uint16_t> fileToStratum, uint16_t lastStratum, const vector<core::FileRef> &workspaceFiles,
+                     uint32_t epoch)
+    : evictedGs(move(evictedGs)), evictedIndexedFinalGS(std::move(evictedIndexedFinalGS)),
+      fileToStratum{move(fileToStratum)}, lastStratum{lastStratum}, initialWorkspaceFilesSize{workspaceFiles.size()},
       epoch(epoch) {}
 
 void UndoState::restore(unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast::ParsedFile> &indexedFinalGS,
-                        vector<core::FileRef> &workspaceFiles) {
+                        vector<uint16_t> &fileToStratum, uint16_t &lastStratum, vector<core::FileRef> &workspaceFiles) {
     indexedFinalGS = std::move(evictedIndexedFinalGS);
     gs = move(evictedGs);
+
+    fileToStratum = move(this->fileToStratum);
+    lastStratum = this->lastStratum;
 
     if (workspaceFiles.size() != this->initialWorkspaceFilesSize) {
         workspaceFiles.erase(workspaceFiles.begin() + this->initialWorkspaceFilesSize, workspaceFiles.end());

--- a/main/lsp/UndoState.h
+++ b/main/lsp/UndoState.h
@@ -18,6 +18,12 @@ class UndoState final {
     // Stores index trees containing data stored in `gs` that have been evicted during the slow path operation.
     UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS;
 
+    // The saved file-to-stratum mapping from the previous slow path.
+    std::vector<uint16_t> fileToStratum;
+
+    // The id of the last stratum in the previous slow path.
+    const uint16_t lastStratum;
+
     // The size of the workspaceFiles vector when the slow path started. Tracked so that we can roll back additions to
     // the vector from new files added in the canceled edit.
     const size_t initialWorkspaceFilesSize;
@@ -27,12 +33,14 @@ public:
     const uint32_t epoch;
 
     UndoState(std::unique_ptr<core::GlobalState> evictedGs, UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS,
+              std::vector<uint16_t> fileToStratum, uint16_t lastStratum,
               const std::vector<core::FileRef> &workspaceFiles, uint32_t epoch);
 
     /**
      * Undoes the slow path changes represented by this class.
      */
     void restore(std::unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast::ParsedFile> &indexedFinalGS,
+                 std::vector<uint16_t> &fileToStratum, uint16_t &lastStratum,
                  std::vector<core::FileRef> &workspaceFiles);
 
     /**


### PR DESCRIPTION
This exposes the file to stratum mapping produced by `pipeline::computePackageStrata` through the `LSPTypechecker` and `LSPTypecheckerDelegate` classes. This is currently unused, but is required for integrating preemption with package-directed mode.

One consequence of this change is that the `UndoState` now also manages the old stratum mapping so that it can be restored on a slow path cancellation. An alternative to this would be to stash the stratum mapping inside of the `GlobalState` which would simplify plumbing it around. However, we then need to pay attention to it in the suite of copy functions that exist on the `GlobalState`.

### Motivation
Stabilizing package-directed mode with LSP.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This PR involves plumbing data through that doesn't get used yet. I'll defer more thorough testing to #10129.