### PR TITLE
Fix FileStratumMapping methods

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -970,13 +970,11 @@ void LSPTypechecker::updateConfigAndGsFromOptions(const DidChangeConfigurationPa
     }
 }
 
-core::packages::Stratum FileStratumMapping::getStratumForUris(absl::Span<const string_view> paths) const {
+core::packages::Stratum FileStratumMapping::getStratumForFiles(absl::Span<const core::FileRef> refs) const {
     core::packages::Stratum stratum(0);
-    for (auto path : paths) {
-        auto ref = this->tc.state().findFileByPath(path);
-
+    for (auto ref : refs) {
         // Fall back on the last stratum for new files.
-        if (!ref.exists()) {
+        if (!ref.exists() || ref.id() >= this->tc.fileToStratum.size()) {
             return this->tc.lastStratum;
         }
 
@@ -986,11 +984,26 @@ core::packages::Stratum FileStratumMapping::getStratumForUris(absl::Span<const s
     return stratum;
 }
 
-core::packages::Stratum FileStratumMapping::getStratumForUri(std::string_view path) const {
-    auto ref = this->tc.state().findFileByPath(path);
+core::packages::Stratum FileStratumMapping::getStratumForPaths(absl::Span<const string_view> paths) const {
+    vector<core::FileRef> refs;
+    refs.reserve(paths.size());
+    absl::c_transform(paths, back_inserter(refs),
+                      [&gs = this->tc.state()](auto path) { return gs.findFileByPath(path); });
+    return this->getStratumForFiles(refs);
+}
 
+core::packages::Stratum FileStratumMapping::getStratumForUris(absl::Span<const string_view> uris) const {
+    vector<core::FileRef> refs;
+    refs.reserve(uris.size());
+    absl::c_transform(uris, back_inserter(refs), [&gs = this->tc.state(), &config = *this->tc.config](auto uri) {
+        return config.uri2FileRef(gs, uri);
+    });
+    return this->getStratumForFiles(refs);
+}
+
+core::packages::Stratum FileStratumMapping::getStratumForFile(core::FileRef ref) const {
     // Fall back on the last stratum for new files.
-    if (!ref.exists()) {
+    if (!ref.exists() || ref.id() >= this->tc.fileToStratum.size()) {
         return this->tc.lastStratum;
     }
 

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -226,14 +226,38 @@ class FileStratumMapping {
 
 public:
     /**
-     * Get the id of the stratum that an edit involving these files could be checked at.
+     * Get the id of the stratum that an edit involving these file refs could be checked at.
      */
-    core::packages::Stratum getStratumForUris(absl::Span<const std::string_view> edit) const;
+    core::packages::Stratum getStratumForFiles(absl::Span<const core::FileRef> frefs) const;
 
     /**
-     * Get the id of the stratum that an edit involving this file could be checked at.
+     * Get the id of the stratum that an edit involving these paths could be checked at.
      */
-    core::packages::Stratum getStratumForUri(std::string_view uri) const;
+    core::packages::Stratum getStratumForPaths(absl::Span<const std::string_view> paths) const;
+
+    /**
+     * Get the id of the stratum that an edit involving these uris could be checked at.
+     */
+    core::packages::Stratum getStratumForUris(absl::Span<const std::string_view> uris) const;
+
+    /**
+     * Get the id of the stratum that an edit involving this file ref could be checked at.
+     */
+    core::packages::Stratum getStratumForFile(core::FileRef ref) const;
+
+    /**
+     * Get the id of the stratum that an edit involving this path could be checked at.
+     */
+    core::packages::Stratum getStratumForPath(const std::string_view path) const {
+        return this->getStratumForFile(this->tc.state().findFileByPath(path));
+    }
+
+    /**
+     * Get the id of the stratum that an edit involving this uri could be checked at.
+     */
+    core::packages::Stratum getStratumForUri(std::string_view uri) const {
+        return this->getStratumForFile(this->tc.config->uri2FileRef(this->tc.state(), uri));
+    }
 
     /**
      * Get the id of the last stratum in the condensation graph.


### PR DESCRIPTION
The `FileStratumMapping::getStratumForUri` and `FileStratumMapping::getStratumForUris` methods were not going throug the `LSPConfiguration::uri2FileRef` method before looking up entries in the stratum, which resulted in all preemption tasks that weren't already tracking paths getting rescheduled to the final stratum. As these methods are currently unused, there's no fallout from this, but on #10129 this causes preemption tests to fail.

I've expanded the set of methods available on `FileStratumMapping` to include variants for `FileRef`s, paths, and uris, so that we have all options available to us when using this mapping in #10129.

### Motivation
Fixing the file to stratum mapping used by package-directed preemption.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See tests in #10129.
