### PR TITLE
Add type to `Kernel.caller`

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -135,6 +135,20 @@ module Kernel
   # c(4)   #=> []
   # c(5)   #=> nil
   # ```
+  sig do
+    params(
+        start_or_range: Integer,
+        length: Integer,
+    )
+    .returns(T.nilable(T::Array[String]))
+  end
+  sig do
+    params(
+        start_or_range: T::Range[Integer],
+    )
+    .returns(T.nilable(T::Array[String]))
+  end
+  sig {returns(T::Array[String])}
   def self.caller(start_or_range=T.unsafe(nil), length=T.unsafe(nil)); end
 
   # Returns the current execution stack---an array containing backtrace location

--- a/test/cli/package-prefix-enforcement/test.out
+++ b/test/cli/package-prefix-enforcement/test.out
@@ -200,8 +200,8 @@ nested/nested.rb:61: Method `void` does not exist on `T.class_of(TopLevel::Foo)`
     nested/nested.rb:61: Replace with `load`
     61 |    sig {void}
                  ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1664: Defined here
-    1664 |  def load(filename, arg0=T.unsafe(nil)); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
+      NN |  def load(filename, arg0=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 nested/nested.test.rb:19: Cannot initialize the module `Root` by constant assignment https://srb.help/4022
@@ -285,8 +285,8 @@ commands/foo_command.rb:4: File belongs to package `Root::Commands::Foo` but def
 extend_sig.rb:4: `include` may only be used on constants in the package that owns them https://srb.help/5084
      4 |  include T::Sig
                   ^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#L26: Symbol originally defined here
-    26 |class Module < Object
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Symbol originally defined here
+    NN |class Module < Object
         ^^^^^^^^^^^^^^^^^^^^^
     __package.rb:3: Package defined here is not a `prelude_package`
      3 |class Root < PackageSpec

--- a/test/cli/package-prefix-enforcement/test.sh
+++ b/test/cli/package-prefix-enforcement/test.sh
@@ -1,3 +1,3 @@
 cd test/cli/package-prefix-enforcement || exit 1
 
-../../../main/sorbet --silence-dev-message --sorbet-packages --max-threads=0 . 2>&1
+../../../main/sorbet --silence-dev-message --censor-for-snapshot-tests --sorbet-packages --max-threads=0 . 2>&1

--- a/test/cli/package-private/test.out
+++ b/test/cli/package-private/test.out
@@ -73,8 +73,8 @@ a/a.rb:24: Method `void` does not exist on `T.class_of(Global)` https://srb.help
     a/a.rb:24: Replace with `load`
     24 |    sig { void }
                   ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1664: Defined here
-    1664 |  def load(filename, arg0=T.unsafe(nil)); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
+      NN |  def load(filename, arg0=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 a/a.rb:27: Method `sig` does not exist on `T.class_of(Global)` https://srb.help/7003
@@ -100,8 +100,8 @@ a/a.rb:27: Method `void` does not exist on `T.class_of(Global)` https://srb.help
     a/a.rb:27: Replace with `load`
     27 |    sig { void }
                   ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1664: Defined here
-    1664 |  def load(filename, arg0=T.unsafe(nil)); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
+      NN |  def load(filename, arg0=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 a/a.rb:30: Method `sig` does not exist on `T.class_of(Global)` https://srb.help/7003
@@ -127,8 +127,8 @@ a/a.rb:30: Method `void` does not exist on `T.class_of(Global)` https://srb.help
     a/a.rb:30: Replace with `load`
     30 |    sig { void }
                   ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1664: Defined here
-    1664 |  def load(filename, arg0=T.unsafe(nil)); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
+      NN |  def load(filename, arg0=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 a/a.rb:33: Method `sig` does not exist on `T.class_of(Global)` https://srb.help/7003
@@ -154,15 +154,15 @@ a/a.rb:33: Method `void` does not exist on `T.class_of(Global)` https://srb.help
     a/a.rb:33: Replace with `load`
     33 |    sig { void }
                   ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#L1664: Defined here
-    1664 |  def load(filename, arg0=T.unsafe(nil)); end
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/kernel.rbi#LCENSORED: Defined here
+      NN |  def load(filename, arg0=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 a/a.rbi:3: Superclasses may only be set on constants in the package that owns them https://srb.help/5084
      3 |class ::Module < Object
                          ^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#L26: Symbol originally defined here
-    26 |class Module < Object
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Symbol originally defined here
+    NN |class Module < Object
         ^^^^^^^^^^^^^^^^^^^^^
     a/__package.rb:3: Package defined here is not a `prelude_package`
      3 |class A < PackageSpec

--- a/test/cli/package-private/test.sh
+++ b/test/cli/package-private/test.sh
@@ -1,5 +1,5 @@
 cd test/cli/package-private || exit 1
 
-../../../main/sorbet --silence-dev-message --sorbet-packages --max-threads=0 . 2>&1
+../../../main/sorbet --silence-dev-message --censor-for-snapshot-tests --sorbet-packages --max-threads=0 . 2>&1
 
 


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We already had a type for the instance method one. This adds the same type to `Kernel.caller`.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
