### PR TITLE
sorbet-runtime: Remove unused `raw` parameter

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -48,7 +48,7 @@ module T::Private::Methods
   #   (This can matter for circular load-time behavior, where a method is
   #   called while its Signature is being built)
   # - It's `nil` if we've finished building the sig
-  DeclarationBlock = Struct.new(:mod, :loc, :blk_or_decl, :final, :raw)
+  DeclarationBlock = Struct.new(:mod, :loc, :blk_or_decl, :final)
 
   def self.declare_sig(mod, loc, arg, &blk)
     T::Private::DeclState.current.active_declaration = _declare_sig_internal(mod, loc, arg, &blk)
@@ -56,7 +56,7 @@ module T::Private::Methods
     nil
   end
 
-  private_class_method def self._declare_sig_internal(mod, loc, arg, raw: false, &blk)
+  private_class_method def self._declare_sig_internal(mod, loc, arg, &blk)
     install_hooks(mod)
 
     if T::Private::DeclState.current.active_declaration
@@ -68,11 +68,11 @@ module T::Private::Methods
       raise "Invalid argument to `sig`: #{arg}"
     end
 
-    DeclarationBlock.new(mod, loc, blk, arg == :final, raw)
+    DeclarationBlock.new(mod, loc, blk, arg == :final)
   end
 
   def self.start_proc
-    DeclBuilder.new(PROC_TYPE, false)
+    DeclBuilder.new(PROC_TYPE)
   end
 
   def self.finalize_proc(decl)
@@ -233,7 +233,6 @@ module T::Private::Methods
     # This wrapper is very slow, so it will subsequently re-wrap with a much faster wrapper
     # (or unwrap back to the original method).
     key = method_owner_and_name_to_key(mod, method_name)
-    unless current_declaration.raw
       T::Private::ClassUtils.replace_method(original_method, mod, method_name) do |*args, &blk|
         method_sig = T::Private::Methods.maybe_run_sig_block_for_key(key)
         method_sig ||= T::Private::Methods._handle_missing_method_signature(
@@ -259,7 +258,6 @@ module T::Private::Methods
           original_method.bind_call(self, *args, &blk)
         end
       end
-    end
 
     @sig_wrappers[key] = sig_block
     if current_declaration.final
@@ -343,7 +341,7 @@ module T::Private::Methods
       raise "DeclarationBlock for #{declaration_block.mod} at #{declaration_block.loc} should have already been unwrapped"
     end
 
-    builder = DeclBuilder.new(declaration_block.mod, declaration_block.raw)
+    builder = DeclBuilder.new(declaration_block.mod)
     decl = builder.instance_exec(&blk_or_decl).finalize!.decl
     # Record that we've already run `blk` once and constructed a `Declaration`
     declaration_block.blk_or_decl = decl

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -51,12 +51,6 @@ module T::Private::Methods
   DeclarationBlock = Struct.new(:mod, :loc, :blk_or_decl, :final)
 
   def self.declare_sig(mod, loc, arg, &blk)
-    T::Private::DeclState.current.active_declaration = _declare_sig_internal(mod, loc, arg, &blk)
-
-    nil
-  end
-
-  private_class_method def self._declare_sig_internal(mod, loc, arg, &blk)
     install_hooks(mod)
 
     if T::Private::DeclState.current.active_declaration
@@ -68,7 +62,9 @@ module T::Private::Methods
       raise "Invalid argument to `sig`: #{arg}"
     end
 
-    DeclarationBlock.new(mod, loc, blk, arg == :final)
+    T::Private::DeclState.current.active_declaration = DeclarationBlock.new(mod, loc, blk, arg == :final)
+
+    nil
   end
 
   def self.start_proc

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -233,31 +233,31 @@ module T::Private::Methods
     # This wrapper is very slow, so it will subsequently re-wrap with a much faster wrapper
     # (or unwrap back to the original method).
     key = method_owner_and_name_to_key(mod, method_name)
-      T::Private::ClassUtils.replace_method(original_method, mod, method_name) do |*args, &blk|
-        method_sig = T::Private::Methods.maybe_run_sig_block_for_key(key)
-        method_sig ||= T::Private::Methods._handle_missing_method_signature(
-          self,
-          original_method,
-          __callee__ || raise("Unknown __callee__ for method without a signature"),
-        )
+    T::Private::ClassUtils.replace_method(original_method, mod, method_name) do |*args, &blk|
+      method_sig = T::Private::Methods.maybe_run_sig_block_for_key(key)
+      method_sig ||= T::Private::Methods._handle_missing_method_signature(
+        self,
+        original_method,
+        __callee__ || raise("Unknown __callee__ for method without a signature"),
+      )
 
-        # Should be the same logic as CallValidation.wrap_method_if_needed but we
-        # don't want that extra layer of indirection in the callstack
-        if method_sig.mode == T::Private::Methods::Modes.abstract
-          # We're in an interface method, keep going up the chain
-          if defined?(super)
-            super(*args, &blk)
-          else
-            raise NotImplementedError.new("The method `#{method_sig.method_name}` on #{mod} is declared as `abstract`. It does not have an implementation.")
-          end
-        # Note, this logic is duplicated (intentionally, for micro-perf) at `CallValidation.wrap_method_if_needed`,
-        # make sure to keep changes in sync.
-        elsif method_sig.check_level == :always || (method_sig.check_level == :tests && T::Private::RuntimeLevels.check_tests?)
-          CallValidation.validate_call(self, original_method, method_sig, args, blk)
+      # Should be the same logic as CallValidation.wrap_method_if_needed but we
+      # don't want that extra layer of indirection in the callstack
+      if method_sig.mode == T::Private::Methods::Modes.abstract
+        # We're in an interface method, keep going up the chain
+        if defined?(super)
+          super(*args, &blk)
         else
-          original_method.bind_call(self, *args, &blk)
+          raise NotImplementedError.new("The method `#{method_sig.method_name}` on #{mod} is declared as `abstract`. It does not have an implementation.")
         end
+      # Note, this logic is duplicated (intentionally, for micro-perf) at `CallValidation.wrap_method_if_needed`,
+      # make sure to keep changes in sync.
+      elsif method_sig.check_level == :always || (method_sig.check_level == :tests && T::Private::RuntimeLevels.check_tests?)
+        CallValidation.validate_call(self, original_method, method_sig, args, blk)
+      else
+        original_method.bind_call(self, *args, &blk)
       end
+    end
 
     @sig_wrappers[key] = sig_block
     if current_declaration.final

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
@@ -107,9 +107,6 @@ module T::Private::Methods
   sig {params(mod: T::Module[T.anything]).void}
   def self.install_hooks(mod); end
 
-  sig {params(mod: Module, loc: T.nilable(Thread::Backtrace::Location), arg: T.nilable(Symbol), blk: Proc).returns(DeclarationBlock)}
-  private_class_method def self._declare_sig_internal(mod, loc, arg, &blk); end
-
   sig {params(key: String).returns(T.nilable(T::Private::Methods::Signature))}
   private_class_method def self.signature_for_key(key); end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
@@ -14,20 +14,16 @@ module T::Private::Methods
     sig {returns(T::Boolean)}
     attr_accessor :final
 
-    sig {returns(T::Boolean)}
-    attr_accessor :raw
-
     sig do
       params(
         mod: Module,
         loc: T.nilable(Thread::Backtrace::Location),
         blk: Proc,
         final: T::Boolean,
-        raw: T::Boolean
       )
         .void
     end
-    def initialize(mod, loc, blk, final, raw); end
+    def initialize(mod, loc, blk, final); end
   end
 
   @installed_hooks = T.let({}, T::Hash[Module, TrueClass])
@@ -111,8 +107,8 @@ module T::Private::Methods
   sig {params(mod: T::Module[T.anything]).void}
   def self.install_hooks(mod); end
 
-  sig {params(mod: Module, loc: T.nilable(Thread::Backtrace::Location), arg: T.nilable(Symbol), raw: T::Boolean, blk: Proc).returns(DeclarationBlock)}
-  private_class_method def self._declare_sig_internal(mod, loc, arg, raw: false, &blk); end
+  sig {params(mod: Module, loc: T.nilable(Thread::Backtrace::Location), arg: T.nilable(Symbol), blk: Proc).returns(DeclarationBlock)}
+  private_class_method def self._declare_sig_internal(mod, loc, arg, &blk); end
 
   sig {params(key: String).returns(T.nilable(T::Private::Methods::Signature))}
   private_class_method def self.signature_for_key(key); end

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rb
@@ -15,7 +15,7 @@ module T::Private::Methods
       end
     end
 
-    def initialize(mod, raw)
+    def initialize(mod)
       @decl = Declaration.new(
         mod,
         ARG_NOT_PROVIDED, # params
@@ -27,7 +27,6 @@ module T::Private::Methods
         ARG_NOT_PROVIDED, # on_failure
         false, # override_allow_incompatible
         ARG_NOT_PROVIDED, # type_parameters
-        raw
       )
     end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/decl_builder.rbi
@@ -34,9 +34,6 @@ module T::Private::Methods
     sig {returns(T.any(T::Array[Symbol], T.class_of(ARG_NOT_PROVIDED)))}
     attr_accessor :type_parameters
 
-    sig {returns(T::Boolean)}
-    attr_accessor :raw
-
     sig do
       params(
         mod: Module,
@@ -49,7 +46,6 @@ module T::Private::Methods
         on_failure: T.any(T::Array[T.untyped], T.class_of(ARG_NOT_PROVIDED)),
         override_allow_incompatible: T.any(T::Boolean, Symbol),
         type_parameters: T.any(T::Array[Symbol], T.class_of(ARG_NOT_PROVIDED)),
-        raw: T::Boolean,
       )
         .void
     end
@@ -63,8 +59,7 @@ module T::Private::Methods
       finalized,
       on_failure,
       override_allow_incompatible,
-      type_parameters,
-      raw
+      type_parameters
     ); end
   end
 
@@ -77,8 +72,8 @@ module T::Private::Methods
     sig {returns(Declaration)}
     def decl; end
 
-    sig {params(mod: Module, raw: T::Boolean).void}
-    def initialize(mod, raw)
+    sig {params(mod: Module).void}
+    def initialize(mod)
       @decl = T.let(nil, Declaration)
     end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The only place that was passing `raw: true` was deleted in a previous 
change (1742103a0f6672911d7dcd98d534ca6480b91adb).

We can drop this flag now.

### Commit summary

Second commit is just whitespace changes.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Covered by tests and type coverage