### PR TITLE
When Sorbet is called with `-a`, don't render errors with autocorrects as red

### DIFF
--- a/core/Error.cc
+++ b/core/Error.cc
@@ -174,9 +174,12 @@ string Error::toString(const GlobalState &gs) const {
         buf << "[" << pkgName << "] ";
     }
 
+    // Sorbet was called with -a, and this error has autocorrects for it. In that case, let's not render the error
+    // header in red, so the user can focus on the errors that don't have an autocorrect associated with them.
+    auto autocorrectApplied = gs.autocorrect && !autocorrects.empty();
     buf << FILE_POS_STYLE << loc.filePosToString(gs) << RESET_STYLE << ": " << ERROR_COLOR
-        << restoreColors(header, ERROR_COLOR) << RESET_COLOR << LOW_NOISE_COLOR << " " << gs.errorUrlBase << what.code
-        << RESET_COLOR;
+        << restoreColors(header, autocorrectApplied ? RESET_COLOR : ERROR_COLOR) << RESET_COLOR << LOW_NOISE_COLOR
+        << " " << gs.errorUrlBase << what.code << RESET_COLOR;
     if (loc.exists()) {
         auto fileLength = loc.file().data(gs).source().size();
         if (loc.beginPos() > fileLength || loc.endPos() > fileLength) {

--- a/core/Error.cc
+++ b/core/Error.cc
@@ -21,6 +21,7 @@ using namespace std;
 namespace {
 
 constexpr auto ERROR_COLOR = rang::fg::red;
+constexpr auto SUCCESS_COLOR = rang::fg::green;
 constexpr auto LOW_NOISE_COLOR = rang::fgB::black;
 constexpr auto DETAIL_COLOR = rang::fg::yellow;
 constexpr auto RESET_COLOR = rang::fg::reset;
@@ -116,7 +117,8 @@ string ErrorSection::toString(const GlobalState &gs) const {
         } else {
             formattedHeader = this->header;
         }
-        buf << indent << DETAIL_COLOR << restoreColors(formattedHeader, DETAIL_COLOR) << RESET_COLOR;
+        auto color = gs.autocorrect ? SUCCESS_COLOR : DETAIL_COLOR;
+        buf << indent << color << restoreColors(formattedHeader, color) << RESET_COLOR;
     } else {
         skipEOL = true;
     }

--- a/core/Error.cc
+++ b/core/Error.cc
@@ -178,6 +178,8 @@ string Error::toString(const GlobalState &gs) const {
 
     // Sorbet was called with -a, and this error has autocorrects for it. In that case, let's not render the error
     // header in red, so the user can focus on the errors that don't have an autocorrect associated with them.
+    // TODO(neil): We might also want to reorder how the error and autocorrect is presented to make it even more
+    // obvious. For example, showing the autocorrect at the top level and nesting the error underneath.
     auto autocorrectApplied = gs.autocorrect && !autocorrects.empty();
     buf << FILE_POS_STYLE << loc.filePosToString(gs) << RESET_STYLE << ": " << ERROR_COLOR
         << restoreColors(header, autocorrectApplied ? RESET_COLOR : ERROR_COLOR) << RESET_COLOR << LOW_NOISE_COLOR


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

If the error has an autocorrect, then we're going to fix it for the user, so it shouldn't be shown as equal importance as errors that don't have an autocorrect for them. Making them all red doesn't provide that seperation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Manual testing.

Without `-a`:
<img width="1282" height="785" alt="image" src="https://github.com/user-attachments/assets/eed48ce9-8b95-4bdb-b7a2-e4ecbcdb998f" />

With `-a`:
<img width="1286" height="785" alt="image" src="https://github.com/user-attachments/assets/b78b0357-944a-4e0c-a447-6e58b1b19e3d" />

