### PR TITLE
Publish to rubygems.org if gems/ changed on master

### DIFF
--- a/.buildkite/publish-ruby-gems.sh
+++ b/.buildkite/publish-ruby-gems.sh
@@ -2,8 +2,13 @@
 
 set -euo pipefail
 
-if [ "${PUBLISH_TO_RUBYGEMS:-}" == "" ]; then
-  echo "Skipping because this build is not the nightly RubyGems scheduled build"
+if [ "${BUILDKITE_BRANCH:-}" != "master" ]; then
+  echo "Skipping because this is not the master branch"
+  exit 0
+fi
+
+if [ "${PUBLISH_TO_RUBYGEMS:-}" == "" ] && git diff --quiet HEAD^..HEAD -- gems/; then
+  echo "Skipping because this is not the nightly RubyGems scheduled build and gems/ was not changed"
   exit 0
 fi
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In the past we avoided publishing to rubygems.org because we would get
500 HTTP reponses from publishing on every commit.

Technically, every new commit might have a new sorbet-static version,
and might want a new publish. But IMO the most important ones are the
sorbet-runtime changes, because those have a little more consequence if
they go wrong and people might want to be able to bisect which
sorbet-runtime version caused the problem. So let's try publishing for
every `gems/` change and see if we can get away with it.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Test in prod