### PR TITLE
Avoid paths in LSPFileUpdates where possible

### DIFF
--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -211,7 +211,7 @@ LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPC
             continue;
         }
 
-        result.extraFiles.emplace_back(oldFile->path());
+        result.extraFiles.emplace_back(ref);
         result.totalChanged += 1;
 
         if (result.totalChanged > (2 * config.opts.lspMaxFilesOnFastPath)) {

--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -14,16 +14,19 @@ class LSPFileUpdates final {
 public:
     // The file refs in the indexer's global state that correspond to files at the same index in the `updatedFiles`
     // vector.
+    //
+    // FileRefs are used here, because we explicitly ensure that the file refs match up between the indexer and
+    // typechecker global states when applying updates in the slow path.
     std::vector<core::FileRef> updatedFileRefs;
 
     // Files that have been updated in this edit, and need to be sync'd with the typechecker's global state.
     std::vector<std::shared_ptr<core::File>> updatedFiles;
 
-    // The paths of any additional files implicated in a fast path edit. This vector stores path
-    // strings because FileRef IDs might be different in the GlobalState used on the indexing thread
-    // and the typechecking thread, but the `LSPFileUpdates` structure must be valid to transfer
-    // ownership from one thread to the other.
-    std::vector<std::string> fastPathExtraFiles;
+    // Any additional files implicated in a fast path edit.
+    //
+    // FileRefs are used here, because we explicitly ensure that the file refs match up between the indexer and
+    // typechecker global states when applying updates in the slow path.
+    std::vector<core::FileRef> fastPathExtraFiles;
 
     // This specific update contains edits with the given epoch
     uint32_t epoch = 0;
@@ -81,7 +84,7 @@ public:
         bool useIncrementalNamer = false;
 
         // Extra files that need to be typechecked because the file mentions the name of one of the changed symbols.
-        std::vector<std::string> extraFiles;
+        std::vector<core::FileRef> extraFiles;
     };
 
     // It would be nice to have this accept `...<const core::File>...`

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -211,17 +211,22 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
 
     vector<core::FileRef> toTypecheck;
     toTypecheck.reserve(updates.fastPathExtraFiles.size() + updates.updatedFiles.size());
-    for (auto &path : updates.fastPathExtraFiles) {
-        auto fref = gs->findFileByPath(path);
-        ENFORCE(fref.exists());
-        toTypecheck.emplace_back(fref);
+
+    absl::c_copy(updates.fastPathExtraFiles, back_inserter(toTypecheck));
+    if constexpr (debug_mode) {
+        for (auto fref : updates.fastPathExtraFiles) {
+            ENFORCE(fref.exists());
+        }
     }
 
     config->logger->debug("Added {} files that were not part of the edit to the update set", toTypecheck.size());
     UnorderedMap<core::FileRef, shared_ptr<const core::FileHash>> oldFoundHashesForFiles;
+    auto ix = -1;
     for (auto &file : updates.updatedFiles) {
-        auto fref = gs->findFileByPath(file->path());
+        ++ix;
+        auto fref = updates.updatedFileRefs[ix];
         ENFORCE(fref.exists(), "New files are not supported in the fast path");
+        ENFORCE(fref == gs->findFileByPath(file->path()));
 
         auto oldFile = gs->replaceFile(fref, std::move(file));
 
@@ -250,6 +255,7 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
     }
 
     updates.updatedFiles.clear();
+    updates.updatedFileRefs.clear();
 
     if (shouldRunIncrementalNamer && gs->packageDB().enabled()) {
         vector<core::FileRef> packageFiles;


### PR DESCRIPTION
This PR makes more use of the fact that we're keeping the indexer and typechecker file tables in sync now, by skipping lookups by file path in the fast path. This also enables us to switch to using `FileRef` values for the extra files, as we know the tables should agree, and no longer need to lookup paths in the typechecker.

### Motivation
Avoiding extra string copies and looking up files by name.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavioral changes expected, refactoring only.
