### PR TITLE
mark tagged `InstructionPtr` construction pathway `noexcept`

### DIFF
--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -308,7 +308,7 @@ class InstructionPtr final {
 
     template <typename T, typename... Args> friend InstructionPtr make_insn(Args &&...);
 
-    static tagged_storage tagPtr(Tag tag, void *i) {
+    static tagged_storage tagPtr(Tag tag, void *i) noexcept {
         auto val = static_cast<tagged_storage>(tag);
         auto maskedPtr = reinterpret_cast<tagged_storage>(i) << 16;
 
@@ -317,7 +317,7 @@ class InstructionPtr final {
 
     static void deleteTagged(Tag tag, void *ptr) noexcept;
 
-    InstructionPtr(Tag tag, Instruction *i) : ptr(tagPtr(tag, i)) {}
+    InstructionPtr(Tag tag, Instruction *i) noexcept : ptr(tagPtr(tag, i)) {}
 
     void resetTagged(tagged_storage i) noexcept {
         Tag tagVal;
@@ -353,7 +353,7 @@ public:
     }
 
     constexpr InstructionPtr() noexcept : ptr(0) {}
-    constexpr InstructionPtr(std::nullptr_t) : ptr(0) {}
+    constexpr InstructionPtr(std::nullptr_t) noexcept : ptr(0) {}
     ~InstructionPtr() {
         if (ptr != 0) {
             deleteTagged(tag(), get());


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is #10260 but for `InstructionPtr`, with a bonus marking of the `nullptr` constructor for good measure.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

If it compiles, it works.
