### PR TITLE
sorbet-runtime: Rework method_added hooks to fire before `sig` is called

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -51,8 +51,6 @@ module T::Private::Methods
   DeclarationBlock = Struct.new(:mod, :loc, :blk_or_decl, :final)
 
   def self.declare_sig(mod, loc, arg, &blk)
-    install_hooks(mod)
-
     if T::Private::DeclState.current.active_declaration
       T::Private::DeclState.current.reset!
       raise "You called sig twice without declaring a method in between"
@@ -561,23 +559,17 @@ module T::Private::Methods
     end
   end
 
+  # Normally, this should be taken care of by simply `extend T::Sig`.
+  #
+  # But there are a few cases where we actually want the hooks to be "viral"
+  # for final modules and final methods, such that we actually want to forcibly
+  # install the hooks even if they would not have naturally been there via
+  # inheritance.
+  #
+  # As such, we don't have to handle quite as many edge cases as `lib/types/sig.rb` does
   def self.install_hooks(mod)
     return if @installed_hooks.include?(mod)
     @installed_hooks[mod] = true
-
-    if mod == TOP_SELF
-      # self at the top-level of a file is weirdly special in Ruby
-      # The Ruby VM on startup creates an `Object.new` and stashes it.
-      # Unlike when we're using sig inside a module, `self` is actually a
-      # normal object, not an instance of Module.
-      #
-      # Thus we can't ask things like mod.singleton_class? (since that's
-      # defined only on Module, not on Object) and even if we could, the places
-      # where we need to install the hooks are special.
-      mod.extend(SingletonMethodHooks) # def self.foo; end (at top level)
-      Object.extend(MethodHooks)       # def foo; end      (at top level)
-      return
-    end
 
     # See https://github.com/sorbet/sorbet/pull/3964 for an explanation of why this
     # check (which theoretically should not be needed) is actually needed.

--- a/gems/sorbet-runtime/lib/types/sig.rb
+++ b/gems/sorbet-runtime/lib/types/sig.rb
@@ -4,6 +4,77 @@
 # Used as a mixin to any class so that you can call `sig`.
 # Docs at https://sorbet.org/docs/sigs
 module T::Sig
+  include T::Private::Methods::MethodHooks
+  include T::Private::Methods::SingletonMethodHooks
+
+  private_class_method def self.included(other)
+    return unless Module == other
+
+    # Module#method_added is normally a no-op method that does not call
+    # `super` and immediately returns `nil`. This means that `method_added`
+    # methods defined on an ancestor of `Module` are never called, so for
+    # `Module` itself, we need to redefine to call `super` to forward to the
+    # `method_added` defined above and which is already in the hierarchy.
+    #
+    # (`singleton_method_added` is defined on `BasicObject`, so ours does
+    # override that one.)
+    other.prepend(T::Private::Methods::MethodHooks)
+  end
+
+  private_class_method def self.extended(other)
+    if other == T::Private::Methods::TOP_SELF
+      # Methods defined via `def foo; end` at the top-level of a file are
+      # actually defined as private instance methods on `Object`, so we have to
+      # register our `method_added` hook there.
+      #
+      # Methods defined via `def self.foo; end` at the top-level are defined on
+      # a special instance of `Object` called `main` (initialized by the VM on
+      # startup), and putting `extend T::Sig` at the top-level of a file has
+      # the effect of putting `singleton_method_added` on the singleton class
+      # of `main`, which is catches those methods.
+      Object.extend(T::Private::Methods::MethodHooks)
+      return
+    end
+
+    return unless Module.===(other) && other.singleton_class?
+
+    # Given this:
+    #
+    #     class A
+    #       class << self
+    #         extend T::Sig
+    #       end
+    #     end
+    #
+    # The `singleton_method_added` hook will end up defined as if
+    # `A.singleton_class.singleton_class#singleton_method_added`[1], so methods
+    # defined via `def self.` inside the `class << self` will be hooked, but
+    # not "instance" methods, because for better or worse Ruby chooses to call
+    # `A.singleton_method_added` even for `def foo` (an instance method) inside
+    # a `class << self` definition.[2]
+    #
+    # This forces a problem on users: they need `extend T::Sig` to make `sig`
+    # callable at the class body, but they need `include T::Sig` to make sure
+    # that the `singleton_method_added` hook lands on the right place. To
+    # avoid users needing to do that, we define an extra
+    # `singleton_method_added` on the `attached_object` of the singleton
+    # class, aka `A.singleton_method_added`.[3]
+    #
+    # [1] Not actually--it will be in the ancestor chain, but callable on
+    #   values of that type.
+    #
+    # [2] I imagine this is for backwards compatibility in the common case of
+    #   one level of `class << self` nesting, so that people can define a
+    #   single `singleton_method_added` hook and have it fire for `def
+    #   self.foo` methods outside and `def foo` inside.
+    #
+    # [3] Before switching to having the hooks defined eagerly `T::Sig`
+    #   itself, this was done lazily via `include(SingletonMethodHooks)`
+    #   instead of `extend(MethodHooks)` on the first call to `sig` inside
+    #   the `class << self`.
+    other.include(T::Private::Methods::SingletonMethodHooks)
+  end
+
   module WithoutRuntime
     # At runtime, does nothing, but statically it is treated exactly the same
     # as T::Sig#sig. Only use it in cases where you can't use T::Sig#sig.

--- a/gems/sorbet-runtime/lib/types/sig.rbi
+++ b/gems/sorbet-runtime/lib/types/sig.rbi
@@ -1,0 +1,22 @@
+# typed: strict
+
+module T::Sig
+  module Private
+    module MethodAdded
+      sig { params(method_name: Symbol).void }
+      private def method_added(method_name); end
+    end
+    module SingletonMethodAdded
+      sig { params(method_name: Symbol).void }
+      private def singleton_method_added(method_name); end
+    end
+
+    TOP_SELF = T.let(self, Object)
+  end
+
+  sig { params(other: T::Module[T.anything]).void }
+  private_class_method def self.included(other); end
+
+  sig { params(other: BasicObject).void }
+  private_class_method def self.extended(other); end
+end

--- a/gems/sorbet-runtime/test/types/final_module.rb
+++ b/gems/sorbet-runtime/test/types/final_module.rb
@@ -208,4 +208,65 @@ class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest
       final!
     end
   end
+
+  it "forbids declaring a non-final method in a final module without T::Sig" do
+    err = assert_raises(RuntimeError) do
+      Module.new do
+        extend T::Helpers
+        final!
+        def foo; end
+      end
+    end
+    assert_match(/was declared as final but its method `foo` was not declared as final/, err.message)
+  end
+
+  it "forbids declaring a non-final class method in a final module without T::Sig" do
+    err = assert_raises(RuntimeError) do
+      Module.new do
+        extend T::Helpers
+        final!
+        def self.foo; end
+      end
+    end
+    assert_match(/was declared as final but its method `foo` was not declared as final/, err.message)
+  end
+
+  it "forbids declaring a non-final method in class << self of a final class without T::Sig" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        extend T::Helpers
+        final!
+        class << self
+          def foo; end
+        end
+      end
+    end
+    assert_match(/was declared as final but its method `foo` was not declared as final/, err.message)
+  end
+
+  it "forbids declaring a non-final class method when final! is in class << self" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        class << self
+          extend T::Helpers
+          final!
+        end
+        def self.foo; end
+      end
+    end
+    assert_match(/was declared as final but its method `foo` was not declared as final/, err.message)
+  end
+
+  it "forbids declaring a non-final method inside class << self when final! is in class << self" do
+    err = assert_raises(RuntimeError) do
+      Class.new do
+        class << self
+          extend T::Helpers
+          final!
+          def foo; end
+        end
+      end
+    end
+    assert_match(/was declared as final but its method `foo` was not declared as final/, err.message)
+  end
 end

--- a/gems/sorbet-runtime/test/types/fixtures/module_include_t_sig.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/module_include_t_sig.rb
@@ -1,0 +1,59 @@
+# typed: true
+require_relative '../../../lib/sorbet-runtime'
+
+class Module
+  include T::Sig
+end
+
+module M
+  sig { returns(Integer) }
+  def baz
+    puts 'called M#baz'
+
+    T.unsafe('bad')
+  end
+end
+
+class A
+  include M
+
+  sig { returns(Integer) }
+  def foo
+    puts 'called A#foo'
+
+    T.unsafe('nope')
+  end
+
+  sig { returns(Symbol) }
+  def self.bar
+    puts 'called A.bar'
+
+    T.unsafe(0.0)
+  end
+end
+
+a = A.new
+
+begin
+  a.foo
+  puts "foo() did not raise a TypeError!"
+rescue TypeError => e
+  result = /Expected.*got type.*$/.match(e.message)&.to_s
+  puts result
+end
+
+begin
+  A.bar
+  puts "bar() did not raise a TypeError!"
+rescue TypeError => e
+  result = /Expected.*got type.*$/.match(e.message)&.to_s
+  puts result
+end
+
+begin
+  a.baz
+  puts "baz() did not raise a TypeError!"
+rescue TypeError => e
+  result = /Expected.*got type.*$/.match(e.message)&.to_s
+  puts result
+end

--- a/gems/sorbet-runtime/test/types/module_include_t_sig.rb
+++ b/gems/sorbet-runtime/test/types/module_include_t_sig.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+class Opus::Types::Test::ModuleIncludeTSig < Critic::Unit::UnitTest
+  MODULE_INCLUDE_T_SIG_FIXTURE = "#{__dir__}/fixtures/module_include_t_sig.rb"
+
+  it 'sigs work on all classes/modules when Module includes T::Sig' do
+    result, status = Open3.capture2("ruby", MODULE_INCLUDE_T_SIG_FIXTURE)
+    assert(status.success?, "ruby failed (exit #{status.exitstatus})")
+    assert_equal(<<~EXPECTED, result)
+      called A#foo
+      Expected type Integer, got type String with value "nope"
+      called A.bar
+      Expected type Symbol, got type Float with value 0.0
+      called M#baz
+      Expected type Integer, got type String with value "bad"
+    EXPECTED
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm working on making syntax like this work:

```ruby
abstract def foo; end
override def foo; end
final def foo; end
```

For this syntax to work without a `sig` (e.g., because we inferred the result
type of the method, or because the method is `abstract` and had a type provided
with an RBS comment, etc.), it must be the case that the `method_added` hooks
fire even when there wasn't a `sig` that recorded a `DeclarationBlock` object
first. The `method_added` hook will have to fire, with a "dummy" sig, so that it
can be used in the `abstract`/`override`/`final`/etc. DSL methods.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests, also Stripe's codebase