### PR TITLE
Add overload of `instance_exec` for better typing

### DIFF
--- a/rbi/core/basic_object.rbi
+++ b/rbi/core/basic_object.rbi
@@ -273,6 +273,26 @@ class BasicObject
   end
   def instance_eval(arg0=T.unsafe(nil), filename=T.unsafe(nil), lineno=T.unsafe(nil), &blk); end
 
+  ### Note: a safer signature for the *args case of instance_exec might be something like
+  ###
+  ###     sig do
+  ###       type_parameters(:U, :V)
+  ###       .params(
+  ###           args: T.type_parameter(:V),
+  ###           blk: T.proc.bind(T.untyped).params(args: T.type_parameter(:V)).returns(T.type_parameter(:U)),
+  ###       )
+  ###       .returns(T.type_parameter(:U))
+  ###     end
+  ###
+  ### Which indicates that the block parameters' types are determined by the
+  ### arguments passed to `instance_exec`, but in practice code using
+  ### `instance_exec` likes to assume the first block param has the first
+  ### argument's type, the second has the second's, etc. but the above
+  ### signature would force the params to be operated on homogenously. So in
+  ### the interest of being useful and not pedantic, use the signature below, which
+  ### types the block params as either not present (if there are no args) or
+  ### untyped if there are.
+
   # Executes the given block within the context of the receiver (*obj*). In
   # order to set the context, the variable `self` is set to *obj* while the code
   # is executing, giving the code access to *obj*'s instance variables.
@@ -288,9 +308,16 @@ class BasicObject
   # k.instance_exec(5) {|x| @secret+x }   #=> 104
   # ```
   sig do
-    type_parameters(:U, :V)
+    type_parameters(:U)
     .params(
-        args: T.type_parameter(:V),
+        blk: T.proc.bind(T.untyped).returns(T.type_parameter(:U)),
+    )
+    .returns(T.type_parameter(:U))
+  end
+  sig do
+    type_parameters(:U)
+    .params(
+        args: T.anything,
         blk: T.proc.bind(T.untyped).params(args: T.untyped).returns(T.type_parameter(:U)),
     )
     .returns(T.type_parameter(:U))

--- a/test/testdata/compiler/sigish_more.rb
+++ b/test/testdata/compiler/sigish_more.rb
@@ -16,6 +16,7 @@ module Sigish
   T::Sig::WithoutRuntime.sig {params(blk: T.proc.bind(DeclBuilder).params(arg0: T.untyped).void).void}
   def sig(&blk)
     DeclBuilder.new.instance_exec(&blk)
+  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Expected `T.proc.returns(T.anything)` but found `T.proc.params(arg0: T.untyped).void` for block argument
   end
 end
 

--- a/test/testdata/rbi/instance_exec.rb
+++ b/test/testdata/rbi/instance_exec.rb
@@ -4,7 +4,7 @@ class A
 end
 
 res = A.new.instance_exec do |arg0|
-  T.reveal_type(arg0) # error: `T.untyped`
+  T.reveal_type(arg0) # error: `NilClass`
   1
 end
 T.reveal_type(res) # error: `Integer`

--- a/test/testdata/rbi/instance_exec.rb
+++ b/test/testdata/rbi/instance_exec.rb
@@ -1,0 +1,16 @@
+# typed: true
+
+class A
+end
+
+res = A.new.instance_exec do |arg0|
+  T.reveal_type(arg0) # error: `T.untyped`
+  1
+end
+T.reveal_type(res) # error: `Integer`
+
+res = A.new.instance_exec(5) do |arg0|
+  T.reveal_type(arg0) # error: `T.untyped`
+  ''
+end
+T.reveal_type(res) # error: `String`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Better types

I had originally closed this in #10174 in haste because I had also made a change
to add a better type for `Module#module_exec`, and saw a bunch of typechecking
errors as a result, and then assumed that they would also apply to this
`instance_exec` case. Specifically the case I had been worried about was that
this change would prevent people from doing

```ruby
x.instance_exec(&proc_with_unknown_arity)
```

But in fact, that's already the case on master today. That's definitely
frustrating, but the `sig` in this change is no worse than what it is today.

There are more issues (#6394, #1142), but we can fix those in future changes. In
particular, I think that the most likely way we fix this would be to make
`::Proc` in the stdlib a generic class, so that it would have something like

```ruby
class ::Proc
  Return = type_member
end
```

and that would allow specifying the sig for `instance_exec` something like this:

```ruby
sig do
  type_parameters(:U)
  .params(
      blk: T.proc.bind(T.untyped).returns(T.type_parameter(:U)),
  )
  .returns(T.type_parameter(:U))
end
# ... possibly do more fixed arities (1-ary, 2-ary, etc.)
sig do
  type_parameters(:U)
  .params(
      args: T.anything,
      blk: T::Proc[T.type_parameter(:U)],
  )
  .returns(T.type_parameter(:U))
end
def instance_exec(*args, &blk); end
```

In this syntax there wouldn't be a way to specify the `.bind` annotation, but
the `bind` is actually associated with the `blk` parameter of the sig itself,
not the `T.proc`, despite being specified on the `T.proc` (preventing it from
being used inside `T.any(...)`, because we wouldn't know what to do two `.bind`
annotations). Anyways, that's all for a future change--this change is at least
no worse, and makes the 0-ary case better.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tests show before+after