### PR TITLE
Fix crash from `ClassDef` in constant lit scope

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -682,6 +682,18 @@ public:
             }
         }
     }
+
+    void postTransformUnresolvedConstantLit(core::Context ctx, ast::ExpressionPtr &tree) {
+        auto &scope = ast::cast_tree_nonnull<ast::UnresolvedConstantLit>(tree).scope;
+        ast::TreeWalk::apply(ctx, *this, scope);
+    }
+
+    void postTransformConstantLit(core::Context ctx, ast::ExpressionPtr &tree) {
+        auto original = ast::cast_tree_nonnull<ast::ConstantLit>(tree).original();
+        if (original != nullptr) {
+            ast::TreeWalk::apply(ctx, *this, original->scope);
+        }
+    }
 };
 
 using BehaviorLocs = InlinedVector<core::Loc, 1>;

--- a/test/testdata/resolver/fuzz_ancestor.rb
+++ b/test/testdata/resolver/fuzz_ancestor.rb
@@ -19,3 +19,10 @@ class A
   #          ^ error: `include` must only contain constant literals
   #          ^ error: Method `c` does not exist on `T.class_of(A)`
 end
+
+  (class A < 0;end)::B
+  #          ^ error: Superclasses must only contain constant literals
+# ^^^^^^^^^^^^^^^^^^^^ error: Dynamic constant references are unsupported
+  (class A < puts;end)::B
+  #          ^^^^ error: Superclasses must only contain constant literals
+# ^^^^^^^^^^^^^^^^^^^^^^^ error: Dynamic constant references are unsupported


### PR DESCRIPTION
The `TreeWalk` code for `UnresolvedConstantLit` doesn't automatically
recurse on `scope`, nor does `ConstantLit` recurse on `original`.

I have thought about whether it makes sense to fix this in the treemap
code in the past. For example, I had to fix another similar class of bug
in aa7efabde8e750d534e22440a93a515c65788188 (in resolver). I had written
this:

> * Recover better from "Dynamic constant ref" errors
>
> Our current pipeline would basically entirely ignore the dynamic
> scopes for code like
>
>     x.foo::BAR
>
> That's usually fine for Sorbet (Sorbet codebases have to accept this
> limitation of Sorbet), except that it can happen as a result of a
> partially written Ruby file, e.g.
>
>     x.
>     Foo::Bar
>
> Our parser sees this as `x.Foo()::Bar` as is (without extra error
> recovery), and in particular we would like to be able to see the `x.`
> as the start of a method call whose method name hasn't been provided
> yet.
>
> The solution is to make sure that even if we aren't going to attempt
> to ingest the `x.Foo()` for the purpose of constant resolution, we
> should at least let is fall through infer so that `x` gets assigned a
> type.
>
> A note about the implementation below: it appears that our TreeMap
> abstraction only allows post-transforms on `UnresolvedConstantLit`,
> and doesn't recursively map over the `scope` field. I noticed that
> `Substitute.cc` gets around this by just doing the `TreeMap::apply`
> directly, which works for us too. My first attempt was to build out
> `TreeMap` to recurse over the scopes, but this seemed less invasive.

It's unclear to me the ramifications of doing this for all treemaps.
Many places are already doing the right thing by recursing manually, or
actually don't want to recurse (such that recursing would be wasteful).
Especially given how absurdly common constant literals are in our
codebase, I worry that recursing everywhere by default might be the
wrong choice.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #10200


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The included test crashes on master.