### PR TITLE
Introduce `# stratum` and `# enable-package-directed` in tests

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -529,6 +529,11 @@ pipeline_tests(
             "testdata/**/*.rbi",
             "testdata/**/*.exp",
         ],
+        # package-directed is known to be incompatible with the LSP tests for now
+        # todo(gdritter): fix this!
+        exclude = [
+            "testdata/packager/directed-*/**/*",
+        ],
     ),
     "LSPTests",
     extra_files = ["testdata/lsp/rubyfmt-stub/rubyfmt"],
@@ -566,6 +571,10 @@ pipeline_tests(
             # Prism LSP known failures: hover with RBS
             "testdata/lsp/hover_rbs.rb",
             "testdata/lsp/hover_rbs_assertions_let.rb",
+
+            # package-directed is known to be incompatible with the LSP tests for now
+            # todo(gdritter): fix this!
+            "testdata/packager/directed-*/**/*",
         ],
     ),
     "PrismLSPTests",

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -11,7 +11,6 @@
 #include "main/lsp/LSPConfiguration.h"
 #include "test/helpers/lsp.h"
 #include "test/helpers/position_assertions.h"
-#include <charconv>
 #include <iterator>
 #include <regex>
 #include <string.h>
@@ -2617,10 +2616,10 @@ string HierarchyRefAssertion::toString() const {
 shared_ptr<StratumAssertion> StratumAssertion::make(string_view filename, unique_ptr<Range> &range, int assertionLine,
                                                     string_view assertionContents, string_view assertionType) {
     int value;
-    auto [_, ec] = from_chars(assertionContents.data(), assertionContents.data() + assertionContents.size(), value);
+    int success = absl::SimpleAtoi(assertionContents, &value);
     {
         INFO("Invalid integer value: '" << assertionContents << "'");
-        CHECK_EQ(ec, std::errc{});
+        CHECK(success);
     }
     return make_shared<StratumAssertion>(filename, range, assertionLine, value);
 }

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -11,6 +11,7 @@
 #include "main/lsp/LSPConfiguration.h"
 #include "test/helpers/lsp.h"
 #include "test/helpers/position_assertions.h"
+#include <charconv>
 #include <iterator>
 #include <regex>
 #include <string.h>
@@ -268,6 +269,7 @@ const UnorderedMap<
         {"uniquely-defined-behavior", BooleanPropertyAssertion::make},
         {"check-out-of-order-constant-references", BooleanPropertyAssertion::make},
         {"enable-packager", BooleanPropertyAssertion::make},
+        {"enable-package-directed", BooleanPropertyAssertion::make},
         {"enable-experimental-rbs-comments", BooleanPropertyAssertion::make},
         {"enable-experimental-requires-ancestor", BooleanPropertyAssertion::make},
         {"enable-experimental-rspec", BooleanPropertyAssertion::make},
@@ -303,6 +305,7 @@ const UnorderedMap<
         {"find-hierarchy-refs", FindHierarchyRefsAssertion::make},
         {"hierarchy-ref", HierarchyRefAssertion::make},
         {"enable-test-packages", BooleanPropertyAssertion::make},
+        {"stratum", StratumAssertion::make},
 };
 
 // Ignore any comments that have these labels (e.g. `# typed: true`).
@@ -558,28 +561,6 @@ unique_ptr<Range> RangeAssertion::makeRange(int sourceLine, int startChar, int e
     return make_unique<Range>(make_unique<Position>(sourceLine, startChar), make_unique<Position>(sourceLine, endChar));
 }
 
-vector<shared_ptr<ErrorAssertion>>
-RangeAssertion::getErrorAssertions(const vector<shared_ptr<RangeAssertion>> &assertions) {
-    vector<shared_ptr<ErrorAssertion>> rv;
-    for (auto assertion : assertions) {
-        if (auto assertionOfType = dynamic_pointer_cast<ErrorAssertion>(assertion)) {
-            rv.push_back(assertionOfType);
-        }
-    }
-    return rv;
-}
-
-vector<shared_ptr<UntypedAssertion>>
-RangeAssertion::getUntypedAssertions(const vector<shared_ptr<RangeAssertion>> &assertions) {
-    vector<shared_ptr<UntypedAssertion>> rv;
-    for (auto assertion : assertions) {
-        if (auto assertionOfType = dynamic_pointer_cast<UntypedAssertion>(assertion)) {
-            rv.push_back(assertionOfType);
-        }
-    }
-    return rv;
-}
-
 vector<shared_ptr<RangeAssertion>> parseAssertionsForFile(const shared_ptr<core::File> &file) {
     vector<shared_ptr<RangeAssertion>> assertions;
 
@@ -748,6 +729,8 @@ realmain::options::Options RangeAssertion::parseOptions(vector<shared_ptr<RangeA
 
     vector<string> defaultLayers = {};
     opts.packagerLayers = StringPropertyAssertions::getValues("packager-layers", assertions).value_or(defaultLayers);
+
+    opts.packageDirected = BooleanPropertyAssertion::getValue("enable-package-directed", assertions).value_or(false);
 
     return opts;
 }
@@ -2629,6 +2612,24 @@ shared_ptr<HierarchyRefAssertion> HierarchyRefAssertion::make(string_view filena
 
 string HierarchyRefAssertion::toString() const {
     return fmt::format("find-hierarchy-refs: {}", symbol);
+}
+
+shared_ptr<StratumAssertion> StratumAssertion::make(string_view filename, unique_ptr<Range> &range, int assertionLine,
+                                                    string_view assertionContents, string_view assertionType) {
+    int value;
+    auto [_, ec] = from_chars(assertionContents.data(), assertionContents.data() + assertionContents.size(), value);
+    {
+        INFO("Invalid integer value: '" << assertionContents << "'");
+        CHECK_EQ(ec, std::errc{});
+    }
+    return make_shared<StratumAssertion>(filename, range, assertionLine, value);
+}
+
+StratumAssertion::StratumAssertion(string_view filename, unique_ptr<Range> &range, int assertionLine, int value)
+    : RangeAssertion(filename, range, assertionLine), value(value){};
+
+string StratumAssertion::toString() const {
+    return fmt::format("stratum: {}", value);
 }
 
 } // namespace sorbet::test

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -13,9 +13,6 @@ using namespace sorbet::realmain::lsp;
 // This is needed to skip error assertions when running under Prism
 extern realmain::options::Parser parser;
 
-class ErrorAssertion;
-class UntypedAssertion;
-
 /**
  * An assertion that is relevant to a specific set of characters on a line.
  * If Range is set such that the start character is 0 and end character is END_OF_LINE_POS, then the assertion
@@ -44,13 +41,19 @@ public:
     }
 
     /**
-     * Filters a vector of assertions and returns only ErrorAssertions.
+     * Returns all the assertions of type `T`
      */
-    static std::vector<std::shared_ptr<ErrorAssertion>>
-    getErrorAssertions(const std::vector<std::shared_ptr<RangeAssertion>> &assertions);
-
-    static std::vector<std::shared_ptr<UntypedAssertion>>
-    getUntypedAssertions(const std::vector<std::shared_ptr<RangeAssertion>> &assertions);
+    template <class T>
+    std::vector<std::shared_ptr<T>> static getAssertions(
+        const std::vector<std::shared_ptr<RangeAssertion>> &assertions) {
+        std::vector<std::shared_ptr<T>> rv;
+        for (auto assertion : assertions) {
+            if (auto assertionOfType = std::dynamic_pointer_cast<T>(assertion)) {
+                rv.push_back(assertionOfType);
+            }
+        }
+        return rv;
+    }
 
     const std::string filename;
     const std::unique_ptr<Range> range;
@@ -619,6 +622,20 @@ public:
                                                        int assertionLine, std::string_view assertionContents,
                                                        std::string_view assertionType);
     const std::string symbol;
+    std::string toString() const override;
+};
+
+// # stratum: 0
+class StratumAssertion final : public RangeAssertion {
+public:
+    static std::shared_ptr<StratumAssertion> make(std::string_view filename, std::unique_ptr<Range> &range,
+                                                  int assertionLine, std::string_view assertionContents,
+                                                  std::string_view assertionType);
+
+    const int value;
+
+    StratumAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine, int value);
+
     std::string toString() const override;
 };
 

--- a/test/lsp_test_runner.cc
+++ b/test/lsp_test_runner.cc
@@ -354,7 +354,7 @@ void testQuickFixCodeActions(LSPWrapper &lspWrapper, Expectations &test, const v
     transform(ignoredCodeActionAssertions.begin(), ignoredCodeActionAssertions.end(),
               back_inserter(ignoredCodeActionKinds), getCodeActionKind);
 
-    auto errors = RangeAssertion::getErrorAssertions(assertions);
+    auto errors = RangeAssertion::getAssertions<ErrorAssertion>(assertions);
     UnorderedMap<string, vector<shared_ptr<RangeAssertion>>> errorsByFilename;
     for (auto &error : errors) {
         errorsByFilename[error->filename].emplace_back(error);
@@ -566,7 +566,7 @@ TEST_CASE("LSPTest") {
     if (test.expectations.contains("autogen")) {
         // Some autogen tests assume that some errors will occur from the resolver step, others assume the resolver
         // won't run.
-        if (!RangeAssertion::getErrorAssertions(assertions).empty()) {
+        if (!RangeAssertion::getAssertions<ErrorAssertion>(assertions).empty()) {
             // ...and stop after the resolver phase if there are errors
             lspWrapper->opts->stopAfterPhase = realmain::options::Phase::RESOLVER;
         } else {
@@ -638,11 +638,12 @@ TEST_CASE("LSPTest") {
             auto responses = getLSPResponsesFor(*lspWrapper, move(updates));
             updateDiagnostics(config, testFileUris, responses, diagnostics);
             bool errorAssertionsPassed = ErrorAssertion::checkAll(
-                test.sourceFileContents, RangeAssertion::getErrorAssertions(assertions), diagnostics, errorPrefixes[i]);
+                test.sourceFileContents, RangeAssertion::getAssertions<ErrorAssertion>(assertions), diagnostics,
+                errorPrefixes[i]);
 
-            bool untypedAssertionsPassed =
-                UntypedAssertion::checkAll(test.sourceFileContents, RangeAssertion::getUntypedAssertions(assertions),
-                                           diagnostics, errorPrefixes[i]);
+            bool untypedAssertionsPassed = UntypedAssertion::checkAll(
+                test.sourceFileContents, RangeAssertion::getAssertions<UntypedAssertion>(assertions), diagnostics,
+                errorPrefixes[i]);
 
             slowPathPassed = errorAssertionsPassed && untypedAssertionsPassed;
         }
@@ -950,8 +951,9 @@ TEST_CASE("LSPTest") {
                 testDocumentSymbols(*lspWrapper, test, nextId, testFileUris[originalFile], updateFile);
             }
 
-            const bool passed = ErrorAssertion::checkAll(
-                updatesAndContents, RangeAssertion::getErrorAssertions(assertions), diagnostics, errorPrefix);
+            const bool passed =
+                ErrorAssertion::checkAll(updatesAndContents, RangeAssertion::getAssertions<ErrorAssertion>(assertions),
+                                         diagnostics, errorPrefix);
 
             if (!passed) {
                 // Abort if an update fails its assertions, as subsequent updates will likely fail as well.

--- a/test/parser_test_runner.cc
+++ b/test/parser_test_runner.cc
@@ -172,7 +172,8 @@ TEST_CASE("WhitequarkParserTest") {
             auto path = error->loc.file().data(gs).path();
             diagnostics[string(path.begin(), path.end())].push_back(std::move(diag));
         }
-        ErrorAssertion::checkAll(test.sourceFileContents, RangeAssertion::getErrorAssertions(assertions), diagnostics);
+        ErrorAssertion::checkAll(test.sourceFileContents, RangeAssertion::getAssertions<ErrorAssertion>(assertions),
+                                 diagnostics);
     }
 
     MESSAGE("errors OK");

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -461,8 +461,6 @@ TEST_CASE("PerPhaseTest") { // NOLINT
     }
 
     auto assertions = RangeAssertion::parseAssertions(test.sourceFileContents);
-    // TODO(jez) Make sure we add an assertion for `package-directed: true`
-    // Right now, `opts.packageDirected` is always false
     auto opts = RangeAssertion::parseOptions(assertions);
     opts.censorForSnapshotTests = true;
     opts.sorbetPackagesHint = "PACKAGE_ERROR_HINT";
@@ -528,6 +526,17 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     vector<ast::ParsedFile> stratumFiles;
     auto strata = realmain::pipeline::computePackageStrata(*gs, trees, filesSpan, opts);
+
+    for (auto &stratumAssertion : RangeAssertion::getAssertions<StratumAssertion>(assertions)) {
+        auto file = gs->findFileByPath(stratumAssertion->filename);
+        int actualStratum = strata.fileToStratum[file.id()];
+        if (actualStratum != stratumAssertion->value) {
+            ADD_FAIL_CHECK_AT(string(stratumAssertion->filename).c_str(), stratumAssertion->assertionLine + 1,
+                              "Expected " << stratumAssertion->filename << " at stratum " << stratumAssertion->value
+                                          << "; got " << actualStratum);
+        }
+    }
+
     for (auto &stratum : strata.strata) {
         stratumFiles.clear();
         stratumFiles.reserve(stratum.packageFiles.size() + stratum.sourceFiles.size());
@@ -740,7 +749,8 @@ TEST_CASE("PerPhaseTest") { // NOLINT
             auto path = error->loc.file().data(*gs).path();
             diagnostics[string(path.begin(), path.end())].push_back(std::move(diag));
         }
-        ErrorAssertion::checkAll(test.sourceFileContents, RangeAssertion::getErrorAssertions(assertions), diagnostics);
+        ErrorAssertion::checkAll(test.sourceFileContents, RangeAssertion::getAssertions<ErrorAssertion>(assertions),
+                                 diagnostics);
     }
 
     // Allow later phases to have errors that we didn't test for

--- a/test/testdata/packager/directed-prelude/a/__package.rb
+++ b/test/testdata/packager/directed-prelude/a/__package.rb
@@ -1,0 +1,11 @@
+# typed: strict
+# enable-packager: true
+# enable-package-directed: true
+
+# Necessarily at 0 because we're a prelude package
+
+# stratum: 0
+
+class A < PackageSpec
+  prelude_package
+end

--- a/test/testdata/packager/directed-prelude/b/__package.rb
+++ b/test/testdata/packager/directed-prelude/b/__package.rb
@@ -1,0 +1,9 @@
+# typed: strict
+
+# Stratum 1 because we depend on A, at 0
+
+# stratum: 1
+
+class B < PackageSpec
+  import A
+end

--- a/test/testdata/packager/directed-prelude/c/__package.rb
+++ b/test/testdata/packager/directed-prelude/c/__package.rb
@@ -1,0 +1,10 @@
+# typed: strict
+
+# Stratum 0 despite depending on A because we too are a prelude package
+
+# stratum: 0
+
+class C < PackageSpec
+  prelude_package
+  import A
+end

--- a/test/testdata/packager/directed-simple/a/__package.rb
+++ b/test/testdata/packager/directed-simple/a/__package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+# enable-packager: true
+# enable-package-directed: true
+
+# stratum: 0
+
+class A < PackageSpec
+end

--- a/test/testdata/packager/directed-simple/b/__package.rb
+++ b/test/testdata/packager/directed-simple/b/__package.rb
@@ -1,0 +1,9 @@
+# typed: strict
+
+# Stratum 1 because we depend on A, at 0
+
+# stratum: 1
+
+class B < PackageSpec
+  import A
+end

--- a/test/testdata/packager/directed-simple/c/__package.rb
+++ b/test/testdata/packager/directed-simple/c/__package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+# Stratum 2 because we depend on B, at 1
+# stratum: 2
+
+class C < PackageSpec
+  import B
+end

--- a/test/testdata/packager/directed-simple/d/__package.rb
+++ b/test/testdata/packager/directed-simple/d/__package.rb
@@ -1,0 +1,10 @@
+# typed: strict
+
+# at 1 because we depend on A but have a cycle with E
+
+# stratum: 1
+
+class D < PackageSpec
+  import A
+  import E
+end

--- a/test/testdata/packager/directed-simple/e/__package.rb
+++ b/test/testdata/packager/directed-simple/e/__package.rb
@@ -1,0 +1,9 @@
+# typed: strict
+
+# at 1 because we depend on A but have a cycle with E
+
+# stratum: 1
+
+class E < PackageSpec
+  import D
+end

--- a/test/testdata/packager/directed-unpackaged/downstream/__package.rb
+++ b/test/testdata/packager/directed-unpackaged/downstream/__package.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Downstream < PackageSpec
+end

--- a/test/testdata/packager/directed-unpackaged/downstream/downstream.rb
+++ b/test/testdata/packager/directed-unpackaged/downstream/downstream.rb
@@ -1,0 +1,22 @@
+# typed: strict
+
+# stratum: 0
+
+module Downstream
+  # this is not imported, but that means that this stratum doesn't
+  # know anything about it, so it manifests as an unresolved constant
+  MyPackage::MyClass
+# ^^^^^^^^^ error: Unable to resolve
+
+  # because this was defined in `MyPackage`, we can't have seen it yet
+  UnpackagedTheSequel
+# ^^^^^^^^^^^^^^^^^^^ error: Unable to resolve
+
+  # this is defined by an RBI and not imported
+  MyPackage::MyRbiConstant
+# ^^^^^^^^^ error: Unable to resolve
+
+  # because this was defined in `MyPackage`, we can't have seen it yet
+  SomethingCompletelyDifferent
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve
+end

--- a/test/testdata/packager/directed-unpackaged/gem.rbi
+++ b/test/testdata/packager/directed-unpackaged/gem.rbi
@@ -1,0 +1,6 @@
+# error: File `
+# typed: true
+
+module ::Minitest
+
+end

--- a/test/testdata/packager/directed-unpackaged/other_package_imported/__package.rb
+++ b/test/testdata/packager/directed-unpackaged/other_package_imported/__package.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class OtherPackageImported < PackageSpec
+  export OtherPackageImported::ExportedClass
+end

--- a/test/testdata/packager/directed-unpackaged/other_package_imported/exported_class.rb
+++ b/test/testdata/packager/directed-unpackaged/other_package_imported/exported_class.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+# stratum: 0
+
+class OtherPackageImported::ExportedClass
+end

--- a/test/testdata/packager/directed-unpackaged/other_package_not_imported/__package.rb
+++ b/test/testdata/packager/directed-unpackaged/other_package_not_imported/__package.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# typed: strict
+
+# stratum: 0
+
+class OtherPackageNotImported < PackageSpec
+  export OtherPackageNotImported::ExportedClass
+end

--- a/test/testdata/packager/directed-unpackaged/other_package_not_imported/exported_class.rb
+++ b/test/testdata/packager/directed-unpackaged/other_package_not_imported/exported_class.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class OtherPackageNotImported::ExportedClass
+end

--- a/test/testdata/packager/directed-unpackaged/packaged/__package.rb
+++ b/test/testdata/packager/directed-unpackaged/packaged/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+
+class MyPackage < PackageSpec
+  import OtherPackageImported
+  export MyPackage::MyClass
+end

--- a/test/testdata/packager/directed-unpackaged/packaged/packaged-file.rb
+++ b/test/testdata/packager/directed-unpackaged/packaged/packaged-file.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+
+# stratum: 1
+
+class MyPackage::MyClass
+end

--- a/test/testdata/packager/directed-unpackaged/packaged/packaged.rbi
+++ b/test/testdata/packager/directed-unpackaged/packaged/packaged.rbi
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+# typed: strict
+
+class MyPackage::MyRbiConstant
+end
+
+# This will be an error because it defines a constant which does
+# not match the enclosing namespace
+class SomethingElse
+    # ^^^^^^^^^^^^^ error: defines a constant that does not match this namespace
+end
+
+# This will be okay because of the leading `::`
+class ::SomethingCompletelyDifferent
+end

--- a/test/testdata/packager/directed-unpackaged/packaged/unpackaged-file.rb
+++ b/test/testdata/packager/directed-unpackaged/packaged/unpackaged-file.rb
@@ -1,0 +1,25 @@
+# typed: true
+
+# Because this constant has a leading `::`, the packager allows us to
+# define things on it despite it not belonging to the enclosing namespace
+class ::UnpackagedTheSequel
+  # despite being in a constant not governed by this package, we still
+  # subject the internals to import restrictions:
+  def test
+    # this is defined in unpackaged code, so okay
+    puts UnpackagedCode
+
+    # this is defined in an unpackaged RBI, so okay
+    puts Minitest
+
+    # this is defined within the same package, so okay
+    puts MyPackage::MyClass.new
+
+    # this is defined within an imported package, so okay
+    puts OtherPackageImported::ExportedClass.new
+
+    # this is defined in a non-imported package
+    puts OtherPackageNotImported::ExportedClass.new
+    #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `OtherPackageNotImported::ExportedClass` resolves but its package is not imported
+  end
+end

--- a/test/testdata/packager/directed-unpackaged/unpackaged-code.rb
+++ b/test/testdata/packager/directed-unpackaged/unpackaged-code.rb
@@ -1,0 +1,12 @@
+# error: File `
+# frozen_string_literal: true
+# typed: true
+# enable-packager: true
+# enable-package-directed: true
+
+# stratum: 0
+
+# Despite this being in a packaged context, this constant is
+# unpackaged and therefore can be freely used by packaged code.
+module UnpackagedCode
+end


### PR DESCRIPTION
This introduces two new test assertions: `# enable-package-directed`, which is a boolean assertion that can turn on package-directed mode, and `# stratum`, which can assert that the containing file is in a particular stratum after the condensation computation. Eventually, we presumably will want to make package-directed mode the default, but as of now, it does differ from non-package-directed mode in a few key respects and this lets us test the expectations around both modes.

This is mostly pulled out of #10166, but addresses the preliminary feedback there.

### Motivation
Giving us the ability to test some assumptions around package-directed mode!

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added a few package-directed test cases.