### PR TITLE
Update the TestCase rewriter to drop kwargs constraint

### DIFF
--- a/rewriter/TestCase.cc
+++ b/rewriter/TestCase.cc
@@ -14,7 +14,7 @@ void TestCase::run(core::MutableContext ctx, ast::ClassDef *klass) {
     for (auto &stat : klass->rhs) {
         if (auto send = ast::cast_tree<ast::Send>(stat)) {
             if (send->fun == core::Names::test()) {
-                if (send->numPosArgs() == 1 && !send->hasKwArgs() && send->hasBlock()) {
+                if (send->numPosArgs() == 1 && send->hasBlock()) {
                     auto arg0 = ast::cast_tree<ast::Literal>(send->getPosArg(0));
 
                     if (arg0 && arg0->isString()) {

--- a/test/testdata/rewriter/test_case.rb
+++ b/test/testdata/rewriter/test_case.rb
@@ -45,6 +45,9 @@ class MyTest < ActiveSupport::TestCase
   test "valid method call" do
   end
 
+  test "valid method call with keyword args", focus: true do
+  end
+
   test "block is evaluated in the context of an instance" do
     assert true
   end

--- a/test/testdata/rewriter/test_case.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/test_case.rb.rewrite-tree.exp
@@ -35,6 +35,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.void()
     end
 
+    def test_valid_method_call_with_keyword_args<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.void()
+    end
+
     def test_block_is_evaluated_in_the_context_of_an_instance<<todo method>>(&<blk>)
       <self>.assert(true)
     end
@@ -99,6 +107,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     <runtime method definition of test_valid_method_call>
+
+    <runtime method definition of test_valid_method_call_with_keyword_args>
 
     <runtime method definition of test_block_is_evaluated_in_the_context_of_an_instance>
 


### PR DESCRIPTION
Drop the kwargs constraint when attempting to re-write `test` methods into functions. 
 
### Motivation

With the plan for ActiveSupport tests to support tags as optional kwargs for a call to `test`, I'm relaxing the constraint as we already operating with test tags. Having tags currently means that it falls back on block evaluation which doesn't currently support binding ivars to the correct place resulting in strict files needing to degrade to true.

### Test plan

See included automated tests.
