### PR TITLE
move `SendAndBlockLink` storage into `CFG`

### DIFF
--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -62,12 +62,30 @@ LocalRef CFG::enterLocal(core::LocalVariable variable) {
     return ref;
 }
 
+LinkRef CFG::enterLink(core::NameRef fun, core::LocOffsets loc, vector<core::ParamInfo::Flags> &&paramFlags) {
+    auto id = links.size();
+    links.emplace_back(make_shared<core::SendAndBlockLink>(fun, loc, std::move(paramFlags)));
+    return LinkRef(static_cast<uint32_t>(id));
+}
+
+shared_ptr<core::SendAndBlockLink> &CFG::linkFor(LinkRef ref) {
+    ENFORCE(ref.id() < links.size());
+    return links[ref.id()];
+}
+
+const shared_ptr<core::SendAndBlockLink> &CFG::linkFor(LinkRef ref) const {
+    ENFORCE(ref.id() < links.size());
+    return links[ref.id()];
+}
+
 CFG::CFG() {
     freshBlock(0); // entry;
     freshBlock(0); // dead code;
     deadBlock()->bexit.elseb = deadBlock();
     deadBlock()->bexit.thenb = deadBlock();
     deadBlock()->bexit.cond.variable = LocalRef::unconditional();
+
+    links.emplace_back(nullptr);
 
     UnfreezeCFGLocalVariables unfreezeVars(*this);
     // Enter a few fixed local variables

--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -85,6 +85,8 @@ CFG::CFG() {
     deadBlock()->bexit.thenb = deadBlock();
     deadBlock()->bexit.cond.variable = LocalRef::unconditional();
 
+    // The default LinkRef is 0; we push a nullptr here so e.g. a Send without a block can
+    // simply use its default LinkRef without having to branch.
     links.emplace_back(nullptr);
 
     UnfreezeCFGLocalVariables unfreezeVars(*this);

--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -86,7 +86,7 @@ CFG::CFG() {
     deadBlock()->bexit.cond.variable = LocalRef::unconditional();
 
     // The default LinkRef is 0; we push a nullptr here so e.g. a Send without a block can
-    // simply use its default LinkRef without having to branch.
+    // simply use its default LinkRef to index into the array instead of having to branch.
     links.emplace_back(nullptr);
 
     UnfreezeCFGLocalVariables unfreezeVars(*this);

--- a/cfg/CFG.h
+++ b/cfg/CFG.h
@@ -9,7 +9,7 @@
 #include <memory>
 
 #include "cfg/Instructions.h"
-
+#include "cfg/LinkRef.h"
 //
 // This file defines the IR that the inference algorithm operates on.
 // A CFG (control flow graph) is a directed graph of "basic blocks" which are
@@ -190,6 +190,10 @@ public:
     ReadsAndWrites findAllReadsAndWrites(core::Context ctx);
     LocalRef enterLocal(core::LocalVariable variable);
 
+    LinkRef enterLink(core::NameRef fun, core::LocOffsets loc, std::vector<core::ParamInfo::Flags> &&paramFlags);
+    std::shared_ptr<core::SendAndBlockLink> &linkFor(LinkRef);
+    const std::shared_ptr<core::SendAndBlockLink> &linkFor(LinkRef) const;
+
 private:
     CFG();
     BasicBlock *freshBlock(int outerLoops);
@@ -206,6 +210,8 @@ private:
      * Map from LocalVariable -> LocalRef. Used to de-dupe variables in localVariables.
      */
     UnorderedMap<core::LocalVariable, LocalRef> localVariableToLocalRef;
+
+    std::vector<std::shared_ptr<core::SendAndBlockLink>> links;
 };
 
 } // namespace sorbet::cfg

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -4,6 +4,7 @@
 #include "common/typecase.h"
 #include "core/Names.h"
 #include "core/TypeConstraint.h"
+#include "cfg/CFG.h"
 #include <memory>
 #include <utility>
 
@@ -77,11 +78,11 @@ Return::Return(LocalRef what, core::LocOffsets whatLoc) : what(what), whatLoc(wh
 }
 
 string SolveConstraint::toString(const core::GlobalState &gs, const CFG &cfg) const {
-    return fmt::format("Solve<{}, {}>", this->send.toString(gs, cfg), this->link->fun.toString(gs));
+    return fmt::format("Solve<{}, {}>", this->send.toString(gs, cfg), cfg.linkFor(this->link)->fun.toString(gs));
 }
 
 string SolveConstraint::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
-    return fmt::format("Solve {{ send = {}, link = {} }}", this->send.toString(gs, cfg), this->link->fun.showRaw(gs));
+    return fmt::format("Solve {{ send = {}, link = {} }}", this->send.toString(gs, cfg), cfg.linkFor(this->link)->fun.showRaw(gs));
 }
 
 string Return::toString(const core::GlobalState &gs, const CFG &cfg) const {
@@ -93,30 +94,30 @@ string Return::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) co
                        this->what.showRaw(gs, cfg, tabs + 1));
 }
 
-BlockReturn::BlockReturn(shared_ptr<core::SendAndBlockLink> link, LocalRef what) : link(std::move(link)), what(what) {
+BlockReturn::BlockReturn(LinkRef link, LocalRef what) : link(link), what(what) {
     categoryCounterInc("cfg", "blockreturn");
 }
 
 string BlockReturn::toString(const core::GlobalState &gs, const CFG &cfg) const {
-    return fmt::format("blockreturn<{}> {}", this->link->fun.toString(gs), this->what.toString(gs, cfg));
+    return fmt::format("blockreturn<{}> {}", cfg.linkFor(this->link)->fun.toString(gs), this->what.toString(gs, cfg));
 }
 
 string BlockReturn::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
     return fmt::format("BlockReturn {{\n{0}&nbsp;link = {1},\n{0}&nbsp;what = {2},\n{0}}}", spacesForTabLevel(tabs),
-                       this->link->fun.showRaw(gs), this->what.showRaw(gs, cfg, tabs + 1));
+                       cfg.linkFor(this->link)->fun.showRaw(gs), this->what.showRaw(gs, cfg, tabs + 1));
 }
 
-LoadSelf::LoadSelf(shared_ptr<core::SendAndBlockLink> link, LocalRef fallback)
-    : fallback(fallback), link(std::move(link)) {
+LoadSelf::LoadSelf(LinkRef link, LocalRef fallback)
+    : fallback(fallback), link(link) {
     categoryCounterInc("cfg", "loadself");
 }
 
 string LoadSelf::toString(const core::GlobalState &gs, const CFG &cfg) const {
-    return fmt::format("loadSelf({})", this->link->fun.toString(gs));
+    return fmt::format("loadSelf({})", cfg.linkFor(this->link)->fun.toString(gs));
 }
 
 string LoadSelf::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
-    return fmt::format("LoadSelf {{ link = {} }}", this->link->fun.showRaw(gs));
+    return fmt::format("LoadSelf {{ link = {} }}", cfg.linkFor(this->link)->fun.showRaw(gs));
 }
 
 Send::SendInitializer::SendInitializer(Send *snd) : snd(snd), refs(snd->argRefs()), locs(snd->argLocs()) {}
@@ -156,7 +157,7 @@ Send::~Send() {
 }
 
 core::LocOffsets Send::locWithoutBlock(core::LocOffsets bindLoc) {
-    if (this->link == nullptr) {
+    if (!this->link) {
         // This location is slightly better, because it will include the last `)` if that exists,
         // which means that queries for things like
         //
@@ -281,11 +282,11 @@ const core::ParamInfo &ArgPresent::argument(const core::GlobalState &gs) const {
 }
 
 string LoadYieldParams::toString(const core::GlobalState &gs, const CFG &cfg) const {
-    return fmt::format("load_yield_params({})", this->link->fun.toString(gs));
+    return fmt::format("load_yield_params({})", cfg.linkFor(this->link)->fun.toString(gs));
 }
 
 string LoadYieldParams::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
-    return fmt::format("LoadYieldParams {{ link = {0} }}", this->link->fun.showRaw(gs));
+    return fmt::format("LoadYieldParams {{ link = {0} }}", cfg.linkFor(this->link)->fun.showRaw(gs));
 }
 
 string YieldParamPresent::toString(const core::GlobalState &gs, const CFG &cfg) const {

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -123,7 +123,7 @@ string LoadSelf::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) 
 Send::SendInitializer::SendInitializer(Send *snd) : snd(snd), refs(snd->argRefs()), locs(snd->argLocs()) {}
 
 Send::SendInitializer Send::make(LocalRef recv, core::LocOffsets receiverLoc, core::NameRef fun,
-                                 core::LocOffsets funLoc, uint16_t numPosArgs, bool isPrivateOk, size_t numArgs) {
+                                 core::LocOffsets funLoc, uint16_t numPosArgs, bool isPrivateOk, uint32_t numArgs) {
     size_t totalSize = Parent::totalSizeToAlloc<LocalRef, core::TypePtr, core::LocOffsets>(numArgs, numArgs, numArgs);
     void *p = ::operator new(totalSize);
     Send *snd = new (p) Send(recv, receiverLoc, fun, funLoc, numPosArgs, isPrivateOk, numArgs);
@@ -135,7 +135,7 @@ Send::SendInitializer Send::make(LocalRef recv, core::LocOffsets receiverLoc, co
 }
 
 Send::Send(LocalRef recv, core::LocOffsets receiverLoc, core::NameRef fun, core::LocOffsets funLoc, uint16_t numPosArgs,
-           bool isPrivateOk, size_t numArgs)
+           bool isPrivateOk, uint32_t numArgs)
     : isPrivateOk(isPrivateOk), numPosArgs(numPosArgs), fun(fun), recv(recv), funLoc(funLoc), receiverLoc(receiverLoc),
       numArgs(numArgs) {
     ENFORCE(numPosArgs <= numArgs, "Expected {} positional arguments, but only have {} args", numPosArgs, numArgs);

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -1,10 +1,10 @@
 #include "Instructions.h"
 
+#include "cfg/CFG.h"
 #include "common/strings/formatting.h"
 #include "common/typecase.h"
 #include "core/Names.h"
 #include "core/TypeConstraint.h"
-#include "cfg/CFG.h"
 #include <memory>
 #include <utility>
 
@@ -82,7 +82,8 @@ string SolveConstraint::toString(const core::GlobalState &gs, const CFG &cfg) co
 }
 
 string SolveConstraint::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
-    return fmt::format("Solve {{ send = {}, link = {} }}", this->send.toString(gs, cfg), cfg.linkFor(this->link)->fun.showRaw(gs));
+    return fmt::format("Solve {{ send = {}, link = {} }}", this->send.toString(gs, cfg),
+                       cfg.linkFor(this->link)->fun.showRaw(gs));
 }
 
 string Return::toString(const core::GlobalState &gs, const CFG &cfg) const {
@@ -107,8 +108,7 @@ string BlockReturn::showRaw(const core::GlobalState &gs, const CFG &cfg, int tab
                        cfg.linkFor(this->link)->fun.showRaw(gs), this->what.showRaw(gs, cfg, tabs + 1));
 }
 
-LoadSelf::LoadSelf(LinkRef link, LocalRef fallback)
-    : fallback(fallback), link(link) {
+LoadSelf::LoadSelf(LinkRef link, LocalRef fallback) : fallback(fallback), link(link) {
     categoryCounterInc("cfg", "loadself");
 }
 

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -1,6 +1,7 @@
 #ifndef SORBET_INSTRUCTIONS_H
 #define SORBET_INSTRUCTIONS_H
 
+#include "cfg/LinkRef.h"
 #include "cfg/LocalRef.h"
 #include "core/Context.h"
 #include "core/GlobalState.h"
@@ -238,8 +239,8 @@ CheckSize(Alias, 8, 8);
 INSN(SolveConstraint) : public Instruction {
 public:
     LocalRef send;
-    std::shared_ptr<core::SendAndBlockLink> link;
-    SolveConstraint(std::shared_ptr<core::SendAndBlockLink> link, LocalRef send) : send(send), link(std::move(link)) {
+    LinkRef link;
+    SolveConstraint(LinkRef link, LocalRef send) : send(send), link(link) {
         categoryCounterInc("cfg", "solveconstraint");
     };
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
@@ -269,7 +270,7 @@ public:
     core::LocOffsets funLoc;
     core::LocOffsets receiverLoc;
     const size_t numArgs;
-    std::shared_ptr<core::SendAndBlockLink> link;
+    LinkRef link;
 
     // We only need this for the first two sets of trailing types, but it's
     // defined identically for all three types and it's convenient to have it
@@ -385,10 +386,10 @@ CheckSize(Return, 24, 8);
 
 INSN(BlockReturn) : public Instruction {
 public:
-    std::shared_ptr<core::SendAndBlockLink> link;
+    LinkRef link;
     VariableUseSite what;
 
-    BlockReturn(std::shared_ptr<core::SendAndBlockLink> link, LocalRef what);
+    BlockReturn(LinkRef link, LocalRef what);
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
@@ -397,8 +398,8 @@ CheckSize(BlockReturn, 32, 8);
 INSN(LoadSelf) : public Instruction {
 public:
     LocalRef fallback;
-    std::shared_ptr<core::SendAndBlockLink> link;
-    LoadSelf(std::shared_ptr<core::SendAndBlockLink> link, LocalRef fallback);
+    LinkRef link;
+    LoadSelf(LinkRef link, LocalRef fallback);
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
@@ -456,9 +457,9 @@ CheckSize(ArgPresent, 8, 8);
 
 INSN(LoadYieldParams) : public Instruction {
 public:
-    std::shared_ptr<core::SendAndBlockLink> link;
+    LinkRef link;
 
-    LoadYieldParams(std::shared_ptr<core::SendAndBlockLink> link) : link(std::move(link)) {
+    LoadYieldParams(LinkRef link) : link(std::move(link)) {
         categoryCounterInc("cfg", "loadyieldparams");
     };
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -260,7 +260,7 @@ INSN(Send) : public Instruction, private core::TrailingObjects<Send, LocalRef, c
     }
 
     Send(LocalRef recv, core::LocOffsets receiverLoc, core::NameRef fun, core::LocOffsets funLoc, uint16_t numPosArgs,
-         bool isPrivateOk, size_t numArgs);
+         bool isPrivateOk, uint32_t numArgs);
 
 public:
     bool isPrivateOk;
@@ -269,7 +269,7 @@ public:
     VariableUseSite recv;
     core::LocOffsets funLoc;
     core::LocOffsets receiverLoc;
-    const size_t numArgs;
+    const uint32_t numArgs;
     LinkRef link;
 
     // We only need this for the first two sets of trailing types, but it's
@@ -339,7 +339,7 @@ public:
     };
 
     static SendInitializer make(LocalRef recv, core::LocOffsets receiverLoc, core::NameRef fun, core::LocOffsets funLoc,
-                                uint16_t numPosArgs, bool isPrivateOk, size_t numArgs);
+                                uint16_t numPosArgs, bool isPrivateOk, uint32_t numArgs);
 
     absl::Span<LocalRef> argRefs() {
         return span<LocalRef>();
@@ -371,7 +371,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Send, 56, 8);
+CheckSize(Send, 48, 8);
 
 INSN(Return) : public Instruction {
 public:

--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -246,7 +246,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(SolveConstraint, 24, 8);
+CheckSize(SolveConstraint, 8, 8);
 
 INSN(Send) : public Instruction, private core::TrailingObjects<Send, LocalRef, core::TypePtr, core::LocOffsets> {
     friend core::TrailingObjects<Send, LocalRef, core::TypePtr, core::LocOffsets>;
@@ -371,7 +371,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(Send, 64, 8);
+CheckSize(Send, 56, 8);
 
 INSN(Return) : public Instruction {
 public:
@@ -393,7 +393,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(BlockReturn, 32, 8);
+CheckSize(BlockReturn, 24, 8);
 
 INSN(LoadSelf) : public Instruction {
 public:
@@ -403,7 +403,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(LoadSelf, 24, 8);
+CheckSize(LoadSelf, 8, 8);
 
 INSN(Literal) : public Instruction {
 public:
@@ -465,7 +465,7 @@ public:
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs = 0) const;
 };
-CheckSize(LoadYieldParams, 16, 8);
+CheckSize(LoadYieldParams, 8, 8);
 
 INSN(YieldParamPresent) : public Instruction {
 public:

--- a/cfg/LinkRef.h
+++ b/cfg/LinkRef.h
@@ -10,7 +10,7 @@ class LinkRef final {
 
 public:
     LinkRef() = default;
-    LinkRef(uint32_t id) noexcept : _id(id) {}
+    explicit LinkRef(uint32_t id) noexcept : _id(id) {}
     LinkRef(const LinkRef &) = default;
     LinkRef(LinkRef &&) = default;
     LinkRef &operator=(LinkRef &&) = default;

--- a/cfg/LinkRef.h
+++ b/cfg/LinkRef.h
@@ -26,6 +26,6 @@ public:
 };
 CheckSize(LinkRef, 4, 4);
 
-}
+} // namespace sorbet::cfg
 
 #endif

--- a/cfg/LinkRef.h
+++ b/cfg/LinkRef.h
@@ -1,0 +1,31 @@
+#ifndef SORBET_CFG_LINKREF_H
+#define SORBET_CFG_LINKREF_H
+
+#include "common/common.h"
+
+namespace sorbet::cfg {
+
+class LinkRef final {
+    uint32_t _id = 0;
+
+public:
+    LinkRef() = default;
+    LinkRef(uint32_t id) noexcept : _id(id) {}
+    LinkRef(const LinkRef &) = default;
+    LinkRef(LinkRef &&) = default;
+    LinkRef &operator=(LinkRef &&) = default;
+    LinkRef &operator=(const LinkRef &) = default;
+
+    operator bool() const noexcept {
+        return _id != 0;
+    }
+
+    uint32_t id() const noexcept {
+        return this->_id;
+    }
+};
+CheckSize(LinkRef, 4, 4);
+
+}
+
+#endif

--- a/cfg/builder/builder.h
+++ b/cfg/builder/builder.h
@@ -60,7 +60,7 @@ public:
     BasicBlock *nextScope;
     BasicBlock *breakScope;
     BasicBlock *rescueScope;
-    std::shared_ptr<core::SendAndBlockLink> *link = nullptr;
+    LinkRef link;
     UnorderedMap<core::SymbolRef, LocalRef> &aliases;
     UnorderedMap<core::NameRef, LocalRef> &discoveredUndeclaredFields;
 
@@ -70,7 +70,7 @@ public:
     CFGContext withBlockBreakTarget(LocalRef blockBreakTarget);
     CFGContext withLoopBreakTarget(LocalRef blockBreakTarget);
     CFGContext withLoopScope(BasicBlock *nextScope, BasicBlock *breakScope, bool insideRubyBlock = false);
-    CFGContext withSendAndBlockLink(std::shared_ptr<core::SendAndBlockLink> &link);
+    CFGContext withSendAndBlockLink(LinkRef link);
 
     LocalRef newTemporary(core::NameRef name);
 

--- a/cfg/builder/builder_entry.cc
+++ b/cfg/builder/builder_entry.cc
@@ -287,9 +287,9 @@ CFGContext CFGContext::withLoopScope(BasicBlock *nextScope, BasicBlock *breakSco
     return ret;
 }
 
-CFGContext CFGContext::withSendAndBlockLink(shared_ptr<core::SendAndBlockLink> &link) {
+CFGContext CFGContext::withSendAndBlockLink(LinkRef link) {
     auto ret = CFGContext(*this);
-    ret.link = &link;
+    ret.link = link;
     return ret;
 }
 

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -824,8 +824,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::ExpressionPtr &what, Ba
                             blockReturnLoc = blockLast->exprs.back().loc;
                         }
 
-                        synthesizeExpr(blockLast, dead, blockReturnLoc,
-                                       make_insn<BlockReturn>(link, blockrv));
+                        synthesizeExpr(blockLast, dead, blockReturnLoc, make_insn<BlockReturn>(link, blockrv));
                     }
 
                     unconditionalJump(blockLast, headerBlock, cctx.inWhat, s.loc);

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -258,9 +258,8 @@ BasicBlock *CFGBuilder::walkBlockReturn(CFGContext cctx, core::LocOffsets loc, c
     auto afterNext = walk(cctx.withTarget(exprSym), expr, current);
     if (afterNext != cctx.inWhat.deadBlock() && cctx.isInsideRubyBlock) {
         LocalRef dead = cctx.newTemporary(core::Names::nextTemp());
-        ENFORCE(cctx.link != nullptr);
-        ENFORCE(cctx.link->get() != nullptr);
-        afterNext->exprs.emplace_back(dead, loc, make_insn<BlockReturn>(*cctx.link, exprSym));
+        ENFORCE(cctx.inWhat.linkFor(cctx.link).get() != nullptr);
+        afterNext->exprs.emplace_back(dead, loc, make_insn<BlockReturn>(cctx.link, exprSym));
     }
 
     if (cctx.nextScope == nullptr) {
@@ -723,7 +722,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::ExpressionPtr &what, Ba
                     for (auto &e : blockParamFlags) {
                         paramFlags.emplace_back(e.flags);
                     }
-                    auto link = make_shared<core::SendAndBlockLink>(s.fun, block->loc, move(paramFlags));
+                    auto link = cctx.inWhat.enterLink(s.fun, block->loc, move(paramFlags));
                     auto send = std::move(snd).asInsnPtr();
                     (*cast_instruction<Send>(send)).link = link;
                     LocalRef sendTemp = cctx.newTemporary(core::Names::blockPreCallTemp());
@@ -826,7 +825,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::ExpressionPtr &what, Ba
                         }
 
                         synthesizeExpr(blockLast, dead, blockReturnLoc,
-                                       make_insn<BlockReturn>(std::move(link), blockrv));
+                                       make_insn<BlockReturn>(link, blockrv));
                     }
 
                     unconditionalJump(blockLast, headerBlock, cctx.inWhat, s.loc);

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -50,7 +50,7 @@ core::TypePtr extractArgType(core::Context ctx, cfg::Send &send, core::DispatchC
     return to;
 }
 
-void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, cfg::Send *snd,
+void extractSendArgumentKnowledge(core::Context ctx, cfg::CFG &cfg, core::LocOffsets bindLoc, cfg::Send *snd,
                                   const UnorderedMap<cfg::LocalRef, InlinedVector<core::NameRef, 1>> &blockLocals,
                                   UnorderedMap<core::NameRef, core::TypePtr> &blockArgRequirements,
                                   const core::NameRef currentMethodName) {
@@ -88,7 +88,7 @@ void extractSendArgumentKnowledge(core::Context ctx, core::LocOffsets bindLoc, c
                                     snd->recv.type,
                                     wrappedFullType,
                                     snd->recv.type,
-                                    snd->link.get(),
+                                    cfg.linkFor(snd->link).get(),
                                     originForUninitialized,
                                     snd->isPrivateOk,
                                     suppressErrors,
@@ -213,7 +213,7 @@ UnorderedMap<core::NameRef, core::TypePtr> guessArgumentTypes(core::Context ctx,
 
                 if (shouldFindArgumentTypes) {
                     auto currentMethodName = cfg.symbol.data(ctx)->name;
-                    extractSendArgumentKnowledge(ctx, bind.loc, snd, blockLocals, blockArgRequirements,
+                    extractSendArgumentKnowledge(ctx, cfg, bind.loc, snd, blockLocals, blockArgRequirements,
                                                  currentMethodName);
                 }
             }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1051,7 +1051,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 core::DispatchArgs dispatchArgs{send.fun,        locs,
                                                 send.numPosArgs, args,
                                                 recvType.type,   recvType,
-                                                recvType.type,   send.link.get(),
+                                                recvType.type,   inWhat.linkFor(send.link).get(),
                                                 ownerLoc,        send.isPrivateOk,
                                                 suppressErrors,  inWhat.symbol.data(ctx)->name};
                 auto dispatched = recvType.type.dispatchCall(ctx, dispatchArgs);
@@ -1202,7 +1202,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                                                 send.funLoc, locWithoutBlock));
                 }
                 if (send.link) {
-                    send.link->result = move(retainedResult);
+                    inWhat.linkFor(send.link)->result = move(retainedResult);
                 }
                 if (send.fun == core::Names::toHashDup()) {
                     ENFORCE(send.numArgs == 1, "Desugar invariant");
@@ -1309,7 +1309,8 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
             [&](cfg::SolveConstraint &i) {
                 core::TypePtr type;
                 // TODO: this should repeat the same dance with Or and And components that dispatchCall does
-                const auto &main = i.link->result->main;
+                auto &link = inWhat.linkFor(i.link);
+                const auto &main = link->result->main;
                 if (main.constr) {
                     if (!main.constr->solve(ctx)) {
                         if (auto e = ctx.beginError(bind.loc, core::errors::Infer::GenericMethodConstraintUnsolved)) {
@@ -1325,12 +1326,12 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                     // Write back into the DispatchResult so that retained results affect LSP queries.
                     // (Note that the SendResponse has already been pushed, with a shared_ptr to the
                     // DispatchResult we're mutating here)
-                    i.link->result->returnType = type;
+                    link->result->returnType = type;
                 } else {
-                    type = i.link->result->returnType;
+                    type = link->result->returnType;
                 }
                 auto loc = ctx.locAt(bind.loc);
-                type = flatmapHack(ctx, main.receiver, type, i.link->fun, loc, inWhat.symbol.data(ctx)->name);
+                type = flatmapHack(ctx, main.receiver, type, link->fun, loc, inWhat.symbol.data(ctx)->name);
                 tp.type = std::move(type);
                 tp.origins.emplace_back(loc);
             },
@@ -1395,18 +1396,19 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 tp.origins.emplace_back(ctx.locAt(bind.loc));
             },
             [&](cfg::LoadYieldParams &insn) {
-                ENFORCE(insn.link);
-                ENFORCE(insn.link->result);
-                ENFORCE(insn.link->result->main.blockPreType);
+                auto &link = inWhat.linkFor(insn.link);
+                ENFORCE(link);
+                ENFORCE(link->result);
+                ENFORCE(link->result->main.blockPreType);
 
-                auto &procType = insn.link->result->main.blockPreType;
+                auto &procType = link->result->main.blockPreType;
                 auto params = procType.getCallArguments(ctx, core::Names::call());
-                auto it = insn.link->result->secondary.get();
+                auto it = link->result->secondary.get();
                 while (it != nullptr) {
                     auto &secondaryProcType = it->main.blockPreType;
                     if (secondaryProcType != nullptr) {
                         auto secondaryParams = secondaryProcType.getCallArguments(ctx, core::Names::call());
-                        switch (insn.link->result->secondaryKind) {
+                        switch (link->result->secondaryKind) {
                             case core::DispatchResult::Combinator::OR:
                                 params = core::Types::any(ctx, params, secondaryParams);
                                 break;
@@ -1433,7 +1435,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 // TODO(nelhage): If this block is a lambda, not a proc, this
                 // rule doesn't apply. We don't model the distinction accurately
                 // yet.
-                auto &blkParams = insn.link->paramFlags;
+                auto &blkParams = link->paramFlags;
                 auto tuple = core::cast_type<core::TupleType>(params);
                 if (blkParams.size() > 1 && !blkParams.front().isRepeated && tuple && tuple->elems.size() == 1 &&
                     tuple->elems.front().derivesFrom(ctx, core::Symbols::Array())) {
@@ -1557,19 +1559,20 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 }
             },
             [&](cfg::BlockReturn &i) {
-                ENFORCE(i.link);
-                ENFORCE(i.link->result->main.blockReturnType != nullptr);
+                auto &link = inWhat.linkFor(i.link);
+                ENFORCE(link);
+                ENFORCE(link->result->main.blockReturnType != nullptr);
 
                 const core::TypeAndOrigins &typeAndOrigin = getAndFillTypeAndOrigin(i.what);
-                auto expectedType = i.link->result->main.blockReturnType;
+                auto expectedType = link->result->main.blockReturnType;
                 if (core::Types::isSubType(ctx, core::Types::void_(), expectedType)) {
                     expectedType = core::Types::top();
                 }
                 bool isSubtype;
                 core::ErrorSection::Collector errorDetailsCollector;
-                if (i.link->result->main.constr) {
+                if (link->result->main.constr) {
                     isSubtype = core::Types::isSubTypeUnderConstraint(
-                        ctx, *i.link->result->main.constr, typeAndOrigin.type, expectedType,
+                        ctx, *link->result->main.constr, typeAndOrigin.type, expectedType,
                         core::UntypedMode::AlwaysCompatible, errorDetailsCollector);
                 } else {
                     isSubtype = core::Types::isSubType(ctx, typeAndOrigin.type, expectedType, errorDetailsCollector);
@@ -1579,7 +1582,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                         e.setHeader("Expected `{}` but found `{}` for block result type", expectedType.show(ctx),
                                     typeAndOrigin.type.show(ctx));
 
-                        const auto &bspec = i.link->result->main.method.data(ctx)->parameters.back();
+                        const auto &bspec = link->result->main.method.data(ctx)->parameters.back();
                         ENFORCE(bspec.flags.isBlock, "The last symbol must be the block arg");
                         e.addErrorSection(
                             core::TypeAndOrigins::explainExpected(ctx, expectedType, bspec.loc, "block result type"));
@@ -1633,12 +1636,13 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 tp.origins.emplace_back(ctx.locAt(bind.loc));
             },
             [&](cfg::LoadSelf &l) {
-                ENFORCE(l.link);
-                auto tpo = getTypeFromRebind(ctx, l.link->result->main, l.fallback);
-                auto it = l.link->result->secondary.get();
+                auto &link = inWhat.linkFor(l.link);
+                ENFORCE(link);
+                auto tpo = getTypeFromRebind(ctx, link->result->main, l.fallback);
+                auto it = link->result->secondary.get();
                 while (it != nullptr) {
                     auto secondaryTpo = getTypeFromRebind(ctx, it->main, l.fallback);
-                    switch (l.link->result->secondaryKind) {
+                    switch (link->result->secondaryKind) {
                         case core::DispatchResult::Combinator::OR:
                             tpo.type = core::Types::any(ctx, tpo.type, secondaryTpo.type);
                             break;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This PR implements the idea discussed in https://github.com/sorbet/sorbet/pull/9727#issuecomment-3618928657 and following for shrinking the size of `cfg::Send` even further than #9704 did.  It has the happy effect of shrinking a few other CFG instructions as well.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests, plus a run through Stripe's codebase.
