### PR TITLE
Add optional `flags` param to `Send0` and `Send1` helpers

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -557,8 +557,8 @@ public:
 
         Send::Flags flags;
         flags.isPrivateOk = true;
-        return Send(loc, Self(superKeywordLoc.copyWithZeroLength()), method, superKeywordLoc, 1,
-                    SendArgs(make_expression<ast::ZSuperArgs>(superKeywordLoc.copyEndWithZeroLength())), flags);
+        return Send1(loc, Self(superKeywordLoc.copyWithZeroLength()), method, superKeywordLoc,
+                     make_expression<ast::ZSuperArgs>(superKeywordLoc.copyEndWithZeroLength()), flags);
     }
 
     static ExpressionPtr Magic(core::LocOffsets loc) {

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -42,9 +42,10 @@ public:
         return send;
     }
 
-    static ExpressionPtr Send0(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, core::LocOffsets funLoc) {
+    static ExpressionPtr Send0(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, core::LocOffsets funLoc,
+                               Send::Flags flags = {}) {
         Send::ARGS_store nargs;
-        return Send(loc, std::move(recv), fun, funLoc, 0, std::move(nargs));
+        return Send(loc, std::move(recv), fun, funLoc, 0, std::move(nargs), flags);
     }
 
     static ExpressionPtr Send0Block(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun,
@@ -58,8 +59,8 @@ public:
     }
 
     static ExpressionPtr Send1(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, core::LocOffsets funLoc,
-                               ExpressionPtr arg1) {
-        return Send(loc, std::move(recv), fun, funLoc, 1, SendArgs(std::move(arg1)));
+                               ExpressionPtr arg1, Send::Flags flags = {}) {
+        return Send(loc, std::move(recv), fun, funLoc, 1, SendArgs(std::move(arg1)), flags);
     }
 
     static ExpressionPtr Send2(core::LocOffsets loc, ExpressionPtr recv, core::NameRef fun, core::LocOffsets funLoc,

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -798,10 +798,7 @@ ast::ExpressionPtr Desugarer::desugarMlhs(core::LocOffsets loc, PrismNode *lhs, 
             if (PM_NODE_FLAG_P(callTargetNode, PM_CALL_NODE_FLAGS_SAFE_NAVIGATION)) {
                 auto body = [&val](ast::ExpressionPtr receiverTempLocal, core::LocOffsets parentLoc,
                                    core::NameRef methodName, core::LocOffsets methodNameLoc) {
-                    ast::Send::ARGS_store arguments;
-                    arguments.emplace_back(move(val));
-
-                    return MK::Send(parentLoc, move(receiverTempLocal), methodName, methodNameLoc, 1, move(arguments));
+                    return MK::Send1(parentLoc, move(receiverTempLocal), methodName, methodNameLoc, move(val));
                 };
 
                 auto expr =
@@ -818,11 +815,7 @@ ast::ExpressionPtr Desugarer::desugarMlhs(core::LocOffsets loc, PrismNode *lhs, 
                 ast::Send::Flags flags;
                 flags.isPrivateOk = PM_NODE_FLAG_P(callTargetNode, PM_CALL_NODE_FLAGS_IGNORE_VISIBILITY);
 
-                ast::Send::ARGS_store arguments;
-                arguments.emplace_back(move(val));
-
-                stats.emplace_back(
-                    MK::Send(cloc, move(receiver), methodName, methodNameLoc, 1, move(arguments), flags));
+                stats.emplace_back(MK::Send1(cloc, move(receiver), methodName, methodNameLoc, move(val), flags));
             }
         } else {
             ast::ExpressionPtr lh = desugar(c);

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -1586,7 +1586,7 @@ ast::ExpressionPtr Desugarer::desugarSendOpAssign(pm_node_t *untypedNode) {
     ast::Send::Flags flags;
     flags.isPrivateOk = PM_NODE_FLAG_P(untypedNode, PM_CALL_NODE_FLAGS_IGNORE_VISIBILITY);
 
-    auto lhs = MK::Send(lhsLoc, move(receiverExpr), name, messageLoc, 0, ast::Send::ARGS_store{}, flags);
+    auto lhs = MK::Send0(lhsLoc, move(receiverExpr), name, messageLoc, flags);
     auto rhs = desugar(node->value);
 
     if constexpr (Kind == OpAssignKind::Operator) {

--- a/rewriter/TEnum.cc
+++ b/rewriter/TEnum.cc
@@ -256,11 +256,10 @@ void TEnum::run(core::MutableContext ctx, ast::ClassDef *klass) {
         auto sig = ast::MK::Sig0(klass->declLoc, std::move(return_type_ast));
         auto method = ast::MK::SyntheticMethod0(klass->loc, klass->declLoc, core::Names::serialize(),
                                                 ast::MK::RaiseTypedUnimplemented(klass->declLoc));
-        ast::Send::ARGS_store nargs;
         ast::Send::Flags flags;
         flags.isPrivateOk = true;
-        auto visibility = ast::MK::Send(klass->declLoc, ast::MK::Self(klass->declLoc), core::Names::public_(),
-                                        klass->declLoc, 0, std::move(nargs), flags);
+        auto visibility = ast::MK::Send0(klass->declLoc, ast::MK::Self(klass->declLoc), core::Names::public_(),
+                                         klass->declLoc, flags);
 
         klass->rhs.emplace_back(std::move(visibility));
         klass->rhs.emplace_back(std::move(sig));


### PR DESCRIPTION
### Motivation

Similar to `Send0Block()`, this let's the Send0/Send1 helpers be applied in a few more places, including 2 more usages coming up in #10239

### Test plan

Pure refactor.
