### PR TITLE
Add a helper in DidChangeConfigurationTask

### DIFF
--- a/main/lsp/notifications/did_change_configuration.cc
+++ b/main/lsp/notifications/did_change_configuration.cc
@@ -21,12 +21,24 @@ void DidChangeConfigurationTask::index(LSPIndexer &indexer) {
     indexer.updateConfigAndGsFromOptions(*params);
 }
 
-void DidChangeConfigurationTask::run(LSPTypecheckerDelegate &tc) {
-    tc.updateConfigAndGsFromOptions(*params);
+namespace {
+
+vector<core::FileRef> getOpenFileRefs(const LSPTypecheckerDelegate &tc, absl::Span<const string_view> openFilePaths) {
     vector<core::FileRef> openFileRefs;
-    for (auto const &path : openFilePaths) {
+    openFileRefs.reserve(openFilePaths.size());
+
+    for (auto path : openFilePaths) {
         openFileRefs.push_back(tc.state().findFileByPath(path));
     }
+
+    return openFileRefs;
+}
+
+} // namespace
+
+void DidChangeConfigurationTask::run(LSPTypecheckerDelegate &tc) {
+    tc.updateConfigAndGsFromOptions(*params);
+    auto openFileRefs = getOpenFileRefs(tc, this->openFilePaths);
     auto updates = tc.getNoopUpdate(openFileRefs);
     updates->epoch = epoch;
     tc.typecheckOnFastPath(std::move(updates), {});


### PR DESCRIPTION
Add a helper for building a vector of file refs in `DidChangeConfigurationTask`.

### Motivation
Preparation for landing package-directed preemption.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Refactoring change only.
