### PR TITLE
Add a test case to show that `typed: ignore` files are not checked by `min_typed_level`

### DIFF
--- a/test/cli/packager_min_typed_level/test/test_too_low_ignore.rb
+++ b/test/cli/packager_min_typed_level/test/test_too_low_ignore.rb
@@ -1,0 +1,5 @@
+# typed: ignore
+# Note that no error is reported here even those 'ignore' < 'true'
+
+class Test::Project::MyPackage::TestTooLow
+end

--- a/test/cli/packager_min_typed_level/too_low_ignore.rb
+++ b/test/cli/packager_min_typed_level/too_low_ignore.rb
@@ -1,0 +1,5 @@
+# typed: ignore
+# Note that no error is reported here even those 'ignore' < 'strict'
+
+class Project::MyPackage::TooLow
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Adds 2 `typed: ignore` files to a package with a `min_typed_level` and `tests_min_typed_level` higher than that and show that no error is reported.

I think it might be worth reporting an error here, but that's something to think about elsewhere.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I expected (wrongly) that there would be an error if a file was marked `typed: ignore` in a package where the `min_typed_level` is higher than that, so I wanted to add a test case to capture the behaviour there.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
