### PR TITLE
Indicate what stratum we're scheduled to on an early exit

### DIFF
--- a/core/lsp/PreemptionTaskManager.cc
+++ b/core/lsp/PreemptionTaskManager.cc
@@ -49,6 +49,14 @@ PreemptionTask::RunResult PreemptionTaskManager::tryRunScheduledPreemptionTask(c
     TypecheckEpochManager::assertConsistentThread(
         typecheckingThreadId, "PreemptionTaskManager::tryRunScheduledPreemptionTask", "typechecking thread");
 
+    // We exit early if there's no task present to ensure that the value of `runnableAt` is valid. The call to
+    // `trySchedulePreemptionTask` is what resets `runnableAt`, so if there's no task present it doesn't make sense to
+    // consult `runnableAt` to determine if we've reached the stratum that can support the task.
+    auto preemptTask = atomic_load(&this->preemptTask);
+    if (preemptTask == nullptr) {
+        return result;
+    }
+
     // We can early-exit if we know that it's not possible to run preemption yet, but if we know that rescheduling is
     // not possible, we should run to completion.
     if (allowReschedule) {
@@ -59,9 +67,7 @@ PreemptionTask::RunResult PreemptionTaskManager::tryRunScheduledPreemptionTask(c
         }
     }
 
-    auto preemptTask = atomic_load(&this->preemptTask);
-    if (preemptTask != nullptr &&
-        atomic_compare_exchange_strong(&this->preemptTask, &preemptTask, shared_ptr<PreemptionTask>(nullptr))) {
+    if (atomic_compare_exchange_strong(&this->preemptTask, &preemptTask, shared_ptr<PreemptionTask>(nullptr))) {
         // Capture with write lock before running task. Ensures that all worker threads park before we proceed.
         absl::MutexLock lock(&typecheckMutex);
         // The error queue is where typechecking puts all typechecking errors. For a given edit, Sorbet LSP runs

--- a/core/lsp/PreemptionTaskManager.cc
+++ b/core/lsp/PreemptionTaskManager.cc
@@ -51,8 +51,12 @@ PreemptionTask::RunResult PreemptionTaskManager::tryRunScheduledPreemptionTask(c
 
     // We can early-exit if we know that it's not possible to run preemption yet, but if we know that rescheduling is
     // not possible, we should run to completion.
-    if (allowReschedule && currentStratum < this->runnableAt.load()) {
-        return result;
+    if (allowReschedule) {
+        auto runnableStratum = this->runnableAt.load();
+        if (currentStratum < runnableStratum) {
+            result.setRescheduledStratum(runnableStratum);
+            return result;
+        }
     }
 
     auto preemptTask = atomic_load(&this->preemptTask);

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -447,12 +447,16 @@ TEST_CASE("PreemptionReschedulingWorksAsExpected") {
               .progress());
     CHECK_EQ(1, task->runCount);
 
-    // This should not run the scheduled task, as we haven't made it to stratum 2 yet.
+    // This should not run the scheduled task, as we haven't made it to stratum 2 yet: it will indicate that preemption
+    // is rescheduled, but that no tasks were handled.
     ++currentStratum;
-    CHECK_FALSE(
-        preemptManager
-            ->tryRunScheduledPreemptionTask(*gs, core::packages::Stratum(currentStratum), /* allowReschedule */ true)
-            .progress());
+    {
+        auto result = preemptManager->tryRunScheduledPreemptionTask(*gs, core::packages::Stratum(currentStratum),
+                                                                    /* allowReschedule */ true);
+        CHECK(result.progress());
+        CHECK(result.wasRescheduled());
+        CHECK_FALSE(result.getTasksHandled());
+    }
     CHECK_EQ(1, task->runCount);
 
     // This should run and clear the task.


### PR DESCRIPTION
If a scheduled preemption task has already been delayed to a later stratum that we haven't reached yet, we can indicate that the task still isn't runnable by setting the rescheduled field in the `PreemptionTask::RunResult` that's returned by `tryRunScheduledPreemptionTask`. This requires us to check for the presence of a preemption task before potentially exiting early, so we now test for a preemption task's presence before checking for an early exit, and then swapping the shared pointer only when we're considering running the task.

This fixes a deadlock in loop that tests for expected preemptions, by noticing that preemption won't be possible at the current stratum, rather than indicating that no work was done.

### Motivation
Testing package-directed preemption.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included test changes.