### PR TITLE
Don't give direct access to the typechecker when determining file stratum

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -859,22 +859,6 @@ vector<unique_ptr<core::Error>> LSPTypechecker::retypecheck(vector<core::FileRef
     return errorCollector->drainErrors();
 }
 
-core::packages::Stratum LSPTypechecker::getStratumForEdit(absl::Span<const core::FileRef> edit) const {
-    core::packages::Stratum stratum(0);
-
-    for (auto fref : edit) {
-        if (fref.id() >= this->fileToStratum.size()) {
-            // Indicate that this can only run at the end of the slow path, as we don't have any information about this
-            // file.
-            return this->lastStratum;
-        }
-
-        stratum = std::max(stratum, this->fileToStratum[fref.id()]);
-    }
-
-    return stratum;
-}
-
 ast::ExpressionPtr LSPTypechecker::getLocalVarTrees(core::FileRef fref) const {
     auto preserveConcreteSyntax = true;
     auto afterDesugar = pipeline::desugarOne(config->opts, *gs, fref, preserveConcreteSyntax);
@@ -986,6 +970,33 @@ void LSPTypechecker::updateConfigAndGsFromOptions(const DidChangeConfigurationPa
     }
 }
 
+core::packages::Stratum FileStratumMapping::getStratumForUris(absl::Span<const string_view> paths) const {
+    core::packages::Stratum stratum(0);
+    for (auto path : paths) {
+        auto ref = this->tc.state().findFileByPath(path);
+
+        // Fall back on the last stratum for new files.
+        if (!ref.exists()) {
+            return this->tc.lastStratum;
+        }
+
+        stratum = std::max(stratum, this->tc.fileToStratum[ref.id()]);
+    }
+
+    return stratum;
+}
+
+core::packages::Stratum FileStratumMapping::getStratumForUri(std::string_view path) const {
+    auto ref = this->tc.state().findFileByPath(path);
+
+    // Fall back on the last stratum for new files.
+    if (!ref.exists()) {
+        return this->tc.lastStratum;
+    }
+
+    return this->tc.fileToStratum[ref.id()];
+}
+
 LSPTypecheckerDelegate::LSPTypecheckerDelegate(TaskQueue &queue, WorkerPool &workers, LSPTypechecker &typechecker)
     : typechecker(typechecker), queue{queue}, workers(workers) {}
 
@@ -1040,10 +1051,6 @@ void LSPTypecheckerDelegate::updateConfigAndGsFromOptions(const DidChangeConfigu
 
 unique_ptr<LSPFileUpdates> LSPTypecheckerDelegate::getNoopUpdate(absl::Span<const core::FileRef> frefs) const {
     return typechecker.getNoopUpdate(frefs);
-}
-
-core::packages::Stratum LSPTypecheckerDelegate::getStratumForEdit(absl::Span<const core::FileRef> edit) const {
-    return typechecker.getStratumForEdit(edit);
 }
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -37,11 +37,14 @@ struct LSPQueryResult {
 };
 
 class UndoState;
+class FileStratumMapping;
 
 /**
  * Encapsulates typechecker operations and enforces that they happen on a single thread.
  */
 class LSPTypechecker final {
+    friend class FileStratumMapping;
+
     /** Contains the ID of the thread responsible for typechecking. */
     std::thread::id typecheckerThreadId;
     /**
@@ -209,24 +212,40 @@ public:
     std::unique_ptr<LSPFileUpdates> getNoopUpdate(absl::Span<const core::FileRef> frefs) const;
 
     /**
+     * Return a helper that can query information about package strata, without exposing the rest of the typechecker.
+     */
+    FileStratumMapping getFileStratumMapping() const;
+};
+
+class FileStratumMapping {
+    friend class LSPTypechecker;
+
+    const LSPTypechecker &tc;
+
+    FileStratumMapping(const LSPTypechecker &tc) : tc{tc} {}
+
+public:
+    /**
      * Get the id of the stratum that an edit involving these files could be checked at.
      */
-    core::packages::Stratum getStratumForEdit(absl::Span<const core::FileRef> edit) const;
+    core::packages::Stratum getStratumForUris(absl::Span<const std::string_view> edit) const;
 
     /**
      * Get the id of the stratum that an edit involving this file could be checked at.
      */
-    core::packages::Stratum getStratumForUri(std::string_view uri) const {
-        return this->getStratumForEdit({this->config->uri2FileRef(*this->gs, uri)});
-    }
+    core::packages::Stratum getStratumForUri(std::string_view uri) const;
 
     /**
      * Get the id of the last stratum in the condensation graph.
      */
     core::packages::Stratum getLastStratum() const {
-        return this->lastStratum;
+        return this->tc.lastStratum;
     }
 };
+
+inline FileStratumMapping LSPTypechecker::getFileStratumMapping() const {
+    return FileStratumMapping{*this};
+}
 
 /**
  * Provides lambdas with a set of operations that they are allowed to do with the LSPTypechecker.
@@ -271,14 +290,8 @@ public:
 
     void updateConfigAndGsFromOptions(const DidChangeConfigurationParams &options) const;
     std::unique_ptr<LSPFileUpdates> getNoopUpdate(absl::Span<const core::FileRef> frefs) const;
-    core::packages::Stratum getStratumForEdit(absl::Span<const core::FileRef> edit) const;
-
-    core::packages::Stratum getLastStratum() const {
-        return typechecker.getLastStratum();
-    }
-
-    core::packages::Stratum getStratumForUri(std::string_view uri) const {
-        return typechecker.getStratumForUri(uri);
+    FileStratumMapping getFileStratumMapping() const {
+        return this->typechecker.getFileStratumMapping();
     }
 };
 } // namespace sorbet::realmain::lsp


### PR DESCRIPTION
Introduce a wrapper type, `FileStratumMapping`, that exposes only the operations of `LSPTypechecker` that are necessary for asking questions of the condensation stratum. This is a refactoring of the implementation in #10182, to ensure that we're exposing as little of the `LSPTypechecker` as possible in #10129 when determining what stratum a task can run at.

### Motivation
Cleaning up the interface to the file->stratum mapping.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Refactoring only.
