### PR TITLE
Keep the arg to describe in the tree

### DIFF
--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -792,10 +792,7 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::
 
             // Preserve the original constant reference in the tree so Sorbet can
             // resolve it for hover and go-to-definition.
-            if (recvIsRSpec && ast::isa_tree<ast::UnresolvedConstantLit>(arg)) {
-                return ast::MK::InsSeq1(send->loc, arg.deepCopy(), move(classDef));
-            }
-            return classDef;
+            return ast::MK::InsSeq1(send->loc, arg.deepCopy(), move(classDef));
         }
 
         case core::Names::after().rawId():

--- a/test/testdata/rewriter/before_do.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/before_do.rb.rewrite-tree.exp
@@ -36,13 +36,16 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of initialize>
 
-    class <emptyTree>::<C <describe 'example'>><<C <todo sym>>> < (<self>)
-      ::T::Sig::WithoutRuntime.sig() do ||
-        <self>.void()
-      end
+    begin
+      "example"
+      class <emptyTree>::<C <describe 'example'>><<C <todo sym>>> < (<self>)
+        ::T::Sig::WithoutRuntime.sig() do ||
+          <self>.void()
+        end
 
-      def <it 'does thing'><<todo method>>(&<blk>)
-        <emptyTree>::<C T>.reveal_type(@x)
+        def <it 'does thing'><<todo method>>(&<blk>)
+          <emptyTree>::<C T>.reveal_type(@x)
+        end
       end
     end
   end

--- a/test/testdata/rewriter/describe_with_expression.rb
+++ b/test/testdata/rewriter/describe_with_expression.rb
@@ -5,9 +5,11 @@ end
 
 class Test
   describe("".dne) do
+            # ^^^ error: Method `dne` does not exist on `String` component of `String("")`
   end
 
   describe A do
+         # ^ error: Unable to resolve constant `A`
   end
 
   describe B do

--- a/test/testdata/rewriter/describe_with_expression.rb
+++ b/test/testdata/rewriter/describe_with_expression.rb
@@ -1,0 +1,18 @@
+# typed: true
+
+class B
+end
+
+class Test
+  describe("".dne) do
+  end
+
+  describe A do
+  end
+
+  describe B do
+  end
+
+  describe "a" do
+  end
+end

--- a/test/testdata/rewriter/describe_with_expression.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/describe_with_expression.rb.rewrite-tree.exp
@@ -3,16 +3,28 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C Test><<C <todo sym>>> < (::<todo sym>)
-    class <emptyTree>::<C <describe '"".dne()'>><<C <todo sym>>> < (<self>)
+    begin
+      "".dne()
+      class <emptyTree>::<C <describe '"".dne()'>><<C <todo sym>>> < (<self>)
+      end
     end
 
-    class <emptyTree>::<C <describe 'A'>><<C <todo sym>>> < (<self>)
+    begin
+      <emptyTree>::<C A>
+      class <emptyTree>::<C <describe 'A'>><<C <todo sym>>> < (<self>)
+      end
     end
 
-    class <emptyTree>::<C <describe 'B'>><<C <todo sym>>> < (<self>)
+    begin
+      <emptyTree>::<C B>
+      class <emptyTree>::<C <describe 'B'>><<C <todo sym>>> < (<self>)
+      end
     end
 
-    class <emptyTree>::<C <describe 'a'>><<C <todo sym>>> < (<self>)
+    begin
+      "a"
+      class <emptyTree>::<C <describe 'a'>><<C <todo sym>>> < (<self>)
+      end
     end
   end
 end

--- a/test/testdata/rewriter/describe_with_expression.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/describe_with_expression.rb.rewrite-tree.exp
@@ -1,0 +1,18 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C B><<C <todo sym>>> < (::<todo sym>)
+  end
+
+  class <emptyTree>::<C Test><<C <todo sym>>> < (::<todo sym>)
+    class <emptyTree>::<C <describe '"".dne()'>><<C <todo sym>>> < (<self>)
+    end
+
+    class <emptyTree>::<C <describe 'A'>><<C <todo sym>>> < (<self>)
+    end
+
+    class <emptyTree>::<C <describe 'B'>><<C <todo sym>>> < (<self>)
+    end
+
+    class <emptyTree>::<C <describe 'a'>><<C <todo sym>>> < (<self>)
+    end
+  end
+end

--- a/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest.rb.rewrite-tree.exp
@@ -87,19 +87,22 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    class <emptyTree>::<C <describe 'some inner tests'>><<C <todo sym>>> < (<self>)
-      def inside_method<<todo method>>(&<blk>)
-        <emptyTree>
-      end
-
-      def <it 'works inside'><<todo method>>(&<blk>)
-        begin
-          <self>.outside_method()
-          <self>.inside_method()
+    begin
+      "some inner tests"
+      class <emptyTree>::<C <describe 'some inner tests'>><<C <todo sym>>> < (<self>)
+        def inside_method<<todo method>>(&<blk>)
+          <emptyTree>
         end
-      end
 
-      <runtime method definition of inside_method>
+        def <it 'works inside'><<todo method>>(&<blk>)
+          begin
+            <self>.outside_method()
+            <self>.inside_method()
+          end
+        end
+
+        <runtime method definition of inside_method>
+      end
     end
 
     <runtime method definition of instance_helper>
@@ -110,23 +113,26 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @random_method_ivar = <cast:let>(3, <todo sym>, <emptyTree>::<C Integer>)
     end
 
-    class <emptyTree>::<C <describe 'Object'>><<C <todo sym>>> < (<self>)
-      def <it 'Object'><<todo method>>(&<blk>)
-        <emptyTree>
-      end
+    begin
+      <emptyTree>::<C Object>
+      class <emptyTree>::<C <describe 'Object'>><<C <todo sym>>> < (<self>)
+        def <it 'Object'><<todo method>>(&<blk>)
+          <emptyTree>
+        end
 
-      def <it 'Object'><<todo method>>(&<blk>)
-        <emptyTree>
-      end
+        def <it 'Object'><<todo method>>(&<blk>)
+          <emptyTree>
+        end
 
-      begin
-        <emptyTree>::<C Object>
-        <emptyTree>
-      end
+        begin
+          <emptyTree>::<C Object>
+          <emptyTree>
+        end
 
-      begin
-        <emptyTree>::<C Object>
-        <emptyTree>
+        begin
+          <emptyTree>::<C Object>
+          <emptyTree>
+        end
       end
     end
 
@@ -138,12 +144,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.junk()
     end
 
-    class <emptyTree>::<C <describe 'a non-ideal situation'>><<C <todo sym>>> < (<self>)
-      def <it 'contains nested describes'><<todo method>>(&<blk>)
-        <emptyTree>
-      end
+    begin
+      "a non-ideal situation"
+      class <emptyTree>::<C <describe 'a non-ideal situation'>><<C <todo sym>>> < (<self>)
+        def <it 'contains nested describes'><<todo method>>(&<blk>)
+          begin
+            "nobody should write this but we should still parse it"
+            <emptyTree>
+          end
+        end
 
-      class <emptyTree>::<C <describe 'nobody should write this but we should still parse it'>><<C <todo sym>>> < (<self>)
+        class <emptyTree>::<C <describe 'nobody should write this but we should still parse it'>><<C <todo sym>>> < (<self>)
+        end
       end
     end
 
@@ -166,25 +178,28 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  class <emptyTree>::<C <describe 'extends T::Sig'>><<C <todo sym>>> < (<self>)
-    <self>.sig() do ||
-      <self>.returns(<emptyTree>::<C Integer>)
-    end
-
-    def example<<todo method>>(&<blk>)
-      0
-    end
-
-    def <it 'calls example'><<todo method>>(&<blk>)
-      begin
-        res = <self>.example()
-        <emptyTree>::<C T>.reveal_type(res)
+  begin
+    "extends T::Sig"
+    class <emptyTree>::<C <describe 'extends T::Sig'>><<C <todo sym>>> < (<self>)
+      <self>.sig() do ||
+        <self>.returns(<emptyTree>::<C Integer>)
       end
+
+      def example<<todo method>>(&<blk>)
+        0
+      end
+
+      def <it 'calls example'><<todo method>>(&<blk>)
+        begin
+          res = <self>.example()
+          <emptyTree>::<C T>.reveal_type(res)
+        end
+      end
+
+      <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+      <runtime method definition of example>
     end
-
-    <self>.extend(<emptyTree>::<C T>::<C Sig>)
-
-    <runtime method definition of example>
   end
 
   <runtime method definition of junk>

--- a/test/testdata/rewriter/minitest_describe_in_it.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_describe_in_it.rb.rewrite-tree.exp
@@ -1,36 +1,54 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C ClassA><<C <todo sym>>> < (::<todo sym>)
     def <it 'first_test'><<todo method>>(&<blk>)
-      <emptyTree>
+      begin
+        "BAR"
+        <emptyTree>
+      end
     end
 
     class <emptyTree>::<C <describe 'BAR'>><<C <todo sym>>> < (<self>)
     end
 
-    class <emptyTree>::<C <describe 'OUTER'>><<C <todo sym>>> < (<self>)
-      def <it 'second_test'><<todo method>>(&<blk>)
-        <emptyTree>
-      end
+    begin
+      "OUTER"
+      class <emptyTree>::<C <describe 'OUTER'>><<C <todo sym>>> < (<self>)
+        def <it 'second_test'><<todo method>>(&<blk>)
+          begin
+            "QUX"
+            <emptyTree>
+          end
+        end
 
-      class <emptyTree>::<C <describe 'QUX'>><<C <todo sym>>> < (<self>)
+        class <emptyTree>::<C <describe 'QUX'>><<C <todo sym>>> < (<self>)
+        end
       end
     end
   end
 
   module <emptyTree>::<C ModuleB><<C <todo sym>>> < ()
     def <it 'first_test'><<todo method>>(&<blk>)
-      <emptyTree>
+      begin
+        "BAR"
+        <emptyTree>
+      end
     end
 
     class <emptyTree>::<C <describe 'BAR'>><<C <todo sym>>> < (::<todo sym>)
     end
 
-    class <emptyTree>::<C <describe 'OUTER'>><<C <todo sym>>> < (::<todo sym>)
-      def <it 'second_test'><<todo method>>(&<blk>)
-        <emptyTree>
-      end
+    begin
+      "OUTER"
+      class <emptyTree>::<C <describe 'OUTER'>><<C <todo sym>>> < (::<todo sym>)
+        def <it 'second_test'><<todo method>>(&<blk>)
+          begin
+            "QUX"
+            <emptyTree>
+          end
+        end
 
-      class <emptyTree>::<C <describe 'QUX'>><<C <todo sym>>> < (<self>)
+        class <emptyTree>::<C <describe 'QUX'>><<C <todo sym>>> < (<self>)
+        end
       end
     end
   end

--- a/test/testdata/rewriter/minitest_hover.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_hover.rb.rewrite-tree.exp
@@ -37,44 +37,47 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   <emptyTree>::<C X> = "hello"
 
-  class <emptyTree>::<C <describe 'example'>><<C <todo sym>>> < (<self>)
-    def <it '::<Magic>.<string-interpolate>("outside test_each ", x)'><<todo method>>(&<blk>)
-      <emptyTree>
-    end
-
-    def <it '::<Magic>.<string-interpolate>("outside test_each ", <self>.y())'><<todo method>>(&<blk>)
-      <emptyTree>
-    end
-
-    def <it '::<Magic>.<string-interpolate>("outside test_each ", <emptyTree>::<C X>)'><<todo method>>(&<blk>)
-      <emptyTree>
-    end
-
-    def <it '::<Magic>.<string-interpolate>("bar ", x)'><<todo method>>(&<blk>)
-      ["foo"].each() do |x|
+  begin
+    "example"
+    class <emptyTree>::<C <describe 'example'>><<C <todo sym>>> < (<self>)
+      def <it '::<Magic>.<string-interpolate>("outside test_each ", x)'><<todo method>>(&<blk>)
         <emptyTree>
       end
-    end
 
-    x = "hello"
+      def <it '::<Magic>.<string-interpolate>("outside test_each ", <self>.y())'><<todo method>>(&<blk>)
+        <emptyTree>
+      end
 
-    begin
-      ::<Magic>.<string-interpolate>("outside test_each ", x)
-      <emptyTree>
-    end
+      def <it '::<Magic>.<string-interpolate>("outside test_each ", <emptyTree>::<C X>)'><<todo method>>(&<blk>)
+        <emptyTree>
+      end
 
-    begin
-      ::<Magic>.<string-interpolate>("outside test_each ", <self>.y())
-      <emptyTree>
-    end
+      def <it '::<Magic>.<string-interpolate>("bar ", x)'><<todo method>>(&<blk>)
+        ["foo"].each() do |x|
+          <emptyTree>
+        end
+      end
 
-    begin
-      ::<Magic>.<string-interpolate>("outside test_each ", <emptyTree>::<C X>)
-      <emptyTree>
-    end
+      x = "hello"
 
-    <self>.test_each(["foo"]) do |x|
-      <runtime method definition of <it '::<Magic>.<string-interpolate>("bar ", x)'>>
+      begin
+        ::<Magic>.<string-interpolate>("outside test_each ", x)
+        <emptyTree>
+      end
+
+      begin
+        ::<Magic>.<string-interpolate>("outside test_each ", <self>.y())
+        <emptyTree>
+      end
+
+      begin
+        ::<Magic>.<string-interpolate>("outside test_each ", <emptyTree>::<C X>)
+        <emptyTree>
+      end
+
+      <self>.test_each(["foo"]) do |x|
+        <runtime method definition of <it '::<Magic>.<string-interpolate>("bar ", x)'>>
+      end
     end
   end
 end

--- a/test/testdata/rewriter/minitest_module_context.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_module_context.rb.rewrite-tree.exp
@@ -8,24 +8,33 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   module <emptyTree>::<C M><<C <todo sym>>> < ()
-    class <emptyTree>::<C <describe 'describe'>><<C <todo sym>>> < (::<todo sym>)
-      def <it 'adds a method'><<todo method>>(&<blk>)
-        <emptyTree>
-      end
-
-      class <emptyTree>::<C <describe 'inner'>><<C <todo sym>>> < (<self>)
-        def <it 'inner test'><<todo method>>(&<blk>)
+    begin
+      "describe"
+      class <emptyTree>::<C <describe 'describe'>><<C <todo sym>>> < (::<todo sym>)
+        def <it 'adds a method'><<todo method>>(&<blk>)
           <emptyTree>
+        end
+
+        begin
+          "inner"
+          class <emptyTree>::<C <describe 'inner'>><<C <todo sym>>> < (<self>)
+            def <it 'inner test'><<todo method>>(&<blk>)
+              <emptyTree>
+            end
+          end
         end
       end
     end
 
-    class <emptyTree>::<C <describe 'another'>><<C <todo sym>>> < (::<todo sym>)
-      def <it 'something'><<todo method>>(&<blk>)
-        <self>.foo()
-      end
+    begin
+      "another"
+      class <emptyTree>::<C <describe 'another'>><<C <todo sym>>> < (::<todo sym>)
+        def <it 'something'><<todo method>>(&<blk>)
+          <self>.foo()
+        end
 
-      <self>.include(<emptyTree>::<C Helper>)
+        <self>.include(<emptyTree>::<C Helper>)
+      end
     end
   end
 
@@ -36,9 +45,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of test_method>
 
-    class <emptyTree>::<C <describe 'describe'>><<C <todo sym>>> < (<self>)
-      def <it 'adds a method'><<todo method>>(&<blk>)
-        <self>.test_method()
+    begin
+      "describe"
+      class <emptyTree>::<C <describe 'describe'>><<C <todo sym>>> < (<self>)
+        def <it 'adds a method'><<todo method>>(&<blk>)
+          <self>.test_method()
+        end
       end
     end
   end

--- a/test/testdata/rewriter/minitest_nested_class.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_nested_class.rb.rewrite-tree.exp
@@ -1,11 +1,14 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  class <emptyTree>::<C <describe 'bar'>><<C <todo sym>>> < (<self>)
-    def <it 'foo'><<todo method>>(&<blk>)
-      <self>.p(<emptyTree>::<C X>)
-    end
+  begin
+    "bar"
+    class <emptyTree>::<C <describe 'bar'>><<C <todo sym>>> < (<self>)
+      def <it 'foo'><<todo method>>(&<blk>)
+        <self>.p(<emptyTree>::<C X>)
+      end
 
-    class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
-      <emptyTree>::<C X> = 1
+      class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
+        <emptyTree>::<C X> = 1
+      end
     end
   end
 end

--- a/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_tables.rb.rewrite-tree.exp
@@ -472,46 +472,49 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    class <emptyTree>::<C <describe 'foo'>><<C <todo sym>>> < (<self>)
-      def <it 'hoists constants inside of it'><<todo method>>(&<blk>)
-        [].each() do |val|
-          ::Module.const_set(:CONST, 10)
-        end
-      end
-
-      def <it 'hoists let-ed constants inside of it'><<todo method>>(&<blk>)
-        [].each() do |val|
-          ::Module.const_set(:C2, <cast:let>(10, <todo sym>, <emptyTree>::<C Integer>))
-        end
-      end
-
-      def <it 'hoists path constants inside of it'><<todo method>>(&<blk>)
-        [].each() do |val|
-          <emptyTree>::<C C3>.new()
-        end
-      end
-
-      def hoists_in_let_too<<todo method>>(&<blk>)
-        ::Module.const_set(:C4, 10)
-      end
-
-      <self>.test_each([]) do |val|
-        begin
-          begin
-            <emptyTree>::<C CONST> = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-            <runtime method definition of <it 'hoists constants inside of it'>>
+    begin
+      "foo"
+      class <emptyTree>::<C <describe 'foo'>><<C <todo sym>>> < (<self>)
+        def <it 'hoists constants inside of it'><<todo method>>(&<blk>)
+          [].each() do |val|
+            ::Module.const_set(:CONST, 10)
           end
-          begin
-            <emptyTree>::<C C2> = <cast:let>(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented"), <todo sym>, <emptyTree>::<C Integer>)
-            <runtime method definition of <it 'hoists let-ed constants inside of it'>>
+        end
+
+        def <it 'hoists let-ed constants inside of it'><<todo method>>(&<blk>)
+          [].each() do |val|
+            ::Module.const_set(:C2, <cast:let>(10, <todo sym>, <emptyTree>::<C Integer>))
           end
-          begin
-            <emptyTree>::<C C3> = <emptyTree>::<C Mod>::<C C>
-            <runtime method definition of <it 'hoists path constants inside of it'>>
+        end
+
+        def <it 'hoists path constants inside of it'><<todo method>>(&<blk>)
+          [].each() do |val|
+            <emptyTree>::<C C3>.new()
           end
+        end
+
+        def hoists_in_let_too<<todo method>>(&<blk>)
+          ::Module.const_set(:C4, 10)
+        end
+
+        <self>.test_each([]) do |val|
           begin
-            <emptyTree>::<C C4> = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-            <runtime method definition of hoists_in_let_too>
+            begin
+              <emptyTree>::<C CONST> = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+              <runtime method definition of <it 'hoists constants inside of it'>>
+            end
+            begin
+              <emptyTree>::<C C2> = <cast:let>(::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented"), <todo sym>, <emptyTree>::<C Integer>)
+              <runtime method definition of <it 'hoists let-ed constants inside of it'>>
+            end
+            begin
+              <emptyTree>::<C C3> = <emptyTree>::<C Mod>::<C C>
+              <runtime method definition of <it 'hoists path constants inside of it'>>
+            end
+            begin
+              <emptyTree>::<C C4> = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+              <runtime method definition of hoists_in_let_too>
+            end
           end
         end
       end

--- a/test/testdata/rewriter/rspec_describe.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_describe.rb.rewrite-tree.exp
@@ -12,67 +12,82 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <runtime method definition of self.describe>
   end
 
-  class <emptyTree>::<C <describe 'User'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
-    def name<<todo method>>(&<blk>)
-      "Alice"
-    end
-
-    def <it 'has a name'><<todo method>>(&<blk>)
-      <self>.name()
-    end
-
-    <runtime method definition of name>
-
-    class <emptyTree>::<C <context 'when verified'>><<C <todo sym>>> < (<self>)
-      def verified<<todo method>>(&<blk>)
-        true
+  begin
+    "User"
+    class <emptyTree>::<C <describe 'User'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      def name<<todo method>>(&<blk>)
+        "Alice"
       end
 
-      def <it 'shows verified status'><<todo method>>(&<blk>)
-        begin
-          <self>.name()
-          <self>.verified()
+      def <it 'has a name'><<todo method>>(&<blk>)
+        <self>.name()
+      end
+
+      <runtime method definition of name>
+
+      begin
+        "when verified"
+        class <emptyTree>::<C <context 'when verified'>><<C <todo sym>>> < (<self>)
+          def verified<<todo method>>(&<blk>)
+            true
+          end
+
+          def <it 'shows verified status'><<todo method>>(&<blk>)
+            begin
+              <self>.name()
+              <self>.verified()
+            end
+          end
+
+          <runtime method definition of verified>
         end
       end
-
-      <runtime method definition of verified>
     end
   end
 
-  class <emptyTree>::<C <describe 'User'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
-    def path<<todo method>>(&<blk>)
-      "/some/path"
-    end
+  begin
+    "User"
+    class <emptyTree>::<C <describe 'User'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      def path<<todo method>>(&<blk>)
+        "/some/path"
+      end
 
-    def <it 'has a path'><<todo method>>(&<blk>)
-      <self>.path()
-    end
+      def <it 'has a path'><<todo method>>(&<blk>)
+        <self>.path()
+      end
 
-    <runtime method definition of path>
+      <runtime method definition of path>
+    end
   end
 
-  class <emptyTree>::<C <describe 'User'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
-    def value<<todo method>>(&<blk>)
-      42
-    end
+  begin
+    "User"
+    class <emptyTree>::<C <describe 'User'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      def value<<todo method>>(&<blk>)
+        42
+      end
 
-    def <it 'has a value'><<todo method>>(&<blk>)
-      <self>.value()
-    end
+      def <it 'has a value'><<todo method>>(&<blk>)
+        <self>.value()
+      end
 
-    <runtime method definition of value>
+      <runtime method definition of value>
+    end
   end
 
-  class <emptyTree>::<C <describe 'User'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
-    def count<<todo method>>(&<blk>)
-      10
-    end
+  begin
+    "User"
+    class <emptyTree>::<C <describe 'User'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      def count<<todo method>>(&<blk>)
+        10
+      end
 
-    def <it 'has a count'><<todo method>>(&<blk>)
-      <self>.count()
-    end
+      def <it 'has a count'><<todo method>>(&<blk>)
+        <self>.count()
+      end
 
-    <runtime method definition of count>
+      <runtime method definition of count>
+    end
   end
 
   class <emptyTree>::<C UserClass><<C <todo sym>>> < (::<todo sym>)
@@ -150,27 +165,33 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  class <emptyTree>::<C <describe 'user_symbol'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
-    def data<<todo method>>(&<blk>)
-      "test"
-    end
+  begin
+    :user_symbol
+    class <emptyTree>::<C <describe 'user_symbol'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      def data<<todo method>>(&<blk>)
+        "test"
+      end
 
-    def <it 'has data'><<todo method>>(&<blk>)
-      <self>.data()
-    end
+      def <it 'has data'><<todo method>>(&<blk>)
+        <self>.data()
+      end
 
-    <runtime method definition of data>
+      <runtime method definition of data>
+    end
   end
 
-  class <emptyTree>::<C <describe 'user_symbol'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
-    def result<<todo method>>(&<blk>)
-      true
-    end
+  begin
+    :user_symbol
+    class <emptyTree>::<C <describe 'user_symbol'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      def result<<todo method>>(&<blk>)
+        true
+      end
 
-    def <it 'has a result'><<todo method>>(&<blk>)
-      <self>.result()
-    end
+      def <it 'has a result'><<todo method>>(&<blk>)
+        <self>.result()
+      end
 
-    <runtime method definition of result>
+      <runtime method definition of result>
+    end
   end
 end

--- a/test/testdata/rewriter/rspec_example.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_example.rb.rewrite-tree.exp
@@ -66,62 +66,68 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of eq>
 
-    class <emptyTree>::<C <describe 'inside describe'>><<C <todo sym>>> < (<self>)
-      def my_helper<<todo method>>(&<blk>)
-        <emptyTree>
-      end
+    begin
+      "inside describe"
+      class <emptyTree>::<C <describe 'inside describe'>><<C <todo sym>>> < (<self>)
+        def my_helper<<todo method>>(&<blk>)
+          <emptyTree>
+        end
 
-      def <it><<todo method>>(&<blk>)
-        begin
+        def <it><<todo method>>(&<blk>)
+          begin
+            <self>.my_helper()
+            <self>.described_class()
+          end
+        end
+
+        def <it 'example'><<todo method>>(&<blk>)
           <self>.my_helper()
-          <self>.described_class()
-        end
-      end
-
-      def <it 'example'><<todo method>>(&<blk>)
-        <self>.my_helper()
-      end
-
-      def <it><<todo method>>(&<blk>)
-        <self>.my_helper()
-      end
-
-      def <it 'has access to defined_in_shared_examples'><<todo method>>(&<blk>)
-        [].each() do |x|
-          <self>.defined_in_shared_examples()
-        end
-      end
-
-      <runtime method definition of my_helper>
-
-      module ::<root>::<C <shared_examples 'some examples'>><<C <todo sym>>> < ()
-        def defined_in_shared_examples<<todo method>>(&<blk>)
-          "foo"
         end
 
-        def <it 'a shared example'><<todo method>>(&<blk>)
-          <self>.described_class()
+        def <it><<todo method>>(&<blk>)
+          <self>.my_helper()
         end
 
-        <runtime method definition of defined_in_shared_examples>
-
-        ::<Magic>.requires_ancestor() do ||
-          <emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>
-        end
-      end
-
-      class <emptyTree>::<C <describe 'will include shared examples'>><<C <todo sym>>> < (<self>)
         def <it 'has access to defined_in_shared_examples'><<todo method>>(&<blk>)
-          <self>.defined_in_shared_examples()
+          [].each() do |x|
+            <self>.defined_in_shared_examples()
+          end
         end
 
-        <self>.include(::<root>::<C <shared_examples 'some examples'>>)
-      end
+        <runtime method definition of my_helper>
 
-      <self>.test_each([]) do |x|
+        module ::<root>::<C <shared_examples 'some examples'>><<C <todo sym>>> < ()
+          def defined_in_shared_examples<<todo method>>(&<blk>)
+            "foo"
+          end
+
+          def <it 'a shared example'><<todo method>>(&<blk>)
+            <self>.described_class()
+          end
+
+          <runtime method definition of defined_in_shared_examples>
+
+          ::<Magic>.requires_ancestor() do ||
+            <emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>
+          end
+        end
+
         begin
-          <self>.include(::<root>::<C <shared_examples 'some examples'>>)
-          <runtime method definition of <it 'has access to defined_in_shared_examples'>>
+          "will include shared examples"
+          class <emptyTree>::<C <describe 'will include shared examples'>><<C <todo sym>>> < (<self>)
+            def <it 'has access to defined_in_shared_examples'><<todo method>>(&<blk>)
+              <self>.defined_in_shared_examples()
+            end
+
+            <self>.include(::<root>::<C <shared_examples 'some examples'>>)
+          end
+        end
+
+        <self>.test_each([]) do |x|
+          begin
+            <self>.include(::<root>::<C <shared_examples 'some examples'>>)
+            <runtime method definition of <it 'has access to defined_in_shared_examples'>>
+          end
         end
       end
     end
@@ -142,126 +148,150 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
 
-    class <emptyTree>::<C <describe 'contains generic name group'>><<C <todo sym>>> < (<self>)
-      class <emptyTree>::<C <example_group 'example_group group'>><<C <todo sym>>> < (<self>)
-        def <it><<todo method>>(&<blk>)
-          <self>.outer_helper()
-        end
-      end
-
-      class <emptyTree>::<C <context 'context group'>><<C <todo sym>>> < (<self>)
-        def <it><<todo method>>(&<blk>)
-          <self>.outer_helper()
-        end
-      end
-    end
-
-    class <emptyTree>::<C <xdescribe 'xdescribe group'>><<C <todo sym>>> < (<self>)
-      def <it><<todo method>>(&<blk>)
-        <self>.outer_helper()
-      end
-    end
-
-    class <emptyTree>::<C <describe 'its support'>><<C <todo sym>>> < (<self>)
-      def foo<<todo method>>(&<blk>)
-        "bar"
-      end
-
-      <runtime method definition of foo>
-
-      class <emptyTree>::<C <describe 'bar'>><<C <todo sym>>> < (<self>)
-        def <it><<todo method>>(&<blk>)
-          <self>.expect(<self>.subject().bar()).to(<self>.eq(<self>.foo()))
-        end
-      end
-
-      class <emptyTree>::<C <describe 'bar'>><<C <todo sym>>> < (<self>)
-        def <it><<todo method>>(&<blk>)
-          <self>.expect(<self>.subject().bar()).to(<self>.eq(<self>.foo()))
-        end
-      end
-
-      class <emptyTree>::<C <describe 'size'>><<C <todo sym>>> < (<self>)
-        def <it><<todo method>>(&<blk>)
-          begin
-            ::Module.const_set(:X, 1)
-            <self>.expect(<self>.subject().size()).to(<self>.eq(<emptyTree>::<C X>))
+    begin
+      "contains generic name group"
+      class <emptyTree>::<C <describe 'contains generic name group'>><<C <todo sym>>> < (<self>)
+        begin
+          "example_group group"
+          class <emptyTree>::<C <example_group 'example_group group'>><<C <todo sym>>> < (<self>)
+            def <it><<todo method>>(&<blk>)
+              <self>.outer_helper()
+            end
           end
         end
 
         begin
-          <emptyTree>::<C X> = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
-          <emptyTree>
-        end
-      end
-
-      class <emptyTree>::<C <describe 'size'>><<C <todo sym>>> < (<self>)
-        def <it><<todo method>>(&<blk>)
-          <emptyTree>::<C T>.reveal_type(<self>)
+          "context group"
+          class <emptyTree>::<C <context 'context group'>><<C <todo sym>>> < (<self>)
+            def <it><<todo method>>(&<blk>)
+              <self>.outer_helper()
+            end
+          end
         end
       end
     end
 
-    class <emptyTree>::<C <describe 'its with typed subject'>><<C <todo sym>>> < (<self>)
-      <self>.sig() do ||
-        <self>.returns(<emptyTree>::<C ThingWithSize>)
+    begin
+      "xdescribe group"
+      class <emptyTree>::<C <xdescribe 'xdescribe group'>><<C <todo sym>>> < (<self>)
+        def <it><<todo method>>(&<blk>)
+          <self>.outer_helper()
+        end
       end
+    end
 
-      def subject<<todo method>>(&<blk>)
-        <emptyTree>::<C ThingWithSize>.new()
-      end
-
-      class <emptyTree>::<C ThingWithSize><<C <todo sym>>> < (::<todo sym>)
-        <self>.sig() do ||
-          <self>.returns(<emptyTree>::<C Integer>)
+    begin
+      "its support"
+      class <emptyTree>::<C <describe 'its support'>><<C <todo sym>>> < (<self>)
+        def foo<<todo method>>(&<blk>)
+          "bar"
         end
 
-        def size<<todo method>>(&<blk>)
-          42
+        <runtime method definition of foo>
+
+        class <emptyTree>::<C <describe 'bar'>><<C <todo sym>>> < (<self>)
+          def <it><<todo method>>(&<blk>)
+            <self>.expect(<self>.subject().bar()).to(<self>.eq(<self>.foo()))
+          end
+        end
+
+        class <emptyTree>::<C <describe 'bar'>><<C <todo sym>>> < (<self>)
+          def <it><<todo method>>(&<blk>)
+            <self>.expect(<self>.subject().bar()).to(<self>.eq(<self>.foo()))
+          end
+        end
+
+        class <emptyTree>::<C <describe 'size'>><<C <todo sym>>> < (<self>)
+          def <it><<todo method>>(&<blk>)
+            begin
+              ::Module.const_set(:X, 1)
+              <self>.expect(<self>.subject().size()).to(<self>.eq(<emptyTree>::<C X>))
+            end
+          end
+
+          begin
+            <emptyTree>::<C X> = ::T.unsafe(::Kernel).raise("Sorbet rewriter pass partially unimplemented")
+            <emptyTree>
+          end
+        end
+
+        class <emptyTree>::<C <describe 'size'>><<C <todo sym>>> < (<self>)
+          def <it><<todo method>>(&<blk>)
+            <emptyTree>::<C T>.reveal_type(<self>)
+          end
+        end
+      end
+    end
+
+    begin
+      "its with typed subject"
+      class <emptyTree>::<C <describe 'its with typed subject'>><<C <todo sym>>> < (<self>)
+        <self>.sig() do ||
+          <self>.returns(<emptyTree>::<C ThingWithSize>)
+        end
+
+        def subject<<todo method>>(&<blk>)
+          <emptyTree>::<C ThingWithSize>.new()
+        end
+
+        class <emptyTree>::<C ThingWithSize><<C <todo sym>>> < (::<todo sym>)
+          <self>.sig() do ||
+            <self>.returns(<emptyTree>::<C Integer>)
+          end
+
+          def size<<todo method>>(&<blk>)
+            42
+          end
+
+          <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+          <runtime method definition of size>
         end
 
         <self>.extend(<emptyTree>::<C T>::<C Sig>)
 
-        <runtime method definition of size>
-      end
+        <runtime method definition of subject>
 
-      <self>.extend(<emptyTree>::<C T>::<C Sig>)
-
-      <runtime method definition of subject>
-
-      class <emptyTree>::<C <describe 'size'>><<C <todo sym>>> < (<self>)
-        def <it><<todo method>>(&<blk>)
-          begin
-            <emptyTree>::<C T>.reveal_type(<self>.subject())
-            <self>.expect(<self>.subject().size()).to(<self>.eq(42))
+        class <emptyTree>::<C <describe 'size'>><<C <todo sym>>> < (<self>)
+          def <it><<todo method>>(&<blk>)
+            begin
+              <emptyTree>::<C T>.reveal_type(<self>.subject())
+              <self>.expect(<self>.subject().size()).to(<self>.eq(42))
+            end
           end
         end
-      end
 
-      class <emptyTree>::<C <describe 'no_such_method'>><<C <todo sym>>> < (<self>)
-        def <it><<todo method>>(&<blk>)
-          <self>.expect(<self>.subject().no_such_method()).to(<self>.eq(0))
+        class <emptyTree>::<C <describe 'no_such_method'>><<C <todo sym>>> < (<self>)
+          def <it><<todo method>>(&<blk>)
+            <self>.expect(<self>.subject().no_such_method()).to(<self>.eq(0))
+          end
         end
       end
     end
   end
 
-  class <emptyTree>::<C <context 'B'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
-    def another_outer_helper<<todo method>>(&<blk>)
-      <emptyTree>
-    end
+  begin
+    "B"
+    class <emptyTree>::<C <context 'B'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      def another_outer_helper<<todo method>>(&<blk>)
+        <emptyTree>
+      end
 
-    def <it 'inside B'><<todo method>>(&<blk>)
-      <self>.another_outer_helper()
-    end
+      def <it 'inside B'><<todo method>>(&<blk>)
+        <self>.another_outer_helper()
+      end
 
-    <runtime method definition of another_outer_helper>
+      <runtime method definition of another_outer_helper>
 
-    class <emptyTree>::<C <context 'Nested, no RSpec'>><<C <todo sym>>> < (<self>)
-      def <it 'inside Nested'><<todo method>>(&<blk>)
-        begin
-          <self>.another_outer_helper()
-          <self>.described_class()
+      begin
+        "Nested, no RSpec"
+        class <emptyTree>::<C <context 'Nested, no RSpec'>><<C <todo sym>>> < (<self>)
+          def <it 'inside Nested'><<todo method>>(&<blk>)
+            begin
+              <self>.another_outer_helper()
+              <self>.described_class()
+            end
+          end
         end
       end
     end

--- a/test/testdata/rewriter/rspec_include_examples_dynamic_arg.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_include_examples_dynamic_arg.rb.rewrite-tree.exp
@@ -25,14 +25,20 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   module ::<root>::<C <shared_examples 'runner'>><<C <todo sym>>> < ()
   end
 
-  class <emptyTree>::<C <describe 'consumer'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
-    <self>.include(::<root>::<C <shared_examples 'suite alpha'>>)
+  begin
+    "consumer"
+    class <emptyTree>::<C <describe 'consumer'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      <self>.include(::<root>::<C <shared_examples 'suite alpha'>>)
 
-    <self>.include(::<root>::<C <shared_examples 'suite beta'>>)
+      <self>.include(::<root>::<C <shared_examples 'suite beta'>>)
+    end
   end
 
   <runtime method definition of suite_helper>
 
-  class <emptyTree>::<C <describe 'top-level dynamic'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+  begin
+    "top-level dynamic"
+    class <emptyTree>::<C <describe 'top-level dynamic'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+    end
   end
 end

--- a/test/testdata/rewriter/rspec_it_behaves_like_isolation.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_it_behaves_like_isolation.rb.rewrite-tree.exp
@@ -18,90 +18,39 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C MyClass><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
-    class <emptyTree>::<C <describe 'it_behaves_like provides isolation'>><<C <todo sym>>> < (<self>)
-      <self>.sig() do ||
-        <self>.returns(<emptyTree>::<C Integer>)
-      end
-
-      def shared_value<<todo method>>(&<blk>)
-        100
-      end
-
-      def <it 'outer context has its own value'><<todo method>>(&<blk>)
-        begin
-          result = <self>.shared_value()
-          <emptyTree>::<C T>.reveal_type(result)
-          <self>.expect(result).to(<self>.eq(100))
-        end
-      end
-
-      <self>.extend(<emptyTree>::<C T>::<C Sig>)
-
-      module ::<root>::<C <shared_examples 'shared behavior'>><<C <todo sym>>> < ()
-        <self>.sig() do ||
-          <self>.returns(<emptyTree>::<C String>)
-        end
-
-        def shared_value<<todo method>>(&<blk>)
-          "from_shared"
-        end
-
-        def <it 'uses shared value'><<todo method>>(&<blk>)
-          begin
-            result = <self>.shared_value()
-            <emptyTree>::<C T>.reveal_type(result)
-            <self>.expect(result).to(<self>.eq("from_shared"))
-          end
-        end
-
-        <self>.extend(<emptyTree>::<C T>::<C Sig>)
-
-        <runtime method definition of shared_value>
-
-        ::<Magic>.requires_ancestor() do ||
-          <emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>
-        end
-      end
-
-      <runtime method definition of shared_value>
-
-      <self>.include(::<root>::<C <shared_examples 'shared behavior'>>)
-
-      class <emptyTree>::<C <it_behaves_like 'shared behavior'>><<C <todo sym>>> < (<self>)
-        <self>.include(::<root>::<C <shared_examples 'shared behavior'>>)
-      end
-
-      class <emptyTree>::<C <describe 'method isolation'>><<C <todo sym>>> < (<self>)
+    begin
+      "it_behaves_like provides isolation"
+      class <emptyTree>::<C <describe 'it_behaves_like provides isolation'>><<C <todo sym>>> < (<self>)
         <self>.sig() do ||
           <self>.returns(<emptyTree>::<C Integer>)
         end
 
-        def helper_method<<todo method>>(&<blk>)
-          42
+        def shared_value<<todo method>>(&<blk>)
+          100
         end
 
-        def <it 'outer helper_method is not clobbered'><<todo method>>(&<blk>)
+        def <it 'outer context has its own value'><<todo method>>(&<blk>)
           begin
-            result = <self>.helper_method()
+            result = <self>.shared_value()
             <emptyTree>::<C T>.reveal_type(result)
-            <self>.expect(result).to(<self>.eq(42))
+            <self>.expect(result).to(<self>.eq(100))
           end
         end
 
         <self>.extend(<emptyTree>::<C T>::<C Sig>)
 
-        module ::<root>::<C <shared_examples 'defines helper method'>><<C <todo sym>>> < ()
+        module ::<root>::<C <shared_examples 'shared behavior'>><<C <todo sym>>> < ()
           <self>.sig() do ||
             <self>.returns(<emptyTree>::<C String>)
           end
 
-          def helper_method<<todo method>>(&<blk>)
+          def shared_value<<todo method>>(&<blk>)
             "from_shared"
           end
 
-          def <it 'uses helper from shared'><<todo method>>(&<blk>)
+          def <it 'uses shared value'><<todo method>>(&<blk>)
             begin
-              result = <self>.helper_method()
+              result = <self>.shared_value()
               <emptyTree>::<C T>.reveal_type(result)
               <self>.expect(result).to(<self>.eq("from_shared"))
             end
@@ -109,58 +58,115 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
           <self>.extend(<emptyTree>::<C T>::<C Sig>)
 
-          <runtime method definition of helper_method>
+          <runtime method definition of shared_value>
 
           ::<Magic>.requires_ancestor() do ||
             <emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>
           end
         end
 
-        <runtime method definition of helper_method>
+        <runtime method definition of shared_value>
 
-        class <emptyTree>::<C <it_behaves_like 'defines helper method'>><<C <todo sym>>> < (<self>)
-          <self>.include(::<root>::<C <shared_examples 'defines helper method'>>)
+        <self>.include(::<root>::<C <shared_examples 'shared behavior'>>)
+
+        class <emptyTree>::<C <it_behaves_like 'shared behavior'>><<C <todo sym>>> < (<self>)
+          <self>.include(::<root>::<C <shared_examples 'shared behavior'>>)
         end
-      end
 
-      module ::<root>::<C <shared_examples 'parameterized behavior'>><<C <todo sym>>> < ()
-        def <it 'receives parameter'><<todo method>>(&<blk>)
-          [::T.unsafe(nil)].each() do |expected_value|
-            <self>.expect(expected_value).to(<self>.eq("param_value"))
+        begin
+          "method isolation"
+          class <emptyTree>::<C <describe 'method isolation'>><<C <todo sym>>> < (<self>)
+            <self>.sig() do ||
+              <self>.returns(<emptyTree>::<C Integer>)
+            end
+
+            def helper_method<<todo method>>(&<blk>)
+              42
+            end
+
+            def <it 'outer helper_method is not clobbered'><<todo method>>(&<blk>)
+              begin
+                result = <self>.helper_method()
+                <emptyTree>::<C T>.reveal_type(result)
+                <self>.expect(result).to(<self>.eq(42))
+              end
+            end
+
+            <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+            module ::<root>::<C <shared_examples 'defines helper method'>><<C <todo sym>>> < ()
+              <self>.sig() do ||
+                <self>.returns(<emptyTree>::<C String>)
+              end
+
+              def helper_method<<todo method>>(&<blk>)
+                "from_shared"
+              end
+
+              def <it 'uses helper from shared'><<todo method>>(&<blk>)
+                begin
+                  result = <self>.helper_method()
+                  <emptyTree>::<C T>.reveal_type(result)
+                  <self>.expect(result).to(<self>.eq("from_shared"))
+                end
+              end
+
+              <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+              <runtime method definition of helper_method>
+
+              ::<Magic>.requires_ancestor() do ||
+                <emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>
+              end
+            end
+
+            <runtime method definition of helper_method>
+
+            class <emptyTree>::<C <it_behaves_like 'defines helper method'>><<C <todo sym>>> < (<self>)
+              <self>.include(::<root>::<C <shared_examples 'defines helper method'>>)
+            end
           end
         end
 
-        <runtime method definition of <it 'receives parameter'>>
+        module ::<root>::<C <shared_examples 'parameterized behavior'>><<C <todo sym>>> < ()
+          def <it 'receives parameter'><<todo method>>(&<blk>)
+            [::T.unsafe(nil)].each() do |expected_value|
+              <self>.expect(expected_value).to(<self>.eq("param_value"))
+            end
+          end
 
-        ::<Magic>.requires_ancestor() do ||
-          <emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>
-        end
-      end
+          <runtime method definition of <it 'receives parameter'>>
 
-      class <emptyTree>::<C <it_behaves_like 'parameterized behavior'>><<C <todo sym>>> < (<self>)
-        <self>.include(::<root>::<C <shared_examples 'parameterized behavior'>>)
-      end
-
-      module ::<root>::<C <shared_examples 'math behavior'>><<C <todo sym>>> < ()
-        def <it 'performs calculation'><<todo method>>(&<blk>)
-          [::T.unsafe(nil)].each() do |a, b, result|
-            <self>.expect(a.+(b)).to(<self>.eq(result))
+          ::<Magic>.requires_ancestor() do ||
+            <emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>
           end
         end
 
-        <runtime method definition of <it 'performs calculation'>>
-
-        ::<Magic>.requires_ancestor() do ||
-          <emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>
+        class <emptyTree>::<C <it_behaves_like 'parameterized behavior'>><<C <todo sym>>> < (<self>)
+          <self>.include(::<root>::<C <shared_examples 'parameterized behavior'>>)
         end
-      end
 
-      class <emptyTree>::<C <it_behaves_like 'math behavior'>><<C <todo sym>>> < (<self>)
-        <self>.include(::<root>::<C <shared_examples 'math behavior'>>)
-      end
+        module ::<root>::<C <shared_examples 'math behavior'>><<C <todo sym>>> < ()
+          def <it 'performs calculation'><<todo method>>(&<blk>)
+            [::T.unsafe(nil)].each() do |a, b, result|
+              <self>.expect(a.+(b)).to(<self>.eq(result))
+            end
+          end
 
-      class <emptyTree>::<C <it_behaves_like 'math behavior'>><<C <todo sym>>> < (<self>)
-        <self>.include(::<root>::<C <shared_examples 'math behavior'>>)
+          <runtime method definition of <it 'performs calculation'>>
+
+          ::<Magic>.requires_ancestor() do ||
+            <emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>
+          end
+        end
+
+        class <emptyTree>::<C <it_behaves_like 'math behavior'>><<C <todo sym>>> < (<self>)
+          <self>.include(::<root>::<C <shared_examples 'math behavior'>>)
+        end
+
+        class <emptyTree>::<C <it_behaves_like 'math behavior'>><<C <todo sym>>> < (<self>)
+          <self>.include(::<root>::<C <shared_examples 'math behavior'>>)
+        end
       end
     end
   end

--- a/test/testdata/rewriter/rspec_shared_examples_context.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/rspec_shared_examples_context.rb.rewrite-tree-raw.exp
@@ -91,151 +91,161 @@ ClassDef{
           }
         }]
       rhs = [
-        ClassDef{
-          kind = class
-          name = UnresolvedConstantLit{
-            cnst = <C <U <describe 'single shared example with context'>>>
-            scope = EmptyTree
-          }
-          symbol = <C <U <todo sym>>>
-          ancestors = [Self]
-          rhs = [
-            ClassDef{
-              kind = module
-              name = UnresolvedConstantLit{
-                cnst = <C <U <shared_examples 'my shared example'>>>
-                scope = ConstantLit{
-                  symbol = (class ::<root>)
-                  orig = nullptr
-                }
-              }
-              symbol = <C <U <todo sym>>>
-              ancestors = []
-              rhs = [
-                MethodDef{
-                  flags = {rewriterSynthesized}
-                  name = <U foo_exists><<U <todo method>>>
-                  params = [BlockParam{ expr = UnresolvedIdent{
-                      kind = Local
-                      name = <U <blk>>
-                    } }]
-                  rhs = Literal{ value = "bar" }
-                }
-
-                <runtime method definition of foo_exists>
-
-                ClassDef{
-                  kind = class
-                  name = UnresolvedConstantLit{
-                    cnst = <C <U <context 'context'>>>
-                    scope = EmptyTree
+        InsSeq{
+          stats = [
+            Literal{ value = "single shared example with context" }
+          ],
+          expr = ClassDef{
+            kind = class
+            name = UnresolvedConstantLit{
+              cnst = <C <U <describe 'single shared example with context'>>>
+              scope = EmptyTree
+            }
+            symbol = <C <U <todo sym>>>
+            ancestors = [Self]
+            rhs = [
+              ClassDef{
+                kind = module
+                name = UnresolvedConstantLit{
+                  cnst = <C <U <shared_examples 'my shared example'>>>
+                  scope = ConstantLit{
+                    symbol = (class ::<root>)
+                    orig = nullptr
                   }
-                  symbol = <C <U <todo sym>>>
-                  ancestors = [UnresolvedConstantLit{
-                      cnst = <C <U ExampleGroup>>
-                      scope = UnresolvedConstantLit{
-                        cnst = <C <U Core>>
-                        scope = UnresolvedConstantLit{
-                          cnst = <C <U RSpec>>
-                          scope = EmptyTree
-                        }
+                }
+                symbol = <C <U <todo sym>>>
+                ancestors = []
+                rhs = [
+                  MethodDef{
+                    flags = {rewriterSynthesized}
+                    name = <U foo_exists><<U <todo method>>>
+                    params = [BlockParam{ expr = UnresolvedIdent{
+                        kind = Local
+                        name = <U <blk>>
+                      } }]
+                    rhs = Literal{ value = "bar" }
+                  }
+
+                  <runtime method definition of foo_exists>
+
+                  InsSeq{
+                    stats = [
+                      Literal{ value = "context" }
+                    ],
+                    expr = ClassDef{
+                      kind = class
+                      name = UnresolvedConstantLit{
+                        cnst = <C <U <context 'context'>>>
+                        scope = EmptyTree
                       }
-                    }, UnresolvedConstantLit{
-                      cnst = <C <U <shared_examples 'my shared example'>>>
-                      scope = ConstantLit{
-                        symbol = (class ::<root>)
-                        orig = nullptr
-                      }
-                    }]
-                  rhs = [
-                    MethodDef{
-                      flags = {rewriterSynthesized}
-                      name = <U <it 'works'>><<U <todo method>>>
-                      params = [BlockParam{ expr = UnresolvedIdent{
-                          kind = Local
-                          name = <U <blk>>
-                        } }]
-                      rhs = InsSeq{
-                        stats = [
-                          Send{
-                            flags = {}
-                            recv = Send{
-                              flags = {privateOk}
-                              recv = Self
-                              fun = <U expect>
-                              block = nullptr
-                              pos_args = 1
-                              args = [
-                                Send{
+                      symbol = <C <U <todo sym>>>
+                      ancestors = [UnresolvedConstantLit{
+                          cnst = <C <U ExampleGroup>>
+                          scope = UnresolvedConstantLit{
+                            cnst = <C <U Core>>
+                            scope = UnresolvedConstantLit{
+                              cnst = <C <U RSpec>>
+                              scope = EmptyTree
+                            }
+                          }
+                        }, UnresolvedConstantLit{
+                          cnst = <C <U <shared_examples 'my shared example'>>>
+                          scope = ConstantLit{
+                            symbol = (class ::<root>)
+                            orig = nullptr
+                          }
+                        }]
+                      rhs = [
+                        MethodDef{
+                          flags = {rewriterSynthesized}
+                          name = <U <it 'works'>><<U <todo method>>>
+                          params = [BlockParam{ expr = UnresolvedIdent{
+                              kind = Local
+                              name = <U <blk>>
+                            } }]
+                          rhs = InsSeq{
+                            stats = [
+                              Send{
+                                flags = {}
+                                recv = Send{
                                   flags = {privateOk}
                                   recv = Self
-                                  fun = <U foo_exists>
+                                  fun = <U expect>
                                   block = nullptr
-                                  pos_args = 0
+                                  pos_args = 1
                                   args = [
+                                    Send{
+                                      flags = {privateOk}
+                                      recv = Self
+                                      fun = <U foo_exists>
+                                      block = nullptr
+                                      pos_args = 0
+                                      args = [
+                                      ]
+                                    }
                                   ]
                                 }
-                              ]
-                            }
-                            fun = <U to>
-                            block = nullptr
-                            pos_args = 1
-                            args = [
-                              Send{
-                                flags = {privateOk}
-                                recv = Self
-                                fun = <U eq>
+                                fun = <U to>
                                 block = nullptr
                                 pos_args = 1
                                 args = [
-                                  Literal{ value = "bar" }
+                                  Send{
+                                    flags = {privateOk}
+                                    recv = Self
+                                    fun = <U eq>
+                                    block = nullptr
+                                    pos_args = 1
+                                    args = [
+                                      Literal{ value = "bar" }
+                                    ]
+                                  }
                                 ]
                               }
-                            ]
+                            ],
+                            expr = Send{
+                              flags = {privateOk}
+                              recv = Self
+                              fun = <U this_does_not_exist>
+                              block = nullptr
+                              pos_args = 0
+                              args = [
+                              ]
+                            }
                           }
-                        ],
-                        expr = Send{
-                          flags = {privateOk}
-                          recv = Self
-                          fun = <U this_does_not_exist>
-                          block = nullptr
-                          pos_args = 0
-                          args = [
-                          ]
                         }
-                      }
+                      ]
                     }
-                  ]
-                }
+                  }
 
-                Send{
-                  flags = {}
-                  recv = ConstantLit{
-                    symbol = (class ::<Magic>)
-                    orig = nullptr
-                  }
-                  fun = <U requires_ancestor>
-                  block = Block {
-                    params = [
-                    ]
-                    body = UnresolvedConstantLit{
-                      cnst = <C <U ExampleGroup>>
-                      scope = UnresolvedConstantLit{
-                        cnst = <C <U Core>>
+                  Send{
+                    flags = {}
+                    recv = ConstantLit{
+                      symbol = (class ::<Magic>)
+                      orig = nullptr
+                    }
+                    fun = <U requires_ancestor>
+                    block = Block {
+                      params = [
+                      ]
+                      body = UnresolvedConstantLit{
+                        cnst = <C <U ExampleGroup>>
                         scope = UnresolvedConstantLit{
-                          cnst = <C <U RSpec>>
-                          scope = EmptyTree
+                          cnst = <C <U Core>>
+                          scope = UnresolvedConstantLit{
+                            cnst = <C <U RSpec>>
+                            scope = EmptyTree
+                          }
                         }
                       }
                     }
+                    pos_args = 0
+                    args = [
+                    ]
                   }
-                  pos_args = 0
-                  args = [
-                  ]
-                }
-              ]
-            }
-          ]
+                ]
+              }
+            ]
+          }
         }
       ]
     }

--- a/test/testdata/rewriter/rspec_shared_examples_in_local_context.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_shared_examples_in_local_context.rb.rewrite-tree.exp
@@ -26,11 +26,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  class <emptyTree>::<C <describe 'consumer'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
-    <self>.include(::<root>::<C <shared_examples 'nested context inside local context'>>)
+  begin
+    "consumer"
+    class <emptyTree>::<C <describe 'consumer'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      <self>.include(::<root>::<C <shared_examples 'nested context inside local context'>>)
 
-    <self>.include(::<root>::<C <shared_examples 'nested examples inside local context'>>)
+      <self>.include(::<root>::<C <shared_examples 'nested examples inside local context'>>)
 
-    <self>.include(::<root>::<C <shared_examples 'nested examples_for inside local context'>>)
+      <self>.include(::<root>::<C <shared_examples 'nested examples_for inside local context'>>)
+    end
   end
 end

--- a/test/testdata/rewriter/rspec_shared_examples_in_parameterized_context.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_shared_examples_in_parameterized_context.rb.rewrite-tree.exp
@@ -28,13 +28,16 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  class <emptyTree>::<C <describe 'consumer'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
-    <self>.include(::<root>::<C <shared_examples 'outer parameterized context'>>)
+  begin
+    "consumer"
+    class <emptyTree>::<C <describe 'consumer'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      <self>.include(::<root>::<C <shared_examples 'outer parameterized context'>>)
 
-    <self>.include(::<root>::<C <shared_examples 'nested context inside parameterized'>>)
+      <self>.include(::<root>::<C <shared_examples 'nested context inside parameterized'>>)
 
-    <self>.include(::<root>::<C <shared_examples 'nested examples inside parameterized'>>)
+      <self>.include(::<root>::<C <shared_examples 'nested examples inside parameterized'>>)
 
-    <self>.include(::<root>::<C <shared_examples 'nested examples_for inside parameterized'>>)
+      <self>.include(::<root>::<C <shared_examples 'nested examples_for inside parameterized'>>)
+    end
   end
 end

--- a/test/testdata/rewriter/rspec_shared_examples_param.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_shared_examples_param.rb.rewrite-tree.exp
@@ -18,145 +18,160 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C MyClass><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
-    class <emptyTree>::<C <describe 'single shared example with context'>><<C <todo sym>>> < (<self>)
-      module ::<root>::<C <shared_examples 'my shared example'>><<C <todo sym>>> < ()
-        def foo_exists<<todo method>>(&<blk>)
-          "bar"
-        end
+    begin
+      "single shared example with context"
+      class <emptyTree>::<C <describe 'single shared example with context'>><<C <todo sym>>> < (<self>)
+        module ::<root>::<C <shared_examples 'my shared example'>><<C <todo sym>>> < ()
+          def foo_exists<<todo method>>(&<blk>)
+            "bar"
+          end
 
-        def uses_my_param<<todo method>>(&<blk>)
+          def uses_my_param<<todo method>>(&<blk>)
+            <emptyTree>::<C T>.reveal_type(my_param)
+          end
+
+          def <it '::<Magic>.<string-interpolate>("works for ", my_param)'><<todo method>>(&<blk>)
+            [::T.unsafe(nil)].each() do |my_param|
+              begin
+                <emptyTree>::<C T>.reveal_type(my_param)
+                <self>.expect(<self>.foo_exists()).to(<self>.eq("bar"))
+                <self>.this_does_not_exist()
+              end
+            end
+          end
+
           <emptyTree>::<C T>.reveal_type(my_param)
-        end
 
-        def <it '::<Magic>.<string-interpolate>("works for ", my_param)'><<todo method>>(&<blk>)
-          [::T.unsafe(nil)].each() do |my_param|
-            begin
-              <emptyTree>::<C T>.reveal_type(my_param)
-              <self>.expect(<self>.foo_exists()).to(<self>.eq("bar"))
-              <self>.this_does_not_exist()
-            end
+          <runtime method definition of foo_exists>
+
+          <runtime method definition of uses_my_param>
+
+          <runtime method definition of <it '::<Magic>.<string-interpolate>("works for ", my_param)'>>
+
+          ::<Magic>.requires_ancestor() do ||
+            <emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>
           end
-        end
-
-        <emptyTree>::<C T>.reveal_type(my_param)
-
-        <runtime method definition of foo_exists>
-
-        <runtime method definition of uses_my_param>
-
-        <runtime method definition of <it '::<Magic>.<string-interpolate>("works for ", my_param)'>>
-
-        ::<Magic>.requires_ancestor() do ||
-          <emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>
         end
       end
     end
 
-    class <emptyTree>::<C <describe 'shared context with 2 params'>><<C <todo sym>>> < (<self>)
-      module ::<root>::<C <shared_examples 'context with 2 params'>><<C <todo sym>>> < ()
-        def value1<<todo method>>(&<blk>)
-          param1
-        end
+    begin
+      "shared context with 2 params"
+      class <emptyTree>::<C <describe 'shared context with 2 params'>><<C <todo sym>>> < (<self>)
+        module ::<root>::<C <shared_examples 'context with 2 params'>><<C <todo sym>>> < ()
+          def value1<<todo method>>(&<blk>)
+            param1
+          end
 
-        def value2<<todo method>>(&<blk>)
-          param2
-        end
+          def value2<<todo method>>(&<blk>)
+            param2
+          end
 
-        def <it 'uses the params'><<todo method>>(&<blk>)
-          [::T.unsafe(nil)].each() do |param1, param2|
-            begin
-              <emptyTree>::<C T>.reveal_type(param1)
-              <emptyTree>::<C T>.reveal_type(param2)
+          def <it 'uses the params'><<todo method>>(&<blk>)
+            [::T.unsafe(nil)].each() do |param1, param2|
+              begin
+                <emptyTree>::<C T>.reveal_type(param1)
+                <emptyTree>::<C T>.reveal_type(param2)
+              end
             end
           end
-        end
 
-        <runtime method definition of value1>
+          <runtime method definition of value1>
 
-        <runtime method definition of value2>
+          <runtime method definition of value2>
 
-        <runtime method definition of <it 'uses the params'>>
+          <runtime method definition of <it 'uses the params'>>
 
-        ::<Magic>.requires_ancestor() do ||
-          <emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>
-        end
-      end
-
-      class <emptyTree>::<C <describe 'including context'>><<C <todo sym>>> < (<self>)
-        def <it 'has access to values'><<todo method>>(&<blk>)
-          begin
-            <self>.value1()
-            <self>.value2()
+          ::<Magic>.requires_ancestor() do ||
+            <emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>
           end
         end
 
-        <self>.include(::<root>::<C <shared_examples 'context with 2 params'>>)
+        begin
+          "including context"
+          class <emptyTree>::<C <describe 'including context'>><<C <todo sym>>> < (<self>)
+            def <it 'has access to values'><<todo method>>(&<blk>)
+              begin
+                <self>.value1()
+                <self>.value2()
+              end
+            end
+
+            <self>.include(::<root>::<C <shared_examples 'context with 2 params'>>)
+          end
+        end
       end
     end
 
-    class <emptyTree>::<C <describe 'shared context with 5 params'>><<C <todo sym>>> < (<self>)
-      module ::<root>::<C <shared_examples 'context with 5 params'>><<C <todo sym>>> < ()
-        def value1<<todo method>>(&<blk>)
-          param1
-        end
+    begin
+      "shared context with 5 params"
+      class <emptyTree>::<C <describe 'shared context with 5 params'>><<C <todo sym>>> < (<self>)
+        module ::<root>::<C <shared_examples 'context with 5 params'>><<C <todo sym>>> < ()
+          def value1<<todo method>>(&<blk>)
+            param1
+          end
 
-        def value2<<todo method>>(&<blk>)
-          param2
-        end
+          def value2<<todo method>>(&<blk>)
+            param2
+          end
 
-        def value3<<todo method>>(&<blk>)
-          param3
-        end
+          def value3<<todo method>>(&<blk>)
+            param3
+          end
 
-        def value4<<todo method>>(&<blk>)
-          param4
-        end
+          def value4<<todo method>>(&<blk>)
+            param4
+          end
 
-        def value5<<todo method>>(&<blk>)
-          param5
-        end
+          def value5<<todo method>>(&<blk>)
+            param5
+          end
 
-        def <it 'uses the params'><<todo method>>(&<blk>)
-          [::T.unsafe(nil)].each() do |param1, param2, param3, param4, param5|
-            begin
-              <emptyTree>::<C T>.reveal_type(param1)
-              <emptyTree>::<C T>.reveal_type(param2)
-              <emptyTree>::<C T>.reveal_type(param3)
-              <emptyTree>::<C T>.reveal_type(param4)
-              <emptyTree>::<C T>.reveal_type(param5)
+          def <it 'uses the params'><<todo method>>(&<blk>)
+            [::T.unsafe(nil)].each() do |param1, param2, param3, param4, param5|
+              begin
+                <emptyTree>::<C T>.reveal_type(param1)
+                <emptyTree>::<C T>.reveal_type(param2)
+                <emptyTree>::<C T>.reveal_type(param3)
+                <emptyTree>::<C T>.reveal_type(param4)
+                <emptyTree>::<C T>.reveal_type(param5)
+              end
             end
           end
-        end
 
-        <runtime method definition of value1>
+          <runtime method definition of value1>
 
-        <runtime method definition of value2>
+          <runtime method definition of value2>
 
-        <runtime method definition of value3>
+          <runtime method definition of value3>
 
-        <runtime method definition of value4>
+          <runtime method definition of value4>
 
-        <runtime method definition of value5>
+          <runtime method definition of value5>
 
-        <runtime method definition of <it 'uses the params'>>
+          <runtime method definition of <it 'uses the params'>>
 
-        ::<Magic>.requires_ancestor() do ||
-          <emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>
-        end
-      end
-
-      class <emptyTree>::<C <describe 'including context'>><<C <todo sym>>> < (<self>)
-        def <it 'has access to values'><<todo method>>(&<blk>)
-          begin
-            <self>.value1()
-            <self>.value2()
-            <self>.value3()
-            <self>.value4()
-            <self>.value5()
+          ::<Magic>.requires_ancestor() do ||
+            <emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>
           end
         end
 
-        <self>.include(::<root>::<C <shared_examples 'context with 5 params'>>)
+        begin
+          "including context"
+          class <emptyTree>::<C <describe 'including context'>><<C <todo sym>>> < (<self>)
+            def <it 'has access to values'><<todo method>>(&<blk>)
+              begin
+                <self>.value1()
+                <self>.value2()
+                <self>.value3()
+                <self>.value4()
+                <self>.value5()
+              end
+            end
+
+            <self>.include(::<root>::<C <shared_examples 'context with 5 params'>>)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Similar to #10250, keep the arg to `describe` in the tree instead of converting it to a string.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

For gen-packages mode, we need to see references to all constants used in a package so that we generate the right imports and exports. Without the args emitted, we might miss references if the only place a certain constant is used in the arg to `describe`.

This change also means we'll report type errors on the args, which we didn't before.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
