### PR TITLE
Fix Ruby 3.4 ruby2_keywords warnings in T::Private::ClassUtils

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/class_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/class_utils.rb
@@ -44,7 +44,10 @@ module T::Private::ClassUtils
       end
 
       if block && block.arity < 0 && respond_to?(:ruby2_keywords, true)
-        ruby2_keywords(name)
+        m = instance_method(name)
+        has_rest = m.parameters.any? { |type, _| type == :rest }
+        has_keywords = m.parameters.any? { |type, _| %i[keyrest keyreq key].include?(type) }
+        ruby2_keywords(name) if has_rest && !has_keywords
       end
     end
   end

--- a/gems/sorbet-runtime/test/types/ruby2_keywords.rb
+++ b/gems/sorbet-runtime/test/types/ruby2_keywords.rb
@@ -6,10 +6,10 @@ class Opus::Types::Test::Ruby2KeywordsTest < Critic::Unit::UnitTest
   # Ruby 3.4+, where the VM warns if ruby2_keywords is applied to a method that
   # already handles keywords or does not accept a splat.
 
-  def warnings_for(&block)
+  def warnings_for
     old_stderr = $stderr
     $stderr = StringIO.new
-    block.call
+    yield
     $stderr.string
   ensure
     $stderr = old_stderr

--- a/gems/sorbet-runtime/test/types/ruby2_keywords.rb
+++ b/gems/sorbet-runtime/test/types/ruby2_keywords.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+class Opus::Types::Test::Ruby2KeywordsTest < Critic::Unit::UnitTest
+  # Verifies that sig-wrapped methods do not emit ruby2_keywords warnings on
+  # Ruby 3.4+, where the VM warns if ruby2_keywords is applied to a method that
+  # already handles keywords or does not accept a splat.
+
+  def warnings_for(&block)
+    old_stderr = $stderr
+    $stderr = StringIO.new
+    block.call
+    $stderr.string
+  ensure
+    $stderr = old_stderr
+  end
+
+  it "does not warn for a plain method with no splat" do
+    klass = Class.new do
+      extend T::Sig
+      sig { params(a: Integer, b: Integer).returns(Integer) }
+      def add(a, b) = a + b
+    end
+
+    output = warnings_for { klass.new.add(1, 2) }
+    assert_empty output.lines.grep(/ruby2_keywords/)
+  end
+
+  it "does not warn for a method with only keyword args" do
+    klass = Class.new do
+      extend T::Sig
+      sig { params(a: Integer).returns(Integer) }
+      def double(a:) = a * 2
+    end
+
+    output = warnings_for { klass.new.double(a: 5) }
+    assert_empty output.lines.grep(/ruby2_keywords/)
+  end
+
+  it "does not warn for a method with splat and keyword args" do
+    klass = Class.new do
+      extend T::Sig
+      sig { params(args: Integer, opts: String).returns(NilClass) }
+      def mixed(*args, **opts) = nil
+    end
+
+    output = warnings_for { klass.new.mixed(1, 2, key: "val") }
+    assert_empty output.lines.grep(/ruby2_keywords/)
+  end
+
+  it "does not warn for a method with only a splat" do
+    klass = Class.new do
+      extend T::Sig
+      sig { params(args: Integer).returns(NilClass) }
+      def splat_only(*args) = nil
+    end
+
+    output = warnings_for { klass.new.splat_only(1, 2, 3) }
+    assert_empty output.lines.grep(/ruby2_keywords/)
+  end
+
+  it "correctly calls methods after sig wrapping" do
+    klass = Class.new do
+      extend T::Sig
+      sig { params(a: Integer, b: Integer).returns(Integer) }
+      def add(a, b) = a + b
+
+      sig { params(args: Integer).returns(Integer) }
+      def sum(*args) = args.sum
+
+      sig { params(a: Integer).returns(Integer) }
+      def double(a:) = a * 2
+    end
+
+    instance = klass.new
+    assert_equal 3, instance.add(1, 2)
+    assert_equal 6, instance.sum(1, 2, 3)
+    assert_equal 10, instance.double(a: 5)
+  end
+end


### PR DESCRIPTION
Update `T::Private::ClassUtils.def_with_visibility` to strictly apply `ruby2_keywords` only when necessary.

For ensuring Ruby 2.7+ compatibility used `Enumerable#any?`

### Motivation
Ruby **3.4** strictly warns when `ruby2_keywords` is applied to methods that already handle keyword arguments natively. Because `def_with_visibility` eagerly applies this flag to any method with a `*args` parameter, booting a Sorbet-typed application on Ruby **3.4** currently generates massive amounts of console warning spam:

<img width="343" height="141" alt="Screenshot 2026-05-19 at 3 16 15 AM" src="https://github.com/user-attachments/assets/360af59e-018e-4a2a-850e-ce01cfc048d2" />


### Test plan
Verified locally against a Ruby 3.4 application. Boot-time `ruby2_keywords` warnings are completely silenced, and standard keyword delegation behaviour is preserved.