### PR TITLE
Add a typed sigil to the __package.rb builder output

### DIFF
--- a/test/helpers/packages.cc
+++ b/test/helpers/packages.cc
@@ -21,7 +21,7 @@ const vector<string> PackageHelpers::LAYERS_LIB_APP = {"lib", "app"};
 const vector<string> PackageHelpers::LAYERS_UTIL_LIB_APP = {"util", "lib", "app"};
 
 string PackageTextBuilder::build() {
-    string out = fmt::format("class {} < PackageSpec\n", this->name);
+    string out = fmt::format("# typed: strict\n\nclass {} < PackageSpec\n", this->name);
 
     if (this->preludePackage) {
         fmt::format_to(back_inserter(out), "  prelude_package\n");


### PR DESCRIPTION
The `PackageTextBuilder` wasn't including a `typed` sigil on its output, which complicates using it with the LSP multithreaded tests. This PR adds an unconditional `# typed: strict` to its output.

### Motivation
Fixing test helpers.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No test changes expected.
