### PR TITLE
gen-packages: don't insert multiple `visible_to`s when the package is referenced in multiple files

### DIFF
--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -687,7 +687,7 @@ PackageInfo::aggregateMissingExports(const core::GlobalState &gs, vector<core::S
 }
 
 std::optional<core::AutocorrectSuggestion> PackageInfo::aggregateMissingVisibleTo(
-    const core::GlobalState &gs, std::vector<core::packages::MangledName> &visibleTos, bool visibleToTests) const {
+    const core::GlobalState &gs, UnorderedSet<core::packages::MangledName> &visibleTos, bool visibleToTests) const {
     std::vector<core::AutocorrectSuggestion::Edit> allEdits;
     for (auto &pkgName : visibleTos) {
         auto autocorrect = addVisibleTo(gs, pkgName);

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -335,7 +335,7 @@ public:
     std::optional<core::AutocorrectSuggestion> aggregateMissingExports(const core::GlobalState &gs,
                                                                        std::vector<core::SymbolRef> &toExport) const;
     std::optional<core::AutocorrectSuggestion>
-    aggregateMissingVisibleTo(const core::GlobalState &gs, std::vector<core::packages::MangledName> &visibleTos,
+    aggregateMissingVisibleTo(const core::GlobalState &gs, UnorderedSet<core::packages::MangledName> &visibleTos,
                               bool visibleToTests) const;
 
     std::string renderPackageRbContents(const core::GlobalState &gs, std::vector<Import> newImports,

--- a/packager/GenPackages.cc
+++ b/packager/GenPackages.cc
@@ -169,7 +169,7 @@ void GenPackages::run(core::GlobalState &gs) {
 
     auto toExport = computeToExport(gs);
 
-    auto neededVisibleTo = UnorderedMap<core::packages::MangledName, vector<core::packages::MangledName>>{};
+    auto neededVisibleTo = UnorderedMap<core::packages::MangledName, UnorderedSet<core::packages::MangledName>>{};
     auto neededVisibleToTests = UnorderedMap<core::packages::MangledName, bool>{};
     if (gs.packageDB().anyUpdateVisibilityFor()) {
         Timer timeit(gs.tracer(), "gen_packages.run.build_needed_visible_to");
@@ -198,7 +198,7 @@ void GenPackages::run(core::GlobalState &gs) {
                                 neededVisibleToTests[referencedPackageName] = true;
                             } else {
                                 // Otherwise, add `visible_to pkgName`
-                                neededVisibleTo[referencedPackageName].push_back(pkgName);
+                                neededVisibleTo[referencedPackageName].insert(pkgName);
                             }
                         }
                     }

--- a/test/cli/package-gen-packages/C/lib.rb
+++ b/test/cli/package-gen-packages/C/lib.rb
@@ -1,0 +1,10 @@
+# typed: strict
+
+module C
+  class Lib
+    def self.run
+      puts B::CONSTANT_FROM_B
+      puts E::CONSTANT_FROM_E
+    end
+  end
+end

--- a/test/cli/package-gen-packages/test.out
+++ b/test/cli/package-gen-packages/test.out
@@ -28,7 +28,6 @@ B/__package.rb:3: `B` is missing `visible_to`s https://srb.help/3734
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     B/__package.rb:9: Inserted `visible_to C
-      visible_to C
       visible_to D`
      9 |  visible_to A
                       ^
@@ -59,7 +58,6 @@ E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     E/__package.rb:7: Inserted `visible_to 'tests'
-      visible_to C
       visible_to C`
      7 |  export E::CONSTANT_FROM_E
                                    ^
@@ -107,7 +105,6 @@ class B < PackageSpec
 
   visible_to A
   visible_to C
-  visible_to C
   visible_to D
   visible_to G
 end
@@ -150,7 +147,6 @@ class E < PackageSpec
   export E::CONSTANT_FROM_E
   visible_to 'tests'
   visible_to C
-  visible_to C
 end
 ##############################
 ###### Package directed ######
@@ -162,7 +158,6 @@ B/__package.rb:3: `B` is missing `visible_to`s https://srb.help/3734
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     B/__package.rb:9: Inserted `visible_to C
-      visible_to C
       visible_to D`
      9 |  visible_to A
                       ^
@@ -193,7 +188,6 @@ E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     E/__package.rb:7: Inserted `visible_to 'tests'
-      visible_to C
       visible_to C`
      7 |  export E::CONSTANT_FROM_E
                                    ^
@@ -254,7 +248,6 @@ class B < PackageSpec
 
   visible_to A
   visible_to C
-  visible_to C
   visible_to D
   visible_to G
 end
@@ -296,6 +289,5 @@ class E < PackageSpec
 
   export E::CONSTANT_FROM_E
   visible_to 'tests'
-  visible_to C
   visible_to C
 end

--- a/test/cli/package-gen-packages/test.out
+++ b/test/cli/package-gen-packages/test.out
@@ -28,6 +28,7 @@ B/__package.rb:3: `B` is missing `visible_to`s https://srb.help/3734
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     B/__package.rb:9: Inserted `visible_to C
+      visible_to C
       visible_to D`
      9 |  visible_to A
                       ^
@@ -58,6 +59,7 @@ E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     E/__package.rb:7: Inserted `visible_to 'tests'
+      visible_to C
       visible_to C`
      7 |  export E::CONSTANT_FROM_E
                                    ^
@@ -105,6 +107,7 @@ class B < PackageSpec
 
   visible_to A
   visible_to C
+  visible_to C
   visible_to D
   visible_to G
 end
@@ -147,6 +150,7 @@ class E < PackageSpec
   export E::CONSTANT_FROM_E
   visible_to 'tests'
   visible_to C
+  visible_to C
 end
 ##############################
 ###### Package directed ######
@@ -158,6 +162,7 @@ B/__package.rb:3: `B` is missing `visible_to`s https://srb.help/3734
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     B/__package.rb:9: Inserted `visible_to C
+      visible_to C
       visible_to D`
      9 |  visible_to A
                       ^
@@ -188,6 +193,7 @@ E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     E/__package.rb:7: Inserted `visible_to 'tests'
+      visible_to C
       visible_to C`
      7 |  export E::CONSTANT_FROM_E
                                    ^
@@ -248,6 +254,7 @@ class B < PackageSpec
 
   visible_to A
   visible_to C
+  visible_to C
   visible_to D
   visible_to G
 end
@@ -289,5 +296,6 @@ class E < PackageSpec
 
   export E::CONSTANT_FROM_E
   visible_to 'tests'
+  visible_to C
   visible_to C
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Review commit-by-commit to see the bug.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Don't add duplicate `visible_to`s


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
