### PR TITLE
Delete unused `prelude` static method on `Import`

### DIFF
--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -55,12 +55,6 @@ struct Import {
     Import(MangledName mangledName, ImportType type, core::LocOffsets loc)
         : mangledName(mangledName), type(type), loc(loc) {}
 
-    // Generate a prelude import, with the given origin.
-    // NOTE: the origin must point to something to hang any errors related to the implicit import off of. Currently this
-    // is the declLoc_ of the package that is getting the implicit import, and because of this it's important to not use
-    // these locs when computing locations for autocorrects.
-    static Import prelude(MangledName mangledName, core::LocOffsets implicitLoc);
-
     Import(Import &&other) = default;
     Import(const Import &other) = default;
     Import &operator=(Import &&other) = default;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It's unused.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests pass.