### PR TITLE
sorbet-runtime: Remove `extend T::Sig` from `T::Helpers`

### DIFF
--- a/gems/sorbet-runtime/lib/types/helpers.rb
+++ b/gems/sorbet-runtime/lib/types/helpers.rb
@@ -4,8 +4,6 @@
 # Use as a mixin with extend (`extend T::Helpers`).
 # Docs at https://sorbet.org/docs/
 module T::Helpers
-  extend T::Sig
-
   Private = T::Private
 
   ### Class/Module Helpers ###


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It's possible that someone meant for this to be `include T::Helpers` way
back when. But as written today, `extend T::Helpers` in a module does
not imply `extend T::Sig`.

May as well remove it, because it's probably not something people should be
depending on. Since module singleton classes are final, the only way people
could be depending on this would be if people are writing runtime signatures
directly inside `module T::Helpers; ...; end` itself.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests