### PR TITLE
Switch the typechecking status once during the slow path

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -159,6 +159,7 @@ bool LSPTypechecker::typecheck(unique_ptr<LSPFileUpdates> updates, WorkerPool &w
             filesTypechecked = move(result.filesTypechecked);
 
             ENFORCE(updates->updatedFiles.empty());
+            ENFORCE(updates->updatedFileRefs.empty());
 
             for (auto &ast : result.indexedTrees) {
                 this->indexedFinalGS[ast.file.id()] = move(ast);
@@ -469,6 +470,8 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
         this->gs->errorQueue =
             make_shared<core::ErrorQueue>(this->gs->errorQueue->logger, this->gs->errorQueue->tracer, errorFlusher);
 
+        vector<core::FileRef> updatedFileRefs;
+
         switch (mode) {
             // Initialization fetches the list of files to index from the options
             case SlowPathMode::Init: {
@@ -486,7 +489,8 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
                 if (!updates.updatedFiles.empty()) {
                     applyFileTableUpdates(*this->gs, this->workspaceFiles, *this->config, openFiles, updates);
 
-                    updates.updatedFileRefs.clear();
+                    ENFORCE(updatedFileRefs.empty());
+                    std::swap(updates.updatedFileRefs, updatedFileRefs);
                     updates.updatedFiles.clear();
                 }
 
@@ -494,7 +498,6 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
             }
         }
 
-        ENFORCE(updates.updatedFiles.empty());
         ENFORCE(gs->lspQuery.isEmpty());
 
         auto indexingOp = make_optional<ShowOperation>(*config, ShowOperation::Kind::Indexing);
@@ -580,6 +583,14 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
         auto strata = pipeline::computePackageStrata(*this->gs, packageIndexed, workspaceFilesSpan, this->config->opts);
         this->fileToStratum = move(strata.fileToStratum);
         this->lastStratum = core::packages::Stratum(strata.strata.size() - 1);
+
+        // Determine which stratum this edit will be checked at, so that we have a good reference for when to switch
+        // to the SlowPathNonBlocking status. This isn't exactly correct, as you could switch to editing a file in an
+        // earlier stratum and see requests handled by preemption before the status changes, or edit a file in a later
+        // stratum and see `Loading...` despite the status.
+        auto editStratum = updatedFileRefs.empty() ? this->lastStratum
+                                                   : this->getFileStratumMapping().getStratumForFiles(updatedFileRefs);
+
         for (auto &stratum : strata.strata) {
             vector<ast::ParsedFile> stratumFiles, nonPackagedIndexed;
 
@@ -674,14 +685,16 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
                 }
             }
 
-            // TODO(jvilk): Remove conditional once initial typecheck is preemptible.
-            if (cancelable) {
-                // Inform users that Sorbet should be responsive now.
-                // Explicitly end previous operation before beginning next operation.
-                slowPathOp.emplace(*config, ShowOperation::Kind::SlowPathNonBlocking);
+            if (currentStratum == editStratum) {
+                // TODO(jvilk): Remove conditional once initial typecheck is preemptible.
+                if (cancelable) {
+                    // Inform users that Sorbet should be responsive now.
+                    // Explicitly end previous operation before beginning next operation.
+                    slowPathOp.emplace(*config, ShowOperation::Kind::SlowPathNonBlocking);
+                }
+                // Report how long the slow path blocks preemption.
+                timeit.clone("slow_path.blocking_time");
             }
-            // Report how long the slow path blocks preemption.
-            timeit.clone("slow_path.blocking_time");
 
             // [Test only] Wait for a preemption if one is expected.
             if (updates.preemptionsExpected > 0) [[unlikely]] {

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -5,6 +5,7 @@
 #include "absl/strings/str_replace.h"
 #include "common/common.h"
 #include "test/helpers/lsp.h"
+#include "test/helpers/packages.h"
 
 using namespace std;
 
@@ -1127,6 +1128,92 @@ TEST_CASE_FIXTURE(ProtocolTest, "SignatureHelpInMagicBuildHash") {
         REQUIRE_NE(sigHelp, nullptr);
         REQUIRE_NE(*sigHelp, nullptr);
         REQUIRE_EQ(1, (*sigHelp)->signatures.size());
+    }
+}
+
+TEST_CASE_FIXTURE(ProtocolTest, "ShowOperationPackaged") {
+    auto initOpts = make_shared<realmain::options::Options>();
+    initOpts->cacheSensitiveOptions.sorbetPackages = true;
+    SUBCASE("Monolithic") {
+        initOpts->packageDirected = false;
+        resetState(initOpts);
+    }
+    SUBCASE("PackageDirected") {
+        initOpts->packageDirected = true;
+        resetState(initOpts);
+    }
+
+    vector<pair<string, string>> files = {
+        {"__package.rb", PackageTextBuilder().withName("Root").withExports({"Root::A"}).build()},
+        {"a.rb", "# typed: true\n"
+                 "module Root\n"
+                 "  class A\n"
+                 "    def fun\n"
+                 "    end\n"
+                 "  end\n"
+                 "end\n"},
+        {"foo/__package.rb",
+         PackageTextBuilder().withName("Root::Foo").withExports({"Root::Foo::A"}).withImports({"Root"}).build()},
+        {"foo/a.rb", "# typed: true\n"
+                     "module Root::Foo\n"
+                     "  class A\n"
+                     "    def foo\n"
+                     "      Root::A.new()\n"
+                     "    end\n"
+                     "  end\n"
+                     "end\n"},
+    };
+
+    writeFilesToFS(files);
+
+    for (auto &[path, _] : files) {
+        this->lspWrapper->opts->inputFileNames.emplace_back(fmt::format("{}/{}", this->rootPath, path));
+    }
+
+    auto supportsMarkdown = true;
+    auto supportsCodeActionResolve = true;
+    auto opts = make_unique<SorbetInitializationOptions>();
+    opts->supportsOperationNotifications = true;
+
+    auto checkNameAndStatus = [](auto &resp, std::string name, auto status) {
+        auto &params = get<unique_ptr<SorbetShowOperationParams>>(resp->asNotification().params);
+        CHECK_EQ(params->operationName, name);
+        CHECK_EQ(params->status, status);
+    };
+
+    // The initial slow path.
+    {
+        auto resps = initializeLSP(supportsMarkdown, supportsCodeActionResolve, move(opts));
+        REQUIRE_EQ(resps.size(), 4);
+        REQUIRE(absl::c_all_of(resps, [](auto &resp) { return resp->isNotification(); }));
+        REQUIRE(absl::c_all_of(
+            resps, [](auto &resp) { return resp->asNotification().method == LSPMethod::SorbetShowOperation; }));
+
+        checkNameAndStatus(resps[0], "SlowPathBlocking", SorbetOperationStatus::Start);
+        checkNameAndStatus(resps[1], "Indexing", SorbetOperationStatus::Start);
+        checkNameAndStatus(resps[2], "Indexing", SorbetOperationStatus::End);
+        checkNameAndStatus(resps[3], "SlowPathBlocking", SorbetOperationStatus::End);
+    }
+
+    // Add a new file, kicking off a slow path that supports preemption.
+    {
+        auto resps = send(*openFile("foo/b.rb", "# typed: true\n"
+                                                "module Root::Foo\n"
+                                                "  class B\n"
+                                                "  end\n"
+                                                "end\n"));
+
+        REQUIRE_EQ(resps.size(), 6);
+        REQUIRE(absl::c_all_of(resps, [](auto &resp) { return resp->isNotification(); }));
+        REQUIRE(absl::c_all_of(
+            resps, [](auto &resp) { return resp->asNotification().method == LSPMethod::SorbetShowOperation; }));
+
+        checkNameAndStatus(resps[0], "SlowPathBlocking", SorbetOperationStatus::Start);
+        checkNameAndStatus(resps[1], "Indexing", SorbetOperationStatus::Start);
+        checkNameAndStatus(resps[2], "Indexing", SorbetOperationStatus::End);
+        checkNameAndStatus(resps[3], "SlowPathBlocking", SorbetOperationStatus::End);
+        checkNameAndStatus(resps[4], "SlowPathNonBlocking", SorbetOperationStatus::Start);
+        checkNameAndStatus(resps[5], "SlowPathNonBlocking", SorbetOperationStatus::End);
     }
 }
 


### PR DESCRIPTION
This PR addresses an open question with package-directed typechecking: when should we switch from the `SlowPathBlocking` status to `SlowPathNonBlocking`?

Instead of making the switch after running the resolver (which happens many times during package-directed typechecking) we now switch when we determine that we have processed the stratum where the global state is able to check the whole slow path edit. For initialization this is a bit of a moot point as we never switch, but for edits that kick off the slow path, this somewhat emulates the current behavior of switching the status when preemption is available.

It's not perfect: if you start editing files before or after the stratum that's determined to be necessary for the slow path edit, the status won't really reflect the current availability of preemption. It is however a big improvement over current state where we would flip to `SlowPathNonBlocking` after the first stratum, despite preemption not always being available.

Note that this won't affect behavior at all for the existing monolithic slow path, as it will always determine that the edit takes place in stratum `0`.

### Motivation
Stabilizing package-directed LSP.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included tests.
