### PR TITLE
rubocop: Allow writing to ~/.cache if it's a symlink

### DIFF
--- a/gems/sorbet-runtime/.rubocop.yml
+++ b/gems/sorbet-runtime/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
   NewCops: disable
   SuggestExtensions: false
   TargetRubyVersion: 3.0
+  AllowSymlinksInCacheRootDirectory: true
   Exclude:
     - 'vendor/**/*'
     - 'test/wholesome/vendor/**/*'


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Stripe devboxes set ~/.cache to be a symlink to a different mounted
volume, so running `bex rake rubocop` on devboxes causes all sorts of
warnings to be printed by rubocop.

I don't really understand the point of this check, but the
`.rubocop.yml` in Stripe's main Ruby repo also has this setting, so I
figure we should just copy it.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested with

```
cd gems/sorbet-runtime
bundle exec rake rubocop
```

on a Stripe devbox.