### PR TITLE
Type `described_class` based on the `RSpec.describe` argument

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -280,6 +280,7 @@ NameDef names[] = {
     {"its"},
     {"isExpected", "is_expected"},
     {"expect"},
+    {"describedClass", "described_class"},
     {"before"},
     {"beforeAngles", "<before>"},
     {"after"},

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -160,6 +160,33 @@ ast::ClassDef::RHS_store flattenDescribeBody(ast::ExpressionPtr body) {
     return rhs;
 }
 
+// Returns true if `classBody` already contains a `described_class` method definition (whether
+// explicit `def described_class` or rewritten from `let(:described_class)` / `subject(:described_class)`).
+// The one-level `InsSeq` descent mirrors the output shape of `ConstantMover::addConstantsToExpression`,
+// which wraps a rewritten `let`/`subject` method def in an `InsSeq` when constants are hoisted.
+bool hasUserDefinedDescribedClass(const ast::ClassDef::RHS_store &classBody) {
+    auto isDescribedClassMethod = [](const ast::ExpressionPtr &stmt) {
+        auto methodDef = ast::cast_tree<ast::MethodDef>(stmt);
+        return methodDef && methodDef->name == core::Names::describedClass();
+    };
+    for (const auto &stmt : classBody) {
+        if (isDescribedClassMethod(stmt)) {
+            return true;
+        }
+        if (auto insSeq = ast::cast_tree<ast::InsSeq>(stmt)) {
+            for (const auto &nested : insSeq->stats) {
+                if (isDescribedClassMethod(nested)) {
+                    return true;
+                }
+            }
+            if (isDescribedClassMethod(insSeq->expr)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 string to_s(core::Context ctx, const ast::ExpressionPtr &arg) {
     auto argLit = ast::cast_tree<ast::Literal>(arg);
     string argString;
@@ -788,8 +815,26 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::
                                : arg.loc();
             auto name = ast::MK::UnresolvedConstantParts(nameLoc, {ctx.state.enterNameConstant(testName)});
             auto declLoc = declLocForSendWithBlock(*send);
-            auto classDef = ast::MK::Class(send->loc, declLoc, std::move(name), std::move(ancestors),
-                                           flattenDescribeBody(move(rhs)));
+            auto classBody = flattenDescribeBody(move(rhs));
+
+            // For an RSpec `describe`/`context` with a constant arg, synthesize an instance method
+            // `described_class` typed `T.class_of(arg)`. Without this, callers see the `T.untyped`
+            // return from `RSpec::Core::ExampleGroup#described_class`, or for nested describes the
+            // wrong constant inherited from the enclosing describe. Skipped when the user defines
+            // their own `described_class` to avoid shadowing or duplicate-method errors.
+            if (rspecMode && ast::isa_tree<ast::UnresolvedConstantLit>(arg) &&
+                !hasUserDefinedDescribedClass(classBody)) {
+                auto methodLoc = arg.loc().copyWithZeroLength();
+                auto describedClassMethod =
+                    ast::MK::SyntheticMethod0(arg.loc(), methodLoc, core::Names::describedClass(), arg.deepCopy());
+                ast::cast_tree_nonnull<ast::MethodDef>(describedClassMethod).flags.discardDef = true;
+                auto sig = ast::MK::Sig0(methodLoc, ast::MK::ClassOf(methodLoc, arg.deepCopy()));
+                classBody.emplace_back(std::move(sig));
+                classBody.emplace_back(std::move(describedClassMethod));
+            }
+
+            auto classDef =
+                ast::MK::Class(send->loc, declLoc, std::move(name), std::move(ancestors), std::move(classBody));
 
             // Preserve the original constant reference in the tree so Sorbet can
             // resolve it for hover and go-to-definition.

--- a/test/testdata/rewriter/rspec_describe.rb
+++ b/test/testdata/rewriter/rspec_describe.rb
@@ -72,6 +72,145 @@ RSpec.describe UserClass do
   it "has a name" do
     name
   end
+
+  it "reveals the typed described_class" do
+    T.reveal_type(described_class) # error: Revealed type: `T.class_of(UserClass)`
+    #             ^^^^^^^^^^^^^^^ hover: sig { returns(T.class_of(UserClass)) }
+  end
+
+  it "rejects calls that don't exist on described_class" do
+    described_class.no_such_method # error: Method `no_such_method` does not exist on `T.class_of(UserClass)`
+  end
+end
+
+# Test that `subject` / `let` bodies see the typed `described_class`. The return
+# type of `subject` / `let` is `T.untyped` without an explicit sig, but the body
+# is typechecked, so bogus method calls on `described_class` are caught.
+RSpec.describe UserClass do
+  subject(:user) { described_class.new }
+  let(:bogus) { described_class.no_such_method } # error: Method `no_such_method` does not exist on `T.class_of(UserClass)`
+end
+
+# Test that an explicit sig on `subject` / `let` propagates the typed return
+# type to consumers of the helper, composing with the synthesized
+# `described_class`.
+RSpec.describe UserClass do
+  extend T::Sig
+
+  sig { returns(UserClass) }
+  subject(:user) { described_class.new }
+
+  sig { returns(T.class_of(UserClass)) }
+  let(:klass) { described_class }
+
+  it "propagates the typed return through subject and let" do
+    T.reveal_type(user)  # error: Revealed type: `UserClass`
+    T.reveal_type(klass) # error: Revealed type: `T.class_of(UserClass)`
+  end
+end
+
+# Test that `RSpec.describe` works on a module, not just a class. `described_class`
+# resolves to `T.class_of(SomeModule)`, so module-level methods are callable but
+# `.new` (which doesn't exist on modules) errors.
+module DescribedModule
+  def self.helper; end
+end
+
+RSpec.describe DescribedModule do
+  it "described_class is the singleton type of the module" do
+    T.reveal_type(described_class) # error: Revealed type: `T.class_of(DescribedModule)`
+    described_class.helper
+    described_class.new # error: Method `new` does not exist on `T.class_of(DescribedModule)`
+  end
+end
+
+# Test that `before` and `after` hooks see the typed `described_class`. These
+# are rewritten to instance methods on the synthesized describe class, so they
+# share the same type information as `it` blocks.
+RSpec.describe UserClass do
+  before do
+    T.reveal_type(described_class) # error: Revealed type: `T.class_of(UserClass)`
+    described_class.no_such_method # error: Method `no_such_method` does not exist on `T.class_of(UserClass)`
+  end
+
+  after do
+    described_class.also_missing # error: Method `also_missing` does not exist on `T.class_of(UserClass)`
+  end
+end
+
+# Test that a user-defined `let(:described_class)` overrides the synthesized
+# method. The rewriter detects the existing definition in the class body and
+# skips synthesis so the user's type wins.
+#
+# These tests use dedicated outer classes (rather than reusing `UserClass`)
+# because every `RSpec.describe UserClass do ... end` block in this file is
+# rewritten into the same `<describe 'UserClass'>` synthetic class, and a user
+# override here would collide with the synthesized `described_class` from a
+# sibling block of the same name.
+class AlternateClass
+end
+
+class UserClassWithLetOverride
+end
+
+class UserClassWithDefOverride
+end
+
+class UserClassWithSubjectOverride
+end
+
+RSpec.describe UserClassWithLetOverride do
+  extend T::Sig
+
+  sig { returns(T.class_of(AlternateClass)) }
+  let(:described_class) { AlternateClass }
+
+  it "honors the user-defined described_class via let" do
+    T.reveal_type(described_class) # error: Revealed type: `T.class_of(AlternateClass)`
+  end
+end
+
+# Same as above, but using `def described_class` instead of `let`.
+RSpec.describe UserClassWithDefOverride do
+  extend T::Sig
+
+  sig { returns(T.class_of(AlternateClass)) }
+  def described_class
+    AlternateClass
+  end
+
+  it "honors the user-defined described_class via def" do
+    T.reveal_type(described_class) # error: Revealed type: `T.class_of(AlternateClass)`
+  end
+end
+
+# Same as above, but using `subject(:described_class)`. `subject` with a name
+# argument rewrites to a `def described_class`, so the user-override detector
+# catches it the same way.
+RSpec.describe UserClassWithSubjectOverride do
+  extend T::Sig
+
+  sig { returns(T.class_of(AlternateClass)) }
+  subject(:described_class) { AlternateClass }
+
+  it "honors the user-defined described_class via subject" do
+    T.reveal_type(described_class) # error: Revealed type: `T.class_of(AlternateClass)`
+  end
+end
+
+# Test that `xdescribe` and `fdescribe` (skipped/focused) with a constant arg
+# also synthesize a typed `described_class`, since they share the same case
+# labels in the rewriter as `describe`.
+RSpec.xdescribe UserClass do
+  it "xdescribe propagates described_class" do
+    T.reveal_type(described_class) # error: Revealed type: `T.class_of(UserClass)`
+  end
+end
+
+RSpec.fdescribe UserClass do
+  it "fdescribe propagates described_class" do
+    T.reveal_type(described_class) # error: Revealed type: `T.class_of(UserClass)`
+  end
 end
 
 # Test RSpec.describe with a class and metadata
@@ -81,6 +220,10 @@ RSpec.describe UserClass, :needs_macos do
 
   it "has a value" do
     value
+  end
+
+  it "reveals the typed described_class with metadata args" do
+    T.reveal_type(described_class) # error: Revealed type: `T.class_of(UserClass)`
   end
 end
 
@@ -107,6 +250,64 @@ RSpec.describe Foo::Qux::Baz do
 
   it "creates an instance" do
     instance
+  end
+end
+
+# Test that nested `describe`/`context` with a constant arg overrides
+# `described_class` to the inner constant, while non-constant nested blocks
+# inherit `described_class` from the enclosing constant.
+RSpec.describe Foo::Bar::Baz do
+  it "outer described_class" do
+    T.reveal_type(described_class) # error: Revealed type: `T.class_of(Foo::Bar::Baz)`
+  end
+
+  describe Foo::Qux::Baz do
+    before do
+      T.reveal_type(described_class) # error: Revealed type: `T.class_of(Foo::Qux::Baz)`
+    end
+
+    it "inner describe overrides described_class" do
+      T.reveal_type(described_class) # error: Revealed type: `T.class_of(Foo::Qux::Baz)`
+    end
+  end
+
+  describe "a string argument" do
+    it "does not override described_class" do
+      T.reveal_type(described_class) # error: Revealed type: `T.class_of(Foo::Bar::Baz)`
+    end
+  end
+
+  context :a_symbol_argument do
+    it "does not override described_class" do
+      T.reveal_type(described_class) # error: Revealed type: `T.class_of(Foo::Bar::Baz)`
+    end
+  end
+end
+
+# Test that a user-defined `let(:described_class)` in a *nested* describe skips
+# synthesis only for the inner class — the outer still synthesizes its own
+# typed `described_class`. The nested ClassDef is opaque to the outer's
+# user-override check, so the two are independent.
+class OuterForNestedOverride
+end
+
+class InnerForNestedOverride
+end
+
+RSpec.describe OuterForNestedOverride do
+  extend T::Sig
+
+  it "outer still synthesizes described_class" do
+    T.reveal_type(described_class) # error: Revealed type: `T.class_of(OuterForNestedOverride)`
+  end
+
+  describe InnerForNestedOverride do
+    sig { returns(T.class_of(AlternateClass)) }
+    let(:described_class) { AlternateClass }
+
+    it "inner override wins" do
+      T.reveal_type(described_class) # error: Revealed type: `T.class_of(AlternateClass)`
+    end
   end
 end
 

--- a/test/testdata/rewriter/rspec_describe.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_describe.rb.rewrite-tree.exp
@@ -104,7 +104,252 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.name()
       end
 
+      def <it 'reveals the typed described_class'><<todo method>>(&<blk>)
+        <emptyTree>::<C T>.reveal_type(<self>.described_class())
+      end
+
+      def <it 'rejects calls that don't exist on described_class'><<todo method>>(&<blk>)
+        <self>.described_class().no_such_method()
+      end
+
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.returns(::T.class_of(<emptyTree>::<C UserClass>))
+      end
+
+      def described_class<<todo method>>(&<blk>)
+        <emptyTree>::<C UserClass>
+      end
+
       <runtime method definition of name>
+    end
+  end
+
+  begin
+    <emptyTree>::<C UserClass>
+    class <emptyTree>::<C <describe 'UserClass'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      def user<<todo method>>(&<blk>)
+        <self>.described_class().new()
+      end
+
+      def bogus<<todo method>>(&<blk>)
+        <self>.described_class().no_such_method()
+      end
+
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.returns(::T.class_of(<emptyTree>::<C UserClass>))
+      end
+
+      def described_class<<todo method>>(&<blk>)
+        <emptyTree>::<C UserClass>
+      end
+
+      <runtime method definition of user>
+
+      <runtime method definition of bogus>
+    end
+  end
+
+  begin
+    <emptyTree>::<C UserClass>
+    class <emptyTree>::<C <describe 'UserClass'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      <self>.sig() do ||
+        <self>.returns(<emptyTree>::<C UserClass>)
+      end
+
+      def user<<todo method>>(&<blk>)
+        <self>.described_class().new()
+      end
+
+      <self>.sig() do ||
+        <self>.returns(<emptyTree>::<C T>.class_of(<emptyTree>::<C UserClass>))
+      end
+
+      def klass<<todo method>>(&<blk>)
+        <self>.described_class()
+      end
+
+      def <it 'propagates the typed return through subject and let'><<todo method>>(&<blk>)
+        begin
+          <emptyTree>::<C T>.reveal_type(<self>.user())
+          <emptyTree>::<C T>.reveal_type(<self>.klass())
+        end
+      end
+
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.returns(::T.class_of(<emptyTree>::<C UserClass>))
+      end
+
+      def described_class<<todo method>>(&<blk>)
+        <emptyTree>::<C UserClass>
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      <runtime method definition of user>
+
+      <runtime method definition of klass>
+    end
+  end
+
+  module <emptyTree>::<C DescribedModule><<C <todo sym>>> < ()
+    def self.helper<<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    <runtime method definition of self.helper>
+  end
+
+  begin
+    <emptyTree>::<C DescribedModule>
+    class <emptyTree>::<C <describe 'DescribedModule'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      def <it 'described_class is the singleton type of the module'><<todo method>>(&<blk>)
+        begin
+          <emptyTree>::<C T>.reveal_type(<self>.described_class())
+          <self>.described_class().helper()
+          <self>.described_class().new()
+        end
+      end
+
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.returns(::T.class_of(<emptyTree>::<C DescribedModule>))
+      end
+
+      def described_class<<todo method>>(&<blk>)
+        <emptyTree>::<C DescribedModule>
+      end
+    end
+  end
+
+  begin
+    <emptyTree>::<C UserClass>
+    class <emptyTree>::<C <describe 'UserClass'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      def <before><<todo method>>(&<blk>)
+        begin
+          <emptyTree>::<C T>.reveal_type(<self>.described_class())
+          <self>.described_class().no_such_method()
+        end
+      end
+
+      def <after><<todo method>>(&<blk>)
+        <self>.described_class().also_missing()
+      end
+
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.returns(::T.class_of(<emptyTree>::<C UserClass>))
+      end
+
+      def described_class<<todo method>>(&<blk>)
+        <emptyTree>::<C UserClass>
+      end
+    end
+  end
+
+  class <emptyTree>::<C AlternateClass><<C <todo sym>>> < (::<todo sym>)
+  end
+
+  class <emptyTree>::<C UserClassWithLetOverride><<C <todo sym>>> < (::<todo sym>)
+  end
+
+  class <emptyTree>::<C UserClassWithDefOverride><<C <todo sym>>> < (::<todo sym>)
+  end
+
+  class <emptyTree>::<C UserClassWithSubjectOverride><<C <todo sym>>> < (::<todo sym>)
+  end
+
+  begin
+    <emptyTree>::<C UserClassWithLetOverride>
+    class <emptyTree>::<C <describe 'UserClassWithLetOverride'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      <self>.sig() do ||
+        <self>.returns(<emptyTree>::<C T>.class_of(<emptyTree>::<C AlternateClass>))
+      end
+
+      def described_class<<todo method>>(&<blk>)
+        <emptyTree>::<C AlternateClass>
+      end
+
+      def <it 'honors the user-defined described_class via let'><<todo method>>(&<blk>)
+        <emptyTree>::<C T>.reveal_type(<self>.described_class())
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      <runtime method definition of described_class>
+    end
+  end
+
+  begin
+    <emptyTree>::<C UserClassWithDefOverride>
+    class <emptyTree>::<C <describe 'UserClassWithDefOverride'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      <self>.sig() do ||
+        <self>.returns(<emptyTree>::<C T>.class_of(<emptyTree>::<C AlternateClass>))
+      end
+
+      def described_class<<todo method>>(&<blk>)
+        <emptyTree>::<C AlternateClass>
+      end
+
+      def <it 'honors the user-defined described_class via def'><<todo method>>(&<blk>)
+        <emptyTree>::<C T>.reveal_type(<self>.described_class())
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      <runtime method definition of described_class>
+    end
+  end
+
+  begin
+    <emptyTree>::<C UserClassWithSubjectOverride>
+    class <emptyTree>::<C <describe 'UserClassWithSubjectOverride'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      <self>.sig() do ||
+        <self>.returns(<emptyTree>::<C T>.class_of(<emptyTree>::<C AlternateClass>))
+      end
+
+      def described_class<<todo method>>(&<blk>)
+        <emptyTree>::<C AlternateClass>
+      end
+
+      def <it 'honors the user-defined described_class via subject'><<todo method>>(&<blk>)
+        <emptyTree>::<C T>.reveal_type(<self>.described_class())
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      <runtime method definition of described_class>
+    end
+  end
+
+  begin
+    <emptyTree>::<C UserClass>
+    class <emptyTree>::<C <xdescribe 'UserClass'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      def <it 'xdescribe propagates described_class'><<todo method>>(&<blk>)
+        <emptyTree>::<C T>.reveal_type(<self>.described_class())
+      end
+
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.returns(::T.class_of(<emptyTree>::<C UserClass>))
+      end
+
+      def described_class<<todo method>>(&<blk>)
+        <emptyTree>::<C UserClass>
+      end
+    end
+  end
+
+  begin
+    <emptyTree>::<C UserClass>
+    class <emptyTree>::<C <fdescribe 'UserClass'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      def <it 'fdescribe propagates described_class'><<todo method>>(&<blk>)
+        <emptyTree>::<C T>.reveal_type(<self>.described_class())
+      end
+
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.returns(::T.class_of(<emptyTree>::<C UserClass>))
+      end
+
+      def described_class<<todo method>>(&<blk>)
+        <emptyTree>::<C UserClass>
+      end
     end
   end
 
@@ -117,6 +362,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
       def <it 'has a value'><<todo method>>(&<blk>)
         <self>.value()
+      end
+
+      def <it 'reveals the typed described_class with metadata args'><<todo method>>(&<blk>)
+        <emptyTree>::<C T>.reveal_type(<self>.described_class())
+      end
+
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.returns(::T.class_of(<emptyTree>::<C UserClass>))
+      end
+
+      def described_class<<todo method>>(&<blk>)
+        <emptyTree>::<C UserClass>
       end
 
       <runtime method definition of value>
@@ -146,6 +403,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.instance()
       end
 
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.returns(::T.class_of(<emptyTree>::<C Foo>::<C Bar>::<C Baz>))
+      end
+
+      def described_class<<todo method>>(&<blk>)
+        <emptyTree>::<C Foo>::<C Bar>::<C Baz>
+      end
+
       <runtime method definition of instance>
     end
   end
@@ -161,7 +426,115 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <self>.instance()
       end
 
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.returns(::T.class_of(<emptyTree>::<C Foo>::<C Qux>::<C Baz>))
+      end
+
+      def described_class<<todo method>>(&<blk>)
+        <emptyTree>::<C Foo>::<C Qux>::<C Baz>
+      end
+
       <runtime method definition of instance>
+    end
+  end
+
+  begin
+    <emptyTree>::<C Foo>::<C Bar>::<C Baz>
+    class <emptyTree>::<C <describe 'Foo::Bar::Baz'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      def <it 'outer described_class'><<todo method>>(&<blk>)
+        <emptyTree>::<C T>.reveal_type(<self>.described_class())
+      end
+
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.returns(::T.class_of(<emptyTree>::<C Foo>::<C Bar>::<C Baz>))
+      end
+
+      def described_class<<todo method>>(&<blk>)
+        <emptyTree>::<C Foo>::<C Bar>::<C Baz>
+      end
+
+      begin
+        <emptyTree>::<C Foo>::<C Qux>::<C Baz>
+        class <emptyTree>::<C <describe 'Foo::Qux::Baz'>><<C <todo sym>>> < (<self>)
+          def <before><<todo method>>(&<blk>)
+            <emptyTree>::<C T>.reveal_type(<self>.described_class())
+          end
+
+          def <it 'inner describe overrides described_class'><<todo method>>(&<blk>)
+            <emptyTree>::<C T>.reveal_type(<self>.described_class())
+          end
+
+          ::T::Sig::WithoutRuntime.sig() do ||
+            <self>.returns(::T.class_of(<emptyTree>::<C Foo>::<C Qux>::<C Baz>))
+          end
+
+          def described_class<<todo method>>(&<blk>)
+            <emptyTree>::<C Foo>::<C Qux>::<C Baz>
+          end
+        end
+      end
+
+      begin
+        "a string argument"
+        class <emptyTree>::<C <describe 'a string argument'>><<C <todo sym>>> < (<self>)
+          def <it 'does not override described_class'><<todo method>>(&<blk>)
+            <emptyTree>::<C T>.reveal_type(<self>.described_class())
+          end
+        end
+      end
+
+      begin
+        :a_symbol_argument
+        class <emptyTree>::<C <context 'a_symbol_argument'>><<C <todo sym>>> < (<self>)
+          def <it 'does not override described_class'><<todo method>>(&<blk>)
+            <emptyTree>::<C T>.reveal_type(<self>.described_class())
+          end
+        end
+      end
+    end
+  end
+
+  class <emptyTree>::<C OuterForNestedOverride><<C <todo sym>>> < (::<todo sym>)
+  end
+
+  class <emptyTree>::<C InnerForNestedOverride><<C <todo sym>>> < (::<todo sym>)
+  end
+
+  begin
+    <emptyTree>::<C OuterForNestedOverride>
+    class <emptyTree>::<C <describe 'OuterForNestedOverride'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      def <it 'outer still synthesizes described_class'><<todo method>>(&<blk>)
+        <emptyTree>::<C T>.reveal_type(<self>.described_class())
+      end
+
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.returns(::T.class_of(<emptyTree>::<C OuterForNestedOverride>))
+      end
+
+      def described_class<<todo method>>(&<blk>)
+        <emptyTree>::<C OuterForNestedOverride>
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      begin
+        <emptyTree>::<C InnerForNestedOverride>
+        class <emptyTree>::<C <describe 'InnerForNestedOverride'>><<C <todo sym>>> < (<self>)
+          <self>.sig() do ||
+            <self>.returns(<emptyTree>::<C T>.class_of(<emptyTree>::<C AlternateClass>))
+          end
+
+          def described_class<<todo method>>(&<blk>)
+            <emptyTree>::<C AlternateClass>
+          end
+
+          def <it 'inner override wins'><<todo method>>(&<blk>)
+            <emptyTree>::<C T>.reveal_type(<self>.described_class())
+          end
+
+          <runtime method definition of described_class>
+        end
+      end
     end
   end
 


### PR DESCRIPTION
When the experimental RSpec rewriter sees `RSpec.describe SomeConstant do ... end` (or a nested `describe`/`context SomeConstant`), synthesize an instance method `described_class` typed as `T.class_of(SomeConstant)` on the generated describe class.

Previously `described_class` resolved to `RSpec::Core::ExampleGroup#described_class`, which returns `T.untyped`, hiding type errors at call sites like `described_class.new(...)`.

For non-constant args (strings, symbols, etc.), nothing is synthesized and the existing `T.untyped` fallback is preserved, matching RSpec's runtime behavior.

If the user has already defined `described_class` themselves — via `let(:described_class) { ... }`, `subject(:described_class) { ... }`, or `def described_class` — synthesis is skipped so the user's definition wins. Without this, the synthesized `def described_class` would collide with the user's, silently shadowing their intended type. The check looks one level into top-level `InsSeq`s because `let`/`subject` rewrites can be wrapped by `addConstantsToExpression` when constants are hoisted.

### Motivation

Closes #10256.

`described_class` is a very common pattern in RSpec specs, especially for the canonical "subject under test" idiom:

```ruby
RSpec.describe MyClass do
  subject { described_class.new(...) }
end
```

When this typechecks against `T.untyped`, errors are silently hidden — bogus kwargs, calls to non-existent methods, nilable mismatches, etc. The rewriter already knows the constant (it's preserved in the synthesized tree so hover and go-to-definition resolve to it), so the same information can flow into the type of `described_class`.

I tried this against the Homebrew/brew test suite by swapping in a locally built Sorbet. It surfaced 7 latent type errors across 4 spec files that the previous `T.untyped` was hiding.

### Test plan

`test/testdata/rewriter/rspec_describe.rb` adds `T.reveal_type(described_class)` assertions covering:

- Top-level `RSpec.describe Constant` → `T.class_of(Constant)`
- Nested `describe Constant` inside an outer `RSpec.describe` → overrides to the inner constant
- Nested `context "string"` (non-constant) → inherits the typed `described_class` from the enclosing constant
- `RSpec.describe SomeModule` → `T.class_of(SomeModule)` (module-level methods callable; `.new` errors)
- `subject` / `let` bodies see the typed `described_class`; explicit sigs on `subject` / `let` compose correctly
- `xdescribe` / `fdescribe` with a constant arg synthesize the typed `described_class`
- `before` / `after` hooks at the top level see the synthesized typed `described_class`
- `before` hook inside a nested `describe Constant` sees the *inner* constant's type
- `context :a_symbol_argument` (non-constant) inherits from the enclosing describe
- (Pre-existing) string/symbol args → unchanged `T.untyped` fallback

User-override coverage (synthesis skipped, user's definition wins):

- `let(:described_class) { ... }` with an explicit sig
- `def described_class` with an explicit sig
- `subject(:described_class) { ... }` with an explicit sig
- User override in a *nested* describe — outer still synthesizes, inner skips

The user-override tests use dedicated outer classes rather than reusing `UserClass`, because every `RSpec.describe UserClass do ... end` block in this file is rewritten into the same `<describe 'UserClass'>` synthetic class — a user override there would collide with the synthesized `described_class` from sibling blocks.

