### PR TITLE
Add Untyped shortcut to `_types.rb` `Range` module

### DIFF
--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -342,7 +342,11 @@ module T
 
   module Range
     def self.[](type)
-      T::Types::TypedRange.new(type)
+      if type.is_a?(T::Types::Untyped)
+        T::Types::TypedRange::Untyped.new
+      else
+        T::Types::TypedRange.new(type)
+      end
     end
   end
 

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -887,6 +887,11 @@ module Opus::Types::Test
         instance_without_value = klass.new(r: nil)
         assert_nil(instance_without_value.r)
       end
+
+      it 'returns a TypedRange::Untyped from T::Range[T.untyped]' do
+        type = T::Range[T.untyped]
+        assert_instance_of(T::Types::TypedRange::Untyped, type)
+      end
     end
 
     describe "TypedSet" do


### PR DESCRIPTION
### Motivation

Follow-up to #10255 / #10254 — apologies for missing this when I worked on the original PR; I focused only on the `simple.rb` codepath at the time.

While #10255 fixed the runtime crash in `simple.rb`'s `::Range` branch, the corresponding `_types.rb` `Range` module was still using the pre-#10157 form `TypedRange.new(type)` without an `Untyped` shortcut, unlike `Set` / `Hash` / `Enumerable` / `Enumerator` (and their `Lazy` / `Chain` variants) which all gained that shortcut in #10157.

Currently `T::Range[T.untyped]` returns a `TypedRange.new(<Untyped instance>)`, which works (= no crash) but the resulting class is `TypedRange`, not `TypedRange::Untyped`. This diverges from the `simple.rb` `type_for_module(::Range)` codepath fixed in #10255.

After this change, `T::Range[T.untyped]` returns a `TypedRange::Untyped` instance, matching the rest of the typed wrappers and `simple.rb`'s codepath.

This is purely a consistency tightening — there is no behavior or performance difference today.

Fixes #10258.

### Test plan

Added a single regression test under `describe "TypedRange"` asserting that `T::Range[T.untyped]` returns a `TypedRange::Untyped` instance. Existing test suite (915 runs, 2798 assertions) passes locally.
