### PR TITLE
Move file table updating into a separate function

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -351,6 +351,82 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
     return FastPathResult{move(toTypecheck), move(toCache)};
 }
 
+namespace {
+
+// Determine which files we need to copy into the open files cache (indexedFinalGS), and update the file table to point
+// to the updated files.
+void applyFileTableUpdates(core::GlobalState &gs, vector<core::FileRef> &workspaceFiles, const LSPConfiguration &config,
+                           UnorderedSet<core::FileRef> &openFiles, LSPFileUpdates &updates) {
+    core::UnfreezeFileTable updateFileTable{gs};
+
+    vector<pair<core::FileRef, shared_ptr<core::File>>> newFiles;
+    newFiles.reserve(updates.updatedFiles.size());
+
+    auto usedFiles = gs.filesUsed();
+    auto ix = -1;
+    for (auto &file : updates.updatedFiles) {
+        ++ix;
+
+        auto fref = updates.updatedFileRefs[ix];
+        ENFORCE(fref.exists());
+
+        if (fref.id() >= usedFiles) {
+            newFiles.emplace_back(fref, move(file));
+            continue;
+        }
+
+        ENFORCE(fref == gs.findFileByPath(file->path()), "FileRef mismatch between indexer and typechecker");
+        gs.replaceFile(fref, std::move(file));
+    }
+
+    if (!newFiles.empty()) {
+        // Sort the files by their ref so that we match the order of insertions into the indexer's file
+        // table.
+        fast_sort(newFiles, [](auto &l, auto &r) { return l.first.id() < r.first.id(); });
+
+        workspaceFiles.reserve(workspaceFiles.size() + newFiles.size());
+
+        for (auto &[fref, file] : newFiles) {
+            auto newFref = gs.enterFile(std::move(file));
+
+            // This property relies on `LSPIndexer::commitEdit` never rolling back the effects of
+            // `GlobalState::enterFile` on the indexer's global state, and LSPFileUpdate values never
+            // being dropped or truncated.
+            //
+            // The first assumption is valid as the indexer only grows its file table and never rolls
+            // back to a previous state.
+            //
+            // The second is valid because the consumer of LSPFileUpdate values from
+            // `LSPIndexer::commitEdit` is SorbetWorkspaceEdit, and that task will either be a new edit,
+            // or a merged combination of other edits that have accumulated up to that point. If the
+            // slow path is cancelled we'll roll back the changes to the file table, but the updates
+            // themselves will be merged into the next edit, ensuring that we do ultimately insert those
+            // new files.
+            if (fref != newFref) {
+                ENFORCE(false);
+
+                config.logger->error("Mismatched ref on new file path=\"{}\" expected={} actual={}", file->path(),
+                                     fref.id(), newFref.id());
+            }
+
+            workspaceFiles.emplace_back(newFref);
+        }
+    }
+
+    for (auto fref : updates.updatedFileRefs) {
+        // Not all files present in the update set will be from open files--some could be watchman
+        // update events, and others will be the result of a `textDocument/didClose` notification.
+        // As a result, we may need to remove entries from the set that was eagerly cloned from
+        // `indexedFinalGS`
+        if (fref.data(gs).isOpenInClient()) {
+            openFiles.insert(fref);
+        } else {
+            openFiles.erase(fref);
+        }
+    }
+}
+} // namespace
+
 bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const OwnedKeyValueStore> ownedKvstore,
                                  WorkerPool &workers, shared_ptr<core::ErrorFlusher> errorFlusher,
                                  LSPTypechecker::SlowPathMode mode) {
@@ -407,77 +483,8 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, unique_ptr<const Owned
             case SlowPathMode::Cancelable: {
                 Timer timeit(this->config->logger, "slow_path_init");
 
-                // Determine which files we need to copy into the open files cache (indexedFinalGS), and update the
-                // file table to point to the updated files.
                 if (!updates.updatedFiles.empty()) {
-                    core::UnfreezeFileTable updateFileTable{*this->gs};
-
-                    vector<pair<core::FileRef, shared_ptr<core::File>>> newFiles;
-                    newFiles.reserve(updates.updatedFiles.size());
-
-                    auto usedFiles = this->gs->filesUsed();
-                    auto ix = -1;
-                    for (auto &file : updates.updatedFiles) {
-                        ++ix;
-
-                        auto fref = updates.updatedFileRefs[ix];
-                        ENFORCE(fref.exists());
-
-                        if (fref.id() >= usedFiles) {
-                            newFiles.emplace_back(fref, move(file));
-                            continue;
-                        }
-
-                        ENFORCE(fref == this->gs->findFileByPath(file->path()),
-                                "FileRef mismatch between indexer and typechecker");
-                        this->gs->replaceFile(fref, std::move(file));
-                    }
-
-                    if (!newFiles.empty()) {
-                        // Sort the files by their ref so that we match the order of insertions into the indexer's file
-                        // table.
-                        fast_sort(newFiles, [](auto &l, auto &r) { return l.first.id() < r.first.id(); });
-
-                        this->workspaceFiles.reserve(this->workspaceFiles.size() + newFiles.size());
-
-                        for (auto &[fref, file] : newFiles) {
-                            auto newFref = this->gs->enterFile(std::move(file));
-
-                            // This property relies on `LSPIndexer::commitEdit` never rolling back the effects of
-                            // `GlobalState::enterFile` on the indexer's global state, and LSPFileUpdate values never
-                            // being dropped or truncated.
-                            //
-                            // The first assumption is valid as the indexer only grows its file table and never rolls
-                            // back to a previous state.
-                            //
-                            // The second is valid because the consumer of LSPFileUpdate values from
-                            // `LSPIndexer::commitEdit` is SorbetWorkspaceEdit, and that task will either be a new edit,
-                            // or a merged combination of other edits that have accumulated up to that point. If the
-                            // slow path is cancelled we'll roll back the changes to the file table, but the updates
-                            // themselves will be merged into the next edit, ensuring that we do ultimately insert those
-                            // new files.
-                            if (fref != newFref) {
-                                ENFORCE(false);
-
-                                config->logger->error("Mismatched ref on new file path=\"{}\" expected={} actual={}",
-                                                      file->path(), fref.id(), newFref.id());
-                            }
-
-                            this->workspaceFiles.emplace_back(newFref);
-                        }
-                    }
-
-                    for (auto fref : updates.updatedFileRefs) {
-                        // Not all files present in the update set will be from open files--some could be watchman
-                        // update events, and others will be the result of a `textDocument/didClose` notification.
-                        // As a result, we may need to remove entries from the set that was eagerly cloned from
-                        // `indexedFinalGS`
-                        if (fref.data(*this->gs).isOpenInClient()) {
-                            openFiles.insert(fref);
-                        } else {
-                            openFiles.erase(fref);
-                        }
-                    }
+                    applyFileTableUpdates(*this->gs, this->workspaceFiles, *this->config, openFiles, updates);
 
                     updates.updatedFileRefs.clear();
                     updates.updatedFiles.clear();


### PR DESCRIPTION
The `LSPTypechecker::runSlowPath` method is pretty huge, and it's a little difficult to stay oriented while reading parts of it. This PR moves the file table updating out to a separate function, to make the differences between initialization and the cancelable slow path a bit more clear.

### Motivation
Clarity.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavioral changes, pure refactoring.
