### PR TITLE
Remove lspTypecheckCount

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2016,7 +2016,6 @@ unique_ptr<GlobalState> GlobalState::deepCopyGlobalState(bool keepId) const {
     result->symbolsReferencedByFile = this->symbolsReferencedByFile;
     result->lspQuery = this->lspQuery;
     result->kvstoreUuid = this->kvstoreUuid;
-    result->lspTypecheckCount = this->lspTypecheckCount;
     result->utf8Names.reserve(this->utf8Names.capacity());
     result->constantNames.reserve(this->constantNames.capacity());
     result->uniqueNames.reserve(this->uniqueNames.capacity());

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -605,9 +605,6 @@ public:
 
     FlowId creation; // used to track flow of global states
 
-    // Indicates the number of times LSP has run the type checker with this global state.
-    // Used to ensure GlobalState is in the correct state to process requests.
-    unsigned int lspTypecheckCount = 0;
     // [LSP] Manages typechecking epochs and cancelation.
     std::shared_ptr<lsp::TypecheckEpochManager> epochManager;
 

--- a/main/lsp/LSPLoop.cc
+++ b/main/lsp/LSPLoop.cc
@@ -65,30 +65,6 @@ void LSPLoop::sendCountersToStatsd(chrono::time_point<chrono::steady_clock> curr
 }
 
 namespace {
-class TypecheckCountTask : public LSPTask {
-    int &count;
-
-public:
-    TypecheckCountTask(const LSPConfiguration &config, int &count)
-        : LSPTask(config, LSPMethod::SorbetError), count(count) {}
-
-    bool canPreempt(const LSPIndexer &indexer) const override {
-        return false;
-    }
-
-    void run(LSPTypecheckerDelegate &tc) override {
-        count = tc.state().lspTypecheckCount;
-    }
-};
-} // namespace
-
-int LSPLoop::getTypecheckCount() {
-    int count = 0;
-    typecheckerCoord.syncRun(make_unique<TypecheckCountTask>(*config, count));
-    return count;
-}
-
-namespace {
 class NotifyNotificationOnDestruction {
     absl::Notification &notification;
 

--- a/main/lsp/LSPLoop.h
+++ b/main/lsp/LSPLoop.h
@@ -71,10 +71,6 @@ public:
      * Processes a batch of requests. Performs pre-processing to avoid unnecessary work.
      */
     void processRequests(std::vector<std::unique_ptr<LSPMessage>> messages);
-    /**
-     * (For tests only) Retrieve the number of times typechecking has run.
-     */
-    int getTypecheckCount();
 
     /**
      * (For tests only) Set a flag that forces the slow path to block indefinitely after saving undo state. Setting

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -187,9 +187,6 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
                                                            bool isNoopUpdateForRetypecheck) const {
     ENFORCE(this_thread::get_id() == typecheckerThreadId, "Typechecker can only be used from the typechecker thread.");
     ENFORCE(this->initialized);
-    // We assume gs has been through the slow path, which is guaranteed by the initialization path not being cancelable.
-    ENFORCE(gs->lspTypecheckCount > 0,
-            "Tried to run fast path with a GlobalState object that never had inferencer and resolver runs.");
     // This property is set to 'true' in tests only if the update is expected to take the slow path and get cancelled.
     ENFORCE(!updates.cancellationExpected);
     ENFORCE(updates.preemptionsExpected == 0);
@@ -332,7 +329,6 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
     auto sorted = sortParsedFiles(*gs, *errorReporter, move(resolved));
     const auto cancelable = false;
     pipeline::typecheck(*gs, move(sorted), config->opts, workers, cancelable, this->lastStratum, nullptr);
-    gs->lspTypecheckCount++;
 
     auto duration = timeit.setEndTime();
     std::string files;
@@ -671,8 +667,6 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
                 }
             }
 
-            // Inform the fast path that this global state is OK for typechecking as resolution has completed.
-            gs->lspTypecheckCount++;
             // TODO(jvilk): Remove conditional once initial typecheck is preemptible.
             if (cancelable) {
                 // Inform users that Sorbet should be responsive now.
@@ -817,9 +811,6 @@ void tryApplyDefLocSaver(const core::GlobalState &gs, vector<ast::ParsedFile> &i
 LSPQueryResult LSPTypechecker::query(const core::lsp::Query &q, const vector<core::FileRef> &filesForQuery,
                                      WorkerPool &workers) const {
     ENFORCE(this_thread::get_id() == typecheckerThreadId, "Typechecker can only be used from the typechecker thread.");
-    // We assume gs has been through the slow path, which is guaranteed by the initialization path not being cancelable.
-    ENFORCE(gs->lspTypecheckCount > 0,
-            "Tried to run a query with a GlobalState object that never had inferencer and resolver runs.");
 
     // Replace error queue with one that is owned by this thread.
     auto queryCollector = make_shared<QueryCollector>();
@@ -837,7 +828,6 @@ LSPQueryResult LSPTypechecker::query(const core::lsp::Query &q, const vector<cor
     const auto cancelable = true;
     pipeline::sortBySize(*gs, resolved);
     pipeline::typecheck(*gs, move(resolved), config->opts, workers, cancelable);
-    gs->lspTypecheckCount++;
     gs->lspQuery = core::lsp::Query::noQuery();
     return LSPQueryResult{queryCollector->drainQueryResponses(), nullptr};
 }

--- a/main/lsp/test/lsp_preprocessor_test.cc
+++ b/main/lsp/test/lsp_preprocessor_test.cc
@@ -341,8 +341,6 @@ TEST_CASE("MergesFileUpdatesProperlyAfterCancelation") {
 TEST_CASE("PreemptionTasksWorkAsExpected") {
     auto errorCollector = make_shared<core::ErrorCollector>();
     auto gs = makeGS(errorCollector);
-    // Note: needs to be > 0 otherwise an enforce triggers.
-    gs->lspTypecheckCount++;
     auto preemptManager = make_shared<core::lsp::PreemptionTaskManager>(gs->epochManager);
 
     // Put an error in the queue.
@@ -416,8 +414,6 @@ public:
 TEST_CASE("PreemptionReschedulingWorksAsExpected") {
     auto errorCollector = make_shared<core::ErrorCollector>();
     auto gs = makeGS(errorCollector);
-    // Note: needs to be > 0 otherwise an enforce triggers.
-    gs->lspTypecheckCount++;
     auto preemptManager = make_shared<core::lsp::PreemptionTaskManager>(gs->epochManager);
 
     // Put an error in the queue.
@@ -485,8 +481,6 @@ TEST_CASE("PreemptionReschedulingWorksAsExpected") {
 TEST_CASE("RescheduledPreemptionTasksClearOnCancelation") {
     auto errorCollector = make_shared<core::ErrorCollector>();
     auto gs = makeGS(errorCollector);
-    // Note: needs to be > 0 otherwise an enforce triggers.
-    gs->lspTypecheckCount++;
     auto preemptManager = make_shared<core::lsp::PreemptionTaskManager>(gs->epochManager);
 
     // Put an error in the queue.
@@ -539,8 +533,6 @@ TEST_CASE("RescheduledPreemptionTasksClearOnCancelation") {
 TEST_CASE("RescheduledPreemptionTasksClearOnSuccess") {
     auto errorCollector = make_shared<core::ErrorCollector>();
     auto gs = makeGS(errorCollector);
-    // Note: needs to be > 0 otherwise an enforce triggers.
-    gs->lspTypecheckCount++;
     auto preemptManager = make_shared<core::lsp::PreemptionTaskManager>(gs->epochManager);
 
     // Put an error in the queue.
@@ -583,8 +575,6 @@ TEST_CASE("RescheduledPreemptionTasksClearOnSuccess") {
 TEST_CASE("RescheduledPreemptionTasksClearOnSuccessWrongStratum") {
     auto errorCollector = make_shared<core::ErrorCollector>();
     auto gs = makeGS(errorCollector);
-    // Note: needs to be > 0 otherwise an enforce triggers.
-    gs->lspTypecheckCount++;
     auto preemptManager = make_shared<core::lsp::PreemptionTaskManager>(gs->epochManager);
 
     // Put an error in the queue.

--- a/main/lsp/wrapper.cc
+++ b/main/lsp/wrapper.cc
@@ -164,10 +164,6 @@ void LSPWrapper::enableAllExperimentalFeatures() {
     opts->lspDocumentFormatRubyfmtEnabled = true;
 }
 
-int LSPWrapper::getTypecheckCount() {
-    return lspLoop->getTypecheckCount();
-}
-
 void LSPWrapper::setSlowPathBlocked(bool blocked) {
     lspLoop->setSlowPathBlocked(blocked);
 }

--- a/main/lsp/wrapper.h
+++ b/main/lsp/wrapper.h
@@ -59,11 +59,6 @@ public:
     void enableAllExperimentalFeatures();
 
     /**
-     * (For tests only) Retrieve the number of times typechecking has run.
-     */
-    int getTypecheckCount();
-
-    /**
      * (For tests only) Set a flag that forces the slow path to block indefinitely after saving undo state. Setting
      * this flag to `false` will immediately unblock any currently blocked slow paths.
      */

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -1042,14 +1042,17 @@ TEST_CASE_FIXTURE(ProtocolTest, "OpeningExistingFilesTakesTheFastPath") {
 
     assertErrorDiagnostics(initializeLSP(), {});
 
-    auto typecheckCount = this->lspWrapper->getTypecheckCount();
+    // Clear the counters
+    getCounters();
 
     for (auto &file : files) {
         assertErrorDiagnostics(send(*openFile(file.first, file.second)), {});
-        typecheckCount++;
 
-        // Opening each file should cause one fast path to run, which will increment the typecheck count once.
-        REQUIRE_EQ(this->lspWrapper->getTypecheckCount(), typecheckCount);
+        // Opening each file should cause one fast path to run.
+        auto counters = getCounters();
+        REQUIRE_EQ(counters.getCategoryCounter("lsp.updates", "fastpath"), 1);
+        REQUIRE_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 0);
+        REQUIRE_EQ(counters.getCategoryCounter("lsp.updates", "slowpath_canceled"), 0);
     }
 }
 

--- a/test/lsp/watchman_test_corpus.cc
+++ b/test/lsp/watchman_test_corpus.cc
@@ -105,20 +105,24 @@ TEST_CASE_FIXTURE(ProtocolTest, "MergesMultipleWatchmanUpdates") {
 
     string buggyFileContents = "# typed: true\nclass Foo1\n  def branch\n    1 + \"stuff\"\n  end\nend\n";
     writeFilesToFS({{"foo.rb", buggyFileContents}, {"bar.rb", buggyFileContents}, {"baz.rb", buggyFileContents}});
+
+    // Clear counters
+    getCounters();
+
     assertErrorDiagnostics(send(move(requests)), {
                                                      {"foo.rb", 3, "Expected `Integer`"},
                                                      {"bar.rb", 3, "Expected `Integer`"},
                                                      {"baz.rb", 3, "Expected `Integer`"},
                                                  });
 
-    // getTypecheckCount tracks the number of times typechecking has run on the same version of the typechecker's
-    // GlobalState. It's reset to 1 after each slow path run, and incremented after every fast path.
-    // We expect the merged case to run 1 slow path (where typecheck count would be 1), and the unmerged case to run
-    // 3 slow paths and 2 fast paths (where typecheck count would be 3).
+    auto counters = getCounters();
+
     INFO(fmt::format("Expected Sorbet to apply multiple Watchman updates in one typechecking run, but Sorbet ran "
                      "typechecking {} times.",
-                     lspWrapper->getTypecheckCount()));
-    CHECK_EQ(lspWrapper->getTypecheckCount(), 1);
+                     counters.getCategoryCounter("lsp.updates", "slowpath")));
+    CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 1);
+    CHECK_EQ(counters.getCategoryCounter("lsp.updates", "fastpath"), 0);
+    CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath_canceled"), 0);
 }
 
 TEST_CASE_FIXTURE(ProtocolTest, "ZeroingOutPackageFiles") {


### PR DESCRIPTION
We use the `lspTypecheckCount` in a few `ENFORCE`s, and to track how many times the typechecker has been run. The value of the `ENFORCE`s is not entirely clear at this point, as we usually hit other failures before any involving `lspTypecheckCount`. Additionally, the tests that use `getTypecheckCount` can be reworked in terms of counters, which is a little more consistent with the rest of the tests.

### Motivation
Cleaning up.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See changed tests.
