### PR TITLE
Fix flakiness in multithreaded_protocol_test_corpus

### DIFF
--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -1,4 +1,5 @@
 #include "main/lsp/wrapper.h"
+#include "common/concurrency/WorkerPool.h"
 #include "core/ErrorQueue.h"
 #include "core/NullFlusher.h"
 #include "core/errors/namer.h"
@@ -79,7 +80,15 @@ LSPWrapper::LSPWrapper(unique_ptr<core::GlobalState> gs, shared_ptr<options::Opt
       config_(make_shared<LSPConfiguration>(*opts, output, move(logger), disableFastPath)),
       lspLoop(make_shared<LSPLoop>(std::move(gs), *workers, config_, move(kvstore))), opts(move(opts)) {}
 
-LSPWrapper::~LSPWrapper() = default;
+LSPWrapper::~LSPWrapper() {
+    // Drain any in-flight worker pool tasks before member destruction begins.
+    // If there is still any work on the workers, they assume that `GlobalState` has not been dropped yet.
+    //
+    // We drop the this->lspLoop field before this->workers, which means that we can find ourself in
+    // a state where there are still workers running but the GlobalState they're running against
+    // (owned by threads spawned transitively from LSPLoop) has been dropped.
+    workers->multiplexJobWait("drainWorkers", []() {});
+}
 
 SingleThreadedLSPWrapper::SingleThreadedLSPWrapper(unique_ptr<core::GlobalState> gs, shared_ptr<options::Options> opts,
                                                    shared_ptr<spdlog::logger> logger,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm not sure why this wasn't causing flakiness in CI, but when running
on my aarch64 devbox, I would get between 2 and 4 failures out of 200
that failed with a sanitizer crash like this:

    core/GlobalState.cc:2521:24: runtime error: member access within null pointer of type 'std::shared_ptr<sorbet::core::ErrorQueue>::element_type' (aka 'sorbet::core::ErrorQueue')
        #0 0xbfa4d6bd93d0  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-fastbuild/bin/test/lsp/multithreaded_protocol_test_corpus+0x34b93d0) (BuildId: dab70ea40e7b7881b98779303805b3e3)
        #1 0xbfa4d63f9de0  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-fastbuild/bin/test/lsp/multithreaded_protocol_test_corpus+0x2cd9de0) (BuildId: dab70ea40e7b7881b98779303805b3e3)
        #2 0xbfa4d6eb8d1c  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-fastbuild/bin/test/lsp/multithreaded_protocol_test_corpus+0x3798d1c) (BuildId: dab70ea40e7b7881b98779303805b3e3)
        #3 0xbfa4d6eb6d78  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-fastbuild/bin/test/lsp/multithreaded_protocol_test_corpus+0x3796d78) (BuildId: dab70ea40e7b7881b98779303805b3e3)
        #4 0xbfa4d6f27e84  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-fastbuild/bin/test/lsp/multithreaded_protocol_test_corpus+0x3807e84) (BuildId: dab70ea40e7b7881b98779303805b3e3)
        #5 0xf5b12c255958  (/lib/aarch64-linux-gnu/libc.so.6+0x85958) (BuildId: d5ef86dde36cbd3289566cf5098226035d76f2e1)
        #6 0xf5b12c2bbb48  (/lib/aarch64-linux-gnu/libc.so.6+0xebb48) (BuildId: d5ef86dde36cbd3289566cf5098226035d76f2e1)

Symbolized, crudely:

    === /pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-fastbuild/bin/test/lsp/multithreaded_protocol_test_corpus+0x34b93d0 ===
    sorbet::core::GlobalState::tracer() const
    ??:0:0

    === /pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-fastbuild/bin/test/lsp/multithreaded_protocol_test_corpus+0x2cd9de0 ===
    sorbet::resolver::(anonymous namespace)::ResolveTypeMembersAndFieldsWalk::run(sorbet::core::GlobalState&, std::__1::vector<sorbet::ast::ParsedFile, std::__1::allocator<sorbet::ast::ParsedFile>>, sorbet::WorkerPool&, std::__1::optional<absl::lts_20240722::Span<sorbet::core::ClassOrModuleRef const>>)::'lambda'()::operator()() const
    resolver.cc:0:0

    === /pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-fastbuild/bin/test/lsp/multithreaded_protocol_test_corpus+0x3798d1c ===
    std::__1::__function::__func<sorbet::WorkerPoolImpl::multiplexJob(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void ()>)::$_3, std::__1::allocator<sorbet::WorkerPoolImpl::multiplexJob(std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::function<void ()>)::$_3>, bool ()>::operator()()
    WorkerPoolImpl.cc:0:0

    === /pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-fastbuild/bin/test/lsp/multithreaded_protocol_test_corpus+0x3796d78 ===
    std::__1::__function::__func<sorbet::WorkerPoolImpl::WorkerPoolImpl(int, spdlog::logger&)::$_0, std::__1::allocator<sorbet::WorkerPoolImpl::WorkerPoolImpl(int, spdlog::logger&)::$_0>, void ()>::operator()()
    WorkerPoolImpl.cc:0:0

    === /pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-fastbuild/bin/test/lsp/multithreaded_protocol_test_corpus+0x3807e84 ===
    Joinable::trampoline(void*)
    ??:0:0

    === /lib/aarch64-linux-gnu/libc.so.6+0x85958 ===
    ??
    ??:0:0

    === /lib/aarch64-linux-gnu/libc.so.6+0xebb48 ===
    ??
    ??:0:0

The fix is simple enough.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

```
bazel test \
  --config=buildfarm-sanitized-linux-aarch64 \
  --test_summary=terse \
  --build_tests_only \
  --runs_per_test=200 \
  //test/lsp:multithreaded_protocol_test_corpus
```

Used to fail, now passes.