### PR TITLE
Some speedups to tests

### DIFF
--- a/common/counters/BUILD
+++ b/common/counters/BUILD
@@ -12,6 +12,10 @@ cc_library(
         "Counters.h",
         "Counters_impl.h",
     ],
+    copts = select({
+        "//tools/config:dbg": ["-O2"],
+        "//conditions:default": [],
+    }),
     linkopts = select({
         "@platforms//os:linux": ["-lm"],
         "//conditions:default": [],

--- a/core/serialize/BUILD
+++ b/core/serialize/BUILD
@@ -5,6 +5,10 @@ cc_library(
         "serialize.cc",
     ],
     hdrs = ["serialize.h"],
+    copts = select({
+        "//tools/config:dbg": ["-O2"],
+        "//conditions:default": [],
+    }),
     linkstatic = select({
         "//tools/config:linkshared": 0,
         "//conditions:default": 1,

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -795,8 +795,6 @@ ast::ParsedFilesOrCancelled index(core::GlobalState &gs, absl::Span<const core::
         return empty;
     }
 
-    gs.sanityCheck();
-
     if (files.size() < 3) {
         // Run singlethreaded if only using 2 files
         vector<ast::ParsedFile> parsed;

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -66,7 +66,6 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "MultithreadedWrapperWorks") {
         CHECK_EQ(initCounters.getCategoryCounter("lsp.messages.processed", "initialized"), 1);
         CHECK_EQ(initCounters.getCategoryCounter("lsp.updates", "slowpath"), 1);
         CHECK_EQ(initCounters.getCategoryCounterSum("lsp.updates"), 1);
-        CHECK_EQ(initCounters.getTimings("initial_index").size(), 1);
         CHECK_EQ(initCounters.getCategoryCounterSum("lsp.messages.canceled"), 0);
     }
 

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -43,6 +43,17 @@ constexpr auto timestampGranularity = chrono::milliseconds(2);
 class MultithreadedProtocolTest : public ProtocolTest {
 public:
     MultithreadedProtocolTest() : ProtocolTest(/*multithreading*/ true, /*caching*/ false) {}
+
+    // The timeout here is a balance: we want to wait long enough for all slow path edits to
+    // complete, but not so long that we're just busy waiting. Because the files involved in this
+    // test are generally tiny, 500ms should be plenty of time, but if this is causing flakiness we
+    // will need to adjust this or, ideally, make the slow path faster ;-)
+    void assertSlowPathBlockedAndUnblock(int timeout_ms = 500) {
+        auto &wrapper = dynamic_cast<MultiThreadedLSPWrapper &>(*lspWrapper);
+        auto msg = wrapper.read(timeout_ms);
+        REQUIRE(msg == nullptr);
+        setSlowPathBlocked(false);
+    }
 };
 
 } // namespace
@@ -957,16 +968,7 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "StallInSlowPathWorks") {
         REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
     }
 
-    // We expect the slow path to be blocked, so we want to make sure that we _don't_ receive any messages within a
-    // pretty long time frame---let's say 2000ms.
-    {
-        auto &wrapper = dynamic_cast<MultiThreadedLSPWrapper &>(*lspWrapper);
-        auto msg = wrapper.read(2000);
-        REQUIRE(msg == nullptr);
-    }
-
-    // Unblock the slow path.
-    setSlowPathBlocked(false);
+    assertSlowPathBlockedAndUnblock();
 
     // The slow path should now be unblocked. Wait for typechecking to end.
     {
@@ -1040,16 +1042,7 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "PreemptionCanceledForSlowPathWorks
                           "end\n",
                           4, false, 0));
 
-    // We expect the slow path to be blocked, so we want to make sure that we _don't_ receive any messages within a
-    // pretty long time frame---let's say 2000ms.
-    {
-        auto &wrapper = dynamic_cast<MultiThreadedLSPWrapper &>(*lspWrapper);
-        auto msg = wrapper.read(2000);
-        REQUIRE(msg == nullptr);
-    }
-
-    // Unblock the slow path.
-    setSlowPathBlocked(false);
+    assertSlowPathBlockedAndUnblock();
 
     // The slow path should now be unblocked, and will be canceled immediately.
     {
@@ -1189,16 +1182,7 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "PreemptionCanceledForSlowPathWorks
                           "end\n",
                           4, false, 0));
 
-    // We expect the slow path to be blocked, so we want to make sure that we _don't_ receive any messages within a
-    // pretty long time frame---let's say 2000ms.
-    {
-        auto &wrapper = dynamic_cast<MultiThreadedLSPWrapper &>(*lspWrapper);
-        auto msg = wrapper.read(2000);
-        REQUIRE(msg == nullptr);
-    }
-
-    // Unblock the slow path.
-    setSlowPathBlocked(false);
+    assertSlowPathBlockedAndUnblock();
 
     // The slow path should now be unblocked, and will be canceled immediately.
     {
@@ -1358,16 +1342,7 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "MergingEditsWhenCancellingPreempti
                           "end\n",
                           5, false, 0));
 
-    // We expect the slow path to be blocked, so we want to make sure that we _don't_ receive any messages within a
-    // pretty long time frame---let's say 2000ms.
-    {
-        auto &wrapper = dynamic_cast<MultiThreadedLSPWrapper &>(*lspWrapper);
-        auto msg = wrapper.read(2000);
-        REQUIRE(msg == nullptr);
-    }
-
-    // Unblock the slow path.
-    setSlowPathBlocked(false);
+    assertSlowPathBlockedAndUnblock();
 
     // The slow path should now be unblocked, and will be canceled immediately.
     {

--- a/third_party/lz4.BUILD
+++ b/third_party/lz4.BUILD
@@ -6,6 +6,10 @@ cc_library(
     hdrs = [
         "lib/lz4.h",
     ],
+    copts = select({
+        "@com_stripe_ruby_typer//tools/config:dbg": ["-O2"],
+        "//conditions:default": [],
+    }),
     linkstatic = select({
         "@com_stripe_ruby_typer//tools/config:linkshared": 0,
         "//conditions:default": 1,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I was doing some work that involved `multithreaded_protocol_test_corpus`
recently and was just really annoyed at how slow it was.

Also a while back, I was annoyed by how slow it is to run the whole PosTest
suite or the whole LSPTest suite.

This PR is a series of changes that makes things faster for minimal tradeoffs.
These speedups apply mostly to `--config=dbg`, which is what I use locally so
that my cache is hot and I can always `lldb` something after seeing the test
fail.

There are a few changes:

- Use `-O2`, even in `--config=dbg`, in three compilation units.

  `serialize`, `lz4`, and `common/counters` are a few places where we really
  benefit from `-O2`, because it's doing heavily optimize-able stuff while also
  being exceedingly rare that I want to step into the code in the debugger.

- Don't be so pessimistic when waiting for LSP messages.

  Our multithreaded_protocol_test_corpus is fast enough, especially on the
  classes of files we're testing in this harness. The slowpath is generally very
  fast, and shouldn't be taking more than 500ms to flush a message. We were
  previously waiting 2000ms (× 4 == 6s saving)

- Remove a call to `gs.sanityCheck()`

  A while back while doing some debug perf work, I had tried removing this and
  it caused flakiness. I fixed the flakiness and re-removed it. See the commit
  message.



Overall: (`bazel test --config=dbg`)

-   `//test:test`

    86.567s → 56.720s

-   `//test/lsp:multithreaded_protocol_test_corpus`

    38.849s → 19.033s

-   `//test:test_corpus_lsp`

    248.419s → 113.644s (‼️)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests, timing commands as measured.