### PR TITLE
Change `undef` into a magic method

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -2391,16 +2391,14 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 if (auto e = dctx.ctx.beginIndexerError(what->loc, core::errors::Desugar::UndefUsage)) {
                     e.setHeader("Unsupported method: undef");
                 }
+
                 Send::ARGS_store args;
                 for (auto &expr : undef->exprs) {
                     args.emplace_back(node2TreeImpl(dctx, expr));
                 }
-                auto numPosArgs = args.size();
-                auto res = MK::Send(loc, MK::Constant(loc, core::Symbols::Kernel()), core::Names::undef(), locZeroLen,
-                                    numPosArgs, move(args));
-                // It wasn't a Send to begin with--there's no way this could result in a private
-                // method call error.
-                ast::cast_tree_nonnull<ast::Send>(res).flags.isPrivateOk = true;
+
+                // Desugar `undef :foo, :bar` to `::<Magic>.<undef>(:foo, :bar)`
+                auto res = MK::Send(loc, MK::Magic(loc), core::Names::undef(), locZeroLen, args.size(), move(args));
                 result = move(res);
             },
             [&](parser::CaseMatch *caseMatch) {

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -3343,12 +3343,10 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             ENFORCE(undefNode->names.size > 0, "PM_UNDEF_NODE without names is expected to be a parse error");
 
             auto args = nodeListToStore<ast::Send::ARGS_store>(undefNode->names);
-            auto expr = MK::Send(location, MK::Constant(location, core::Symbols::Kernel()), core::Names::undef(),
-                                 location.copyWithZeroLength(), args.size(), std::move(args));
-            // It wasn't a Send to begin with--there's no way this could result in a private
-            // method call error.
-            ast::cast_tree_nonnull<ast::Send>(expr).flags.isPrivateOk = true;
-            return expr;
+
+            // Desugar `undef :foo, :bar` to `::<Magic>.<undef>(:foo, :bar)`
+            return MK::Send(location, MK::Magic(location), core::Names::undef(), location.copyWithZeroLength(),
+                            args.size(), move(args));
         }
         case PM_UNLESS_NODE: { // An `unless` branch, either in a statement or modifier form.
             auto unlessNode = down_cast<pm_unless_node>(node);

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -759,6 +759,11 @@ void GlobalState::initEmpty() {
     // Synthesize <Magic>.<retry>() => Void
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::retry()).buildWithResult(Types::void_());
 
+    // Synthesize <Magic>.<undef>(*arg0: Symbol) => Void
+    method = enterMethod(*this, Symbols::MagicSingleton(), Names::undef())
+                 .repeatedTypedArg(Names::arg0(), Types::Symbol())
+                 .buildWithResult(Types::void_());
+
     // Synthesize <Magic>.<blockBreak>(args: T.untyped) => T.untyped
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::blockBreak())
                  .untypedArg(Names::arg0())

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -21,7 +21,7 @@ namespace sorbet::core {
 using namespace std;
 
 const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 211;
-const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 52;
+const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 53;
 const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 20;
 const int Symbols::MAX_SYNTHETIC_TYPEPARAMETER_SYMBOLS = 6;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 103;

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -56,7 +56,7 @@ NameDef names[] = {
     {"orOp", "|"},
     {"backtick", "`"},
     {"defined_p", "defined?"},
-    {"undef"},
+    {"undef", "<undef>"},
     {"each"},
     {"subclasses"},
     {"transpose"},

--- a/main/lsp/requests/completion.cc
+++ b/main/lsp/requests/completion.cc
@@ -81,8 +81,7 @@ const RubyKeyword rubyKeywords[] = {
     {"super", "Calls the current method in a superclass."},
     {"then", "Indicates the end of conditional blocks in control structures."},
     {"true", "Boolean true."},
-    // This is also defined on Kernel
-    // {"undef", "Prevents a class or module from responding to a method call."},
+    {"undef", "Prevents a class or module from responding to a method call."},
     {"unless", "Used for unless and modifier unless expressions.", "unless ${1:expr}\n  $0\nend", "unless/end"},
     {"until", "Creates a loop that executes until the condition is true.", "until ${1:expr}\n  $0\nend", "until/end"},
     // Would really like to dedent the line too...

--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -736,14 +736,6 @@ module Kernel
   sig {returns(T.self_type)}
   def trust(); end
 
-  sig do
-    params(
-        arg: BasicObject,
-    )
-    .void
-  end
-  def undef(*arg); end
-
   sig {returns(T.self_type)}
   def untaint(); end
 

--- a/test/prism_regression/undef.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/undef.rb.desugar-tree-raw.exp
@@ -8,12 +8,12 @@ ClassDef{
     }]
   rhs = [
     Send{
-      flags = {privateOk}
+      flags = {}
       recv = ConstantLit{
-        symbol = (module ::Kernel)
+        symbol = (class ::<Magic>)
         orig = nullptr
       }
-      fun = <U undef>
+      fun = <U <undef>>
       block = nullptr
       pos_args = 1
       args = [
@@ -22,12 +22,12 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {}
       recv = ConstantLit{
-        symbol = (module ::Kernel)
+        symbol = (class ::<Magic>)
         orig = nullptr
       }
-      fun = <U undef>
+      fun = <U <undef>>
       block = nullptr
       pos_args = 1
       args = [
@@ -36,12 +36,12 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {}
       recv = ConstantLit{
-        symbol = (module ::Kernel)
+        symbol = (class ::<Magic>)
         orig = nullptr
       }
-      fun = <U undef>
+      fun = <U <undef>>
       block = nullptr
       pos_args = 2
       args = [

--- a/test/testdata/lsp/completion/enum_case.A.rbedited
+++ b/test/testdata/lsp/completion/enum_case.A.rbedited
@@ -32,5 +32,5 @@ def example(my_enum)
   #               ^ apply-completion: [C] item: 0
 
   my_enum.
-    #     ^ apply-completion: [D] item: 122
+    #     ^ apply-completion: [D] item: 121
 end # error: unexpected token "end"

--- a/test/testdata/lsp/completion/enum_case.B.rbedited
+++ b/test/testdata/lsp/completion/enum_case.B.rbedited
@@ -32,5 +32,5 @@ def example(my_enum)
   #               ^ apply-completion: [C] item: 0
 
   my_enum.
-    #     ^ apply-completion: [D] item: 122
+    #     ^ apply-completion: [D] item: 121
 end # error: unexpected token "end"

--- a/test/testdata/lsp/completion/enum_case.C.rbedited
+++ b/test/testdata/lsp/completion/enum_case.C.rbedited
@@ -32,5 +32,5 @@ def example(my_enum)
   #               ^ apply-completion: [C] item: 0
 
   my_enum.
-    #     ^ apply-completion: [D] item: 122
+    #     ^ apply-completion: [D] item: 121
 end # error: unexpected token "end"

--- a/test/testdata/lsp/completion/enum_case.D.rbedited
+++ b/test/testdata/lsp/completion/enum_case.D.rbedited
@@ -32,5 +32,5 @@ def example(my_enum)
   else
     T.absurd(my_enum)
   end
-    #     ^ apply-completion: [D] item: 122
+    #     ^ apply-completion: [D] item: 121
 end # error: unexpected token "end"

--- a/test/testdata/lsp/completion/enum_case.rb
+++ b/test/testdata/lsp/completion/enum_case.rb
@@ -26,5 +26,5 @@ def example(my_enum)
   #               ^ apply-completion: [C] item: 0
 
   my_enum.
-    #     ^ apply-completion: [D] item: 122
+    #     ^ apply-completion: [D] item: 121
 end # error: unexpected token "end"

--- a/test/testdata/lsp/completion/keywords.rb
+++ b/test/testdata/lsp/completion/keywords.rb
@@ -134,7 +134,5 @@ class A; end
 A.new.the # error: does not exist
 #        ^ completion: then
 
-# undef_method comes before undef because undef is a method on Kernel
-# but undef_method is a method on Module (Module < Object < Kernel)
 unde # error: does not exist
-#   ^ completion: undef_method, undef
+#   ^ completion: undef, undef_method

--- a/test/testdata/parser/misc.rb.desugar-tree.exp
+++ b/test/testdata/parser/misc.rb.desugar-tree.exp
@@ -205,7 +205,7 @@ rescue <emptyTree>::<C E> => x
     7
   end
 
-  ::Kernel.undef(:x, :y)
+  ::<Magic>.<undef>(:x, :y)
 
   ["a", "b"]
 


### PR DESCRIPTION
### Motivation

The RBI falsely claimed that `undef` is a method on `Kernel`. It's not a method on `Kernel`, or anywhere at all:

```ruby
class Demo
  p method_defined?(:undef) # => false
end
```

`undef` is a keyword in the language similar to `alias`, and not a method.

This PR:

1. Renames the symbol to `<undef>` to clarify its magic status.
2. Changes the desugared method call's receiver to `<Magic>`, which is where the sig for the method now lives.
3. Turns off `isPrivateOk`, which isn't relevant here.

### Test plan

Covered by existing tests, whose expectation has been updated.