### PR TITLE
Document Prism-supported splat in block paramters

### DIFF
--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -826,13 +826,6 @@ ast::ExpressionPtr Desugarer::desugarMlhs(core::LocOffsets loc, PrismNode *lhs, 
             }
         } else {
             ast::ExpressionPtr lh = desugar(c);
-            if (auto restParam = ast::cast_tree<ast::RestParam>(lh)) {
-                if (auto e = ctx.beginIndexerError(lh.loc(), core::errors::Desugar::UnsupportedRestArgsDestructure)) {
-                    e.setHeader("Unsupported rest args in destructure");
-                }
-                lh = move(restParam->expr);
-            }
-
             auto lhloc = lh.loc();
             stats.emplace_back(MK::Assign(lhloc, move(lh), move(val)));
         }

--- a/test/BUILD
+++ b/test/BUILD
@@ -274,6 +274,10 @@ pipeline_tests(
         exclude = [
             "testdata/rbs/**/*.rb",
             "testdata/rbs/**/*.exp",
+
+            # Cases where Prism has a better output than the legacy parser,
+            # and a different `_prism.rb` test exists to characterize Prism's behaviour.
+            "testdata/desugar/star_in_block_arg_prism.rb",
         ],
     ),
     "PosTests",
@@ -537,6 +541,10 @@ pipeline_tests(
         # todo(gdritter): fix this!
         exclude = [
             "testdata/packager/directed-*/**/*",
+
+            # Cases where Prism has a better output than the legacy parser,
+            # and a different `_prism.rb` test exists to characterize Prism's behaviour.
+            "testdata/desugar/star_in_block_arg_prism.rb",
         ],
     ),
     "LSPTests",

--- a/test/BUILD
+++ b/test/BUILD
@@ -293,6 +293,10 @@ pipeline_tests(
             "testdata/rbs/**/*.rb",
             "testdata/rbs/**/*.exp",
 
+            # Cases where Prism has a better output than the legacy parser,
+            # and a different `_prism.rb` test exists to characterize Prism's behaviour.
+            "testdata/desugar/star_in_block_arg.rb",
+
             # Prism allows a new line between `.` and `end` as a way to call a method called literally `#end`.
             # The legacy parser treats this as an incomplete call to `x.<method-name-missing>()`, which is much
             # nicer behaviour, which we eventually want to support with Prism as well.
@@ -470,7 +474,6 @@ pipeline_tests(
             # Prism desugared tree doesn't match legacy desugared tree (desugar differences)
             "testdata/desugar/destructure_rest.rb",
             "testdata/desugar/splat.rb",
-            "testdata/desugar/star_in_block_arg.rb",
             "testdata/infer/generics/validator.rb",
             "testdata/lsp/fast_path/alias_stub_module__*.rb",
             "testdata/lsp/fast_path/not_enough_files/not_enough_files__*.rb",

--- a/test/testdata/desugar/star_in_block_arg_prism.desugar-tree.exp
+++ b/test/testdata/desugar/star_in_block_arg_prism.desugar-tree.exp
@@ -1,0 +1,23 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+  <self>.sig() do ||
+    <self>.params(:blk, <emptyTree>::<C T>.proc().params(:args, <emptyTree>::<C Integer>).void()).void()
+  end
+
+  def foo<<todo method>>(&blk)
+    <emptyTree>
+  end
+
+  <self>.foo() do |<destructure>$2|
+    begin
+      begin
+        <assignTemp>$3 = <destructure>$2
+        <assignTemp>$4 = ::<Magic>.<expand-splat>(<assignTemp>$3, 0, 0)
+        args = <assignTemp>$4.to_ary()
+        <assignTemp>$3
+      end
+      <emptyTree>::<C T>.reveal_type(args)
+    end
+  end
+end

--- a/test/testdata/desugar/star_in_block_arg_prism.rb
+++ b/test/testdata/desugar/star_in_block_arg_prism.rb
@@ -7,6 +7,6 @@ sig {params(blk: T.proc.params(args: Integer).void).void}
 def foo(&blk)
 end
 
-foo do |(*args)| # error: Unsupported rest args in destructure
+foo do |(*args)|
   T.reveal_type(args) # error: Revealed type: `Integer`
 end


### PR DESCRIPTION
### Motivation

[Error 3009](https://sorbet.org/docs/error-reference#3009) doesn't apply to Prism. It handles this syntax just fine.


### Test plan

Introduces a new test to characterize the Prism-specific behaviour.