### PR TITLE
Fix crash in lexer around tNL tokens

### DIFF
--- a/parser/parser/cc/driver.cc
+++ b/parser/parser/cc/driver.cc
@@ -153,6 +153,15 @@ ForeignPtr base_driver::rewind_and_munge_body_if_dedented(SelfPtr self, token_t 
         // But bodyStartToken is tNL if empty body, which fails the assertion in compare_indent_level
         this->rewind_to_tok_start(endToken);
         return body;
+    } else if (bodyStartToken->type() == token_type::tNL) {
+        // There are some cases where the file is so messed up that the parse is very unexpected.
+        // The `tNL` token can sneak in when the grammar decided to produce an empty `stmts`. When
+        // there's an empty production, the @$ (the yyloc information) uses whatever happened to be
+        // the most recent token, which might be a `tNL`. `compare_indent_level` only works when
+        // comparing non-`tNL` tokens, so we actually need to be very defensive against there being
+        // sneaky tNL tokens. Give up, and say that the method body was properly indented
+        this->rewind_to_tok_start(endToken);
+        return body;
     } else if (this->lex.compare_indent_level(bodyStartToken, beginToken) <= 0) {
         // Not even the very first thing in the body is indented. Treat this like empty method.
         this->rewind_and_reset(headerEndPos);

--- a/test/BUILD
+++ b/test/BUILD
@@ -317,6 +317,7 @@ pipeline_tests(
             "testdata/parser/error_recovery/constant_only_scope.rb",
             "testdata/parser/error_recovery/def_missing_end_1.rb",
             "testdata/parser/error_recovery/def_missing_end_2.rb",
+            "testdata/parser/error_recovery/def_reswords.rb",
             "testdata/parser/error_recovery/defn_indent_1.rb",
             "testdata/parser/error_recovery/defn_indent_2.rb",
             "testdata/parser/error_recovery/defn_indent_3.rb",

--- a/test/testdata/parser/error_recovery/def_reswords.rb
+++ b/test/testdata/parser/error_recovery/def_reswords.rb
@@ -1,0 +1,5 @@
+# typed: false
+  def
+# ^^^ error: Hint: this "def" token might not be followed by a method name
+# ^^^ error: Hint: this "def" token is not closed before the end of the file
+  ensure # error: "end of file"


### PR DESCRIPTION
### Commit summary

- **Add failing test** (7ce5ca23d5)

  Wanted to make sure that it crashes even with the `# error` comments and
  `# typed:` sigil. The minimal test is just

  ```ruby
  def
    ensure
  ```

- **Admit defeat** (636a896e49)

  I thought for a while about how to fix this in a better way. The root
  failure is that we hit an assertion in `compare_indent_level` that says
  "it only makes sense to compare the indentation level of two tokens if
  they're not `tNL` tokens." Adding this guard here basicaly weakens that
  assertion.

  It would have been better if we could have figured out how to get the
  `bodyStartToken` to not be `tNL`, but I'm sort of coming to the
  conclusion that due to empty production rules, it could kind of sneak in
  from anywhere. If the grammar decides to make an empty production, bison
  will use whatever the most recently lexed token was for the empty stmts'
  `@$` loc. We _could_ change the default, so that they're initialized as
  `nullptr` in that case possibly? But I think to do that we would have to
  write code in every empty production rule (possibly, didn't think too
  hard about that).

  In any case, I think it's probably just safer to be defensive,
  especially if we're hoping that this code doesn't live very long. I've
  already verified that Prism is able to recover well enough on this
  input, so we should just not crash.

- **Ignore this test** (16d317dd9b)

  Prism thinks this is a method `def ensure` with an empty body.

  Sorbet thinks this is a method `def <method-def-name-missing>` with a
  body containing `<ErrorNode>`.

  ```diff
  test/pipeline_test_runner.cc:321: ERROR: Prism desugared tree does not match legacy desugared tree
  @@ -12,7 +12,7 @@
       MethodDef{
         loc = 2:3-6:1
         flags = {}
  -      name = <U <method-def-name-missing>><<U <todo method>>>
  +      name = <U ensure><<U <todo method>>>
         args = [BlockParam{ loc = , expr = UnresolvedIdent{
             loc =
             kind = Local
  @@ -19,13 +19,10 @@
             name = <U <blk>>
           } }]
  -      rhs = Rescue{
  -        loc = 5:3-5:9
  -        body = EmptyTree
  -        rescueCases = [
  -        ]
  -        else = EmptyTree
  -        ensure = EmptyTree
  +      rhs = ConstantLit{
  +        loc = 182-205
  +        symbol = (static-field ::<ErrorNode>)
  +        orig = nullptr
         }
       }
     ]
   }
  ```


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #10201


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.