### PR TITLE
Sparse checkout for `all-succeeded.sh`

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -131,6 +131,15 @@ steps:
 # Success Phase - Allow the PR to be merged
   - label: "All tests and builds succeeded"
     command: '.buildkite/all-succeeded.sh'
+    agents:
+      # Run this on arbiter, because we already have the sparse-checkout plugin installed there,
+      # so we can be marginally faster by not having to re-download it all the
+      # time on each elastic CI worker when they start up.
+      os: arbiter
+    plugins:
+      - 'sparse-checkout#v1.6.0':
+          paths:
+            - .buildkite
 
   - label: ":linux: publish-ruby-gems.sh (non-blocking)"
     command: '.buildkite/publish-ruby-gems.sh < /dev/null'


### PR DESCRIPTION
This step takes 27s right now, 25s of which are cloning sorbet/sorbet.

By contrast, our "Reading pipeline.yaml" step takes 10s, 6s of which are
doing the sparse checkout of sorbet.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Slightly faster CI


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

CI-only change