### PR TITLE
Delete `LSPTask::needsMultithreading`

### DIFF
--- a/main/lsp/LSPTask.cc
+++ b/main/lsp/LSPTask.cc
@@ -261,10 +261,6 @@ bool LSPRequestTask::cancel(const MessageId &id) {
     return false;
 }
 
-bool LSPTask::needsMultithreading(const LSPIndexer &indexer) const {
-    return false;
-}
-
 bool LSPTask::isDelayable() const {
     return false;
 }
@@ -274,8 +270,7 @@ bool LSPTask::cancel(const MessageId &id) {
 }
 
 bool LSPTask::canPreempt(const LSPIndexer &indexer) const {
-    // A task that can preempt cannot be multithreaded.
-    return !needsMultithreading(indexer);
+    return true;
 }
 
 vector<unique_ptr<Location>>

--- a/main/lsp/LSPTask.h
+++ b/main/lsp/LSPTask.h
@@ -75,8 +75,6 @@ public:
 
     virtual bool canPreempt(const LSPIndexer &) const;
 
-    virtual bool needsMultithreading(const LSPIndexer &) const;
-
     // Returns the phase at which the task is complete. Some tasks only need to interface with the preprocessor or the
     // indexer. The default implementation returns RUN.
     virtual Phase finalPhase() const;

--- a/main/lsp/notifications/initialized.cc
+++ b/main/lsp/notifications/initialized.cc
@@ -28,8 +28,8 @@ void InitializedTask::run(LSPTypecheckerDelegate &typechecker) {
     typechecker.resumeTaskQueue(*this);
 }
 
-bool InitializedTask::needsMultithreading(const LSPIndexer &indexer) const {
-    return true;
+bool InitializedTask::canPreempt(const LSPIndexer &indexer) const {
+    return false;
 }
 
 void InitializedTask::setGlobalState(unique_ptr<core::GlobalState> gs) {

--- a/main/lsp/notifications/initialized.h
+++ b/main/lsp/notifications/initialized.h
@@ -26,8 +26,7 @@ public:
 
     void setGlobalState(std::unique_ptr<core::GlobalState> gs);
     void setKeyValueStore(std::unique_ptr<KeyValueStore> kvstore);
-
-    bool needsMultithreading(const LSPIndexer &indexer) const override;
+    bool canPreempt(const LSPIndexer &indexer) const override;
 };
 } // namespace sorbet::realmain::lsp
 

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -157,10 +157,6 @@ bool SorbetWorkspaceEditTask::canPreempt(const LSPIndexer &index) const {
     return getTypecheckingPath(index) == TypecheckingPath::Fast;
 }
 
-bool SorbetWorkspaceEditTask::needsMultithreading(const LSPIndexer &index) const {
-    return getTypecheckingPath(index) != TypecheckingPath::Fast;
-}
-
 const SorbetWorkspaceEditParams &SorbetWorkspaceEditTask::getParams() const {
     return *params;
 }

--- a/main/lsp/notifications/sorbet_workspace_edit.h
+++ b/main/lsp/notifications/sorbet_workspace_edit.h
@@ -37,7 +37,6 @@ public:
 
     bool canPreempt(const LSPIndexer &index) const override;
     TypecheckingPath getTypecheckingPath(const LSPIndexer &index) const;
-    bool needsMultithreading(const LSPIndexer &index) const override;
 };
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -15,8 +15,8 @@ ReferencesTask::ReferencesTask(const LSPConfiguration &config, MessageId id, uni
     : LSPRequestTask(config, move(id), LSPMethod::TextDocumentReferences), params(move(params)),
       hierarchyReferences(hierarchyReferences) {}
 
-bool ReferencesTask::needsMultithreading(const LSPIndexer &indexer) const {
-    return true;
+bool ReferencesTask::canPreempt(const LSPIndexer &indexer) const {
+    return false;
 }
 
 namespace {

--- a/main/lsp/requests/references.h
+++ b/main/lsp/requests/references.h
@@ -15,7 +15,7 @@ public:
 
     std::unique_ptr<ResponseMessage> runRequest(LSPTypecheckerDelegate &typechecker) override;
 
-    bool needsMultithreading(const LSPIndexer &indexer) const override;
+    bool canPreempt(const LSPIndexer &indexer) const override;
 };
 
 } // namespace sorbet::realmain::lsp


### PR DESCRIPTION
This was only used in places where we override `canPreempt`, so… just use `canPreempt`!

### Motivation
Cleaning up the interface.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
