### PR TITLE
Enforce clang-tidy in CI, enable bugprone-use-after-move

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -179,15 +179,15 @@ build:release-sanitized-mac --define jemalloc=false
 ## Configuration used to to as much testing as possible in CI
 ##
 build:test-sanitized-linux --config=release-sanitized-linux --config=dbg --nostamp --define release=false
-test:test-sanitized-linux --test_env="UBSAN_OPTIONS=print_stacktrace=1"
-test:test-sanitized-linux --test_env="ASAN_OPTIONS=detect_leaks=0"
+common:test-sanitized-linux --test_env="UBSAN_OPTIONS=print_stacktrace=1"
+common:test-sanitized-linux --test_env="ASAN_OPTIONS=detect_leaks=0"
 
 build:test-sanitized-linux-aarch64 --config=release-sanitized-linux-aarch64 --config=dbg --nostamp --define release=false
-test:test-sanitized-linux-aarch64 --test_env="UBSAN_OPTIONS=print_stacktrace=1"
-test:test-sanitized-linux-aarch64 --test_env="ASAN_OPTIONS=detect_leaks=0"
+common:test-sanitized-linux-aarch64 --test_env="UBSAN_OPTIONS=print_stacktrace=1"
+common:test-sanitized-linux-aarch64 --test_env="ASAN_OPTIONS=detect_leaks=0"
 
 build:test-sanitized-mac --config=release-sanitized-mac --config=dbg --nostamp --define release=false
-test:test-sanitized-mac --test_env="UBSAN_OPTIONS=print_stacktrace=1"
+common:test-sanitized-mac --test_env="UBSAN_OPTIONS=print_stacktrace=1"
 
 build:reduce-intermediate-file-size-base --copt=-g0 --linkopt=-g0 # used by buildfarm to have less debug information on disk
 build:reduce-intermediate-file-size-base --strip=always

--- a/.bazelrc
+++ b/.bazelrc
@@ -326,3 +326,9 @@ common:ci --color yes
 
 # enables a lot of features in mac instruments profiler
 build:instruments --linkopt=-framework --linkopt=CoreFoundation
+
+# clang-tidy via bazel_clang_tidy aspect
+build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
+build:clang-tidy --output_groups=report
+build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config
+build:clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=//tools/clang_tidy

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -40,7 +40,9 @@ steps:
   - label: ":mac: test-static-sanitized.sh (master only)"
     command: '.buildkite/test-static-sanitized.sh < /dev/null'
     branches: "master"
-    artifact_paths: _out_/profile.json
+    artifact_paths:
+      - _out_/profile.json
+      - _out_/clang_tidy_profile.json
     agents:
       os: mac
     # TODO(jez) We should only retry for specific error.
@@ -50,7 +52,9 @@ steps:
 
   - label: ":linux: test-static-sanitized.sh"
     command: '.buildkite/test-static-sanitized.sh < /dev/null'
-    artifact_paths: _out_/profile.json
+    artifact_paths:
+      - _out_/profile.json
+      - _out_/clang_tidy_profile.json
     <<: *elastic
 
   - label: ":linux: test-vscode-extension.sh"

--- a/.buildkite/test-static-sanitized.sh
+++ b/.buildkite/test-static-sanitized.sh
@@ -14,25 +14,26 @@ case "${unameOut}" in
     *)          exit 1
 esac
 
-test_args=()
+build_args=()
 
 if [[ "linux" == "$platform" ]]; then
-  test_args+=("--config=buildfarm-sanitized-linux")
+  build_args+=("--config=buildfarm-sanitized-linux")
 elif [[ "mac" == "$platform" ]]; then
-  test_args+=("--config=buildfarm-sanitized-mac")
+  build_args+=("--config=buildfarm-sanitized-mac")
 fi
 
 export JOB_NAME=test-static-sanitized
 # shellcheck source-path=SCRIPTDIR/..
 source .buildkite/tools/setup-bazel.sh
 
-echo -- will run with "${test_args[@]}"
+echo -- will run with "${build_args[@]}"
 
 err=0
 
 mkdir -p _out_
 
-test_args+=(
+test_args=(
+  "${build_args[@]}"
   "--build_tests_only"
   "//..."
 )
@@ -79,6 +80,30 @@ if [ "$err" -ne 0 ]; then
   echo '```' >> "$failing_tests"
 
   buildkite-agent annotate --context "test-static-sanitized.sh" --style error --append < "$failing_tests"
+fi
 
+# Run clang-tidy even if tests failed (reuses the same build config for cache hits)
+clang_tidy_err=0
+./bazel build \
+  --keep_going \
+  --config=clang-tidy \
+  "${build_args[@]}" \
+  --experimental_generate_json_trace_profile \
+  --profile=_out_/clang_tidy_profile.json \
+  //... \
+  || clang_tidy_err=$?
+
+if [ "$clang_tidy_err" -ne 0 ]; then
+  {
+    echo 'There were clang-tidy errors. To reproduce locally:'
+    echo
+    echo '```bash'
+    echo './bazel build --keep_going --config=clang-tidy --config=dbg //...'
+    echo '```'
+  } | buildkite-agent annotate --context "clang-tidy" --style error --append
+fi
+
+if [ "$err" -ne 0 ]; then
   exit "$err"
 fi
+exit "$clang_tidy_err"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+---
+Checks: '-*,abseil-duration-addition'
+WarningsAsErrors: ''

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,4 @@
 ---
 Checks: '-*,abseil-duration-addition'
 WarningsAsErrors: ''
+UseColor: true

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "clang_tidy_config",
+    srcs = [".clang-tidy"],
+    visibility = ["//visibility:public"],
+)

--- a/README.md
+++ b/README.md
@@ -1083,6 +1083,44 @@ You are encouraged to play around with various clang-based tools which use the
     -style=file -assume-filename=<CURRENT_FILE>
     ```
 
+-   [clang-tidy] -- Clang-based static analysis / linting
+
+    We run `clang-tidy` in CI via a Bazel aspect. To run it locally:
+
+    ```bash
+    # Run on all targets
+    ./bazel build --keep_going --config=clang-tidy --config=dbg //...
+
+    # Run on a single target (note: only runs on files *directly* in that target)
+    ./bazel build --config=clang-tidy --config=dbg //main/lsp:lsp
+    ```
+
+    The checks and their configuration live in `.clang-tidy` at the repo
+    root.
+
+    `clang-tidy` supports the same `compilation_commands.json` database that
+    `clangd` does, but unfortunately it doesn't seem to support the `directory`
+    argument. We have a wrapper script you can point your editor at that `cd`'s
+    and then runs the `clang-tidy` built by our toolchain:
+
+    ```vim
+    if filereadable("./compile_commands.json")
+      " I set these to use clangd via nvim-lsp, but you could have clangd here.
+      let g:ale_linters.c = []
+      let g:ale_linters.cpp = []
+
+      if filereadable(".clang-tidy") && filereadable("tools/scripts/clang-tidy")
+        let g:ale_linters.c += ['clangtidy']
+        let g:ale_linters.cpp += ['clangtidy']
+        let g:ale_cpp_clangtidy_executable = 'tools/scripts/clang-tidy'
+        let g:ale_cpp_clangtidy_extra_options = '--use-color=0'
+      endif
+    endif
+    ```
+
+    Liek `clangd`, this requires that you have recently built `//main:sorbet` or
+    some target that includes the file you were hoping to check.
+
 -   [CLion] -- JetBrains C/C++ IDE
 
     CLion can be made aware of the `compile_commands.json` database.
@@ -1105,6 +1143,7 @@ You are encouraged to play around with various clang-based tools which use the
 [rtags]: https://github.com/Andersbakken/rtags
 [clangd]: https://clang.llvm.org/extra/clangd.html
 [clang-format]: https://clang.llvm.org/docs/ClangFormat.html
+[clang-tidy]: https://clang.llvm.org/extra/clang-tidy/
 [CLion]: https://www.jetbrains.com/clion/
 [vscode-clangd]: https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd
 

--- a/ast/desugar/test/desugar_test.cc
+++ b/ast/desugar/test/desugar_test.cc
@@ -21,7 +21,7 @@ using namespace std;
 auto logger = spdlog::stderr_color_mt("desugar_test");
 auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger);
 
-TEST_CASE("SimpleDesugar") { // NOLINT
+TEST_CASE("SimpleDesugar") {
     sorbet::core::GlobalState gs(errorQueue);
     gs.initEmpty();
     sorbet::core::UnfreezeNameTable nameTableAccess(gs);
@@ -34,7 +34,7 @@ TEST_CASE("SimpleDesugar") { // NOLINT
     auto o1 = sorbet::ast::desugar::node2Tree(ctx, move(ast));
 }
 
-TEST_CASE("SimplePrismDesugar") { // NOLINT
+TEST_CASE("SimplePrismDesugar") {
     sorbet::core::GlobalState gs(errorQueue);
     gs.initEmpty();
     sorbet::core::UnfreezeNameTable nameTableAccess(gs);

--- a/common/test/common_test.cc
+++ b/common/test/common_test.cc
@@ -8,7 +8,7 @@
 
 namespace sorbet::common {
 
-TEST_CASE("Levenstein") { // NOLINT
+TEST_CASE("Levenstein") {
     Levenstein levenstein;
     CHECK_EQ(2, levenstein.distance("Mama", "Papa", 10));
     CHECK_EQ(5, levenstein.distance("Ruby", "Scala", 10));

--- a/core/serialize/test/serialize_test.cc
+++ b/core/serialize/test/serialize_test.cc
@@ -11,7 +11,7 @@ namespace sorbet::core::serialize {
 
 auto logger = spdlog::stderr_color_mt("serialize_test");
 
-TEST_CASE("U4") { // NOLINT
+TEST_CASE("U4") {
     Pickler p;
     p.putU4(0);
     p.putU4(1);
@@ -22,7 +22,7 @@ TEST_CASE("U4") { // NOLINT
     CHECK_EQ(u.getU4(), 4294967295);
 }
 
-TEST_CASE("U4U1") { // NOLINT
+TEST_CASE("U4U1") {
     Pickler p;
     p.putU4(0);
     p.putU4(0);
@@ -45,7 +45,7 @@ TEST_CASE("U4U1") { // NOLINT
     CHECK_EQ(u.getU4(), 4294967295);
 }
 
-TEST_CASE("U8") { // NOLINT
+TEST_CASE("U8") {
     Pickler p;
     p.putS8(0);
     p.putS8(1);
@@ -58,7 +58,7 @@ TEST_CASE("U8") { // NOLINT
     CHECK_EQ(u.getS8(), 9223372036854775807);
 }
 
-TEST_CASE("Strings") { // NOLINT
+TEST_CASE("Strings") {
     Pickler p;
     p.putStr("");
     p.putStr("a");

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -139,7 +139,7 @@ struct FileIsTypedCase {
     StrictLevel strict;
 };
 
-TEST_CASE("FileIsTyped") { // NOLINT
+TEST_CASE("FileIsTyped") {
     vector<FileIsTypedCase> cases = {
         {"", StrictLevel::None},
         {"# typed: true", StrictLevel::True},
@@ -164,7 +164,7 @@ TEST_CASE("FileIsTyped") { // NOLINT
     }
 }
 
-TEST_CASE("Substitute") { // NOLINT
+TEST_CASE("Substitute") {
     GlobalState gs1(errorQueue);
     gs1.initEmpty();
 

--- a/namer/test/namer_test.cc
+++ b/namer/test/namer_test.cc
@@ -76,7 +76,7 @@ TEST_CASE("namer tests") {
         REQUIRE_EQ(1, symbol->parameters.size());
     }
 
-    SUBCASE("Idempotent") { // NOLINT
+    SUBCASE("Idempotent") {
         auto baseSymbols = gs.symbolsUsedTotal();
         auto baseMethods = gs.methodsUsed();
         auto baseNames = gs.namesUsedTotal();
@@ -107,7 +107,7 @@ TEST_CASE("namer tests") {
         REQUIRE_EQ(baseNames + 2, gs.namesUsedTotal());
     }
 
-    SUBCASE("NameClass") { // NOLINT
+    SUBCASE("NameClass") {
         auto tree = getTree(gs, "class Test; class Foo; end; end");
         {
             auto localTree = sorbet::local_vars::LocalVars::run(gs, move(tree));
@@ -127,7 +127,7 @@ TEST_CASE("namer tests") {
         REQUIRE_EQ(1, fooInfo->members().size());
     }
 
-    SUBCASE("InsideClass") { // NOLINT
+    SUBCASE("InsideClass") {
         auto tree = getTree(gs, "class Test; class Foo; def bar; end; end; end");
         {
             auto localTree = sorbet::local_vars::LocalVars::run(gs, move(tree));

--- a/parser/test/parser_test.cc
+++ b/parser/test/parser_test.cc
@@ -19,7 +19,7 @@ using namespace std;
 auto logger = spdlog::stderr_color_mt("parser_test");
 auto errorQueue = make_shared<sorbet::core::ErrorQueue>(*logger, *logger);
 
-TEST_CASE("SimpleParse") { // NOLINT
+TEST_CASE("SimpleParse") {
     sorbet::core::GlobalState gs(errorQueue);
     gs.initEmpty();
     sorbet::core::UnfreezeNameTable nameTableAccess(gs);
@@ -39,7 +39,7 @@ struct DedentTest {
     string_view out;
 };
 
-TEST_CASE("TestDedent") { // NOLINT
+TEST_CASE("TestDedent") {
     vector<DedentTest> cases = {
         {2, "    hi"sv, "  hi"sv},
         {10, "  \t    hi"sv, "  hi"sv},

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -448,7 +448,7 @@ void autogen(core::GlobalState &gs, vector<core::FileRef> files, ExpectationHand
     handler.checkExpectations();
 }
 
-TEST_CASE("PerPhaseTest") { // NOLINT
+TEST_CASE("PerPhaseTest") {
     Expectations test = Expectations::getExpectations(singleTest);
 
     auto inputPath = test.folder + test.basename;

--- a/third_party/bazel_clang_tidy/clang_tidy_BUILD.patch
+++ b/third_party/bazel_clang_tidy/clang_tidy_BUILD.patch
@@ -1,0 +1,13 @@
+# bazel_clang_tidy added a load("@rules_shell") in
+# https://github.com/erenon/bazel_clang_tidy/pull/100 for Bazel 8.x
+# compatibility. Sorbet uses Bazel 7.x where sh_binary is still a native
+# rule, and we don't want to pull in the rules_shell dependency.
+# Remove this patch when upgrading to Bazel 8+.
+--- a/clang_tidy/BUILD
++++ b/clang_tidy/BUILD
+@@ -1,5 +1,3 @@
+-load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+-
+ sh_binary(
+     name = "clang_tidy",
+     srcs = ["run_clang_tidy.sh"],

--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -208,6 +208,15 @@ def register_sorbet_dependencies():
     )
 
     http_archive(
+        name = "bazel_clang_tidy",
+        url = "https://github.com/erenon/bazel_clang_tidy/archive/c4d35e0d0b838309358e57a2efed831780f85cd0.tar.gz",
+        sha256 = "96da6e935ccc91045cf928dbc57f22508a2729c51f7fb3f56178017b0deb9b3c",
+        strip_prefix = "bazel_clang_tidy-c4d35e0d0b838309358e57a2efed831780f85cd0",
+        patches = ["@com_stripe_ruby_typer//third_party:bazel_clang_tidy/clang_tidy_BUILD.patch"],
+        patch_args = ["-p1"],
+    )
+
+    http_archive(
         name = "io_bazel_rules_go",
         sha256 = "d6ab6b57e48c09523e93050f13698f708428cfd5e619252e369d377af6597707",
         url = "https://github.com/bazelbuild/rules_go/releases/download/v0.43.0/rules_go-v0.43.0.zip",

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -10,6 +10,7 @@ compilation_database(
     name = "compdb",
     testonly = True,
     output_base = OUTPUT_BASE,
+    tags = ["manual"],
     targets = [
         # BEGIN compile_commands targets
         "//ast:ast",

--- a/tools/clang_tidy/BUILD
+++ b/tools/clang_tidy/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "clang_tidy",
+    srcs = ["@llvm_toolchain_15_0_7_llvm//:bin/clang-tidy"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/scripts/clang-tidy
+++ b/tools/scripts/clang-tidy
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Can't use a system-wide installed `clang-tidy` unless there are also
+# system-wide installed header files relative to that binary (e.g., can't just
+# copy clang-tidy to ~/bin like for `clang-format`)
+#
+# If invoke the `clang-tidy` binary from within the exec root, it will find the system headers.
+#
+# But there's another problem, which is that it doesn't seems like clang-tidy
+# respects the "directory" option in `compile_commands.json` (?) leading to it
+# to not find bazel library things, like anything in external/com_google_absl
+#
+# We can work around this with our own script for editors to use.
+
+cd "$(dirname "$0")/../../bazel-sorbet"
+exec external/llvm_toolchain_15_0_7/bin/clang-tidy "$@"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

I was able to get `clang-tidy` running on Sorbet last night

If we disable all the checks (and wait for [this PR](https://github.com/sorbet/sorbet/pull/10193)), clang-tidy is clean, so we _could_ turn it on in enforcing mode in CI if we wanted.

The only reason why I wanted this was because I wanted to see whether I could turn on use-after-move diagnostics, but it turns out [clangd doesn't support the checks that require "static analyzer"](https://github.com/clangd/clangd/issues/905), use-after-move included. Editor integration would require ALE + clang-tidy, which is pretty slow (e.g., 7s post save in resolver.cc). Given that I think that people might not turn it on in their editor, and some of the checks that I could see us enabling for clang-tidy would be pretty pedantic, e.g. use-after-move flags code like `foo(x.size(), move(x))` (because argument evaluation order is unspecified), and if we were being so pedantic like that, I'd really want people to get early feedback about their changes.

Another alternative might be to use something like [GitHub Checks](https://stackoverflow.com/questions/67919168/github-checks-api-vs-check-runs-vs-check-suites#:~:text=Can%20create%20annotations%20for%20specific%20lines%20of%20code) to comment on PR, instead of failing CI.

In any case, I figured I'd open the PR, because getting it integrated was mostly trivial, but did involve a slight `.patch` file because the upstream project did some things that in practice drop support for pre-bazel-8

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

The clang-tidy step seems to add ~2 minutes to `test-static-sanitized.sh`, and this is the distribution of clang-tidy on individual files, as measured by the `clang_tidy_profile.json` file:

```
Files analyzed: 568
Total CPU time: 3703s (61.7m)
Mean: 6.5s  |  Median: 6.3s  |  p90: 9.8s  |  p99: 13.1s

Top 25 slowest:
    21.0s  test/pipeline_test_runner.cc
    17.3s  test/helpers/position_assertions.cc
    16.3s  test/lsp_test_runner.cc
    13.8s  resolver/resolver.cc
    13.3s  main/lsp/test/lsp_preprocessor_test.cc
    13.1s  main/lsp/LSPTypechecker.cc
    13.1s  main/lsp/test/generate_lsp_messages_test.cc
    12.4s  main/lsp/requests/completion.cc
    12.1s  main/realmain.cc
    11.6s  test/helpers/lsp.cc
    11.5s  main/lsp/LSPPreprocessor.cc
    11.5s  main/pipeline/pipeline.cc
    11.3s  main/lsp/requests/workspace_symbols.cc
    11.3s  main/lsp/LSPLoop.cc
    11.3s  main/lsp/requests/code_action.cc
    11.0s  main/lsp/requests/document_symbol.cc
    11.0s  main/lsp/requests/rename.cc
    10.9s  main/lsp/requests/references.cc
    10.9s  main/lsp/requests/hover.cc
    10.9s  main/lsp/requests/definition.cc
    10.8s  test/lsp/protocol_test_corpus.cc
    10.7s  main/lsp/LSPIndexer.cc
    10.6s  main/lsp/requests/document_highlight.cc
    10.6s  test/lsp/ProtocolTest.cc
    10.6s  main/lsp/LSPTask.cc

Distribution:
   0- 2s:  36  ##############
   2- 4s:  18  #######
   4- 6s: 205  ################################################################################
   6- 8s: 171  ##################################################################
   8-10s:  91  ###################################
  10-15s:  44  #################
  15-25s:   3  #
```