### PR TITLE
sorbet-runtime: Typing changes for call_validation

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -74,7 +74,13 @@ module T::Private::Methods::CallValidation
   def self.create_validator_method(mod, original_method, method_sig, original_visibility)
     has_fixed_arity = method_sig.kwarg_types.empty? && method_sig.rest_type.nil? && method_sig.keyrest_type.nil? &&
       original_method.parameters.all? { |(kind, _name)| kind == :req || kind == :block }
-    can_skip_block_type = method_sig.block_type.nil? || method_sig.block_type.valid?(nil)
+
+    # nil implies block_type.nil?
+    # true implies !block_type.nil? and block_type.valid?(nil)
+    # false implies !block_type.nil? and !block_type.valid?(nil)
+    # This formulation avoids a type error without introducing extra method calls or local vars
+    can_skip_block_type = method_sig.block_type&.valid?(nil) != false
+
     ok_for_fast_path = has_fixed_arity && can_skip_block_type && !method_sig.bind && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path
 
     all_args_are_simple = ok_for_fast_path && method_sig.arg_types.all? { |_name, type| type.is_a?(T::Types::Simple) }

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -84,18 +84,20 @@ module T::Private::Methods::CallValidation
     ok_for_fast_path = has_fixed_arity && can_skip_block_type && !method_sig.bind && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path
 
     all_args_are_simple = ok_for_fast_path && method_sig.arg_types.all? { |_name, type| type.is_a?(T::Types::Simple) }
-    simple_method = all_args_are_simple && method_sig.effective_return_type.is_a?(T::Types::Simple)
-    simple_procedure = all_args_are_simple && method_sig.effective_return_type.is_a?(T::Private::Types::Void)
+
+    effective_return_type = method_sig.effective_return_type
+    simple_method = all_args_are_simple && effective_return_type.is_a?(T::Types::Simple)
+    simple_procedure = all_args_are_simple && effective_return_type.is_a?(T::Private::Types::Void)
 
     # All the types for which valid? unconditionally returns `true`
     return_is_ignorable =
-      method_sig.effective_return_type.equal?(T::Types::Untyped::Private::INSTANCE) ||
-      method_sig.effective_return_type.equal?(T::Types::Anything::Private::INSTANCE) ||
-      method_sig.effective_return_type.equal?(T::Types::AttachedClassType::Private::INSTANCE) ||
-      method_sig.effective_return_type.equal?(T::Types::SelfType::Private::INSTANCE) ||
-      method_sig.effective_return_type.is_a?(T::Types::TypeParameter) ||
-      method_sig.effective_return_type.is_a?(T::Types::TypeVariable) ||
-      (method_sig.effective_return_type.is_a?(T::Types::Simple) && method_sig.effective_return_type.raw_type.equal?(BasicObject))
+      effective_return_type.equal?(T::Types::Untyped::Private::INSTANCE) ||
+      effective_return_type.equal?(T::Types::Anything::Private::INSTANCE) ||
+      effective_return_type.equal?(T::Types::AttachedClassType::Private::INSTANCE) ||
+      effective_return_type.equal?(T::Types::SelfType::Private::INSTANCE) ||
+      effective_return_type.is_a?(T::Types::TypeParameter) ||
+      effective_return_type.is_a?(T::Types::TypeVariable) ||
+      (effective_return_type.is_a?(T::Types::Simple) && effective_return_type.raw_type.equal?(BasicObject))
 
     returns_anything_method = all_args_are_simple && return_is_ignorable
 
@@ -107,7 +109,7 @@ module T::Private::Methods::CallValidation
           create_validator_method_skip_return_fast(mod, original_method, method_sig, original_visibility)
         elsif simple_procedure
           create_validator_procedure_fast(mod, original_method, method_sig, original_visibility)
-        elsif ok_for_fast_path && method_sig.effective_return_type.is_a?(T::Private::Types::Void)
+        elsif ok_for_fast_path && effective_return_type.is_a?(T::Private::Types::Void)
           create_validator_procedure_medium(mod, original_method, method_sig, original_visibility)
         elsif ok_for_fast_path && return_is_ignorable
           create_validator_method_skip_return_medium(mod, original_method, method_sig, original_visibility)

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -187,8 +187,8 @@ class T::Private::Methods::Signature
     # causes forwarding **kwargs to do the wrong thing: see https://bugs.ruby-lang.org/issues/10708
     # and https://bugs.ruby-lang.org/issues/11860.
     args_length = args.length
-    if (args_length > @req_arg_count) && (!@kwarg_types.empty? || !@keyrest_type.nil?) && args[-1].is_a?(Hash)
-      kwargs = args[-1]
+    if (args_length > @req_arg_count) && (!@kwarg_types.empty? || !@keyrest_type.nil?) && (last_arg = args[-1]).is_a?(Hash)
+      kwargs = last_arg
       args_length -= 1
     else
       kwargs = EMPTY_HASH
@@ -208,7 +208,8 @@ class T::Private::Methods::Signature
       # Process given pre-rest args. When there are no rest args,
       # this is just the given number of args.
       while it < args_length && it < @arg_types.length
-        yield @arg_types[it][0], args[it], @arg_types[it][1]
+        arg_type = @arg_types.fetch(it)
+        yield arg_type[0], args[it], arg_type[1]
         it += 1
       end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm working on getting better type coverage for `sorbet-runtime`, I wanted to
pull out some of the less trivial changes to `call_validation` so that they
could be tested independently.

This change is stacked on an octopus merge, so be sure to only review the change
from the merge commit. I have named the octopus merge, so you can also see it in
the compare view, but I do not want to specify it because I've already had one
PR recently closed when I deleted these tmp base branches in the wrong order:

<https://github.com/sorbet/sorbet/compare/jez-rbi-base...jez-call-validation-typing>


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests and Stripe's codeabse