### PR TITLE
Support exports with the test __package.rb builder

### DIFF
--- a/test/helpers/packages.cc
+++ b/test/helpers/packages.cc
@@ -43,6 +43,10 @@ string PackageTextBuilder::build() {
         fmt::format_to(back_inserter(out), "  test_import {}\n", i);
     }
 
+    for (auto &e : this->exports) {
+        fmt::format_to(back_inserter(out), "  export {}\n", e);
+    }
+
     fmt::format_to(back_inserter(out), "end\n");
 
     return out;

--- a/test/helpers/packages.h
+++ b/test/helpers/packages.h
@@ -23,6 +23,7 @@ class PackageTextBuilder {
     std::string strictDeps;
     std::string layer;
     std::vector<std::string> imports;
+    std::vector<std::string> exports;
     std::vector<std::string> testImports;
     bool preludePackage;
 
@@ -44,6 +45,11 @@ public:
 
     PackageTextBuilder &withImports(std::vector<std::string> imports) {
         this->imports = std::move(imports);
+        return *this;
+    }
+
+    PackageTextBuilder &withExports(std::vector<std::string> imports) {
+        this->exports = std::move(imports);
         return *this;
     }
 


### PR DESCRIPTION
Support adding exports to the `__package.rb` file builder that we use in tests.

### Motivation
Making it easier to construct test cases in #10129.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavioral change, prework for testing in #10129.
