### PR TITLE
Reap the watchman CLI child cleanly on LSP shutdown

### DIFF
--- a/main/lsp/BUILD
+++ b/main/lsp/BUILD
@@ -29,6 +29,7 @@ cc_library(
         "json_enums.h",
         "lsp_messages_gen_helpers.h",
         "watchman/WatchmanProcess.h",
+        "watchman/WatchmanShutdown.h",
     ],
     hdrs = [
         "ConvertToSingletonClassMethod.h",
@@ -220,6 +221,22 @@ cc_test(
         "lsp",
         "//payload",
         "//test/helpers",
+        "@doctest//doctest",
+        "@doctest//doctest:main",
+    ],
+)
+
+cc_test(
+    name = "watchman_shutdown_test",
+    size = "small",
+    srcs = ["test/watchman_shutdown_test.cc"],
+    linkstatic = select({
+        "//tools/config:linkshared": 0,
+        "//conditions:default": 1,
+    }),
+    visibility = ["//tools:__pkg__"],
+    deps = [
+        "lsp",
         "@doctest//doctest",
         "@doctest//doctest:main",
     ],

--- a/main/lsp/test/watchman_shutdown_test.cc
+++ b/main/lsp/test/watchman_shutdown_test.cc
@@ -1,0 +1,153 @@
+#include "doctest/doctest.h"
+// has to go first as it violates our requirements
+#include "main/lsp/watchman/WatchmanShutdown.h"
+#include <csignal>
+#include <exception>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+using namespace std;
+
+namespace sorbet::realmain::lsp::watchman::test {
+namespace {
+
+// A drop-in stand-in for `subprocess::Popen` that records the calls
+// `shutdownWatchmanChild` makes and lets each test script the `poll()` response.
+struct FakePopen {
+    int closeInputCalls = 0;
+    int pollCalls = 0;
+    std::vector<int> killSignals;
+
+    // `poll()` returns -1 (still running) until the `pollCalls`'th call, at which point it
+    // returns `exitCode`. INT_MAX means "never exits on its own".
+    int pollsBeforeExit = numeric_limits<int>::max();
+    int exitCode = 0;
+
+    // If set, `close_input()` rethrows this. Used to verify the best-effort wrappers.
+    exception_ptr throwOnCloseInput;
+    bool throwOnPoll = false;
+    bool throwOnKill = false;
+
+    void close_input() {
+        closeInputCalls++;
+        if (throwOnCloseInput) {
+            rethrow_exception(throwOnCloseInput);
+        }
+    }
+
+    int poll() {
+        pollCalls++;
+        if (throwOnPoll) {
+            throw runtime_error("poll failed");
+        }
+        if (pollCalls >= pollsBeforeExit) {
+            return exitCode;
+        }
+        return -1;
+    }
+
+    void kill(int sig) {
+        killSignals.push_back(sig);
+        if (throwOnKill) {
+            throw runtime_error("kill failed");
+        }
+    }
+};
+
+// Happy path: child exits on stdin EOF before we run out of poll attempts.
+// We should close stdin, observe the exit via poll, and skip the kill escalation.
+TEST_CASE("shutdownWatchmanChild reaps via stdin EOF") {
+    FakePopen p;
+    p.pollsBeforeExit = 3;
+
+    shutdownWatchmanChild(p);
+
+    CHECK(p.closeInputCalls == 1);
+    CHECK(p.pollCalls == 3);
+    CHECK(p.killSignals.empty());
+}
+
+// Fallback path: child exits on SIGTERM within the grace period. We should SIGTERM, observe the
+// exit via poll, and skip the SIGKILL escalation entirely.
+TEST_CASE("shutdownWatchmanChild SIGTERMs and returns when the child responds") {
+    FakePopen p;
+    // Survive the 10 EOF polls, exit on the 15th poll overall (5 polls into the SIGTERM grace).
+    p.pollsBeforeExit = 15;
+
+    shutdownWatchmanChild(p);
+
+    CHECK(p.closeInputCalls == 1);
+    CHECK(p.pollCalls == 15);
+    CHECK(p.killSignals == vector<int>{SIGTERM});
+}
+
+// Wedged path: child ignores SIGTERM. After the SIGTERM grace period we must SIGKILL.
+// We rely on non-blocking poll (not wait()) to reap so that a D-state child cannot hang us.
+TEST_CASE("shutdownWatchmanChild SIGKILLs when SIGTERM is ignored and reaps via poll") {
+    FakePopen p;
+    // Exits at the very end of the post-SIGKILL poll grace period (10 EOF + 100 SIGTERM + 25 KILL).
+    p.pollsBeforeExit = 135;
+
+    shutdownWatchmanChild(p);
+
+    CHECK(p.closeInputCalls == 1);
+    CHECK(p.pollCalls == 135);
+    CHECK(p.killSignals == vector<int>{SIGTERM, SIGKILL});
+}
+
+// D-state guarantee: even if the child never exits after SIGKILL, we must not block sorbet's
+// shutdown. The post-SIGKILL poll loop is bounded; we return rather than calling a blocking wait.
+TEST_CASE("shutdownWatchmanChild does not block when SIGKILL is undeliverable") {
+    FakePopen p;
+    p.pollsBeforeExit = numeric_limits<int>::max();
+
+    shutdownWatchmanChild(p);
+
+    CHECK(p.closeInputCalls == 1);
+    CHECK(p.pollCalls == 135);
+    CHECK(p.killSignals == vector<int>{SIGTERM, SIGKILL});
+}
+
+// Best-effort wrapping: an exception in close_input must not prevent the rest of the sequence
+// from running, and must not propagate out (the caller is a noexcept destructor).
+TEST_CASE("shutdownWatchmanChild swallows close_input exceptions and continues") {
+    FakePopen p;
+    p.throwOnCloseInput = make_exception_ptr(runtime_error("EPIPE"));
+    p.pollsBeforeExit = numeric_limits<int>::max();
+
+    CHECK_NOTHROW(shutdownWatchmanChild(p));
+
+    CHECK(p.closeInputCalls == 1);
+    CHECK(p.pollCalls == 135);
+    CHECK(p.killSignals == vector<int>{SIGTERM, SIGKILL});
+}
+
+// If poll() throws, we treat that as "child is gone" and stop early — kill does not run.
+// This mirrors the production behavior where a throwing poll usually means the child was already
+// reaped out from under us (e.g. someone else called wait()).
+TEST_CASE("shutdownWatchmanChild stops cleanly when poll throws") {
+    FakePopen p;
+    p.throwOnPoll = true;
+
+    CHECK_NOTHROW(shutdownWatchmanChild(p));
+
+    CHECK(p.closeInputCalls == 1);
+    CHECK(p.pollCalls == 1);
+    CHECK(p.killSignals.empty());
+}
+
+// Final guarantee: kill is best-effort. A throwing SIGTERM must not stop us from escalating
+// to SIGKILL, and a throwing SIGKILL must not propagate out of the noexcept destructor.
+TEST_CASE("shutdownWatchmanChild swallows kill exceptions and still escalates") {
+    FakePopen p;
+    p.pollsBeforeExit = numeric_limits<int>::max();
+    p.throwOnKill = true;
+
+    CHECK_NOTHROW(shutdownWatchmanChild(p));
+
+    CHECK(p.killSignals == vector<int>{SIGTERM, SIGKILL});
+}
+
+} // namespace
+} // namespace sorbet::realmain::lsp::watchman::test

--- a/main/lsp/watchman/WatchmanProcess.cc
+++ b/main/lsp/watchman/WatchmanProcess.cc
@@ -1,4 +1,5 @@
 #include "WatchmanProcess.h"
+#include "WatchmanShutdown.h"
 #include "absl/strings/strip.h"
 #include "common/FileOps.h"
 #include "common/common.h"
@@ -49,6 +50,16 @@ void WatchmanProcess::start() {
 
         auto p = subprocess::Popen({watchmanPath.c_str(), "-j", "-p", "--no-pretty"},
                                    subprocess::output{subprocess::PIPE}, subprocess::input{subprocess::PIPE});
+
+        // Declared after `p` so it only runs if construction succeeded. Runs on every exit path
+        // out of this scope — normal return, break, or exception — so the watchman child is
+        // always reaped before this thread returns.
+        struct ShutdownGuard {
+            subprocess::Popen &p;
+            ~ShutdownGuard() noexcept {
+                shutdownWatchmanChild(p);
+            }
+        } shutdownGuard{p};
 
         string modifiedWorkspace = workSpace;
         if (!watchmanNamespace.empty()) {

--- a/main/lsp/watchman/WatchmanProcess.cc
+++ b/main/lsp/watchman/WatchmanProcess.cc
@@ -10,6 +10,8 @@
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
 #include "subprocess.hpp"
+#include <chrono>
+#include <thread>
 
 using namespace std;
 
@@ -40,6 +42,40 @@ template <typename F> void catchDeserializationError(spdlog::logger &logger, con
     }
 }
 
+// Attempt to shut down the watchman CLI cleanly. The CLI's `-p` (persistent) mode keeps a unix
+// socket connection to the watchman daemon open until its stdin closes AND its parent has gone
+// away. If we just let Popen go out of scope we close the FDs, but cpp-subprocess never reaps —
+// the daemon-connection socket can outlive sorbet, leaving the daemon to grow thread/port
+// counts unboundedly across editor restarts. So: close stdin, give it a beat to exit on EOF,
+// then SIGTERM if it's still around, and reap.
+void shutdownWatchmanChild(subprocess::Popen &p, spdlog::logger &logger) {
+    try {
+        p.close_input();
+    } catch (...) {
+        // best-effort
+    }
+    for (int i = 0; i < 10; i++) {
+        try {
+            if (p.poll() != -1) {
+                return;
+            }
+        } catch (...) {
+            return;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    try {
+        p.kill(SIGTERM);
+    } catch (...) {
+        // best-effort
+    }
+    try {
+        p.wait();
+    } catch (...) {
+        // best-effort
+    }
+}
+
 } // namespace
 
 void WatchmanProcess::start() {
@@ -49,6 +85,17 @@ void WatchmanProcess::start() {
 
         auto p = subprocess::Popen({watchmanPath.c_str(), "-j", "-p", "--no-pretty"},
                                    subprocess::output{subprocess::PIPE}, subprocess::input{subprocess::PIPE});
+
+        // Declared after `p` so it only runs if construction succeeded. Runs on every exit path
+        // out of this scope — normal return, break, or exception — so the watchman child is
+        // always reaped before this thread returns.
+        struct ShutdownGuard {
+            subprocess::Popen &p;
+            spdlog::logger &logger;
+            ~ShutdownGuard() noexcept {
+                shutdownWatchmanChild(p, logger);
+            }
+        } shutdownGuard{p, *logger};
 
         string modifiedWorkspace = workSpace;
         if (!watchmanNamespace.empty()) {

--- a/main/lsp/watchman/WatchmanShutdown.h
+++ b/main/lsp/watchman/WatchmanShutdown.h
@@ -1,0 +1,72 @@
+#ifndef RUBY_TYPER_LSP_WATCHMAN_WATCHMANSHUTDOWN_H
+#define RUBY_TYPER_LSP_WATCHMAN_WATCHMANSHUTDOWN_H
+
+#include <chrono>
+#include <csignal>
+#include <thread>
+
+namespace sorbet::realmain::lsp::watchman {
+
+// Attempt to shut down the watchman CLI cleanly. The CLI's `-p` (persistent) mode keeps a unix
+// socket connection to the watchman daemon open until its stdin closes AND its parent has gone
+// away. If we just let Popen go out of scope we close the FDs, but cpp-subprocess never reaps —
+// the daemon-connection socket can outlive sorbet, leaving the daemon to grow thread/port
+// counts unboundedly across editor restarts. So: close stdin, give it a beat to exit on EOF,
+// then SIGTERM if it's still around, give it another beat to handle the signal, then SIGKILL
+// as a last resort so a wedged watchman cannot block sorbet from exiting. Reap unconditionally.
+//
+// Templated on the subprocess type so tests can inject a FakePopen without spawning a real child
+// process. Each step is best-effort wrapped so a failure in one stage cannot prevent the rest of
+// the shutdown sequence from running.
+template <typename Subprocess> void shutdownWatchmanChild(Subprocess &p) {
+    // Returns true if the child exited (or poll failed, which we treat as "gone").
+    auto pollUntilExitedFor = [&p](int attempts) -> bool {
+        for (int i = 0; i < attempts; i++) {
+            try {
+                if (p.poll() != -1) {
+                    return true;
+                }
+            } catch (...) {
+                return true;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+        return false;
+    };
+
+    try {
+        p.close_input();
+    } catch (...) {
+        // best-effort
+    }
+    // 10 * 20ms = 200ms grace period for the EOF-driven shutdown.
+    if (pollUntilExitedFor(10)) {
+        return;
+    }
+    try {
+        p.kill(SIGTERM);
+    } catch (...) {
+        // best-effort
+    }
+    // 100 * 20ms = 2s grace period for SIGTERM to be handled before we escalate.
+    if (pollUntilExitedFor(100)) {
+        return;
+    }
+    try {
+        p.kill(SIGKILL);
+    } catch (...) {
+        // best-effort
+    }
+    // After SIGKILL the kernel terminates the child essentially immediately, except in the edge
+    // case of uninterruptible kernel sleep (D-state, typically an unresponsive filesystem) — there
+    // the signal is queued but cannot be delivered until the syscall returns, and a blocking
+    // wait() would hang. So we poll (non-blocking waitpid(WNOHANG) under the hood) instead of
+    // wait(). A successful poll reaps the child. If the bounded grace period elapses without a
+    // reap, give up rather than block sorbet's shutdown — any leaked zombie is cleaned up by the
+    // kernel when sorbet exits, which is the very next thing that happens.
+    pollUntilExitedFor(25);
+}
+
+} // namespace sorbet::realmain::lsp::watchman
+
+#endif // RUBY_TYPER_LSP_WATCHMAN_WATCHMANSHUTDOWN_H

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -75,6 +75,7 @@ compilation_database(
         "//main/lsp:lsp_file_updates_test",
         "//main/lsp:lsp_preprocessor_test",
         "//main/lsp:lsp_test",
+        "//main/lsp:watchman_shutdown_test",
         "//main/minimize:minimize",
         "//main/options:options",
         "//main/options:options_test",


### PR DESCRIPTION
### Motivation

The watchman CLI Sorbet spawns with `-j -p --no-pretty` keeps a unix
socket connection to the watchman daemon open as long as it's alive.
Today, `~WatchmanProcess` lets the cpp-subprocess `Popen` go out of
scope: that closes the FDs but never reaps the child. The
daemon-connection socket can outlive sorbet, so editors that restart
sorbet repeatedly (e.g. on configuration change, repo switch, or LSP
restart) accumulate watchman daemon-side connections — the daemon's
thread and Mach port counts (visible in macOS Activity Monitor's
Memory → Ports column) grow without bound until it eventually has to
be restarted by hand.

#### Who this affects

The bug lives in the sorbet binary itself, so any LSP client that
spawns `sorbet --lsp` is affected: VSCode, Neovim, Emacs, JetBrains,
Cursor, Helix, Ruby LSP with the Sorbet addon, etc. The leak fires on
every LSP session shutdown.

**Independently observed outside Shopify** (this is not a
Shopify-specific bug — three groups noticed it independently within
weeks of each other):

- @jez (Stripe, sorbet maintainer) — hit it via **Vim**, reported on
  #10128: *"I happened to notice the orphaned watchman processes today
  also. However, I use Sorbet through Vim, not VS Code."* Explicitly
  asked for a server-side fix there, which is what this PR is.
- @bdewater-thatch (Thatch) — hit it via **VSCode**, filed parallel
  PR #10128 after noticing accumulating watchman processes; endorsed
  this PR's approach in a comment here.
- Shopify — hit via VSCode (this PR's author); A/B confirmed below.

**Public reach estimate.** The sorbet VSCode marketplace listing
reports ~1.04M cumulative installs; applying typical 5–15%
cumulative-to-MAU ratios for an established extension puts active
VSCode users in the ~50k–150k range. Adding Vim / Emacs / RubyMine /
Ruby LSP raises the global active LSP-user estimate to roughly
**~75k–200k developers**. The leak fires silently on every session
shutdown for that whole population; most users never notice because
the bloat lives on the watchman daemon side, not in sorbet itself.

**At Shopify** (30-day windows ending 2026-05-11), as a concrete data
point of leak prevalence at one large adopter:

- **≥191 monthly active LSP developers** running sorbet --lsp via the
  VSCode extension — `bigquery:sdp-ingest.monorail.monorail_sorbet_lsp_3`,
  ~49 weekday DAU, 1,014 sessions across 93 repos. This is a **floor**:
  the table is populated only when the VSCode extension also has the
  `sorbet-internal.metrics` extension installed, and it captures zero
  events from Neovim / JetBrains / Cursor / Ruby LSP / etc.
- **Up to ~1,069 engineers across 147 repos** are sorbet users at all —
  `bigquery:sdp-ingest.monorail.monorail_dev_command_invoke_5` filtered
  to `payload.name = 'typecheck'`, 1,101 machines / 66,160 invocations
  over 30 days. This is the broadest sorbet-user population; the
  LSP-affected subset sits somewhere between the two bounds.

#### The fix

Factor the shutdown sequence out to `main/lsp/watchman/WatchmanShutdown.h`
as a templated `shutdownWatchmanChild<Subprocess>` (templated so tests
can inject a fake without spawning a real watchman child). The
`WatchmanProcess` read loop installs an RAII guard that runs the
sequence on every exit path — normal return, break, or exception:

1. Close stdin so the CLI sees EOF.
2. Poll briefly (10 × 20ms = 200ms) for an EOF-driven exit. Happy path.
3. SIGTERM. Poll for a 2s grace period (100 × 20ms).
4. SIGKILL as last resort.
5. Non-blocking poll (waitpid `WNOHANG`) for 500ms to reap.

Each step is best-effort wrapped so a failing stage can't prevent the
rest of the sequence from running. The post-SIGKILL reap deliberately
uses non-blocking poll instead of a blocking `wait()`, so a child stuck
in uninterruptible kernel sleep (D-state, typically an unresponsive
filesystem) cannot hang sorbet's shutdown. Worst-case bounded shutdown
delay is ~2.7s; typical path is the EOF reap in tens of ms.

### Test plan

#### Unit tests (new)

`//main/lsp:watchman_shutdown_test` — focused unit test on the shutdown
algorithm, using a `FakePopen` that records calls and lets each test
script the `poll()` response sequence. 7 cases / 22 assertions, all
passing:

- EOF reap (skip kill escalation)
- SIGTERM response (skip SIGKILL)
- SIGKILL escalation, child reaped via non-blocking poll
- D-state survival — `pollsBeforeExit = INT_MAX`, asserts no blocking wait
- `close_input` exception swallowed; sequence continues
- `poll` exception treated as "child gone"; stops cleanly
- `kill` exception swallowed; SIGKILL still escalates after SIGTERM throws

```
./bazel test //main/lsp:watchman_shutdown_test
# [doctest] test cases: 7 | 7 passed | 0 failed | 0 skipped
# [doctest] assertions: 22 | 22 passed | 0 failed
```

#### Existing suite (regression check)

`//test/lsp:watchman_test_corpus` still passes — these tests exercise
the LSP-message layer with a fake watchman; the refactor is transparent
to them.

```
./bazel test //test/lsp:watchman_test_corpus    # PASSED
```

#### End-to-end manual A/B

Drove 5 LSP `initialize` → `shutdown` → `exit` cycles against a
freshly-built sorbet, watching child PIDs and counting client processes
and daemon-side socket FDs before/after:

| | child reaped on shutdown? | leaked client procs (Δ) | daemon socket FDs (Δ) |
|---|---|---|---|
| master (unpatched) | no — all 5 survived | +5 | +5 |
| this PR | yes — all 5 reaped within ~1s | 0 | 0 |