### PR TITLE
sorbet-runtime: Add failing test for final methods

### DIFF
--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -13,6 +13,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
 
   CLASS_REGEX_STR = "#<Class:0x[0-9a-f]+>"
   CLASS_CLASS_REGEX_STR = "#<Class:#<Class:0x[0-9a-f]+>>"
+  INSTANCE_CLASS_REGEX_STR = "#<Class:#<#<Class:0x[0-9a-f]+>:0x[0-9a-f]+>>"
   MODULE_REGEX_STR = "#<Module:0x[0-9a-f]+>"
 
   private def assert_msg_matches(regex, final_line, method_line, explanation, err)
@@ -737,6 +738,21 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
     Module.new do
       include m1, m1
     end
+  end
+
+  it "forbids overriding a final method on an instance's singleton class via extend" do
+    m = Module.new do
+      extend T::Sig
+      sig(:final) { void }
+      def foo; end
+    end
+    klass = Class.new
+    instance = klass.new
+    instance.extend(m)
+    err = assert_raises(RuntimeError) do
+      def instance.foo; end
+    end
+    assert_overridden_err('foo', MODULE_REGEX_STR, INSTANCE_CLASS_REGEX_STR, __LINE__ - 8, __LINE__ - 2, err)
   end
 
   it "allows extending modules again" do


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is fixed by #10220, but testing that change on pay-server revealed that
there was a gap in our test coverage. I wanted to have a branch that proves that
this test failed on master before I commit this alongside those fixes.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

test-only change