### PR TITLE
sync `Enumerable#inject` sig with `Enumerable#reduce`

### DIFF
--- a/rbi/core/enumerable.rbi
+++ b/rbi/core/enumerable.rbi
@@ -870,17 +870,17 @@ module Enumerable
     .returns(T.untyped)
   end
   sig do
-    params(
-        initial: T.untyped,
-        blk: T.proc.params(arg0: T.untyped, arg1: Elem).returns(T.untyped),
+    type_parameters(:U).params(
+        initial: T.type_parameter(:U),
+        blk: T.proc.params(arg0: T.type_parameter(:U), arg1: Elem).returns(T.type_parameter(:U)),
     )
-    .returns(T.untyped)
+    .returns(T.type_parameter(:U))
   end
   sig do
-    params(
-        blk: T.proc.params(arg0: T.untyped, arg1: Elem).returns(T.untyped),
+    type_parameters(:U).params(
+        blk: T.proc.params(arg0: T.any(Elem, T.type_parameter(:U)), arg1: Elem).returns(T.type_parameter(:U)),
     )
-    .returns(T.untyped)
+    .returns(T.nilable(T.type_parameter(:U)))
   end
   def inject(initial=T.unsafe(nil), arg0=T.unsafe(nil), &blk); end
 

--- a/test/testdata/infer/takes_no_block_inject.rb
+++ b/test/testdata/infer/takes_no_block_inject.rb
@@ -2,3 +2,4 @@
 
 foo = T::Array[Integer].new
 foo.inject(nil) {|sum, x| sum ? sum + x : x}
+#                               ^^^^^^^ error: This code is unreachable

--- a/test/testdata/rbi/enumerable.rb
+++ b/test/testdata/rbi/enumerable.rb
@@ -77,12 +77,12 @@ def example(xs)
   T.reveal_type(res) # error: `String`
 
   res = xs.inject('') do |acc, x|
-    T.reveal_type(acc) # error: `T.untyped`
+    T.reveal_type(acc) # error: `String`
     T.reveal_type(x) # error: `Integer`
     new_acc = acc + x.to_s
-    T.reveal_type(new_acc) # error: `T.untyped`
+    T.reveal_type(new_acc) # error: `String`
   end
-  T.reveal_type(res) # error: `T.untyped`
+  T.reveal_type(res) # error: `String`
 end
 
 int_or_str_array = T::Array[T.any(Integer, String)].new


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These two methods are the same underlying code, but their sigs were out-of-sync; if you used `reduce`, you got nice types, and if you used `inject`, you got `T.untyped`.

This is less than desirable, so let's update the sig for `Enumerable#inject`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Testing on Stripe's codebase.
