### PR TITLE
Error on orphaned RBS signature comments before non-method statements

### DIFF
--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -116,6 +116,33 @@ void CommentsAssociator::consumeCommentsBetweenLines(int startLine, int endLine,
     commentByLine.erase(startIt, it);
 }
 
+void CommentsAssociator::consumeOrphanedSignatureComments(int startLine, int endLine) {
+    auto source = ctx.file.data(ctx).source();
+    for (auto it = commentByLine.begin(); it != commentByLine.end();) {
+        if (it->first <= startLine) {
+            ++it;
+            continue;
+        }
+        if (it->first >= endLine) {
+            break;
+        }
+        auto commentBegin = it->second.loc.beginPos();
+        auto detail = core::Loc::pos2Detail(ctx.file.data(ctx), commentBegin);
+        auto lineStart = source.substr(commentBegin - (detail.column - 1), detail.column - 1);
+        if (lineStart.find_first_not_of(" \t") != string_view::npos) {
+            ++it;
+            continue;
+        }
+        if (absl::StartsWith(it->second.string, RBS_PREFIX) ||
+            absl::StartsWith(it->second.string, MULTILINE_RBS_PREFIX)) {
+            if (auto e = ctx.beginIndexerError(it->second.loc, core::errors::Rewriter::RBSUnusedComment)) {
+                e.setHeader("Unused RBS signature comment. No method definition found after it");
+            }
+        }
+        it = commentByLine.erase(it);
+    }
+}
+
 void CommentsAssociator::consumeCommentsUntilLine(int line) {
     auto it = commentByLine.begin();
     while (it != commentByLine.end()) {
@@ -377,7 +404,9 @@ void CommentsAssociator::walkStatements(parser::NodeVec &nodes) {
         auto inserted = maybeInsertStandalonePlaceholders(nodes, i, lastLine, beginLine);
         i += inserted;
 
+        auto prevLastLine = lastLine;
         walkNode(stmt);
+        consumeOrphanedSignatureComments(prevLastLine, beginLine);
 
         lastLine = core::Loc::pos2Detail(ctx.file.data(ctx), stmt->loc.endPos()).line;
     }

--- a/rbs/CommentsAssociator.h
+++ b/rbs/CommentsAssociator.h
@@ -48,6 +48,7 @@ private:
     void associateSignatureCommentsToNode(parser::Node *node);
     void consumeCommentsInsideNode(parser::Node *node, std::string kind);
     void consumeCommentsBetweenLines(int startLine, int endLine, std::string kind);
+    void consumeOrphanedSignatureComments(int startLine, int endLine);
     void consumeCommentsUntilLine(int line);
     std::optional<uint32_t> locateTargetLine(parser::Node *node);
 

--- a/rbs/prism/CommentsAssociatorPrism.cc
+++ b/rbs/prism/CommentsAssociatorPrism.cc
@@ -159,6 +159,33 @@ void CommentsAssociatorPrism::consumeCommentsBetweenLines(int startLine, int end
     commentByLine.erase(startIt, it);
 }
 
+void CommentsAssociatorPrism::consumeOrphanedSignatureComments(int startLine, int endLine) {
+    auto source = ctx.file.data(ctx).source();
+    for (auto it = commentByLine.begin(); it != commentByLine.end();) {
+        if (it->first <= startLine) {
+            ++it;
+            continue;
+        }
+        if (it->first >= endLine) {
+            break;
+        }
+        auto commentBegin = it->second.loc.beginPos();
+        auto detail = core::Loc::pos2Detail(ctx.file.data(ctx), commentBegin);
+        auto lineStart = source.substr(commentBegin - (detail.column - 1), detail.column - 1);
+        if (lineStart.find_first_not_of(" \t") != std::string_view::npos) {
+            ++it;
+            continue;
+        }
+        if (absl::StartsWith(it->second.string, RBS_PREFIX) ||
+            absl::StartsWith(it->second.string, MULTILINE_RBS_PREFIX)) {
+            if (auto e = ctx.beginIndexerError(it->second.loc, core::errors::Rewriter::RBSUnusedComment)) {
+                e.setHeader("Unused RBS signature comment. No method definition found after it");
+            }
+        }
+        it = commentByLine.erase(it);
+    }
+}
+
 void CommentsAssociatorPrism::consumeCommentsUntilLine(int line) {
     auto it = commentByLine.begin();
     while (it != commentByLine.end()) {
@@ -532,7 +559,9 @@ void CommentsAssociatorPrism::walkStatements(pm_node_list_t &nodes) {
         auto inserted = maybeInsertStandalonePlaceholders(nodes, i, lastLine, beginLine);
         i += inserted;
 
+        auto prevLastLine = lastLine;
         walkNode(stmt);
+        consumeOrphanedSignatureComments(prevLastLine, beginLine);
 
         lastLine = posToLine(stmtLoc.endPos());
     }

--- a/rbs/prism/CommentsAssociatorPrism.h
+++ b/rbs/prism/CommentsAssociatorPrism.h
@@ -69,6 +69,7 @@ private:
     void associateSignatureCommentsToNode(pm_node_t *node);
     void consumeCommentsInsideNode(pm_node_t *node, std::string_view kind);
     void consumeCommentsBetweenLines(int startLine, int endLine, std::string_view kind);
+    void consumeOrphanedSignatureComments(int startLine, int endLine);
     void consumeCommentsUntilLine(int line);
     std::optional<uint32_t> locateTargetLine(pm_node_t *node);
     core::LocOffsets translateLocation(pm_location_t location);

--- a/test/testdata/rbs/sig_before_non_def.rb
+++ b/test/testdata/rbs/sig_before_non_def.rb
@@ -1,0 +1,37 @@
+# typed: true
+# enable-experimental-rbs-comments: true
+
+# Signature comment before a non-method statement should be an error
+#: (Integer) -> void # error: Unused RBS signature comment. No method definition found after it
+
+puts "hello"
+
+def foo(x)
+end
+
+# Signature comment before an assignment
+#: (String) -> void # error: Unused RBS signature comment. No method definition found after it
+
+x = 1
+
+def bar(x)
+end
+
+# Normal case: signature directly before def should still work
+#: (Integer) -> void
+def baz(x)
+  T.reveal_type(x) # error: Revealed type: `Integer`
+end
+
+# Normal case: blank line between sig and def still works
+#: (String) -> void
+
+def qux(x)
+  T.reveal_type(x) # error: Revealed type: `String`
+end
+
+# Normal case: signature before visibility + def still works
+#: (Integer) -> void
+private def priv(x)
+  T.reveal_type(x) # error: Revealed type: `Integer`
+end

--- a/test/testdata/rbs/sig_before_non_def.rb
+++ b/test/testdata/rbs/sig_before_non_def.rb
@@ -7,6 +7,7 @@
 puts "hello"
 
 def foo(x)
+  T.reveal_type(x) # error: Revealed type: `T.untyped`
 end
 
 # Signature comment before an assignment
@@ -15,6 +16,7 @@ end
 x = 1
 
 def bar(x)
+  T.reveal_type(x) # error: Revealed type: `T.untyped`
 end
 
 # Normal case: signature directly before def should still work


### PR DESCRIPTION
## Summary

RBS signature comments placed before non-method statements now produce an error instead of silently attaching to the next method definition.

[Before this change](https://sorbet.run/?arg=--enable-experimental-rbs-comments#%23%20typed%3A%20true%0A%0A%23%3A%20%28Integer%29%20-%3E%20void%0A%0Aputs%20%22hello%22%0A%0Adef%20foo%28x%29%0A%20%20T.reveal_type%28x%29%20%23%20error%3A%20Revealed%20type%3A%20%60Integer%60%0Aend%0A), the signature silently attaches to `foo`:

```ruby
#: (Integer) -> void   # no error

puts "hello"

def foo(x)
  T.reveal_type(x)    # Integer (wrong!)
end
```

After this change:

```ruby
#: (Integer) -> void   # error: Unused RBS signature comment. No method definition found after it

puts "hello"

def foo(x)
end
```

## How it works

`associateSignatureCommentsToNode` greedily collects all RBS comments before a node's start line. Comments left in the gap between statements were never consumed, so they'd accumulate and get picked up by the next `def`.

After walking each statement in `walkStatements`, we now call `consumeOrphanedSignatureComments` to clean up any standalone RBS comments remaining in the gap between the previous and current statement. Handlers that accept signature comments (`def`, `class`, `module`, visibility sends like `private def`) consume them during `walkNode`, so the post-walk cleanup only catches genuinely orphaned ones.

Inline assertion comments (e.g. `x #: as String`) are preserved by checking that only whitespace precedes the comment on its line.

## Test plan

See tests.