### PR TITLE
Add a newtype for Stratum

### DIFF
--- a/core/lsp/PreemptionTask.h
+++ b/core/lsp/PreemptionTask.h
@@ -2,8 +2,7 @@
 #define SORBET_LSP_PREEMPTION_TASK_H
 
 #include "common/common.h"
-#include <cstdint>
-#include <optional>
+#include "core/packages/Stratum.h"
 
 namespace sorbet::core::lsp {
 // Generic interface for tasks that can run at preemption points.
@@ -27,7 +26,7 @@ public:
         bool tasksHandled_ = false;
         bool wasRescheduled_ = false;
 
-        uint16_t rescheduled = 0;
+        packages::Stratum rescheduled;
 
     public:
         RunResult() = default;
@@ -43,14 +42,14 @@ public:
         }
 
         // Indicate that the preemption task would like to be run again at the provided stratum.
-        void setRescheduledStratum(uint16_t stratum) {
+        void setRescheduledStratum(packages::Stratum stratum) {
             this->wasRescheduled_ = true;
             this->rescheduled = stratum;
         }
 
         // Fetch the stratum that the preemption task requested to be rescheduled to (only valid if
         // `setRescheduledStratum` has been called).
-        uint16_t getRescheduledStratum() const {
+        packages::Stratum getRescheduledStratum() const {
             ENFORCE(this->wasRescheduled_);
             return this->rescheduled;
         }
@@ -68,7 +67,7 @@ public:
 
     // Run the preemption task. Returning a non-empty result indicates that there is more work to do, and that it can't
     // be done until the stratum indicated.
-    virtual RunResult run(uint16_t currentStratum) = 0;
+    virtual RunResult run(packages::Stratum currentStratum) = 0;
 
     // Optional hook called when the task has been run to completion. Any notification to unblock other threads should
     // be done here to avoid accidentally unblocking work that could interact with the preemption scheduler.

--- a/core/lsp/PreemptionTaskManager.cc
+++ b/core/lsp/PreemptionTaskManager.cc
@@ -33,7 +33,7 @@ bool PreemptionTaskManager::trySchedulePreemptionTask(shared_ptr<PreemptionTask>
         // slot is empty, this should not have any affect on an existing task. However, if there was somehow a task
         // already scheduled that had set `runnableAt`, this would cause it to run again immediately and then
         // potentially defer itself again.
-        runnableAt.store(0);
+        runnableAt.store(packages::Stratum());
 
         success = atomic_compare_exchange_strong(&preemptTask, &existingTask, move(task));
     });
@@ -42,7 +42,7 @@ bool PreemptionTaskManager::trySchedulePreemptionTask(shared_ptr<PreemptionTask>
 }
 
 PreemptionTask::RunResult PreemptionTaskManager::tryRunScheduledPreemptionTask(const core::GlobalState &gs,
-                                                                               uint16_t currentStratum,
+                                                                               packages::Stratum currentStratum,
                                                                                bool allowReschedule) {
     PreemptionTask::RunResult result;
 

--- a/core/lsp/PreemptionTaskManager.h
+++ b/core/lsp/PreemptionTaskManager.h
@@ -3,6 +3,7 @@
 
 #include "core/GlobalState.h"
 #include "core/lsp/PreemptionTask.h"
+#include "core/packages/Stratum.h"
 #include <memory>
 
 namespace sorbet::core::lsp {
@@ -37,7 +38,7 @@ private:
     //    blocked waiting for a notification from the running task's `finish` method. Again, this logic is pretty
     //    specific to the `PreemptionLoop` implementation, but that's also the only non-test implementation of
     //    `PreemeptionTask`.
-    std::atomic<uint16_t> runnableAt = 0;
+    std::atomic<packages::Stratum> runnableAt;
 
 public:
     PreemptionTaskManager(std::shared_ptr<TypecheckEpochManager> epochManager);
@@ -51,8 +52,8 @@ public:
     // cleared out. Otherwise there is the possibility that it might get rescheduled, which would cause problems the
     // next time preemption was scheduled from the main thread. Handles running task with a fresh errorQueue, and
     // restoring previous errorQueue when done.
-    PreemptionTask::RunResult tryRunScheduledPreemptionTask(const core::GlobalState &gs, uint16_t currentStratum,
-                                                            bool allowReschedule);
+    PreemptionTask::RunResult tryRunScheduledPreemptionTask(const core::GlobalState &gs,
+                                                            packages::Stratum currentStratum, bool allowReschedule);
     // Run only from processing thread.
     // Tries to cancel the scheduled preemption task. Returns true if it succeeds.
     bool tryCancelScheduledPreemptionTask(std::shared_ptr<PreemptionTask> &task);

--- a/core/lsp/TypecheckEpochManager.cc
+++ b/core/lsp/TypecheckEpochManager.cc
@@ -63,7 +63,7 @@ bool TypecheckEpochManager::tryCancelSlowPath(uint32_t newEpoch) {
 
 bool TypecheckEpochManager::tryCommitEpoch(core::GlobalState &gs, uint32_t epoch, bool isCancelable,
                                            shared_ptr<PreemptionTaskManager> preemptionManager,
-                                           function<uint16_t()> typecheck) {
+                                           function<packages::Stratum()> typecheck) {
     assertConsistentThread(typecheckingThreadId, "TypecheckEpochManager::tryCommitEpoch", "typechecking");
     if (!isCancelable) {
         typecheck();

--- a/core/lsp/TypecheckEpochManager.h
+++ b/core/lsp/TypecheckEpochManager.h
@@ -2,6 +2,7 @@
 #define SORBET_LSP_TYPECHECKEPOCHMANAGER_H
 
 #include "core/core.h"
+#include "core/packages/Stratum.h"
 #include <cstdint>
 #include <memory>
 
@@ -54,7 +55,8 @@ public:
     // Tries to commit the given epoch. Returns true if the commit succeeded, or false if it was canceled.
     // The presence of PreemptionTaskManager determines if this commit is preemptible.
     bool tryCommitEpoch(core::GlobalState &gs, uint32_t epoch, bool isCancelable,
-                        std::shared_ptr<PreemptionTaskManager> preemptionManager, std::function<uint16_t()> typecheck);
+                        std::shared_ptr<PreemptionTaskManager> preemptionManager,
+                        std::function<packages::Stratum()> typecheck);
     // Grabs the epoch lock, and calls function with the current typechecking status.
     void withEpochLock(std::function<void(TypecheckingStatus)> lambda) const;
 };

--- a/core/packages/Stratum.h
+++ b/core/packages/Stratum.h
@@ -1,0 +1,51 @@
+#ifndef SORBET_CORE_PACKAGES_STRATUM_H
+#define SORBET_CORE_PACKAGES_STRATUM_H
+
+#include <cstdint>
+
+namespace sorbet::core::packages {
+
+// The index of a group of packages in the condensation graph traversal.
+class Stratum {
+    // We use uint16_t here, even though that might seem small, as overflowing a uint16_t would require a non-cyclic
+    // chain of 65535 dependencies in the package graph. At time of writing (2026-04-29), the largest stratum we've
+    // observed has been less than 200, so hopefully we won't need to change this for a long time.
+    uint16_t stratum = 0;
+
+public:
+    Stratum() = default;
+    constexpr explicit Stratum(uint16_t stratum) : stratum{stratum} {}
+
+    // Fetch the raw id
+    constexpr uint16_t rawId() const {
+        return this->stratum;
+    }
+
+    constexpr bool operator==(Stratum other) const {
+        return this->stratum == other.stratum;
+    }
+
+    constexpr bool operator!=(Stratum other) const {
+        return this->stratum != other.stratum;
+    }
+
+    constexpr bool operator<(Stratum other) const {
+        return this->stratum < other.stratum;
+    }
+
+    constexpr bool operator<=(Stratum other) const {
+        return this->stratum <= other.stratum;
+    }
+
+    constexpr bool operator>(Stratum other) const {
+        return this->stratum > other.stratum;
+    }
+
+    constexpr bool operator>=(Stratum other) const {
+        return this->stratum >= other.stratum;
+    }
+};
+
+} // namespace sorbet::core::packages
+
+#endif

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -325,9 +325,7 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
                         : pipeline::incrementalResolve(*gs, move(updatedIndexed), nullopt, config->opts, workers);
     auto sorted = sortParsedFiles(*gs, *errorReporter, move(resolved));
     const auto cancelable = false;
-    // TODO(trevor): ultimately this should be the maximum stratum, but for now this is acceptable.
-    const auto currentStratum = 0;
-    pipeline::typecheck(*gs, move(sorted), config->opts, workers, cancelable, currentStratum, nullptr);
+    pipeline::typecheck(*gs, move(sorted), config->opts, workers, cancelable, this->lastStratum, nullptr);
     gs->lspTypecheckCount++;
 
     auto duration = timeit.setEndTime();
@@ -388,7 +386,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
     auto &epochManager = *this->gs->epochManager;
     // Note: Commits can only be canceled if this edit is cancelable, LSP is running across multiple threads, and the
     // cancelation feature is enabled.
-    auto committed = epochManager.tryCommitEpoch(*this->gs, epoch, cancelable, preemptManager, [&]() -> uint16_t {
+    auto committed = epochManager.tryCommitEpoch(*this->gs, epoch, cancelable, preemptManager, [&]() {
         // Replace error queue with one that is owned by this thread.
         this->gs->errorQueue =
             make_shared<core::ErrorQueue>(this->gs->errorQueue->logger, this->gs->errorQueue->tracer, errorFlusher);
@@ -522,7 +520,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
             // This is a bit of a lie: we haven't gotten the first stratum to a state where we could run preemption
             // tasks yet, but any errors raised by running a preemption action on this incomplete global state will be
             // transient.
-            uint16_t firstStratum = 0;
+            core::packages::Stratum firstStratum(0);
 
             auto numPackageFiles = pipeline::partitionPackageFiles(*this->gs, workspaceFilesSpan);
             auto inputPackageFiles = workspaceFilesSpan.first(numPackageFiles);
@@ -568,15 +566,15 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
         // This is cast to a uint16_t everywhere it's used. This seems bad, but it should be fine because:
         // 1. we increment in the beginning of the loop before any use
         // 2. overflowing a uint16_t would mean that we have a chain of dependencies that's >65535 packages long
-        int currentStratum = -1;
+        int stratumIx = -1;
 
         auto strata = pipeline::computePackageStrata(*this->gs, packageIndexed, workspaceFilesSpan, this->config->opts);
         this->fileToStratum = move(strata.fileToStratum);
-        this->lastStratum = strata.strata.size() - 1;
+        this->lastStratum = core::packages::Stratum(strata.strata.size() - 1);
         for (auto &stratum : strata.strata) {
             vector<ast::ParsedFile> stratumFiles, nonPackagedIndexed;
 
-            ++currentStratum;
+            core::packages::Stratum currentStratum(++stratumIx);
 
             // When we unpartition the package and non-package files, we'll realloc stratumFiles to hold everything.
             stratumFiles.reserve(stratum.packageFiles.size() + stratum.sourceFiles.size());
@@ -731,7 +729,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
             Exception::raise("Slow path failed to handle all expected preemptions");
         }
 
-        return currentStratum;
+        return core::packages::Stratum(stratumIx);
     });
 
     gs->lspQuery = core::lsp::Query::noQuery();
@@ -861,8 +859,8 @@ vector<unique_ptr<core::Error>> LSPTypechecker::retypecheck(vector<core::FileRef
     return errorCollector->drainErrors();
 }
 
-uint16_t LSPTypechecker::getStratumForEdit(absl::Span<const core::FileRef> edit) const {
-    uint16_t stratum = 0;
+core::packages::Stratum LSPTypechecker::getStratumForEdit(absl::Span<const core::FileRef> edit) const {
+    core::packages::Stratum stratum(0);
 
     for (auto fref : edit) {
         if (fref.id() >= this->fileToStratum.size()) {
@@ -1044,7 +1042,7 @@ unique_ptr<LSPFileUpdates> LSPTypecheckerDelegate::getNoopUpdate(absl::Span<cons
     return typechecker.getNoopUpdate(frefs);
 }
 
-uint16_t LSPTypecheckerDelegate::getStratumForEdit(absl::Span<const core::FileRef> edit) const {
+core::packages::Stratum LSPTypecheckerDelegate::getStratumForEdit(absl::Span<const core::FileRef> edit) const {
     return typechecker.getStratumForEdit(edit);
 }
 

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -4,6 +4,7 @@
 #include "ast/ast.h"
 #include "core/ErrorFlusher.h"
 #include "core/core.h"
+#include "core/packages/Stratum.h"
 #include "main/lsp/ErrorReporter.h"
 #include "main/lsp/LSPConfiguration.h"
 #include "main/lsp/LSPFileUpdates.h"
@@ -86,9 +87,9 @@ class LSPTypechecker final {
     bool slowPathBlocked ABSL_GUARDED_BY(slowPathBlockedMutex) = false;
     absl::Mutex slowPathBlockedMutex;
 
-    std::vector<uint16_t> fileToStratum;
+    std::vector<core::packages::Stratum> fileToStratum;
 
-    uint16_t lastStratum = 0;
+    core::packages::Stratum lastStratum;
 
     enum class SlowPathMode {
         Init,
@@ -210,19 +211,19 @@ public:
     /**
      * Get the id of the stratum that an edit involving these files could be checked at.
      */
-    uint16_t getStratumForEdit(absl::Span<const core::FileRef> edit) const;
+    core::packages::Stratum getStratumForEdit(absl::Span<const core::FileRef> edit) const;
 
     /**
      * Get the id of the stratum that an edit involving this file could be checked at.
      */
-    uint16_t getStratumForUri(std::string_view uri) const {
+    core::packages::Stratum getStratumForUri(std::string_view uri) const {
         return this->getStratumForEdit({this->config->uri2FileRef(*this->gs, uri)});
     }
 
     /**
      * Get the id of the last stratum in the condensation graph.
      */
-    uint16_t getLastStratum() const {
+    core::packages::Stratum getLastStratum() const {
         return this->lastStratum;
     }
 };
@@ -270,13 +271,13 @@ public:
 
     void updateConfigAndGsFromOptions(const DidChangeConfigurationParams &options) const;
     std::unique_ptr<LSPFileUpdates> getNoopUpdate(absl::Span<const core::FileRef> frefs) const;
-    uint16_t getStratumForEdit(absl::Span<const core::FileRef> edit) const;
+    core::packages::Stratum getStratumForEdit(absl::Span<const core::FileRef> edit) const;
 
-    uint16_t getLastStratum() const {
+    core::packages::Stratum getLastStratum() const {
         return typechecker.getLastStratum();
     }
 
-    uint16_t getStratumForUri(std::string_view uri) const {
+    core::packages::Stratum getStratumForUri(std::string_view uri) const {
         return typechecker.getStratumForUri(uri);
     }
 };

--- a/main/lsp/LSPTypecheckerCoordinator.cc
+++ b/main/lsp/LSPTypecheckerCoordinator.cc
@@ -165,7 +165,7 @@ public:
         }
     }
 
-    RunResult run(uint16_t currentStratum) override {
+    RunResult run(core::packages::Stratum currentStratum) override {
         RunResult result;
 
         // Destruct timer, if specified. Causes metric to be reported.

--- a/main/lsp/UndoState.cc
+++ b/main/lsp/UndoState.cc
@@ -9,14 +9,15 @@ using namespace std;
 
 namespace sorbet::realmain::lsp {
 UndoState::UndoState(unique_ptr<core::GlobalState> evictedGs, UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS,
-                     vector<uint16_t> fileToStratum, uint16_t lastStratum, const vector<core::FileRef> &workspaceFiles,
-                     uint32_t epoch)
+                     vector<core::packages::Stratum> fileToStratum, core::packages::Stratum lastStratum,
+                     const vector<core::FileRef> &workspaceFiles, uint32_t epoch)
     : evictedGs(move(evictedGs)), evictedIndexedFinalGS(std::move(evictedIndexedFinalGS)),
       fileToStratum{move(fileToStratum)}, lastStratum{lastStratum}, initialWorkspaceFilesSize{workspaceFiles.size()},
       epoch(epoch) {}
 
 void UndoState::restore(unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast::ParsedFile> &indexedFinalGS,
-                        vector<uint16_t> &fileToStratum, uint16_t &lastStratum, vector<core::FileRef> &workspaceFiles) {
+                        vector<core::packages::Stratum> &fileToStratum, core::packages::Stratum &lastStratum,
+                        vector<core::FileRef> &workspaceFiles) {
     indexedFinalGS = std::move(evictedIndexedFinalGS);
     gs = move(evictedGs);
 

--- a/main/lsp/UndoState.h
+++ b/main/lsp/UndoState.h
@@ -4,6 +4,7 @@
 #include "ast/ast.h"
 #include "core/FileHash.h"
 #include "core/core.h"
+#include "core/packages/Stratum.h"
 
 namespace sorbet::realmain::lsp {
 class LSPConfiguration;
@@ -19,10 +20,10 @@ class UndoState final {
     UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS;
 
     // The saved file-to-stratum mapping from the previous slow path.
-    std::vector<uint16_t> fileToStratum;
+    std::vector<core::packages::Stratum> fileToStratum;
 
     // The id of the last stratum in the previous slow path.
-    const uint16_t lastStratum;
+    const core::packages::Stratum lastStratum;
 
     // The size of the workspaceFiles vector when the slow path started. Tracked so that we can roll back additions to
     // the vector from new files added in the canceled edit.
@@ -33,14 +34,14 @@ public:
     const uint32_t epoch;
 
     UndoState(std::unique_ptr<core::GlobalState> evictedGs, UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS,
-              std::vector<uint16_t> fileToStratum, uint16_t lastStratum,
+              std::vector<core::packages::Stratum> fileToStratum, core::packages::Stratum lastStratum,
               const std::vector<core::FileRef> &workspaceFiles, uint32_t epoch);
 
     /**
      * Undoes the slow path changes represented by this class.
      */
     void restore(std::unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast::ParsedFile> &indexedFinalGS,
-                 std::vector<uint16_t> &fileToStratum, uint16_t &lastStratum,
+                 std::vector<core::packages::Stratum> &fileToStratum, core::packages::Stratum &lastStratum,
                  std::vector<core::FileRef> &workspaceFiles);
 
     /**

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -11,6 +11,7 @@
 #include "core/lsp/PreemptionTask.h"
 #include "core/lsp/PreemptionTaskManager.h"
 #include "core/lsp/TypecheckEpochManager.h"
+#include "core/packages/Stratum.h"
 #include "main/lsp/LSPLoop.h"
 #include "main/lsp/LSPOutput.h"
 #include "main/lsp/LSPTask.h"
@@ -115,7 +116,7 @@ public:
     CountingTask(shared_ptr<core::lsp::PreemptionTaskManager> preemptManager, core::GlobalState &gs)
         : preemptManager(move(preemptManager)), gs(gs) {}
 
-    RunResult run(uint16_t currentStratum) override {
+    RunResult run(core::packages::Stratum currentStratum) override {
         RunResult result;
 
         // The task should run with typecheck mutex held with a write lock.
@@ -350,7 +351,7 @@ TEST_CASE("PreemptionTasksWorkAsExpected") {
                                       vector<core::ErrorSection>(), vector<core::AutocorrectSuggestion>(), false));
 
     // No preemption task registered.
-    uint16_t currentStratum = 0;
+    core::packages::Stratum currentStratum(0);
     CHECK_FALSE(
         preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
 
@@ -387,13 +388,13 @@ TEST_CASE("PreemptionTasksWorkAsExpected") {
 
 class ReschedulingTask : public core::lsp::PreemptionTask {
 public:
-    const uint16_t targetStratum;
+    const core::packages::Stratum targetStratum;
     int runCount = 0;
     bool successful = false;
 
     ReschedulingTask(uint16_t targetStratum) : targetStratum{targetStratum} {}
 
-    RunResult run(uint16_t currentStratum) override {
+    RunResult run(core::packages::Stratum currentStratum) override {
         RunResult result;
 
         CHECK_FALSE(this->successful);
@@ -427,7 +428,9 @@ TEST_CASE("PreemptionReschedulingWorksAsExpected") {
     // No preemption task registered.
     uint16_t currentStratum = 0;
     CHECK_FALSE(
-        preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
+        preemptManager
+            ->tryRunScheduledPreemptionTask(*gs, core::packages::Stratum(currentStratum), /* allowReschedule */ true)
+            .progress());
 
     auto task = make_shared<ReschedulingTask>(2);
 
@@ -439,24 +442,32 @@ TEST_CASE("PreemptionReschedulingWorksAsExpected") {
     CHECK(preemptManager->trySchedulePreemptionTask(task));
 
     // This should run scheduled task, but not clear it.
-    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
+    CHECK(preemptManager
+              ->tryRunScheduledPreemptionTask(*gs, core::packages::Stratum(currentStratum), /* allowReschedule */ true)
+              .progress());
     CHECK_EQ(1, task->runCount);
 
     // This should not run the scheduled task, as we haven't made it to stratum 2 yet.
     ++currentStratum;
     CHECK_FALSE(
-        preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
+        preemptManager
+            ->tryRunScheduledPreemptionTask(*gs, core::packages::Stratum(currentStratum), /* allowReschedule */ true)
+            .progress());
     CHECK_EQ(1, task->runCount);
 
     // This should run and clear the task.
     ++currentStratum;
-    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
+    CHECK(preemptManager
+              ->tryRunScheduledPreemptionTask(*gs, core::packages::Stratum(currentStratum), /* allowReschedule */ true)
+              .progress());
     CHECK_EQ(2, task->runCount);
 
     // Running at stratum 3 should show no preemption tasks run
     ++currentStratum;
     CHECK_FALSE(
-        preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
+        preemptManager
+            ->tryRunScheduledPreemptionTask(*gs, core::packages::Stratum(currentStratum), /* allowReschedule */ true)
+            .progress());
     CHECK_EQ(2, task->runCount);
     CHECK(task->successful);
 
@@ -482,7 +493,9 @@ TEST_CASE("RescheduledPreemptionTasksClearOnCancelation") {
     // No preemption task registered.
     uint16_t currentStratum = 0;
     CHECK_FALSE(
-        preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
+        preemptManager
+            ->tryRunScheduledPreemptionTask(*gs, core::packages::Stratum(currentStratum), /* allowReschedule */ true)
+            .progress());
 
     auto task = make_shared<ReschedulingTask>(2);
 
@@ -494,12 +507,16 @@ TEST_CASE("RescheduledPreemptionTasksClearOnCancelation") {
     CHECK(preemptManager->trySchedulePreemptionTask(task));
 
     // This should run scheduled task, but not clear it.
-    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
+    CHECK(preemptManager
+              ->tryRunScheduledPreemptionTask(*gs, core::packages::Stratum(currentStratum), /* allowReschedule */ true)
+              .progress());
     CHECK_EQ(1, task->runCount);
 
     // If we cancel at this point and schedule a new task, that should be successful.
     CHECK(gs->epochManager->tryCancelSlowPath(3));
-    CHECK(preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ false).progress());
+    CHECK(preemptManager
+              ->tryRunScheduledPreemptionTask(*gs, core::packages::Stratum(currentStratum), /* allowReschedule */ false)
+              .progress());
 
     // Allow the task to be scheduled again, now that cancellation has run and we've cleared out the preemption task
     // slot.
@@ -528,7 +545,7 @@ TEST_CASE("RescheduledPreemptionTasksClearOnSuccess") {
                                       vector<core::ErrorSection>(), vector<core::AutocorrectSuggestion>(), false));
 
     // No preemption task registered.
-    uint16_t currentStratum = 0;
+    core::packages::Stratum currentStratum(0);
     CHECK_FALSE(
         preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
 
@@ -546,7 +563,7 @@ TEST_CASE("RescheduledPreemptionTasksClearOnSuccess") {
         CHECK(
             preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
         CHECK_EQ(1, task->runCount);
-        return 2;
+        return core::packages::Stratum(2);
     }));
 
     // tryCommitEpoch will be successful, and the task will have run to completion.
@@ -572,7 +589,7 @@ TEST_CASE("RescheduledPreemptionTasksClearOnSuccessWrongStratum") {
                                       vector<core::ErrorSection>(), vector<core::AutocorrectSuggestion>(), false));
 
     // No preemption task registered.
-    uint16_t currentStratum = 0;
+    core::packages::Stratum currentStratum(0);
     CHECK_FALSE(
         preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
 
@@ -590,7 +607,7 @@ TEST_CASE("RescheduledPreemptionTasksClearOnSuccessWrongStratum") {
         CHECK(
             preemptManager->tryRunScheduledPreemptionTask(*gs, currentStratum, /* allowReschedule */ true).progress());
         CHECK_EQ(1, task->runCount);
-        return 1;
+        return core::packages::Stratum(1);
     }));
 
     // tryCommitEpoch will be successful, but the task will not report success, as it can only run at stratum >= 2.

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -856,7 +856,7 @@ PackageStrata computePackageStrata(const core::GlobalState &gs, vector<ast::Pars
 
     PackageStrata result;
 
-    result.fileToStratum = vector<uint16_t>(gs.filesUsed(), 0);
+    result.fileToStratum = vector<core::packages::Stratum>(gs.filesUsed(), core::packages::Stratum(0));
 
     if (!opts.packageDirected) {
         result.strata = {CondensationStratumInfo{absl::MakeSpan(packageFiles), sourceFiles}};
@@ -897,7 +897,7 @@ PackageStrata computePackageStrata(const core::GlobalState &gs, vector<ast::Pars
             if (!pkgName.exists()) {
                 // This is a file with no package, so we unconditionally put it in the first stratum. This means that
                 // it'll be checked at the same time as the first stratum of packaged code.
-                result.fileToStratum[ix] = 0;
+                result.fileToStratum[ix] = core::packages::Stratum(0);
                 continue;
             }
 
@@ -906,10 +906,10 @@ PackageStrata computePackageStrata(const core::GlobalState &gs, vector<ast::Pars
             auto &info = stratumMapping[pkgName];
             if (file->isPackagedTest() || file->isPackagedTestHelper()) {
                 ENFORCE(info.testStratum < USHRT_MAX);
-                result.fileToStratum[ix] = info.testStratum;
+                result.fileToStratum[ix] = core::packages::Stratum(info.testStratum);
             } else {
                 ENFORCE(info.applicationStratum < USHRT_MAX);
-                result.fileToStratum[ix] = info.applicationStratum;
+                result.fileToStratum[ix] = core::packages::Stratum(info.applicationStratum);
             }
         }
 
@@ -966,8 +966,10 @@ PackageStrata computePackageStrata(const core::GlobalState &gs, vector<ast::Pars
         }
 
         {
-            auto it = absl::c_find_if(sourceSpan, [currentStratum, &fileToStratum = as_const(result.fileToStratum)](
-                                                      auto file) { return fileToStratum[file.id()] > currentStratum; });
+            auto it = absl::c_find_if(sourceSpan,
+                                      [currentStratum, &fileToStratum = as_const(result.fileToStratum)](auto file) {
+                                          return fileToStratum[file.id()] > core::packages::Stratum(currentStratum);
+                                      });
             auto len = std::distance(sourceSpan.begin(), it);
             resultStratum.sourceFiles = sourceSpan.subspan(0, len);
             sourceSpan = sourceSpan.subspan(len);
@@ -1480,7 +1482,7 @@ void typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Op
 } // namespace
 
 void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> &&what, const options::Options &opts,
-               WorkerPool &workers, bool cancelable, uint16_t currentStratum,
+               WorkerPool &workers, bool cancelable, core::packages::Stratum currentStratum,
                shared_ptr<core::lsp::PreemptionTaskManager> preemptionManager, bool intentionallyLeakASTs) {
     // Unless the error queue had a critical error, only typecheck should flush errors to the client, otherwise we will
     // drop errors in LSP mode.

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -6,6 +6,7 @@
 #include "common/concurrency/WorkerPool.h"
 #include "common/kvstore/KeyValueStore.h"
 #include "core/FileHash.h"
+#include "core/packages/Stratum.h"
 #include "main/options/options.h"
 
 namespace sorbet::core::lsp {
@@ -62,7 +63,7 @@ struct PackageStrata {
 
     // The mapping of a core::FileRef to the stratum it occurs in. We identify individual strata with a uint16_t,
     // because overflowing that value would require a dependency chain of length greater than 65535.
-    std::vector<uint16_t> fileToStratum;
+    std::vector<core::packages::Stratum> fileToStratum;
 };
 
 // Using the condensation graph, sort the package and source files according to the stratum they would show up in a
@@ -106,7 +107,8 @@ std::vector<ast::ParsedFile> incrementalResolve(
 // If `intentionallyLeakASTs` is `true`, typecheck will leak the ASTs rather than pay the cost of deleting them
 // properly, which is a significant speedup on large codebases.
 void typecheck(const core::GlobalState &gs, std::vector<ast::ParsedFile> &&what, const options::Options &opts,
-               WorkerPool &workers, bool cancelable = false, uint16_t currentStratum = 0,
+               WorkerPool &workers, bool cancelable = false,
+               core::packages::Stratum currentStratum = core::packages::Stratum(),
                std::shared_ptr<core::lsp::PreemptionTaskManager> preemptionManager = nullptr,
                bool intentionallyLeakASTs = false);
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -712,7 +712,8 @@ int realmain(int argc, char *argv[]) {
                     // In --gen-packages mode, we skip typecheck because we only want to show packaging related errors,
                     // and skipping typecheck saves a significant amount of time.
                     pipeline::sortBySize(*gs, stratumFiles);
-                    pipeline::typecheck(*gs, move(stratumFiles), opts, *workers, /* cancelable */ false, currentStratum,
+                    pipeline::typecheck(*gs, move(stratumFiles), opts, *workers, /* cancelable */ false,
+                                        core::packages::Stratum(currentStratum),
                                         /* preemptionManager */ nullptr, intentionallyLeakASTs);
 
                     if (gs->hadCriticalError()) {

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -2621,14 +2621,15 @@ shared_ptr<StratumAssertion> StratumAssertion::make(string_view filename, unique
         INFO("Invalid integer value: '" << assertionContents << "'");
         CHECK(success);
     }
-    return make_shared<StratumAssertion>(filename, range, assertionLine, value);
+    return make_shared<StratumAssertion>(filename, range, assertionLine, core::packages::Stratum(value));
 }
 
-StratumAssertion::StratumAssertion(string_view filename, unique_ptr<Range> &range, int assertionLine, int value)
+StratumAssertion::StratumAssertion(string_view filename, unique_ptr<Range> &range, int assertionLine,
+                                   core::packages::Stratum value)
     : RangeAssertion(filename, range, assertionLine), value(value){};
 
 string StratumAssertion::toString() const {
-    return fmt::format("stratum: {}", value);
+    return fmt::format("stratum: {}", value.rawId());
 }
 
 } // namespace sorbet::test

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -1,6 +1,7 @@
 #ifndef TEST_HELPERS_POSITION_ASSERTIONS_H
 #define TEST_HELPERS_POSITION_ASSERTIONS_H
 
+#include "core/packages/Stratum.h"
 #include "main/lsp/json_types.h"
 #include "main/lsp/wrapper.h"
 #include "main/options/options.h"
@@ -632,9 +633,10 @@ public:
                                                   int assertionLine, std::string_view assertionContents,
                                                   std::string_view assertionType);
 
-    const int value;
+    const core::packages::Stratum value;
 
-    StratumAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine, int value);
+    StratumAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
+                     core::packages::Stratum value);
 
     std::string toString() const override;
 };

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -529,11 +529,11 @@ TEST_CASE("PerPhaseTest") { // NOLINT
 
     for (auto &stratumAssertion : RangeAssertion::getAssertions<StratumAssertion>(assertions)) {
         auto file = gs->findFileByPath(stratumAssertion->filename);
-        int actualStratum = strata.fileToStratum[file.id()];
+        auto actualStratum = strata.fileToStratum[file.id()];
         if (actualStratum != stratumAssertion->value) {
             ADD_FAIL_CHECK_AT(stratumAssertion->filename.c_str(), stratumAssertion->assertionLine + 1,
-                              "Expected " << stratumAssertion->filename << " at stratum " << stratumAssertion->value
-                                          << "; got " << actualStratum);
+                              "Expected " << stratumAssertion->filename << " at stratum "
+                                          << stratumAssertion->value.rawId() << "; got " << actualStratum.rawId());
         }
     }
 


### PR DESCRIPTION
To avoid accidentally confusing ids with stratum identifiers, this PR introduces a newtype of `uint16_t`. I opted to make the constructor explicit to avoid any accidental conversions, but would be happy to revert that if it seems like there's too much noise in this PR.

### Motivation
Making it harder to mess up when working with stratum identifiers.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No changes expected, refactoring only.
