### PR TITLE
Support package-directed mode with preemption assertions

### DIFF
--- a/core/lsp/PreemptionTask.h
+++ b/core/lsp/PreemptionTask.h
@@ -1,6 +1,7 @@
 #ifndef SORBET_LSP_PREEMPTION_TASK_H
 #define SORBET_LSP_PREEMPTION_TASK_H
 
+#include "common/common.h"
 #include <cstdint>
 #include <optional>
 
@@ -11,16 +12,57 @@ public:
     PreemptionTask() = default;
     virtual ~PreemptionTask() = default;
 
-    struct RunResult {
-        // True if one or more tasks were handled by the preemption task.
-        bool tasksHandled = false;
+    // There are four possible states that the `RunResult` type represents:
+    // 1. No tasks were processed by the preemption task, and it wasn't rescheduled for a later stratum when operating
+    //    in package-directed mode. This can occur when the main thread schedules a preemption task because it
+    //    determines that there are preemption-supporting tasks at the head of the queue, but those tasks get canceled
+    //    before preemption has the opportunity to run.
+    // 2. The preemption task successfully handles all of the tasks in the queue that support preemption, and doesn't
+    //    need to reschedule itself for a later stratum.
+    // 3. The preemption task successfully handles some of the tasks in the queue, but needs to reschedule itself for a
+    //    later stratum to handle the rest.
+    // 4. The preemption task cannot handle any of the tasks in the queue, but can at a later stratum. It has requested
+    //    to be rescheduled to run at that stratum.
+    class RunResult {
+        bool tasksHandled_ = false;
+        bool wasRescheduled_ = false;
 
-        // Non-empty if there's more work to do, but it can't happen until the supplied stratum.
-        std::optional<uint16_t> rescheduled;
+        uint16_t rescheduled = 0;
+
+    public:
+        RunResult() = default;
+
+        // Indicate that tasks from the queue were handled during preemption.
+        void setTasksHandled() {
+            this->tasksHandled_ = true;
+        }
+
+        // True if the preemption task handled tasks from the queue.
+        bool getTasksHandled() const {
+            return this->tasksHandled_;
+        }
+
+        // Indicate that the preemption task would like to be run again at the provided stratum.
+        void setRescheduledStratum(uint16_t stratum) {
+            this->wasRescheduled_ = true;
+            this->rescheduled = stratum;
+        }
+
+        // Fetch the stratum that the preemption task requested to be rescheduled to (only valid if
+        // `setRescheduledStratum` has been called).
+        uint16_t getRescheduledStratum() const {
+            ENFORCE(this->wasRescheduled_);
+            return this->rescheduled;
+        }
+
+        // True if the preemption task encountered a task that it could process at a later stratum.
+        bool wasRescheduled() const {
+            return this->wasRescheduled_;
+        }
 
         // Returns true if the preemption task handled some tasks or determined that it needs to be rescheduled.
         bool progress() const {
-            return this->tasksHandled || this->rescheduled.has_value();
+            return this->tasksHandled_ || this->wasRescheduled_;
         }
     };
 

--- a/core/lsp/PreemptionTask.h
+++ b/core/lsp/PreemptionTask.h
@@ -11,9 +11,22 @@ public:
     PreemptionTask() = default;
     virtual ~PreemptionTask() = default;
 
+    struct RunResult {
+        // True if one or more tasks were handled by the preemption task.
+        bool tasksHandled = false;
+
+        // Non-empty if there's more work to do, but it can't happen until the supplied stratum.
+        std::optional<uint16_t> rescheduled;
+
+        // Returns true if the preemption task handled some tasks or determined that it needs to be rescheduled.
+        bool progress() const {
+            return this->tasksHandled || this->rescheduled.has_value();
+        }
+    };
+
     // Run the preemption task. Returning a non-empty result indicates that there is more work to do, and that it can't
     // be done until the stratum indicated.
-    virtual std::optional<uint16_t> run(uint16_t currentStratum) = 0;
+    virtual RunResult run(uint16_t currentStratum) = 0;
 
     // Optional hook called when the task has been run to completion. Any notification to unblock other threads should
     // be done here to avoid accidentally unblocking work that could interact with the preemption scheduler.

--- a/core/lsp/PreemptionTaskManager.cc
+++ b/core/lsp/PreemptionTaskManager.cc
@@ -69,11 +69,11 @@ PreemptionTask::RunResult PreemptionTaskManager::tryRunScheduledPreemptionTask(c
                                                       make_shared<core::NullFlusher>());
         gs.tracer().debug("[Typechecker] Beginning preemption task.");
         result = preemptTask->run(currentStratum);
-        if (allowReschedule && result.rescheduled.has_value()) {
+        if (allowReschedule && result.wasRescheduled()) {
             // In this case the task has indicated that there's more work to do, but that it can't occur until the
             // stratum named in `result`. We re-queue the task, and remember the stratum that we can run at so that we
             // can early exit in future calls to `tryRunScheduledPreemptionTask`.
-            this->runnableAt.store(*result.rescheduled);
+            this->runnableAt.store(result.getRescheduledStratum());
 
             // As we haven't called `finish` yet, we're assuming unique access to the preemptTask slot: LSPLoop will be
             // blocked as the PreemptionLoop won't have notified it yet.

--- a/core/lsp/PreemptionTaskManager.cc
+++ b/core/lsp/PreemptionTaskManager.cc
@@ -41,15 +41,18 @@ bool PreemptionTaskManager::trySchedulePreemptionTask(shared_ptr<PreemptionTask>
     return success;
 }
 
-bool PreemptionTaskManager::tryRunScheduledPreemptionTask(const core::GlobalState &gs, uint16_t currentStratum,
-                                                          bool allowReschedule) {
+PreemptionTask::RunResult PreemptionTaskManager::tryRunScheduledPreemptionTask(const core::GlobalState &gs,
+                                                                               uint16_t currentStratum,
+                                                                               bool allowReschedule) {
+    PreemptionTask::RunResult result;
+
     TypecheckEpochManager::assertConsistentThread(
         typecheckingThreadId, "PreemptionTaskManager::tryRunScheduledPreemptionTask", "typechecking thread");
 
     // We can early-exit if we know that it's not possible to run preemption yet, but if we know that rescheduling is
     // not possible, we should run to completion.
     if (allowReschedule && currentStratum < this->runnableAt.load()) {
-        return false;
+        return result;
     }
 
     auto preemptTask = atomic_load(&this->preemptTask);
@@ -65,7 +68,7 @@ bool PreemptionTaskManager::tryRunScheduledPreemptionTask(const core::GlobalStat
         gs.errorQueue = make_shared<core::ErrorQueue>(previousErrorQueue->logger, previousErrorQueue->tracer,
                                                       make_shared<core::NullFlusher>());
         gs.tracer().debug("[Typechecker] Beginning preemption task.");
-        auto result = preemptTask->run(currentStratum);
+        result = preemptTask->run(currentStratum);
         if (allowReschedule && result.rescheduled.has_value()) {
             // In this case the task has indicated that there's more work to do, but that it can't occur until the
             // stratum named in `result`. We re-queue the task, and remember the stratum that we can run at so that we
@@ -85,9 +88,9 @@ bool PreemptionTaskManager::tryRunScheduledPreemptionTask(const core::GlobalStat
             gs.tracer().debug("[Typechecker] Preemption task complete.");
         }
         gs.errorQueue = move(previousErrorQueue);
-        return true;
     }
-    return false;
+
+    return result;
 }
 
 bool PreemptionTaskManager::tryCancelScheduledPreemptionTask(shared_ptr<PreemptionTask> &task) {

--- a/core/lsp/PreemptionTaskManager.cc
+++ b/core/lsp/PreemptionTaskManager.cc
@@ -66,11 +66,11 @@ bool PreemptionTaskManager::tryRunScheduledPreemptionTask(const core::GlobalStat
                                                       make_shared<core::NullFlusher>());
         gs.tracer().debug("[Typechecker] Beginning preemption task.");
         auto result = preemptTask->run(currentStratum);
-        if (allowReschedule && result.has_value()) {
+        if (allowReschedule && result.rescheduled.has_value()) {
             // In this case the task has indicated that there's more work to do, but that it can't occur until the
             // stratum named in `result`. We re-queue the task, and remember the stratum that we can run at so that we
             // can early exit in future calls to `tryRunScheduledPreemptionTask`.
-            this->runnableAt.store(*result);
+            this->runnableAt.store(*result.rescheduled);
 
             // As we haven't called `finish` yet, we're assuming unique access to the preemptTask slot: LSPLoop will be
             // blocked as the PreemptionLoop won't have notified it yet.

--- a/core/lsp/PreemptionTaskManager.h
+++ b/core/lsp/PreemptionTaskManager.h
@@ -2,10 +2,10 @@
 #define SORBET_LSP_PREEMPTIONTASKMANAGER_H
 
 #include "core/GlobalState.h"
+#include "core/lsp/PreemptionTask.h"
 #include <memory>
 
 namespace sorbet::core::lsp {
-class PreemptionTask;
 class TypecheckEpochManager;
 class PreemptionTaskManager final {
 private:
@@ -51,7 +51,8 @@ public:
     // cleared out. Otherwise there is the possibility that it might get rescheduled, which would cause problems the
     // next time preemption was scheduled from the main thread. Handles running task with a fresh errorQueue, and
     // restoring previous errorQueue when done.
-    bool tryRunScheduledPreemptionTask(const core::GlobalState &gs, uint16_t currentStratum, bool allowReschedule);
+    PreemptionTask::RunResult tryRunScheduledPreemptionTask(const core::GlobalState &gs, uint16_t currentStratum,
+                                                            bool allowReschedule);
     // Run only from processing thread.
     // Tries to cancel the scheduled preemption task. Returns true if it succeeds.
     bool tryCancelScheduledPreemptionTask(std::shared_ptr<PreemptionTask> &task);

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -679,18 +679,33 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
             timeit.clone("slow_path.blocking_time");
 
             // [Test only] Wait for a preemption if one is expected.
-            while (updates.preemptionsExpected > 0) {
+            if (updates.preemptionsExpected > 0) {
                 auto loopStartTime = Timer::clock_gettime_coarse();
                 auto coarseThreshold = Timer::get_clock_threshold_coarse();
-                while (
-                    !preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true)) {
-                    auto curTime = Timer::clock_gettime_coarse();
-                    if (curTime.usec - loopStartTime.usec > 20'000'000) {
-                        Exception::raise("Slow path timed out waiting for preemption edit");
+                while (updates.preemptionsExpected > 0) {
+                    auto result = preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum,
+                                                                                /* allowReschedule */ true);
+
+                    if (!result.progress()) {
+                        auto curTime = Timer::clock_gettime_coarse();
+                        if (curTime.usec - loopStartTime.usec > 20'000'000) {
+                            Exception::raise("Slow path timed out waiting for preemption edit");
+                        }
+                        Timer::timedSleep(coarseThreshold, *logger, "slow_path.expected_preemption.sleep");
+                        continue;
                     }
-                    Timer::timedSleep(coarseThreshold, *logger, "slow_path.expected_preemption.sleep");
+
+                    if (result.tasksHandled) {
+                        updates.preemptionsExpected--;
+                    }
+
+                    // If we've been rescheduled to a later strautm, there's no way that we'll satisfy all the
+                    // expected preemptions at this point.
+                    if (result.rescheduled.has_value()) {
+                        ENFORCE(*result.rescheduled > currentStratum);
+                        break;
+                    }
                 }
-                updates.preemptionsExpected--;
             }
 
             // [Test only] Wait for a cancellation if one is expected.
@@ -704,11 +719,17 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
                     }
                     Timer::timedSleep(coarseThreshold, *logger, "slow_path.expected_cancellation.sleep");
                 }
+                ENFORCE(updates.preemptionsExpected == 0);
                 return currentStratum;
             }
 
             auto sorted = sortParsedFiles(*gs, *errorReporter, move(maybeResolved.result()));
             pipeline::typecheck(*gs, move(sorted), config->opts, workers, cancelable, currentStratum, preemptManager);
+        }
+
+        // [Test only] Ensure that we handled all expected preemptions
+        if (updates.preemptionsExpected > 0) {
+            Exception::raise("Slow path failed to handle all expected preemptions");
         }
 
         return currentStratum;

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -679,7 +679,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
             timeit.clone("slow_path.blocking_time");
 
             // [Test only] Wait for a preemption if one is expected.
-            if (updates.preemptionsExpected > 0) {
+            if (updates.preemptionsExpected > 0) [[unlikely]] {
                 auto loopStartTime = Timer::clock_gettime_coarse();
                 auto coarseThreshold = Timer::get_clock_threshold_coarse();
                 while (updates.preemptionsExpected > 0) {
@@ -695,14 +695,14 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
                         continue;
                     }
 
-                    if (result.tasksHandled) {
+                    if (result.getTasksHandled()) {
                         updates.preemptionsExpected--;
                     }
 
                     // If we've been rescheduled to a later strautm, there's no way that we'll satisfy all the
                     // expected preemptions at this point.
-                    if (result.rescheduled.has_value()) {
-                        ENFORCE(*result.rescheduled > currentStratum);
+                    if (result.wasRescheduled()) {
+                        ENFORCE(result.getRescheduledStratum() > currentStratum);
                         break;
                     }
                 }
@@ -719,7 +719,6 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
                     }
                     Timer::timedSleep(coarseThreshold, *logger, "slow_path.expected_cancellation.sleep");
                 }
-                ENFORCE(updates.preemptionsExpected == 0);
                 return currentStratum;
             }
 
@@ -728,7 +727,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
         }
 
         // [Test only] Ensure that we handled all expected preemptions
-        if (updates.preemptionsExpected > 0) {
+        if (updates.preemptionsExpected > 0) [[unlikely]] {
             Exception::raise("Slow path failed to handle all expected preemptions");
         }
 

--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -191,7 +191,7 @@ public:
             }
 
             prodCategoryCounterInc("lsp.messages.processed", task->methodString());
-            result.tasksHandled = true;
+            result.setTasksHandled();
 
             if (task->finalPhase() == LSPTask::Phase::INDEX) {
                 continue;

--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -165,7 +165,9 @@ public:
         }
     }
 
-    optional<uint16_t> run(uint16_t currentStratum) override {
+    RunResult run(uint16_t currentStratum) override {
+        RunResult result;
+
         // Destruct timer, if specified. Causes metric to be reported.
         this->timeUntilRun = nullptr;
 
@@ -187,7 +189,9 @@ public:
                     task->index(indexer);
                 }
             }
+
             prodCategoryCounterInc("lsp.messages.processed", task->methodString());
+            result.tasksHandled = true;
 
             if (task->finalPhase() == LSPTask::Phase::INDEX) {
                 continue;
@@ -197,7 +201,7 @@ public:
             task->run(this->delegate);
         }
 
-        return nullopt;
+        return result;
     }
 
     void finish() override {

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -115,7 +115,9 @@ public:
     CountingTask(shared_ptr<core::lsp::PreemptionTaskManager> preemptManager, core::GlobalState &gs)
         : preemptManager(move(preemptManager)), gs(gs) {}
 
-    optional<uint16_t> run(uint16_t currentStratum) override {
+    RunResult run(uint16_t currentStratum) override {
+        RunResult result;
+
         // The task should run with typecheck mutex held with a write lock.
         preemptManager->assertTypecheckMutexHeld();
         // Emulate behavior of most LSP Tasks and drain all diagnostics and query responses.
@@ -123,7 +125,9 @@ public:
         gs.errorQueue->flushAllErrors(gs);
         runCount++;
 
-        return nullopt;
+        result.tasksHandled = true;
+
+        return result;
     }
 };
 
@@ -388,18 +392,22 @@ public:
 
     ReschedulingTask(uint16_t targetStratum) : targetStratum{targetStratum} {}
 
-    optional<uint16_t> run(uint16_t currentStratum) override {
+    RunResult run(uint16_t currentStratum) override {
+        RunResult result;
+
         CHECK_FALSE(this->successful);
 
         this->runCount++;
 
         if (this->targetStratum > currentStratum) {
-            return this->targetStratum;
+            result.rescheduled = this->targetStratum;
+            return result;
         }
 
+        result.tasksHandled = true;
         this->successful = true;
 
-        return nullopt;
+        return result;
     }
 };
 

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -351,7 +351,8 @@ TEST_CASE("PreemptionTasksWorkAsExpected") {
 
     // No preemption task registered.
     uint16_t currentStratum = 0;
-    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
+    CHECK_FALSE(
+        preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
 
     auto task = make_shared<CountingTask>(preemptManager, *gs);
     // Should fail because a slow path is not running, so there's nothing to preempt.
@@ -367,7 +368,7 @@ TEST_CASE("PreemptionTasksWorkAsExpected") {
     CHECK(preemptManager->trySchedulePreemptionTask(task));
 
     // This should run + clear the scheduled task.
-    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
+    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
     CHECK_EQ(1, task->runCount);
 
     // Our error should still be there.
@@ -425,7 +426,8 @@ TEST_CASE("PreemptionReschedulingWorksAsExpected") {
 
     // No preemption task registered.
     uint16_t currentStratum = 0;
-    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
+    CHECK_FALSE(
+        preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
 
     auto task = make_shared<ReschedulingTask>(2);
 
@@ -437,22 +439,24 @@ TEST_CASE("PreemptionReschedulingWorksAsExpected") {
     CHECK(preemptManager->trySchedulePreemptionTask(task));
 
     // This should run scheduled task, but not clear it.
-    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
+    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
     CHECK_EQ(1, task->runCount);
 
     // This should not run the scheduled task, as we haven't made it to stratum 2 yet.
     ++currentStratum;
-    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
+    CHECK_FALSE(
+        preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
     CHECK_EQ(1, task->runCount);
 
     // This should run and clear the task.
     ++currentStratum;
-    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
+    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
     CHECK_EQ(2, task->runCount);
 
     // Running at stratum 3 should show no preemption tasks run
     ++currentStratum;
-    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
+    CHECK_FALSE(
+        preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
     CHECK_EQ(2, task->runCount);
     CHECK(task->successful);
 
@@ -477,7 +481,8 @@ TEST_CASE("RescheduledPreemptionTasksClearOnCancelation") {
 
     // No preemption task registered.
     uint16_t currentStratum = 0;
-    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
+    CHECK_FALSE(
+        preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
 
     auto task = make_shared<ReschedulingTask>(2);
 
@@ -489,12 +494,12 @@ TEST_CASE("RescheduledPreemptionTasksClearOnCancelation") {
     CHECK(preemptManager->trySchedulePreemptionTask(task));
 
     // This should run scheduled task, but not clear it.
-    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
+    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
     CHECK_EQ(1, task->runCount);
 
     // If we cancel at this point and schedule a new task, that should be successful.
     CHECK(gs->epochManager->tryCancelSlowPath(3));
-    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ false));
+    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ false).progress());
 
     // Allow the task to be scheduled again, now that cancellation has run and we've cleared out the preemption task
     // slot.
@@ -524,7 +529,8 @@ TEST_CASE("RescheduledPreemptionTasksClearOnSuccess") {
 
     // No preemption task registered.
     uint16_t currentStratum = 0;
-    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
+    CHECK_FALSE(
+        preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
 
     auto task = make_shared<ReschedulingTask>(2);
 
@@ -537,7 +543,8 @@ TEST_CASE("RescheduledPreemptionTasksClearOnSuccess") {
 
     CHECK(gs->epochManager->tryCommitEpoch(*gs, 2, true, preemptManager, [&]() {
         // This should run scheduled task, but not clear it.
-        CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
+        CHECK(
+            preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
         CHECK_EQ(1, task->runCount);
         return 2;
     }));
@@ -566,7 +573,8 @@ TEST_CASE("RescheduledPreemptionTasksClearOnSuccessWrongStratum") {
 
     // No preemption task registered.
     uint16_t currentStratum = 0;
-    CHECK_FALSE(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
+    CHECK_FALSE(
+        preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
 
     auto task = make_shared<ReschedulingTask>(2);
 
@@ -579,7 +587,8 @@ TEST_CASE("RescheduledPreemptionTasksClearOnSuccessWrongStratum") {
 
     CHECK(gs->epochManager->tryCommitEpoch(*gs, 2, true, preemptManager, [&]() {
         // This should run scheduled task, but not clear it.
-        CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true));
+        CHECK(
+            preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
         CHECK_EQ(1, task->runCount);
         return 1;
     }));

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -125,7 +125,7 @@ public:
         gs.errorQueue->flushAllErrors(gs);
         runCount++;
 
-        result.tasksHandled = true;
+        result.setTasksHandled();
 
         return result;
     }
@@ -401,11 +401,11 @@ public:
         this->runCount++;
 
         if (this->targetStratum > currentStratum) {
-            result.rescheduled = this->targetStratum;
+            result.setRescheduledStratum(this->targetStratum);
             return result;
         }
 
-        result.tasksHandled = true;
+        result.setTasksHandled();
         this->successful = true;
 
         return result;


### PR DESCRIPTION
This PR sets us up for allowing the `preemptionsExpected` assertion to work with package-directed mode. Notably, it modifies the signature of `PreemptionTaskManager::tryRunScheduledPreemptionTask` and `PreemptionTask::run` to return more information about what the `PreemptionTask` did, so that it's now possible to differentiate between the following cases:

1. no preemption task ran,
2. the preemption task ran and consumed all tasks in the queue that support preemption,
3. the preemption task consumed some tasks and reschedule for later, and
4. the preemption task consumed no tasks but did reschedule for later.

Previously we assumed that preemption would happen in exactly one spot during the slow path: right before typechecking. With package-directed mode, we'll run preemption during typechecking for each stratum instead, which means we can't guarantee that we can sit there and churn through all expected preemption tasks before the first call to `pipeline::typecheck`. This PR also modifies that test point in the slow path to detect the case where preemption was rescheduled, to know that it's not going to be able to satisfy the `preemptionsExpected` assertion yet.

### Motivation
Testing package-directed preemption.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See updated tests.
