### PR TITLE
Show more output when these scripts fail in CI

### DIFF
--- a/.buildkite/linters.sh
+++ b/.buildkite/linters.sh
@@ -24,7 +24,7 @@ if ! ./tools/scripts/format_cxx.sh -td &> format_cxx; then
 fi
 
 echo "~~~ Checking that the compilation db builds"
-if ! ./tools/scripts/build_compilation_db.sh &> compdb; then
+if ! ./tools/scripts/build_compilation_db.sh > compdb; then
     globalErr=1
     echo "^^^ +++"
     buildkite-agent annotate --context tools/scripts/build_compilation_db.sh --style error --append < compdb

--- a/.buildkite/linters.sh
+++ b/.buildkite/linters.sh
@@ -10,7 +10,7 @@ set -x
 globalErr=0
 
 echo "~~~ Checking build files"
-if ! ./tools/scripts/format_build_files.sh -t &> buildifier; then
+if ! ./tools/scripts/format_build_files.sh -t > buildifier; then
     globalErr=1
     echo "^^^ +++"
     buildkite-agent annotate --context tools/scripts/format_build_files.sh --style error --append < buildifier

--- a/tools/scripts/build_compilation_db.sh
+++ b/tools/scripts/build_compilation_db.sh
@@ -17,7 +17,19 @@ cd "$(dirname "$0")/../.."
 # folder if they have been cached, which means that clangd won't find them.
 #
 # TODO(jez) Do other compile commands generators work better here?
-./bazel build //tools:compdb --config=dbg "$@"
+bazel_args=(
+  "--ui_event_filters=-info,-stdout,-stderr"
+  "--config=dbg"
+)
+if ! ./bazel build "${bazel_args[@]}" //tools:compdb "$@" >&2; then
+  if ! [ -t 1 ]; then
+    echo '[ERR!] Failed to build //tools:compdb'
+    echo 'Check the logs, or run this locally to reproduce:'
+    echo
+    echo '    ./bazel build --config=dbg //tools:compdb'
+  fi
+  exit 1
+fi
 
 if command -v jq &> /dev/null; then
   jq . < bazel-bin/tools/compile_commands.json > compile_commands.json

--- a/tools/scripts/build_compilation_db.sh
+++ b/tools/scripts/build_compilation_db.sh
@@ -36,3 +36,5 @@ if command -v jq &> /dev/null; then
 else
   cp bazel-bin/tools/compile_commands.json compile_commands.json
 fi
+
+echo '[ .. ] Wrote ./compile_commands.json'

--- a/tools/scripts/format_build_files.sh
+++ b/tools/scripts/format_build_files.sh
@@ -6,13 +6,12 @@ cd "$(dirname "$0")/../.."
 
 
 if [ "$1" == "-t" ]; then
-
   # quieter bazel output
   bazel_args=(
     "--ui_event_filters=-info,-stdout,-stderr"
     "--noshow_progress"
   )
-  if ! bazel run "${bazel_args[@]}" //test/lint/buildifier:lint &> /dev/null; then
+  if ! bazel run "${bazel_args[@]}" //test/lint/buildifier:lint >&2; then
     echo "Some bazel files need to be formatted! Please run:"
     echo
     echo '```sh'

--- a/tools/scripts/format_cxx.sh
+++ b/tools/scripts/format_cxx.sh
@@ -23,7 +23,12 @@ shift $((OPTIND - 1))
 
 cd "$(dirname "$0")/../.."
 
-./bazel build --config=dbg //tools:clang-format &> /dev/null
+bazel_args=(
+  "--ui_event_filters=-info,-stdout,-stderr"
+  "--noshow_progress"
+  "--config=dbg"
+)
+./bazel build "${bazel_args[@]}" //tools:clang-format >&2
 
 if [ "$#" -ne 0 ]; then
     cxx_src=("$@")


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I have a suspicion that we're getting bit by GitHub instability when fetching things.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I tested locally by introducing a bazel build failure (changed the buildtools
sha256 checksum, and typoed the `clang-format` target name) and saw that we do
see the `WARNING` and `ERROR` log lines from bazel, just not anything else.