### PR TITLE
Fix SORBET_VERSION macro to match sorbet_version constant

### DIFF
--- a/sorbet_version/sorbet_version.c
+++ b/sorbet_version/sorbet_version.c
@@ -43,8 +43,8 @@ const int sorbet_is_with_debug_symbols = 1;
 const int sorbet_is_with_debug_symbols = 0;
 #endif
 
-const char sorbet_version[] = SORBET_VERSION; // 0.01 alpha
-const char sorbet_codename[] = SORBET_CODENAME;   // We Try Furiously
+const char sorbet_version[] = SORBET_VERSION;   // 0.01 alpha
+const char sorbet_codename[] = SORBET_CODENAME; // We Try Furiously
 
 const char sorbet_full_version_string[] = SORBET_VERSION "." QUOTED(STABLE_BUILD_SCM_COMMIT_COUNT)
 #if BUILD_RELEASE

--- a/sorbet_version/sorbet_version.c
+++ b/sorbet_version/sorbet_version.c
@@ -11,7 +11,7 @@
  */
 
 // Manual configuration
-#define SORBET_VERSION "0.5"
+#define SORBET_VERSION "0.6"
 #define SORBET_CODENAME ""
 
 // Magic configuration
@@ -43,8 +43,8 @@ const int sorbet_is_with_debug_symbols = 1;
 const int sorbet_is_with_debug_symbols = 0;
 #endif
 
-const char sorbet_version[] = "0.6"; // 0.01 alpha
-const char sorbet_codename[] = "";   // We Try Furiously
+const char sorbet_version[] = SORBET_VERSION; // 0.01 alpha
+const char sorbet_codename[] = SORBET_CODENAME;   // We Try Furiously
 
 const char sorbet_full_version_string[] = SORBET_VERSION "." QUOTED(STABLE_BUILD_SCM_COMMIT_COUNT)
 #if BUILD_RELEASE


### PR DESCRIPTION
PR #9410 updated `sorbet_version[]` from `"0.5"` to `"0.6"` but missed the `SORBET_VERSION` macro defined a few lines above it. That macro is used to build `sorbet_full_version_string`, which is what `srb --version` prints:

```c
// sorbet_version/sorbet_version.c

#define SORBET_VERSION "0.5"          // ← feeds sorbet_full_version_string (--version output)
...
const char sorbet_version[] = "0.6";  // ← the actual version (updated in #9410)

const char sorbet_full_version_string[] = SORBET_VERSION "." QUOTED(STABLE_BUILD_SCM_COMMIT_COUNT) ...
```

Result: `srb --version` reported `Sorbet typechecker 0.5.13145 ...` while the Ruby gem shipped as `0.6.13145`.

**Fix:** update the `SORBET_VERSION` macro to `"0.6"`, and derive `sorbet_version[]` and `sorbet_codename[]` directly from their macros so the version string is defined in exactly one place:

```c
const char sorbet_version[] = SORBET_VERSION;
const char sorbet_codename[] = SORBET_CODENAME;
```

`sorbet_full_version_string` must remain macro-based since C compile-time string concatenation only works with string literals/macros — but now both the `[]` constants and the full version string share a single source of truth.
