### PR TITLE
Fix T.nilable(::Range) crash by adding TypedRange::Untyped

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -99,7 +99,7 @@ module T::Types
           elsif mod == ::Enumerator
             TypedEnumerator::Untyped.new
           elsif mod == ::Range
-            TypedRange.new(type)
+            TypedRange::Untyped.new
           elsif !Object.autoload?(:Set) && Object.const_defined?(:Set) && mod == ::Set
             TypedSet::Untyped.new
           else

--- a/gems/sorbet-runtime/lib/types/types/typed_range.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_range.rb
@@ -25,5 +25,15 @@ module T::Types
     def new(...)
       Range.new(...)
     end
+
+    class Untyped < TypedRange
+      def initialize
+        super(T::Types::Untyped::Private::INSTANCE)
+      end
+
+      def valid?(obj)
+        obj.is_a?(Range)
+      end
+    end
   end
 end

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -851,6 +851,42 @@ module Opus::Types::Test
       it 'can have its metatype instantiated' do
         assert_equal(3..4, T::Range[Integer].new(3, 4))
       end
+
+      it 'returns a TypedRange::Untyped from type_for_module(::Range)' do
+        type = T::Types::Simple::Private::Pool.type_for_module(::Range)
+        assert_instance_of(T::Types::TypedRange::Untyped, type)
+      end
+
+      it 'caches the untyped wrapper instance for ::Range' do
+        x = T::Types::Simple::Private::Pool.type_for_module(::Range)
+        y = T::Types::Simple::Private::Pool.type_for_module(::Range)
+        assert_equal(x.object_id, y.object_id)
+      end
+
+      it 'returns "T::Range[T.untyped]" as the name of the untyped wrapper' do
+        type = T::Types::Simple::Private::Pool.type_for_module(::Range)
+        assert_equal('T::Range[T.untyped]', type.name)
+      end
+
+      it 'validates any Range object with the untyped wrapper' do
+        type = T::Types::Simple::Private::Pool.type_for_module(::Range)
+        assert(type.valid?(0..10))
+        assert(type.valid?('a'..'z'))
+        refute(type.valid?([1, 2, 3]))
+        refute(type.valid?(nil))
+      end
+
+      it 'works with T.nilable(Range) on a T::Struct' do
+        klass = Class.new(T::Struct) do
+          const :r, T.nilable(Range)
+        end
+
+        instance_with_value = klass.new(r: 0..10)
+        assert_equal(0..10, instance_with_value.r)
+
+        instance_without_value = klass.new(r: nil)
+        assert_nil(instance_without_value.r)
+      end
     end
 
     describe "TypedSet" do


### PR DESCRIPTION
### Motivation

#10157 left the `::Range` branch of `T::Types::Simple::Private::Pool#type_for_module` as `TypedRange.new(type)`, where `type` is the LHS local of the surrounding `type = if ... end` and resolves to nil. This makes `T.nilable(::Range)` crash with `Got a NilClass` later when the wrapper's `#name` is computed.

The fix adds `TypedRange::Untyped` (mirroring `TypedHash::Untyped` / `TypedEnumerable::Untyped` / `TypedEnumerator::Untyped` / `TypedSet::Untyped`, no `Private::INSTANCE` since only `TypedArray` uses that pattern) and switches the `::Range` branch to `TypedRange::Untyped.new`.

Fixes #10254.

### Test plan

Added regression tests inside the existing `describe "TypedRange"` block covering: returns a `TypedRange::Untyped`, instance is cached on subsequent calls, `name` returns `"T::Range[T.untyped]"` without raising, `valid?` returns true for Range / false for non-Range, and `T.nilable(Range)` on a `T::Struct` evaluates and round-trips a value.

Manually verified on Ruby 3.3.10 and Ruby 4.0.3 that the unpatched master crashes for the repro and the patch makes it pass. Full sorbet-runtime test suite (914 runs, 2797 assertions) passes locally.
