### PR TITLE
Keep the args to `encrypted_prop` around in the tree

### DIFF
--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -61,6 +61,7 @@ public:
 
         ast::ExpressionPtr *prevStat = nullptr;
         UnorderedMap<void *, vector<ast::ExpressionPtr>> replaceNodes;
+        UnorderedMap<void *, vector<ast::ExpressionPtr>> insertNodes;
         for (auto &stat : classDef->rhs) {
             typecase(
                 stat,
@@ -94,7 +95,7 @@ public:
 
                     nodes = MixinEncryptedProp::run(ctx, &send);
                     if (!nodes.empty()) {
-                        replaceNodes[stat.get()] = std::move(nodes);
+                        insertNodes[stat.get()] = std::move(nodes);
                         return;
                     }
 
@@ -156,7 +157,7 @@ public:
 
             prevStat = &stat;
         }
-        if (replaceNodes.empty()) {
+        if (replaceNodes.empty() && insertNodes.empty()) {
             ModuleFunction::run(ctx, classDef);
             return;
         }
@@ -167,9 +168,21 @@ public:
 
         for (auto &stat : oldRHS) {
             auto replacement = replaceNodes.find(stat.get());
+            auto insertion = insertNodes.find(stat.get());
+            ENFORCE(replacement == replaceNodes.end() || insertion == insertNodes.end(),
+                    "the same statement shouldn't be in both replaceNodes and insertNodes");
             if (replacement == replaceNodes.end()) {
+                // Keep the original statement
                 classDef->rhs.emplace_back(std::move(stat));
+
+                if (insertion != insertNodes.end()) {
+                    // Also add the nodes in insertNodes[stat]
+                    for (auto &newNode : insertion->second) {
+                        classDef->rhs.emplace_back(std::move(newNode));
+                    }
+                }
             } else {
+                // Replace the original with the nodes in replaceNodes[stat]
                 for (auto &newNode : replacement->second) {
                     classDef->rhs.emplace_back(std::move(newNode));
                 }

--- a/test/testdata/rewriter/prop.rb
+++ b/test/testdata/rewriter/prop.rb
@@ -86,10 +86,11 @@ end
 
 class EncryptedProp
   include T::Props
-  def self.encrypted_prop(opts={}); end
+  def self.encrypted_prop(name, kind: nil, **opts); end
   encrypted_prop :foo
   encrypted_prop :bar, migrating: true, immutable: true
   encrypted_prop :with_errors, "".dne
+                                # ^^^ error: Method `dne` does not exist on `String` component of `String("")`
 end
 
 def main

--- a/test/testdata/rewriter/prop.rb
+++ b/test/testdata/rewriter/prop.rb
@@ -89,6 +89,7 @@ class EncryptedProp
   def self.encrypted_prop(opts={}); end
   encrypted_prop :foo
   encrypted_prop :bar, migrating: true, immutable: true
+  encrypted_prop :with_errors, "".dne
 end
 
 def main

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -6057,6 +6057,407 @@ ClassDef{
         }
 
         Send{
+          flags = {rewriterSynthesized}
+          recv = ConstantLit{
+            symbol = (module ::T::Sig::WithoutRuntime)
+            orig = nullptr
+          }
+          fun = <U sig>
+          block = Block {
+            params = [
+            ]
+            body = Send{
+              flags = {}
+              recv = Self
+              fun = <U returns>
+              block = nullptr
+              pos_args = 1
+              args = [
+                Send{
+                  flags = {}
+                  recv = ConstantLit{
+                    symbol = (module ::T)
+                    orig = nullptr
+                  }
+                  fun = <U nilable>
+                  block = nullptr
+                  pos_args = 1
+                  args = [
+                    ConstantLit{
+                      symbol = (class ::String)
+                      orig = nullptr
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+          pos_args = 0
+          args = [
+          ]
+        }
+
+        MethodDef{
+          flags = {rewriterSynthesized}
+          name = <U with_errors><<U <todo method>>>
+          params = [BlockParam{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = Send{
+            flags = {rewriterSynthesized}
+            recv = Send{
+              flags = {}
+              recv = ConstantLit{
+                symbol = (module ::T)
+                orig = nullptr
+              }
+              fun = <U unsafe>
+              block = nullptr
+              pos_args = 1
+              args = [
+                ConstantLit{
+                  symbol = (module ::Kernel)
+                  orig = nullptr
+                }
+              ]
+            }
+            fun = <U raise>
+            block = nullptr
+            pos_args = 1
+            args = [
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
+            ]
+          }
+        }
+
+        Send{
+          flags = {rewriterSynthesized}
+          recv = ConstantLit{
+            symbol = (module ::T::Sig::WithoutRuntime)
+            orig = nullptr
+          }
+          fun = <U sig>
+          block = Block {
+            params = [
+            ]
+            body = Send{
+              flags = {}
+              recv = Self
+              fun = <U returns>
+              block = nullptr
+              pos_args = 1
+              args = [
+                Send{
+                  flags = {}
+                  recv = ConstantLit{
+                    symbol = (module ::T)
+                    orig = nullptr
+                  }
+                  fun = <U nilable>
+                  block = nullptr
+                  pos_args = 1
+                  args = [
+                    UnresolvedConstantLit{
+                      cnst = <C <U EncryptedValue>>
+                      scope = UnresolvedConstantLit{
+                        cnst = <C <U Encryptable>>
+                        scope = UnresolvedConstantLit{
+                          cnst = <C <U Mixins>>
+                          scope = UnresolvedConstantLit{
+                            cnst = <C <U Model>>
+                            scope = UnresolvedConstantLit{
+                              cnst = <C <U DB>>
+                              scope = UnresolvedConstantLit{
+                                cnst = <C <U Opus>>
+                                scope = EmptyTree
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+          pos_args = 0
+          args = [
+          ]
+        }
+
+        MethodDef{
+          flags = {rewriterSynthesized}
+          name = <U encrypted_with_errors><<U <todo method>>>
+          params = [BlockParam{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = Send{
+            flags = {rewriterSynthesized}
+            recv = Send{
+              flags = {}
+              recv = ConstantLit{
+                symbol = (module ::T)
+                orig = nullptr
+              }
+              fun = <U unsafe>
+              block = nullptr
+              pos_args = 1
+              args = [
+                ConstantLit{
+                  symbol = (module ::Kernel)
+                  orig = nullptr
+                }
+              ]
+            }
+            fun = <U raise>
+            block = nullptr
+            pos_args = 1
+            args = [
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
+            ]
+          }
+        }
+
+        Send{
+          flags = {rewriterSynthesized}
+          recv = ConstantLit{
+            symbol = (module ::T::Sig::WithoutRuntime)
+            orig = nullptr
+          }
+          fun = <U sig>
+          block = Block {
+            params = [
+            ]
+            body = Send{
+              flags = {}
+              recv = Send{
+                flags = {}
+                recv = Self
+                fun = <U params>
+                block = nullptr
+                pos_args = 0
+                args = [
+                  Literal{ value = :arg0 }
+                  Send{
+                    flags = {}
+                    recv = ConstantLit{
+                      symbol = (module ::T)
+                      orig = nullptr
+                    }
+                    fun = <U nilable>
+                    block = nullptr
+                    pos_args = 1
+                    args = [
+                      ConstantLit{
+                        symbol = (class ::String)
+                        orig = nullptr
+                      }
+                    ]
+                  }
+                ]
+              }
+              fun = <U returns>
+              block = nullptr
+              pos_args = 1
+              args = [
+                Send{
+                  flags = {}
+                  recv = ConstantLit{
+                    symbol = (module ::T)
+                    orig = nullptr
+                  }
+                  fun = <U nilable>
+                  block = nullptr
+                  pos_args = 1
+                  args = [
+                    ConstantLit{
+                      symbol = (class ::String)
+                      orig = nullptr
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+          pos_args = 0
+          args = [
+          ]
+        }
+
+        MethodDef{
+          flags = {rewriterSynthesized}
+          name = <U with_errors=><<U <todo method>>>
+          params = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockParam{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = Send{
+            flags = {rewriterSynthesized}
+            recv = Send{
+              flags = {}
+              recv = ConstantLit{
+                symbol = (module ::T)
+                orig = nullptr
+              }
+              fun = <U unsafe>
+              block = nullptr
+              pos_args = 1
+              args = [
+                ConstantLit{
+                  symbol = (module ::Kernel)
+                  orig = nullptr
+                }
+              ]
+            }
+            fun = <U raise>
+            block = nullptr
+            pos_args = 1
+            args = [
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
+            ]
+          }
+        }
+
+        Send{
+          flags = {rewriterSynthesized}
+          recv = ConstantLit{
+            symbol = (module ::T::Sig::WithoutRuntime)
+            orig = nullptr
+          }
+          fun = <U sig>
+          block = Block {
+            params = [
+            ]
+            body = Send{
+              flags = {}
+              recv = Send{
+                flags = {}
+                recv = Self
+                fun = <U params>
+                block = nullptr
+                pos_args = 0
+                args = [
+                  Literal{ value = :arg0 }
+                  Send{
+                    flags = {}
+                    recv = ConstantLit{
+                      symbol = (module ::T)
+                      orig = nullptr
+                    }
+                    fun = <U nilable>
+                    block = nullptr
+                    pos_args = 1
+                    args = [
+                      UnresolvedConstantLit{
+                        cnst = <C <U EncryptedValue>>
+                        scope = UnresolvedConstantLit{
+                          cnst = <C <U Encryptable>>
+                          scope = UnresolvedConstantLit{
+                            cnst = <C <U Mixins>>
+                            scope = UnresolvedConstantLit{
+                              cnst = <C <U Model>>
+                              scope = UnresolvedConstantLit{
+                                cnst = <C <U DB>>
+                                scope = UnresolvedConstantLit{
+                                  cnst = <C <U Opus>>
+                                  scope = EmptyTree
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+              fun = <U returns>
+              block = nullptr
+              pos_args = 1
+              args = [
+                Send{
+                  flags = {}
+                  recv = ConstantLit{
+                    symbol = (module ::T)
+                    orig = nullptr
+                  }
+                  fun = <U nilable>
+                  block = nullptr
+                  pos_args = 1
+                  args = [
+                    UnresolvedConstantLit{
+                      cnst = <C <U EncryptedValue>>
+                      scope = UnresolvedConstantLit{
+                        cnst = <C <U Encryptable>>
+                        scope = UnresolvedConstantLit{
+                          cnst = <C <U Mixins>>
+                          scope = UnresolvedConstantLit{
+                            cnst = <C <U Model>>
+                            scope = UnresolvedConstantLit{
+                              cnst = <C <U DB>>
+                              scope = UnresolvedConstantLit{
+                                cnst = <C <U Opus>>
+                                scope = EmptyTree
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+          pos_args = 0
+          args = [
+          ]
+        }
+
+        MethodDef{
+          flags = {rewriterSynthesized}
+          name = <U encrypted_with_errors=><<U <todo method>>>
+          params = [UnresolvedIdent{
+              kind = Local
+              name = <U arg0>
+            }, BlockParam{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U <blk>>
+            } }]
+          rhs = Send{
+            flags = {rewriterSynthesized}
+            recv = Send{
+              flags = {}
+              recv = ConstantLit{
+                symbol = (module ::T)
+                orig = nullptr
+              }
+              fun = <U unsafe>
+              block = nullptr
+              pos_args = 1
+              args = [
+                ConstantLit{
+                  symbol = (module ::Kernel)
+                  orig = nullptr
+                }
+              ]
+            }
+            fun = <U raise>
+            block = nullptr
+            pos_args = 1
+            args = [
+              Literal{ value = "Sorbet rewriter pass partially unimplemented" }
+            ]
+          }
+        }
+
+        Send{
           flags = {privateOk}
           recv = Self
           fun = <U include>
@@ -6086,6 +6487,14 @@ ClassDef{
         <runtime method definition of bar>
 
         <runtime method definition of encrypted_bar>
+
+        <runtime method definition of with_errors>
+
+        <runtime method definition of encrypted_with_errors>
+
+        <runtime method definition of with_errors=>
+
+        <runtime method definition of encrypted_with_errors=>
       ]
     }
 

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -5474,16 +5474,19 @@ ClassDef{
         MethodDef{
           flags = {self}
           name = <U encrypted_prop><<U <todo method>>>
-          params = [OptionalParam{
-              expr = UnresolvedIdent{
+          params = [UnresolvedIdent{
+              kind = Local
+              name = <U name>
+            }, OptionalParam{
+              expr = KeywordArg{ expr = UnresolvedIdent{
                 kind = Local
-                name = <U opts>
-              }
-              default_ = Hash{
-                pairs = [
-                ]
-              }
-            }, BlockParam{ expr = UnresolvedIdent{
+                name = <U kind>
+              } }
+              default_ = Literal{ value = nil }
+            }, RestParam{ expr = KeywordArg{ expr = UnresolvedIdent{
+              kind = Local
+              name = <U opts>
+            } } }, BlockParam{ expr = UnresolvedIdent{
               kind = Local
               name = <U <blk>>
             } }]
@@ -6476,6 +6479,17 @@ ClassDef{
 
         <runtime method definition of self.encrypted_prop>
 
+        Send{
+          flags = {privateOk}
+          recv = Self
+          fun = <U encrypted_prop>
+          block = nullptr
+          pos_args = 1
+          args = [
+            Literal{ value = :foo }
+          ]
+        }
+
         <runtime method definition of foo>
 
         <runtime method definition of encrypted_foo>
@@ -6484,9 +6498,44 @@ ClassDef{
 
         <runtime method definition of encrypted_foo=>
 
+        Send{
+          flags = {privateOk}
+          recv = Self
+          fun = <U encrypted_prop>
+          block = nullptr
+          pos_args = 1
+          args = [
+            Literal{ value = :bar }
+            Literal{ value = :migrating }
+            Literal{ value = true }
+            Literal{ value = :immutable }
+            Literal{ value = true }
+          ]
+        }
+
         <runtime method definition of bar>
 
         <runtime method definition of encrypted_bar>
+
+        Send{
+          flags = {privateOk}
+          recv = Self
+          fun = <U encrypted_prop>
+          block = nullptr
+          pos_args = 2
+          args = [
+            Literal{ value = :with_errors }
+            Send{
+              flags = {}
+              recv = Literal{ value = "" }
+              fun = <U dne>
+              block = nullptr
+              pos_args = 0
+              args = [
+              ]
+            }
+          ]
+        }
 
         <runtime method definition of with_errors>
 

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -696,6 +696,38 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
     end
 
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(::T.nilable(::String))
+    end
+
+    def with_errors<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.returns(::T.nilable(<emptyTree>::<C Opus>::<C DB>::<C Model>::<C Mixins>::<C Encryptable>::<C EncryptedValue>))
+    end
+
+    def encrypted_with_errors<<todo method>>(&<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:arg0, ::T.nilable(::String)).returns(::T.nilable(::String))
+    end
+
+    def with_errors=<<todo method>>(arg0, &<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:arg0, ::T.nilable(<emptyTree>::<C Opus>::<C DB>::<C Model>::<C Mixins>::<C Encryptable>::<C EncryptedValue>)).returns(::T.nilable(<emptyTree>::<C Opus>::<C DB>::<C Model>::<C Mixins>::<C Encryptable>::<C EncryptedValue>))
+    end
+
+    def encrypted_with_errors=<<todo method>>(arg0, &<blk>)
+      ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+    end
+
     <self>.include(<emptyTree>::<C T>::<C Props>)
 
     <runtime method definition of self.encrypted_prop>
@@ -711,6 +743,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <runtime method definition of bar>
 
     <runtime method definition of encrypted_bar>
+
+    <runtime method definition of with_errors>
+
+    <runtime method definition of encrypted_with_errors>
+
+    <runtime method definition of with_errors=>
+
+    <runtime method definition of encrypted_with_errors=>
   end
 
   <runtime method definition of main>

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -644,7 +644,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C EncryptedProp><<C <todo sym>>> < (::<todo sym>)
-    def self.encrypted_prop<<todo method>>(opts = {}, &<blk>)
+    def self.encrypted_prop<<todo method>>(name, kind: = nil, *opts:, &<blk>)
       <emptyTree>
     end
 
@@ -732,6 +732,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of self.encrypted_prop>
 
+    <self>.encrypted_prop(:foo)
+
     <runtime method definition of foo>
 
     <runtime method definition of encrypted_foo>
@@ -740,9 +742,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of encrypted_foo=>
 
+    <self>.encrypted_prop(:bar, :migrating, true, :immutable, true)
+
     <runtime method definition of bar>
 
     <runtime method definition of encrypted_bar>
+
+    <self>.encrypted_prop(:with_errors, "".dne())
 
     <runtime method definition of with_errors>
 

--- a/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=147:4}
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=148:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U AdvancedODM>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=38:1 end=38:18}
     method <C <U AdvancedODM>>#<U array> (<blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:23}
@@ -143,10 +143,12 @@ class <C <U <root>>> < <C <U Object>> ()
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <S <C <U EncryptedProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=87:1 end=87:20}
     type-member(+) <S <C <U EncryptedProp>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U EncryptedProp>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=EncryptedProp) @ Loc {file=test/testdata/rewriter/prop.rb start=87:1 end=87:20}
-    method <S <C <U EncryptedProp>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=87:1 end=93:4}
+    method <S <C <U EncryptedProp>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=87:1 end=94:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
-    method <S <C <U EncryptedProp>> $1>#<U encrypted_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=89:3 end=89:35}
-      argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=89:27 end=89:31}
+    method <S <C <U EncryptedProp>> $1>#<U encrypted_prop> (name, kind, opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=89:3 end=89:51}
+      argument name<> @ Loc {file=test/testdata/rewriter/prop.rb start=89:27 end=89:31}
+      argument kind<optional, keyword> @ Loc {file=test/testdata/rewriter/prop.rb start=89:33 end=89:38}
+      argument opts<keyword, repeated> @ Loc {file=test/testdata/rewriter/prop.rb start=89:46 end=89:50}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U ForeignClass>> < <C <U Object>> () @ Loc {file=test/testdata/rewriter/prop.rb start=35:1 end=35:19}
   class <S <C <U ForeignClass>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/rewriter/prop.rb start=35:1 end=35:19}
@@ -162,7 +164,7 @@ class <C <U <root>>> < <C <U Object>> ()
       argument args<repeated> @ Loc {file=test/testdata/rewriter/prop.rb start=3:20 end=3:24}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
-    method <C <U Object>>#<U main> : private (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=95:1 end=95:9}
+    method <C <U Object>>#<U main> : private (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=96:1 end=96:9}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   module <C <U Opus>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/rewriter/prop.rb start=84:7 end=84:11}
     module <C <U Opus>>::<C <U DB>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/rewriter/prop.rb start=84:7 end=84:15}

--- a/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
+++ b/test/testdata/rewriter/prop.rb.symbol-table-raw.exp
@@ -1,6 +1,6 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=146:4}
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=2:1 end=147:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U AdvancedODM>> < <C <U Object>> (<C <U Props>>) @ Loc {file=test/testdata/rewriter/prop.rb start=38:1 end=38:18}
     method <C <U AdvancedODM>>#<U array> (<blk>) -> AppliedType {       klass = <C <U Array>>       targs = [         <C <U Elem>> = T.untyped       ]     } @ Loc {file=test/testdata/rewriter/prop.rb start=43:5 end=43:23}
@@ -126,14 +126,24 @@ class <C <U <root>>> < <C <U Object>> ()
     method <C <U EncryptedProp>>#<U encrypted_foo=> (foo, <blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=90:3 end=90:22}
       argument foo<> -> T.nilable(Opus::DB::Model::Mixins::Encryptable::EncryptedValue) @ Loc {file=test/testdata/rewriter/prop.rb start=90:19 end=90:22}
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <C <U EncryptedProp>>#<U encrypted_with_errors> (<blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=92:3 end=92:38}
+      argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <C <U EncryptedProp>>#<U encrypted_with_errors=> (with_errors, <blk>) -> Opus::DB::Model::Mixins::Encryptable::EncryptedValue | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=92:3 end=92:38}
+      argument with_errors<> -> T.nilable(Opus::DB::Model::Mixins::Encryptable::EncryptedValue) @ Loc {file=test/testdata/rewriter/prop.rb start=92:19 end=92:30}
+      argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U EncryptedProp>>#<U foo> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=90:3 end=90:22}
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <C <U EncryptedProp>>#<U foo=> (foo, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=90:3 end=90:22}
       argument foo<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=90:19 end=90:22}
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <C <U EncryptedProp>>#<U with_errors> (<blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=92:3 end=92:38}
+      argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
+    method <C <U EncryptedProp>>#<U with_errors=> (with_errors, <blk>) -> String | NilClass @ Loc {file=test/testdata/rewriter/prop.rb start=92:3 end=92:38}
+      argument with_errors<> -> T.nilable(String) @ Loc {file=test/testdata/rewriter/prop.rb start=92:19 end=92:30}
+      argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <S <C <U EncryptedProp>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U ClassMethods>>) @ Loc {file=test/testdata/rewriter/prop.rb start=87:1 end=87:20}
     type-member(+) <S <C <U EncryptedProp>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U EncryptedProp>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=EncryptedProp) @ Loc {file=test/testdata/rewriter/prop.rb start=87:1 end=87:20}
-    method <S <C <U EncryptedProp>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=87:1 end=92:4}
+    method <S <C <U EncryptedProp>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=87:1 end=93:4}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
     method <S <C <U EncryptedProp>> $1>#<U encrypted_prop> (opts, <blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=89:3 end=89:35}
       argument opts<optional> @ Loc {file=test/testdata/rewriter/prop.rb start=89:27 end=89:31}
@@ -152,7 +162,7 @@ class <C <U <root>>> < <C <U Object>> ()
       argument args<repeated> @ Loc {file=test/testdata/rewriter/prop.rb start=3:20 end=3:24}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   class <C <U Object>> < <C <U BasicObject>> (<C <U Object>>, <C <U Kernel>>) @ (Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/json.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/psych.rbi start=removed end=removed}, Loc {file=https://github.com/sorbet/sorbet/tree/master/rbi/core/object.rbi start=removed end=removed})
-    method <C <U Object>>#<U main> : private (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=94:1 end=94:9}
+    method <C <U Object>>#<U main> : private (<blk>) @ Loc {file=test/testdata/rewriter/prop.rb start=95:1 end=95:9}
       argument <blk><block> @ Loc {file=test/testdata/rewriter/prop.rb start=??? end=???}
   module <C <U Opus>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/rewriter/prop.rb start=84:7 end=84:11}
     module <C <U Opus>>::<C <U DB>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/rewriter/prop.rb start=84:7 end=84:15}

--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -8,6 +8,9 @@ cd ../..
 
 if ! command -v parallel &> /dev/null; then
   echo "This script requires GNU parallel to be installed"
+  if [ "$(uname)" == "Darwin" ]; then
+      echo "run brew install parallel to install it"
+  fi
   exit 1
 fi
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Previously, we would only emit the prop name for `encrypted_prop`, and drop the remaining args. This PR changes that to keep the original `encrypted_prop` call (with all the args) in the tree. Review commit-by-commit to see the change.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

For gen-packages mode, we need to see references to all constants used in a package so that we generate the right imports and exports. Without the args emitted, we might miss references if the only place a certain constant is used in the args to `encrypted_prop`.

This change also means we'll report type errors on the args, which we didn't before.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
