### PR TITLE
Fix a use-after-free in a test assertion message

### DIFF
--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -531,7 +531,7 @@ TEST_CASE("PerPhaseTest") { // NOLINT
         auto file = gs->findFileByPath(stratumAssertion->filename);
         int actualStratum = strata.fileToStratum[file.id()];
         if (actualStratum != stratumAssertion->value) {
-            ADD_FAIL_CHECK_AT(string(stratumAssertion->filename).c_str(), stratumAssertion->assertionLine + 1,
+            ADD_FAIL_CHECK_AT(stratumAssertion->filename.c_str(), stratumAssertion->assertionLine + 1,
                               "Expected " << stratumAssertion->filename << " at stratum " << stratumAssertion->value
                                           << "; got " << actualStratum);
         }


### PR DESCRIPTION
The path passed to `ADD_FAIL_CHECK_AT` constructed a temporary string that it called `.c_str()` on, which would null terminate the temporary, return its pointer, and then free it. This caused sanitizer errors when the check failed in CI.

### Motivation
Fixing test failures.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

We don't have any tests that exercise this failure check, but it does pass locally for me now.
