### PR TITLE
Log the worker_pool_size

### DIFF
--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -478,6 +478,8 @@ int realmain(int argc, char *argv[]) {
                          "or set SORBET_SILENCE_DEV_MESSAGE=1 in your shell environment.\n");
         }
     }
+
+    prodCounterSet("thread_pool_size", opts.threads);
     unique_ptr<WorkerPool> workers = WorkerPool::create(opts.threads, *logger);
 
     auto errorFlusher = make_shared<core::ErrorFlusherStdout>();

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -479,7 +479,7 @@ int realmain(int argc, char *argv[]) {
         }
     }
 
-    prodCounterSet("thread_pool_size", opts.threads);
+    prodCounterSet("worker_pool_size", opts.threads);
     unique_ptr<WorkerPool> workers = WorkerPool::create(opts.threads, *logger);
 
     auto errorFlusher = make_shared<core::ErrorFlusherStdout>();


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Some users want to be able to correlate typechecking performance with
available hardware concurrency.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

```
❯ sorbet -e 0 --counters 2>&1 | rg worker_pool_size
                          worker_pool_size :              0

❯ (cd gems/sorbet-runtime && sorbet --counters 2>&1 | rg worker_pool_size)
                          worker_pool_size :             12
```