### PR TITLE
Rework final method checking

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -200,6 +200,7 @@ module T::Private::Methods
   end
 
   def self.add_module_with_final_method(mod, method_name)
+    # Side-effectfully initializes the value if it's not already there
     methods = @modules_with_final[mod]
     if methods.nil?
       methods = {}
@@ -207,11 +208,6 @@ module T::Private::Methods
     end
     methods[method_name] = true
     nil
-  end
-
-  def self.note_module_deals_with_final(mod)
-    # Side-effectfully initialize the value if it's not already there
-    @modules_with_final[mod]
   end
 
   # Only public because it needs to get called below inside the replace_method blocks below.
@@ -286,7 +282,6 @@ module T::Private::Methods
     @sig_wrappers[key] = sig_block
     if current_declaration.final
       @was_ever_final_names[method_name] = true
-      note_module_deals_with_final(mod)
       add_module_with_final_method(mod, method_name)
     end
   end
@@ -522,7 +517,8 @@ module T::Private::Methods
       if !@modules_with_final.include?(source)
         return
       end
-      note_module_deals_with_final(target)
+      # Side-effectfully initialize the value if it's not already there
+      @modules_with_final[target]
       install_hooks(target)
       return
     end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -200,6 +200,8 @@ module T::Private::Methods
   end
 
   def self.add_module_with_final_method(mod, method_name)
+    @was_ever_final_names[method_name] = true
+
     # Side-effectfully initializes the value if it's not already there
     methods = @modules_with_final[mod]
     if methods.nil?
@@ -281,7 +283,6 @@ module T::Private::Methods
 
     @sig_wrappers[key] = sig_block
     if current_declaration.final
-      @was_ever_final_names[method_name] = true
       add_module_with_final_method(mod, method_name)
     end
   end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -131,14 +131,14 @@ module T::Private::Methods
   #
   # we assume that source_method_names has already been filtered to only include method
   # names that were declared final at one point.
-  def self._check_final_ancestors(target, target_ancestors, source_method_names, source)
+  def self._check_final_ancestors(target, source_method_names, source)
     source_ancestors = nil
     if T::Private::IS_TYPECHECKING
       # Need to avoid a pinning error, but don't want to use runtime types in _methods.rb
       source_ancestors = T.let(nil, T.nilable(T::Array[T::Module[T.anything]]))
     end
     # use reverse_each to check farther-up ancestors first, for better error messages.
-    target_ancestors.reverse_each do |ancestor|
+    target.ancestors.reverse_each do |ancestor|
       final_methods = @modules_with_final.fetch(ancestor, nil)
       # In this case, either ancestor didn't have any final methods anywhere in its
       # ancestor chain, or ancestor did have final methods somewhere in its ancestor
@@ -212,7 +212,6 @@ module T::Private::Methods
   def self.note_module_deals_with_final(mod)
     # Side-effectfully initialize the value if it's not already there
     @modules_with_final[mod]
-    @modules_with_final[mod.singleton_class]
   end
 
   # Only public because it needs to get called below inside the replace_method blocks below.
@@ -228,7 +227,7 @@ module T::Private::Methods
     end
     # Don't compute mod.ancestors if we don't need to bother checking final-ness.
     if @was_ever_final_names.include?(method_name) && @modules_with_final.include?(mod)
-      _check_final_ancestors(mod, mod.ancestors, [method_name], nil)
+      _check_final_ancestors(mod, [method_name], nil)
       # We need to fetch the active declaration again, as _check_final_ancestors
       # may have reset it (see the comment in that method for details).
       current_declaration = T::Private::DeclState.current.active_declaration
@@ -287,9 +286,7 @@ module T::Private::Methods
     @sig_wrappers[key] = sig_block
     if current_declaration.final
       @was_ever_final_names[method_name] = true
-      # use hook_mod, not mod, because for example, we want class C to be marked as having final if we def C.foo as
-      # final. change this to mod to see some final_method tests fail.
-      note_module_deals_with_final(hook_mod)
+      note_module_deals_with_final(mod)
       add_module_with_final_method(mod, method_name)
     end
   end
@@ -518,7 +515,7 @@ module T::Private::Methods
 
   # the module target is adding the methods from the module source to itself. we need to check that for all instance
   # methods M on source, M is not defined on any of target's ancestors.
-  def self._hook_impl(target, singleton_class, source)
+  def self._hook_impl(target, source)
     # we do not need to call add_was_ever_final here, because we have already marked
     # any such methods when source was originally defined.
     if !@modules_with_final.include?(target)
@@ -538,8 +535,7 @@ module T::Private::Methods
       return
     end
 
-    target_ancestors = singleton_class ? target.singleton_class.ancestors : target.ancestors
-    _check_final_ancestors(target, target_ancestors, methods, source)
+    _check_final_ancestors(target, methods, source)
   end
 
   def self.set_final_checks_on_hooks(enable)
@@ -563,17 +559,18 @@ module T::Private::Methods
       old_included = Module.instance_method(:included)
       T::Private::ClassUtils.replace_method(old_included, Module, :included) do |arg|
         old_included.bind_call(self, arg)
-        ::T::Private::Methods._hook_impl(arg, false, self)
+        ::T::Private::Methods._hook_impl(arg, self)
       end
       old_extended = Module.instance_method(:extended)
       T::Private::ClassUtils.replace_method(old_extended, Module, :extended) do |arg|
         old_extended.bind_call(self, arg)
-        ::T::Private::Methods._hook_impl(arg, true, self)
+        ::T::Private::Methods._hook_impl(arg.singleton_class, self)
       end
       old_inherited = Class.instance_method(:inherited)
       T::Private::ClassUtils.replace_method(old_inherited, Class, :inherited) do |arg|
         old_inherited.bind_call(self, arg)
-        ::T::Private::Methods._hook_impl(arg, false, self)
+        ::T::Private::Methods._hook_impl(arg, self)
+        ::T::Private::Methods._hook_impl(arg.singleton_class, self.singleton_class)
       end
       @old_hooks = [old_included, old_extended, old_inherited]
     end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
@@ -63,9 +63,6 @@ module T::Private::Methods
   sig {params(mod: Module, method_name: Symbol).returns(NilClass)}
   def self.add_module_with_final_method(mod, method_name); end
 
-  sig {params(mod: Module).void}
-  def self.note_module_deals_with_final(mod); end
-
   sig {params(hook_mod: Module, mod: Module, method_name: Symbol).void}
   def self._on_method_added(hook_mod, mod, method_name); end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
@@ -57,8 +57,8 @@ module T::Private::Methods
 
   IS_TYPECHECKING = T.let(false, T::Boolean)
 
-  sig {params(target: Module, target_ancestors: T::Array[Module], source_method_names: T::Array[Symbol], source: T.nilable(Module)).void}
-  def self._check_final_ancestors(target, target_ancestors, source_method_names, source); end
+  sig {params(target: Module, source_method_names: T::Array[Symbol], source: T.nilable(Module)).void}
+  def self._check_final_ancestors(target, source_method_names, source); end
 
   sig {params(mod: Module, method_name: Symbol).returns(NilClass)}
   def self.add_module_with_final_method(mod, method_name); end
@@ -105,8 +105,8 @@ module T::Private::Methods
   sig {returns(T::Array[T::Private::Methods::Signature])}
   def self.all_checked_tests_sigs; end
 
-  sig {params(target: Module, singleton_class: T::Boolean, source: Module).void}
-  def self._hook_impl(target, singleton_class, source); end
+  sig {params(target: Module, source: Module).void}
+  def self._hook_impl(target, source); end
 
   sig {params(enable: T::Boolean).void}
   def self.set_final_checks_on_hooks(enable); end

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -623,7 +623,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
         extend m2, m1
       end
     end
-    assert_overridden_err('foo', MODULE_REGEX_STR, CLASS_REGEX_STR, __LINE__ - 10, __LINE__ - 3, err)
+    assert_overridden_err('foo', MODULE_REGEX_STR, CLASS_CLASS_REGEX_STR, __LINE__ - 10, __LINE__ - 3, err)
   end
 
   it "allows calling final methods" do

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -13,6 +13,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
 
   CLASS_REGEX_STR = "#<Class:0x[0-9a-f]+>"
   CLASS_CLASS_REGEX_STR = "#<Class:#<Class:0x[0-9a-f]+>>"
+  INSTANCE_CLASS_REGEX_STR = "#<Class:#<#<Class:0x[0-9a-f]+>:0x[0-9a-f]+>>"
   MODULE_REGEX_STR = "#<Module:0x[0-9a-f]+>"
 
   private def assert_msg_matches(regex, final_line, method_line, explanation, err)
@@ -737,6 +738,21 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
     Module.new do
       include m1, m1
     end
+  end
+
+  it "forbids overriding a final method on an instance's singleton class via extend" do
+    m = Module.new do
+      extend T::Sig
+      sig(:final) { void }
+      def foo; end
+    end
+    klass = Class.new
+    instance = klass.new
+    instance.extend(m)
+    err = assert_raises(RuntimeError) do
+      def instance.foo; end
+    end
+    assert_overridden_err('foo', MODULE_REGEX_STR, INSTANCE_CLASS_REGEX_STR, __LINE__ - 8, __LINE__ - 2, err)
   end
 
   it "allows extending modules again" do


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We were being sloppy with the `@modules_with_final` map. For example, given

```ruby
module M
  sig(:final) { void }
  def foo; end
end
```

we would mark `M.singleton_class` as having final methods, even though only `M`
has final methods.

This was causing problems for me when implementing the `final def foo`
construct, because in that method, we only have the `owner` of the method in
scope (`M` for instance methods, `M.singleton_class` for `def self.` methods),
and it was going to be hacky to try to recover the "`hook_mod`" that this code
talked about (see the deleted comment). That comment doesn't really make sense.

We can refactor this code to not operate on `hook_mod` at all, and to do
everything in terms of `mod` aka the Module that owns the method being defined
(vs `hook_mod`, which is the receiver of the `sig` or `final` call,
essentially).

The key insight is that for classes, which establish both an instance and
singleton class inheritance relationship, we have to call `_hook_impl` twice.
For `include` and `extend`, which only establish one inheritance relationship,
we only have to call it once.

It turns out: this change fixes a bug.

This test fails on master, despite this being a real redefinition:

    <https://buildkite.com/sorbet/sorbet/builds/42277#019de085-ee7a-4f84-9b60-7a4f891710ad>

This pattern arises in practice from some `T::Props`-shaped code. Code
making heavy use of prop decoraters leads to code that looks like this:

    module MyPlugin
      include T::Props::Plugin

      module DecoratorMethods
        extend T::Sig
        sig(:final) { void }
        def foo; puts "hello"; end
      end
    end

    class MyModel
      include T::Props
      include MyPlugin
    end

    def (MyModel.decorator).foo; puts "stubbed"; end

Where the last `def` simulates what a stubbing library would do.
`MyModel.decorator` creates an instance of `T::Props::Decorator` like
`#<T::Props::Decorator:0x0000e81949175f98>`, and then the "plugin" code
essentially does

    MyModel.decorator.extend(MyPlugin::DecoratorMethods)

which is absurd but that's the code we live with.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests