### PR TITLE
`T::Utils.first_non_sorbet_caller`

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/caller_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/caller_utils.rb
@@ -3,11 +3,11 @@
 
 module T::Private::CallerUtils
   if Thread.respond_to?(:each_caller_location) # RUBY_VERSION >= "3.2"
-    def self.find_caller
-      skipped_first = false
+    def self.find_caller(callers_to_skip: 0)
+      remaining_to_skip = callers_to_skip + 1
       Thread.each_caller_location do |loc|
-        unless skipped_first
-          skipped_first = true
+        if remaining_to_skip.positive?
+          remaining_to_skip -= 1
           next
         end
 
@@ -18,8 +18,8 @@ module T::Private::CallerUtils
       nil
     end
   else
-    def self.find_caller
-      caller_locations(2).find do |loc|
+    def self.find_caller(callers_to_skip: 0)
+      caller_locations(2 + callers_to_skip).find do |loc|
         !loc.path&.start_with?("<internal:") && yield(loc)
       end
     end

--- a/gems/sorbet-runtime/lib/types/private/caller_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/caller_utils.rb
@@ -2,6 +2,10 @@
 # typed: false
 
 module T::Private::CallerUtils
+  # Fetch the directory name of the file that defines the `T::Private` constant and
+  # add a trailing slash to allow us to match it as a directory prefix.
+  SORBET_RUNTIME_LIB_PATH = File.dirname(T.const_source_location(:Private).first) + File::SEPARATOR
+
   if Thread.respond_to?(:each_caller_location) # RUBY_VERSION >= "3.2"
     def self.find_caller(callers_to_skip: 0)
       remaining_to_skip = callers_to_skip + 1

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -110,11 +110,6 @@ module T::Private::Methods
     T::Types::Proc.new(decl.params, decl.returns)
   end
 
-  # Fetch the directory name of the file that defines the `T::Private` constant and
-  # add a trailing slash to allow us to match it as a directory prefix.
-  SORBET_RUNTIME_LIB_PATH = File.dirname(T.const_source_location(:Private).first) + File::SEPARATOR
-  private_constant :SORBET_RUNTIME_LIB_PATH
-
   # when target includes a module with instance methods source_method_names, ensure there is zero intersection between
   # the final instance methods of target and source_method_names. so, for every m in source_method_names, check if there
   # is already a method defined on one of target_ancestors with the same name that is final.
@@ -156,7 +151,7 @@ module T::Private::Methods
 
         definition_file, definition_line = T::Private::Methods.signature_for_method(ancestor.instance_method(method_name)).method.source_location
         is_redefined = target == ancestor
-        caller_loc = T::Private::CallerUtils.find_caller { |loc| !loc.path.to_s.start_with?(SORBET_RUNTIME_LIB_PATH) }
+        caller_loc = T::Private::CallerUtils.find_caller { |loc| !loc.path.to_s.start_with?(T::Private::CallerUtils::SORBET_RUNTIME_LIB_PATH) }
         extra_info = "\n"
         if caller_loc
           extra_info = (is_redefined ? "Redefined" : "Overridden") + " here: #{caller_loc.path}:#{caller_loc.lineno}\n"

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -165,6 +165,13 @@ module T::Utils
     end
   end
 
+  # Skips Sorbet Runtime stack frames to return the first non-Sorbet caller of the current caller.
+  def self.first_non_sorbet_caller
+    T::Private::CallerUtils.find_caller(callers_to_skip: 1) do |loc|
+      !loc.path.start_with?(T::Private::CallerUtils::SORBET_RUNTIME_LIB_PATH)
+    end
+  end
+
   module Nilable
     # :is_union_type, T::Boolean: whether the type is an T::Types::Union type
     # :non_nilable_type, Class: if it is an T.nilable type, the corresponding underlying type; otherwise, nil.

--- a/gems/sorbet-runtime/test/types/utils.rb
+++ b/gems/sorbet-runtime/test/types/utils.rb
@@ -86,5 +86,52 @@ module Opus::Types::Test
         end
       end
     end
+
+    describe 'T::Utils.first_non_sorbet_caller' do
+      extend T::Sig
+
+      # rubocop:disable Style/ParallelAssignment
+
+      it 'returns the caller frame when called from a sig-wrapped method' do
+        expected_line, loc = [__LINE__, sigged_helper]
+
+        assert_equal(__FILE__, loc.path)
+        assert_equal(expected_line, loc.lineno)
+      end
+
+      it 'skips multiple sorbet-runtime frames inserted by nested sig wrappers' do
+        expected_line, loc = sigged_outer
+
+        assert_equal(__FILE__, loc.path)
+        assert_equal(expected_line, loc.lineno)
+      end
+
+      it 'returns the caller when called from a non-sig method' do
+        expected_line, loc = [__LINE__, plain_helper]
+
+        assert_equal(__FILE__, loc.path)
+        assert_equal(expected_line, loc.lineno)
+      end
+
+      # rubocop:enable Style/ParallelAssignment
+
+      private
+
+      sig { returns(T.nilable(Thread::Backtrace::Location)) }
+      def sigged_helper
+        T::Utils.first_non_sorbet_caller
+      end
+
+      sig { returns([Integer, T.nilable(Thread::Backtrace::Location)]) }
+      def sigged_outer
+        expected_line = __LINE__ + 1
+        loc = sigged_helper
+        [expected_line, loc]
+      end
+
+      def plain_helper
+        T::Utils.first_non_sorbet_caller
+      end
+    end
   end
 end


### PR DESCRIPTION
### Motivation

Sorbet runtime frames can get in the way of other meta-programming that relies on `Kernel.caller_locations`.

This PR adds a helper which figures out the first non-Sorbet-runtime caller, so that applications don't have to hard-code expectations about Sorbet Runtime (e.g. gem folder structure, file names, method names, call frame count, etc.)

### Test plan

See included automated tests.
