### PR TITLE
Remove ENFORCE from fastPathFilesToTypecheck

### DIFF
--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -221,19 +221,18 @@ LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPC
             // The "2 * ..." is so that we can get a rough idea of whether there's an easy
             // bang-for-buck bump we could make to the threshold by reading the logs.
             //
-            // One of two things could be true:
-            // - We're running on the indexer thread to decide typecheckingPath, which only cares about how
-            //   many extra files there are, not what they are.
+            // One of three things could be true:
+            // - We're running on the indexer thread via commitEdit to decide typecheckingPath,
+            //   which only cares about how many extra files there are, not what they are.
+            // - We're running on the indexer thread via canPreempt to decide whether preemption
+            //   is possible, which also only cares about the count.
             // - We're running on the typechecker thread (knowing that typecheckingPath was already
             //   TypecheckingPath::Fast) and simply need to compute the list of files to typecheck.
             //   But that would be a contradiction--because otherwise the indexer would have marked
             //   the update as not being able to take the fast path.
             //
-            // So it's actually only the first thing that's true.
-
-            // Crude indicator of being on indexer thread, as the typechecker thread always
-            // calls us with an empty map of evictedFiles
-            ENFORCE(!evictedFiles.empty());
+            // So it's actually only one of the first two things that's true, and neither of which
+            // care about the full file list, so let's early exit.
             return result;
         }
     }

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -1404,4 +1404,77 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "MergingEditsWhenCancellingPreempti
         CHECK_EQ(counters.getCategoryCounter("lsp.preemption.cancelation", "merged"), 1);
     }
 }
+
+TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanPreemptDoesNotCrashOnEvictedFilesShortCircuit") {
+    // Set lspMaxFilesOnFastPath to 1 so the short-circuit in fastPathFilesToTypecheck
+    // triggers with just a few extra files: totalChanged > 2 * 1 = 2.
+    // (We could do this without, but it would involve making dozens of files that use the symbol)
+    auto opts = make_shared<realmain::options::Options>();
+    opts->lspMaxFilesOnFastPath = 1;
+    resetState(opts);
+
+    auto initOptions = make_unique<SorbetInitializationOptions>();
+    initOptions->enableTypecheckInfo = true;
+    assertErrorDiagnostics(
+        initializeLSP(true /* supportsMarkdown */, true /* supportsCodeActionResolve */, move(initOptions)), {});
+
+    // Sequence of edits:
+    //
+    // - Slow path edit in foo.rb
+    // - While slow path is going, fast path edit in bar.rb that implicates more than lspMaxFilesOnFastPath
+
+    assertErrorDiagnostics(send(*openFile("bar.rb", "# typed: true\n"
+                                                    "class Bar\n"
+                                                    "  extend T::Sig\n"
+                                                    "  sig { returns(String) }\n"
+                                                    "  def compute_value = 'hi'\n"
+                                                    "end\n")),
+                           {});
+    assertErrorDiagnostics(send(*openFile("baz.rb", "# typed: true\n"
+                                                    "class Baz\n"
+                                                    "  def baz_method = Bar.new.compute_value\n"
+                                                    "end\n")),
+                           {});
+    assertErrorDiagnostics(send(*openFile("qux.rb", "# typed: true\n"
+                                                    "class Qux\n"
+                                                    "  def qux_method = Bar.new.compute_value\n"
+                                                    "end\n")),
+                           {});
+    assertErrorDiagnostics(send(*openFile("foo.rb", "# typed: true\n"
+                                                    "class Foo\n"
+                                                    "end")),
+                           {});
+
+    setSlowPathBlocked(true);
+
+    sendAsync(*changeFile("foo.rb",
+                          "# typed: true\n"
+                          "class Foo2\n"
+                          "end",
+                          2));
+
+    // Wait for the slow path to start.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // Fast path edit changes compute_value: which means 3 files on the fast path, triggering the
+    // short-circuit in `fastPathFilesToTypecheck`.
+    sendAsync(*changeFile("bar.rb",
+                          "# typed: true\n"
+                          "class Bar\n"
+                          "  extend T::Sig\n"
+                          "  sig { returns(Integer) }\n"
+                          "  def compute_value = 0\n"
+                          "end\n",
+                          4));
+
+    // Unblock the slow path.
+    setSlowPathBlocked(false);
+
+    // Drain the pipeline with a fence.
+    assertErrorDiagnostics(send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20))), {});
+}
 } // namespace sorbet::test::lsp


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I've been doing a lot of `gems/sorbet-runtime/` development recently, especially
around getting it to typecheck.

I always have my editors configured to use debug builds of Sorbet, and I've been
seeing this crash a bunch.




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Test crashes before these changes.