### PR TITLE
Use GlobalState::newSymbols in more places

### DIFF
--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -703,27 +703,27 @@ public:
 
     // ClassOrModules that have been introduced in the current stratum of files.
     SymbolRange<ClassOrModuleRef> newClassOrModules() const {
-        return this->symbolOffsets.classOrModuleRefs(*this);
+        return this->newSymbols().classOrModuleRefs(*this);
     }
 
     // Methods that have been introduced in the current stratum of files.
     SymbolRange<MethodRef> newMethods() const {
-        return this->symbolOffsets.methodRefs(*this);
+        return this->newSymbols().methodRefs(*this);
     }
 
     // Fields that have been introduced in the current stratum of files.
     SymbolRange<FieldRef> newFields() const {
-        return this->symbolOffsets.fieldRefs(*this);
+        return this->newSymbols().fieldRefs(*this);
     }
 
     // Type members that have been introduced in the current stratum of files.
     SymbolRange<TypeMemberRef> newTypeMemberRefs() const {
-        return this->symbolOffsets.typeMemberRefs(*this);
+        return this->newSymbols().typeMemberRefs(*this);
     }
 
     // Type parameters that have been introduced in the current stratum of files.
     SymbolRange<TypeParameterRef> newTypeParameterRefs() const {
-        return this->symbolOffsets.typeParameterRefs(*this);
+        return this->newSymbols().typeParameterRefs(*this);
     }
 
     void updateSymbolTableOffsets() {


### PR DESCRIPTION
Using `GlobalState::newSymbols` in place of directly accessing `symbolOffsets`
makes it easier to change where the `SymbolTableOffsets` are stored in the
future.

### Motivation
Refactoring in advance of speeding up the LSP slow path.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No changes expected, pure refactor.
