### PR TITLE
cleanup `cfg::LinkRef` to bring it in line with Sorbet conventions

### DIFF
--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -68,16 +68,6 @@ LinkRef CFG::enterLink(core::NameRef fun, core::LocOffsets loc, vector<core::Par
     return LinkRef(static_cast<uint32_t>(id));
 }
 
-shared_ptr<core::SendAndBlockLink> &CFG::linkFor(LinkRef ref) {
-    ENFORCE(ref.id() < links.size());
-    return links[ref.id()];
-}
-
-const shared_ptr<core::SendAndBlockLink> &CFG::linkFor(LinkRef ref) const {
-    ENFORCE(ref.id() < links.size());
-    return links[ref.id()];
-}
-
 CFG::CFG() {
     freshBlock(0); // entry;
     freshBlock(0); // dead code;

--- a/cfg/CFG.h
+++ b/cfg/CFG.h
@@ -110,6 +110,7 @@ public:
     };
 
     friend class CFGBuilder;
+    friend class LinkRef;
     friend class LocalRef;
     friend class UnfreezeCFGLocalVariables;
     /**
@@ -191,8 +192,6 @@ public:
     LocalRef enterLocal(core::LocalVariable variable);
 
     LinkRef enterLink(core::NameRef fun, core::LocOffsets loc, std::vector<core::ParamInfo::Flags> &&paramFlags);
-    std::shared_ptr<core::SendAndBlockLink> &linkFor(LinkRef);
-    const std::shared_ptr<core::SendAndBlockLink> &linkFor(LinkRef) const;
 
 private:
     CFG();

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -78,12 +78,12 @@ Return::Return(LocalRef what, core::LocOffsets whatLoc) : what(what), whatLoc(wh
 }
 
 string SolveConstraint::toString(const core::GlobalState &gs, const CFG &cfg) const {
-    return fmt::format("Solve<{}, {}>", this->send.toString(gs, cfg), cfg.linkFor(this->link)->fun.toString(gs));
+    return fmt::format("Solve<{}, {}>", this->send.toString(gs, cfg), this->link.data(cfg)->fun.toString(gs));
 }
 
 string SolveConstraint::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
     return fmt::format("Solve {{ send = {}, link = {} }}", this->send.toString(gs, cfg),
-                       cfg.linkFor(this->link)->fun.showRaw(gs));
+                       this->link.data(cfg)->fun.showRaw(gs));
 }
 
 string Return::toString(const core::GlobalState &gs, const CFG &cfg) const {
@@ -100,12 +100,12 @@ BlockReturn::BlockReturn(LinkRef link, LocalRef what) : link(link), what(what) {
 }
 
 string BlockReturn::toString(const core::GlobalState &gs, const CFG &cfg) const {
-    return fmt::format("blockreturn<{}> {}", cfg.linkFor(this->link)->fun.toString(gs), this->what.toString(gs, cfg));
+    return fmt::format("blockreturn<{}> {}", this->link.data(cfg)->fun.toString(gs), this->what.toString(gs, cfg));
 }
 
 string BlockReturn::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
     return fmt::format("BlockReturn {{\n{0}&nbsp;link = {1},\n{0}&nbsp;what = {2},\n{0}}}", spacesForTabLevel(tabs),
-                       cfg.linkFor(this->link)->fun.showRaw(gs), this->what.showRaw(gs, cfg, tabs + 1));
+                       this->link.data(cfg)->fun.showRaw(gs), this->what.showRaw(gs, cfg, tabs + 1));
 }
 
 LoadSelf::LoadSelf(LinkRef link, LocalRef fallback) : fallback(fallback), link(link) {
@@ -113,11 +113,11 @@ LoadSelf::LoadSelf(LinkRef link, LocalRef fallback) : fallback(fallback), link(l
 }
 
 string LoadSelf::toString(const core::GlobalState &gs, const CFG &cfg) const {
-    return fmt::format("loadSelf({})", cfg.linkFor(this->link)->fun.toString(gs));
+    return fmt::format("loadSelf({})", this->link.data(cfg)->fun.toString(gs));
 }
 
 string LoadSelf::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
-    return fmt::format("LoadSelf {{ link = {} }}", cfg.linkFor(this->link)->fun.showRaw(gs));
+    return fmt::format("LoadSelf {{ link = {} }}", this->link.data(cfg)->fun.showRaw(gs));
 }
 
 Send::SendInitializer::SendInitializer(Send *snd) : snd(snd), refs(snd->argRefs()), locs(snd->argLocs()) {}
@@ -282,11 +282,11 @@ const core::ParamInfo &ArgPresent::argument(const core::GlobalState &gs) const {
 }
 
 string LoadYieldParams::toString(const core::GlobalState &gs, const CFG &cfg) const {
-    return fmt::format("load_yield_params({})", cfg.linkFor(this->link)->fun.toString(gs));
+    return fmt::format("load_yield_params({})", this->link.data(cfg)->fun.toString(gs));
 }
 
 string LoadYieldParams::showRaw(const core::GlobalState &gs, const CFG &cfg, int tabs) const {
-    return fmt::format("LoadYieldParams {{ link = {0} }}", cfg.linkFor(this->link)->fun.showRaw(gs));
+    return fmt::format("LoadYieldParams {{ link = {0} }}", this->link.data(cfg)->fun.showRaw(gs));
 }
 
 string YieldParamPresent::toString(const core::GlobalState &gs, const CFG &cfg) const {

--- a/cfg/Instructions.cc
+++ b/cfg/Instructions.cc
@@ -157,7 +157,7 @@ Send::~Send() {
 }
 
 core::LocOffsets Send::locWithoutBlock(core::LocOffsets bindLoc) {
-    if (!this->link) {
+    if (!this->link.exists()) {
         // This location is slightly better, because it will include the last `)` if that exists,
         // which means that queries for things like
         //

--- a/cfg/LinkRef.cc
+++ b/cfg/LinkRef.cc
@@ -1,0 +1,18 @@
+#include "cfg/LinkRef.h"
+#include "cfg/CFG.h"
+
+using namespace std;
+
+namespace sorbet::cfg {
+
+shared_ptr<core::SendAndBlockLink> &LinkRef::data(CFG &cfg) {
+    ENFORCE(_id < cfg.links.size());
+    return cfg.links[_id];
+}
+
+const shared_ptr<core::SendAndBlockLink> &LinkRef::data(const CFG &cfg) const {
+    ENFORCE(_id < cfg.links.size());
+    return cfg.links[_id];
+}
+
+} // namespace sorbet::cfg

--- a/cfg/LinkRef.h
+++ b/cfg/LinkRef.h
@@ -3,7 +3,15 @@
 
 #include "common/common.h"
 
+#include <utility>
+
+namespace sorbet::core {
+class SendAndBlockLink;
+}
+
 namespace sorbet::cfg {
+
+class CFG;
 
 class LinkRef final {
     uint32_t _id = 0;
@@ -15,6 +23,9 @@ public:
     LinkRef(LinkRef &&) = default;
     LinkRef &operator=(LinkRef &&) = default;
     LinkRef &operator=(const LinkRef &) = default;
+
+    std::shared_ptr<core::SendAndBlockLink> &data(CFG &cfg);
+    const std::shared_ptr<core::SendAndBlockLink> &data(const CFG &cfg) const;
 
     bool exists() const noexcept {
         return _id != 0;

--- a/cfg/LinkRef.h
+++ b/cfg/LinkRef.h
@@ -30,10 +30,6 @@ public:
     bool exists() const noexcept {
         return _id != 0;
     }
-
-    uint32_t id() const noexcept {
-        return this->_id;
-    }
 };
 CheckSize(LinkRef, 4, 4);
 

--- a/cfg/LinkRef.h
+++ b/cfg/LinkRef.h
@@ -16,7 +16,7 @@ public:
     LinkRef &operator=(LinkRef &&) = default;
     LinkRef &operator=(const LinkRef &) = default;
 
-    operator bool() const noexcept {
+    bool exists() const noexcept {
         return _id != 0;
     }
 

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -258,7 +258,7 @@ BasicBlock *CFGBuilder::walkBlockReturn(CFGContext cctx, core::LocOffsets loc, c
     auto afterNext = walk(cctx.withTarget(exprSym), expr, current);
     if (afterNext != cctx.inWhat.deadBlock() && cctx.isInsideRubyBlock) {
         LocalRef dead = cctx.newTemporary(core::Names::nextTemp());
-        ENFORCE(cctx.inWhat.linkFor(cctx.link).get() != nullptr);
+        ENFORCE(cctx.link.data(cctx.inWhat).get() != nullptr);
         afterNext->exprs.emplace_back(dead, loc, make_insn<BlockReturn>(cctx.link, exprSym));
     }
 

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -88,7 +88,7 @@ void extractSendArgumentKnowledge(core::Context ctx, cfg::CFG &cfg, core::LocOff
                                     snd->recv.type,
                                     wrappedFullType,
                                     snd->recv.type,
-                                    cfg.linkFor(snd->link).get(),
+                                    snd->link.data(cfg).get(),
                                     originForUninitialized,
                                     snd->isPrivateOk,
                                     suppressErrors,

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1038,7 +1038,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 }
 
                 const core::TypeAndOrigins &recvType = getAndFillTypeAndOrigin(send.recv);
-                if (send.link) {
+                if (send.link.exists()) {
                     checkFullyDefined = false;
                 }
                 core::CallLocs locs{
@@ -1150,16 +1150,16 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                     it = it->secondary.get();
                 }
                 shared_ptr<core::DispatchResult> retainedResult;
-                if (send.link) {
+                if (send.link.exists()) {
                     // this type should never be used, thus we put a useless type
                     tp.type = core::Types::void_();
                 } else {
                     tp.type = dispatched.returnType;
                 }
-                if (send.link || lspQueryMatch) {
+                if (send.link.exists() || lspQueryMatch) {
                     retainedResult = make_shared<core::DispatchResult>(std::move(dispatched));
                 }
-                if (send.link) {
+                if (send.link.exists()) {
                     // This should eventually become ENFORCEs but currently they are wrong
                     if (!retainedResult->main.blockReturnType) {
                         // TODO(jez) This only looks at the main component!
@@ -1201,7 +1201,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                                                 send.isPrivateOk, send.numPosArgs, ctx.file, bind.loc, send.receiverLoc,
                                                 send.funLoc, locWithoutBlock));
                 }
-                if (send.link) {
+                if (send.link.exists()) {
                     inWhat.linkFor(send.link)->result = move(retainedResult);
                 }
                 if (send.fun == core::Names::toHashDup()) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1051,7 +1051,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 core::DispatchArgs dispatchArgs{send.fun,        locs,
                                                 send.numPosArgs, args,
                                                 recvType.type,   recvType,
-                                                recvType.type,   inWhat.linkFor(send.link).get(),
+                                                recvType.type,   send.link.data(inWhat).get(),
                                                 ownerLoc,        send.isPrivateOk,
                                                 suppressErrors,  inWhat.symbol.data(ctx)->name};
                 auto dispatched = recvType.type.dispatchCall(ctx, dispatchArgs);
@@ -1202,7 +1202,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                                                 send.funLoc, locWithoutBlock));
                 }
                 if (send.link.exists()) {
-                    inWhat.linkFor(send.link)->result = move(retainedResult);
+                    send.link.data(inWhat)->result = move(retainedResult);
                 }
                 if (send.fun == core::Names::toHashDup()) {
                     ENFORCE(send.numArgs == 1, "Desugar invariant");
@@ -1309,7 +1309,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
             [&](cfg::SolveConstraint &i) {
                 core::TypePtr type;
                 // TODO: this should repeat the same dance with Or and And components that dispatchCall does
-                auto &link = inWhat.linkFor(i.link);
+                auto &link = i.link.data(inWhat);
                 const auto &main = link->result->main;
                 if (main.constr) {
                     if (!main.constr->solve(ctx)) {
@@ -1396,7 +1396,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 tp.origins.emplace_back(ctx.locAt(bind.loc));
             },
             [&](cfg::LoadYieldParams &insn) {
-                auto &link = inWhat.linkFor(insn.link);
+                auto &link = insn.link.data(inWhat);
                 ENFORCE(link);
                 ENFORCE(link->result);
                 ENFORCE(link->result->main.blockPreType);
@@ -1559,7 +1559,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 }
             },
             [&](cfg::BlockReturn &i) {
-                auto &link = inWhat.linkFor(i.link);
+                auto &link = i.link.data(inWhat);
                 ENFORCE(link);
                 ENFORCE(link->result->main.blockReturnType != nullptr);
 
@@ -1636,7 +1636,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 tp.origins.emplace_back(ctx.locAt(bind.loc));
             },
             [&](cfg::LoadSelf &l) {
-                auto &link = inWhat.linkFor(l.link);
+                auto &link = l.link.data(inWhat);
                 ENFORCE(link);
                 auto tpo = getTypeFromRebind(ctx, link->result->main, l.fallback);
                 auto it = link->result->secondary.get();


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Realized that we can do a better job with `LinkRef`from #10274 to make it more like all the other `*Ref` classes that we have.  (I think I thought doing `data` would be gnarly initially, but it turns out we can forward-declare things.  And `exists()` is better than the too-cute `operator bool` anyway.)

You should be able to review commit-by-commit.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

If it compiles, it works.
