### PR TITLE
Guard against failing to spawn rubyfmt

### DIFF
--- a/common/Subprocess.cc
+++ b/common/Subprocess.cc
@@ -154,5 +154,11 @@ optional<sorbet::Subprocess::Result> sorbet::Subprocess::spawn(string executable
         return nullopt;
     }
 
+    if (!WIFEXITED(childStatus)) {
+        // Child was killed by a signal (e.g., segfault, abort). WEXITSTATUS is
+        // only valid when WIFEXITED is true.
+        return nullopt;
+    }
+
     return sorbet::Subprocess::Result{sink.str(), WEXITSTATUS(childStatus)};
 }

--- a/main/lsp/requests/document_formatting.cc
+++ b/main/lsp/requests/document_formatting.cc
@@ -91,6 +91,12 @@ void DocumentFormattingTask::preprocess(LSPPreprocessor &preprocessor) {
         auto originalLineCount = findLineBreaks(sourceView).size();
         auto processResponse = sorbet::Subprocess::spawn(config.opts.rubyfmtPath, vector<string>(), sourceView);
 
+        if (!processResponse.has_value()) {
+            displayError(fmt::format("`rubyfmt` crashed or failed to run while formatting {}.", path), response);
+            config.output->write(move(response));
+            return;
+        }
+
         auto returnCode = processResponse->status;
         auto formattedContents = processResponse->output;
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #10199 

There are plenty of cases where `Subprocess::spawn` fails in ways that
aren't a non-zero exit code from running the process. It's not clear what
to do if one of these happens: let's just show the user it failed.

This is at least better than before, because before we would dereference
`processResponse->status`, which would be a `nullopt` and we'd crash the
`rubyfmt` process.

I was hoping that this might be able to explain our problem where
`rubyfmt` sometimes hangs, but I couldn't reproduce that behavior before
making these changes.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This codepath seems to have no automated tests. The only tests of rubyfmt that
we have are we run all LSP tests with a `rubyfmtPath` of
`test/testdata/lsp/rubyfmt-stub/rubyfmt`, which is a shell script that supports
`rubyfmt-force-exit: ...` annotations in the file. But the process spawning
logic itself is never stress tested, because the file always exists, has the
right permissions, never dies with a signal failure, etc.

I tried testing some cases manually, but I'm not 100% sure how this could
happen. I tried two things:

- `rubyfmt` exists but has not been `chmod +x`'d. Sorbet was able to see
  an error and report that via the `displayError`.

- `rubyfmt` exists but is a bash script that does `kill -SIGABRT $$`.
  This actually didn't crash: Sorbet just replaced the contents of the
  file with an empty string.

That made me wonder if the behavior is OS-specific (we are relying on libc
APIs, so macOS would have a different implementation from Linux).