### PR TITLE
VS Code extension: signal the Sorbet process group on force-kill, not just the wrapper pid

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -385,5 +385,6 @@
   "prettier": {
     "trailingComma": "all",
     "arrowParens": "always"
-  }
+  },
+  "packageManager": "yarn@4.12.0+sha512.f45ab632439a67f8bc759bf32ead036a1f413287b9042726b7cc4818b7b49e14e9423ba49b18f9e06ea4941c1ad062385b1d8760a8d5091a1a31e5f6219afca8"
 }

--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -385,6 +385,5 @@
   "prettier": {
     "trailingComma": "all",
     "arrowParens": "always"
-  },
-  "packageManager": "yarn@4.12.0+sha512.f45ab632439a67f8bc759bf32ead036a1f413287b9042726b7cc4818b7b49e14e9423ba49b18f9e06ea4941c1ad062385b1d8760a8d5091a1a31e5f6219afca8"
+  }
 }

--- a/vscode_extension/src/connections.ts
+++ b/vscode_extension/src/connections.ts
@@ -2,7 +2,35 @@ import { ChildProcess } from "child_process";
 import { Log } from "./log";
 
 /**
+ * Send a signal to the process group on POSIX, or to the process itself on
+ * Windows. Using the process group ensures the signal reaches the actual
+ * Sorbet binary even when it is launched through a wrapper script such as
+ * `bundle exec srb`, which keeps itself alive as the direct child and runs
+ * Sorbet as a subprocess.
+ */
+function signalProcessGroup(p: ChildProcess, signal: NodeJS.Signals): void {
+  if (!p.pid) {
+    return;
+  }
+  try {
+    if (process.platform === "win32") {
+      p.kill(signal);
+    } else {
+      process.kill(-p.pid, signal);
+    }
+  } catch (error) {
+    // ESRCH: process group already gone — that's fine.
+    if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+      throw error;
+    }
+  }
+}
+
+/**
  * Attempts to stop the given child process. Tries a SIGTERM, then a SIGKILL.
+ *
+ * On POSIX the signal is sent to the entire process group so that it reaches
+ * the actual Sorbet binary even when launched through a wrapper script.
  */
 export async function stopProcess(p: ChildProcess, log: Log): Promise<void> {
   return new Promise<void>((resolve) => {
@@ -16,14 +44,14 @@ export async function stopProcess(p: ChildProcess, log: Log): Promise<void> {
     }
     p.on("exit", onExit);
     p.on("error", onExit);
-    p.kill("SIGTERM");
+    signalProcessGroup(p, "SIGTERM");
     setTimeout(() => {
       if (!hasExited) {
         log.debug(
           "Process did not respond to SIGTERM with 1s. Sending a SIGKILL.",
           p.pid,
         );
-        p.kill("SIGKILL");
+        signalProcessGroup(p, "SIGKILL");
         setTimeout(resolve, 100);
       }
     }, 1000);

--- a/vscode_extension/src/sorbetExtensionApi.ts
+++ b/vscode_extension/src/sorbetExtensionApi.ts
@@ -70,6 +70,7 @@ export class SorbetExtensionApiImpl implements Disposable {
         return Status.Disabled;
       case ServerStatus.ERROR:
         return Status.Error;
+      case ServerStatus.STOPPING:
       case ServerStatus.INITIALIZING:
       case ServerStatus.RESTARTING:
         return Status.Start;

--- a/vscode_extension/src/sorbetLanguageClient.ts
+++ b/vscode_extension/src/sorbetLanguageClient.ts
@@ -196,17 +196,8 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
 
     return new Promise<boolean>((resolve) => {
       let resolved = false;
-      const timer =
-        timeoutMs === undefined
-          ? undefined
-          : setTimeout(() => {
-              if (!resolved) {
-                resolved = true;
-                sorbetProcess.removeListener("exit", onExit);
-                sorbetProcess.removeListener("error", onExit);
-                resolve(false);
-              }
-            }, timeoutMs);
+      let timer: ReturnType<typeof setTimeout> | undefined;
+
       const onExit = () => {
         if (!resolved) {
           resolved = true;
@@ -218,6 +209,17 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
           resolve(true);
         }
       };
+
+      if (timeoutMs !== undefined) {
+        timer = setTimeout(() => {
+          if (!resolved) {
+            resolved = true;
+            sorbetProcess.removeListener("exit", onExit);
+            sorbetProcess.removeListener("error", onExit);
+            resolve(false);
+          }
+        }, timeoutMs);
+      }
 
       sorbetProcess.on("exit", onExit);
       sorbetProcess.on("error", onExit);

--- a/vscode_extension/src/sorbetLanguageClient.ts
+++ b/vscode_extension/src/sorbetLanguageClient.ts
@@ -22,6 +22,8 @@ import { instrumentLanguageClient } from "./languageClient.metrics";
 import { SorbetExtensionContext } from "./sorbetExtensionContext";
 import { ServerStatus, RestartReason } from "./types";
 
+const STOP_TIMEOUT_MS = 5000;
+
 const VALID_STATE_TRANSITIONS: ReadonlyMap<
   ServerStatus,
   ReadonlySet<ServerStatus>
@@ -55,6 +57,7 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
   private readonly onStatusChangeEmitter: EventEmitter<ServerStatus>;
   private readonly restart: (reason: RestartReason) => void;
   private sorbetProcess?: ChildProcess;
+  private stopPromise?: Promise<void>;
   // Sometimes this is an errno, not a process exit code. This happens when set
   // via the `.on("error")` handler, instead of the `.on("exit")` handler.
   private sorbetProcessExitCode?: number;
@@ -90,35 +93,134 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
    * to keep it alive. Stops the language server and Sorbet processes, and removes UI items.
    */
   public dispose() {
+    this.stop().catch((error: Error) => {
+      this.context.log.error(
+        "Failed to stop Sorbet client during dispose.",
+        error,
+      );
+    });
+  }
+
+  public async stop(): Promise<void> {
+    if (this.stopPromise) {
+      return this.stopPromise;
+    }
+
     this.onStatusChangeEmitter.dispose();
 
-    let stopped = false;
-    /*
-     * stop() only invokes the then() callback after the language server
-     * ACKs the stop request.
-     * Stopping can time out if the language client is repeatedly failing to
-     * start (e.g. if network is down, or path to Sorbet is incorrect), or if
-     * Sorbet never ACKs the stop request.
-     * In the former case (which is the common case), VS code stops retrying
-     * the connection after we call stop(), but never invokes our callback.
-     * Thus, our solution is to wait 5 seconds for a callback, and stop the
-     * process if we haven't heard back.
-     */
-    const stopTimer = setTimeout(() => {
-      stopped = true;
-      this.context.metrics.emitCountMetric("stop.timed_out", 1);
-      if (this.sorbetProcess?.pid) {
-        stopProcess(this.sorbetProcess, this.context.log);
-      }
-      this.sorbetProcess = undefined;
-    }, 5000);
+    const { sorbetProcess } = this;
 
-    this.languageClient.stop().then(() => {
-      if (!stopped) {
-        clearTimeout(stopTimer);
-        this.context.metrics.emitCountMetric("stop.success", 1);
-        this.context.log.info("Sorbet has stopped.");
-      }
+    this.stopPromise = new Promise<void>((resolve) => {
+      let finished = false;
+      const finish = () => {
+        if (!finished) {
+          finished = true;
+          this.sorbetProcess = undefined;
+          resolve();
+        }
+      };
+      /*
+       * languageClient.stop() only invokes the then() callback after the language
+       * server ACKs the stop request.
+       * Stopping can time out if the language client is repeatedly failing to
+       * start (e.g. if network is down, or path to Sorbet is incorrect), or if
+       * Sorbet never ACKs the stop request.
+       * In the former case (which is the common case), VS code stops retrying
+       * the connection after we call stop(), but never invokes our callback.
+       * Thus, our solution is to wait 5 seconds for a callback, and stop the
+       * process if we haven't heard back.
+       */
+      const stopTimer = setTimeout(() => {
+        this.context.metrics.emitCountMetric("stop.timed_out", 1);
+        if (sorbetProcess?.pid) {
+          this.context.log.warn(
+            "Sorbet client stop timed out after 5s; terminating Sorbet process.",
+            sorbetProcess.pid,
+          );
+          stopProcess(sorbetProcess, this.context.log)
+            .catch((error: Error) => {
+              this.context.log.error(
+                "Failed to terminate Sorbet process.",
+                error,
+              );
+            })
+            .then(finish);
+        } else {
+          finish();
+        }
+      }, STOP_TIMEOUT_MS);
+
+      this.languageClient.stop().then(
+        async () => {
+          clearTimeout(stopTimer);
+          this.context.metrics.emitCountMetric("stop.success", 1);
+          this.context.log.info("Sorbet has stopped.");
+          const exited = await this.waitForProcessExit(
+            sorbetProcess,
+            STOP_TIMEOUT_MS,
+          );
+          if (!exited && sorbetProcess?.pid) {
+            this.context.log.warn(
+              "Sorbet acknowledged shutdown but did not exit within 5s; terminating Sorbet process.",
+              sorbetProcess.pid,
+            );
+            await stopProcess(sorbetProcess, this.context.log);
+          }
+          finish();
+        },
+        async (error: Error) => {
+          clearTimeout(stopTimer);
+          this.context.log.warn("Sorbet client stop failed.", error);
+          if (sorbetProcess?.pid) {
+            await stopProcess(sorbetProcess, this.context.log);
+          }
+          finish();
+        },
+      );
+    });
+
+    return this.stopPromise;
+  }
+
+  private waitForProcessExit(
+    sorbetProcess: ChildProcess | undefined,
+    timeoutMs?: number,
+  ): Promise<boolean> {
+    if (
+      !sorbetProcess ||
+      sorbetProcess.exitCode !== null ||
+      sorbetProcess.signalCode !== null
+    ) {
+      return Promise.resolve(true);
+    }
+
+    return new Promise<boolean>((resolve) => {
+      let resolved = false;
+      const timer =
+        timeoutMs === undefined
+          ? undefined
+          : setTimeout(() => {
+              if (!resolved) {
+                resolved = true;
+                sorbetProcess.removeListener("exit", onExit);
+                sorbetProcess.removeListener("error", onExit);
+                resolve(false);
+              }
+            }, timeoutMs);
+      const onExit = () => {
+        if (!resolved) {
+          resolved = true;
+          if (timer !== undefined) {
+            clearTimeout(timer);
+          }
+          sorbetProcess.removeListener("exit", onExit);
+          sorbetProcess.removeListener("error", onExit);
+          resolve(true);
+        }
+      };
+
+      sorbetProcess.on("exit", onExit);
+      sorbetProcess.on("error", onExit);
     });
   }
 

--- a/vscode_extension/src/sorbetLanguageClient.ts
+++ b/vscode_extension/src/sorbetLanguageClient.ts
@@ -342,6 +342,10 @@ export class SorbetLanguageClient implements Disposable, ErrorHandler {
     this.context.log.debug(">", command, ...args);
     this.sorbetProcess = spawn(command, args, {
       cwd: this.workspaceFolder?.uri.fsPath,
+      // Spawn in a new process group on POSIX so that force-stop signals can
+      // be sent to the group (covering wrapper scripts and the Sorbet binary)
+      // without affecting the VS Code extension host process.
+      detached: process.platform !== "win32",
       env: { ...process.env, ...activeConfig?.env },
     });
     // N.B.: 'exit' is sometimes not invoked if the process exits with an error/fails to start, as per the Node.js docs.

--- a/vscode_extension/src/sorbetStatusBarEntry.ts
+++ b/vscode_extension/src/sorbetStatusBarEntry.ts
@@ -74,6 +74,10 @@ export class SorbetStatusBarEntry implements Disposable {
           text = `${sorbetName}: Disabled`;
           tooltip = "The Sorbet server is disabled.";
           break;
+        case ServerStatus.STOPPING:
+          text = `${sorbetName}: Stopping $(sync~spin)`;
+          tooltip = "The Sorbet server is stopping.";
+          break;
         case ServerStatus.ERROR:
           text = `${sorbetName}: Error`;
           tooltip = "Click for remediation items.";

--- a/vscode_extension/src/sorbetStatusProvider.ts
+++ b/vscode_extension/src/sorbetStatusProvider.ts
@@ -57,8 +57,9 @@ export class SorbetStatusProvider implements Disposable {
       return;
     }
 
-    // Remove existing client from clean-up tracking, if any.
+    // Clean up existing client, if any.
     if (this.wrappedActiveLanguageClient) {
+      this.wrappedActiveLanguageClient.dispose();
       const i = this.disposables.indexOf(this.wrappedActiveLanguageClient);
       if (i !== -1) {
         this.disposables.splice(i, 1);

--- a/vscode_extension/src/sorbetStatusProvider.ts
+++ b/vscode_extension/src/sorbetStatusProvider.ts
@@ -240,7 +240,10 @@ export class SorbetStatusProvider implements Disposable {
     const oldClient = this.activeLanguageClient;
     this.activeLanguageClient = undefined;
     if (oldClient) {
-      this.fireOnStatusChanged({ status: ServerStatus.STOPPING, stopped: true });
+      this.fireOnStatusChanged({
+        status: ServerStatus.STOPPING,
+        stopped: true,
+      });
       await oldClient.stop();
     }
     this.fireOnStatusChanged({ status: newStatus, stopped: true });

--- a/vscode_extension/src/sorbetStatusProvider.ts
+++ b/vscode_extension/src/sorbetStatusProvider.ts
@@ -13,6 +13,7 @@ export type StatusChangedEvent = {
 
 export class SorbetStatusProvider implements Disposable {
   private wrappedActiveLanguageClient?: SorbetLanguageClient;
+  private wrappedServerStatus: ServerStatus;
   private readonly context: SorbetExtensionContext;
   private readonly disposables: Disposable[];
   /** Mutex for startSorbet. Prevents us from starting multiple processes at once. */
@@ -24,6 +25,7 @@ export class SorbetStatusProvider implements Disposable {
 
   constructor(context: SorbetExtensionContext) {
     this.context = context;
+    this.wrappedServerStatus = ServerStatus.DISABLED;
     this.isStarting = false;
     this.lastSorbetRetryTime = 0;
     this.operationStack = [];
@@ -55,9 +57,8 @@ export class SorbetStatusProvider implements Disposable {
       return;
     }
 
-    // Clean-up existing client, if any.
+    // Remove existing client from clean-up tracking, if any.
     if (this.wrappedActiveLanguageClient) {
-      this.wrappedActiveLanguageClient.dispose();
       const i = this.disposables.indexOf(this.wrappedActiveLanguageClient);
       if (i !== -1) {
         this.disposables.splice(i, 1);
@@ -114,6 +115,7 @@ export class SorbetStatusProvider implements Disposable {
    * event listeners are notified.
    */
   private fireOnStatusChanged(data: StatusChangedEvent): void {
+    this.wrappedServerStatus = data.status;
     if (data.stopped) {
       this.operationStack = [];
     }
@@ -163,10 +165,7 @@ export class SorbetStatusProvider implements Disposable {
    * Return current {@link ServerStatus server status}.
    */
   public get serverStatus(): ServerStatus {
-    return (
-      this.activeLanguageClient?.status ||
-      (this.isStarting ? ServerStatus.RESTARTING : ServerStatus.DISABLED)
-    );
+    return this.wrappedServerStatus;
   }
 
   /**
@@ -193,6 +192,7 @@ export class SorbetStatusProvider implements Disposable {
       this.context.log.debug(
         `Waiting ${sleepMS.toFixed(0)}ms before restarting Sorbet…`,
       );
+      this.fireOnStatusChanged({ status: ServerStatus.RESTARTING });
       this.isStarting = true;
       await new Promise((res) => setTimeout(res, sleepMS));
       this.isStarting = false;
@@ -237,8 +237,12 @@ export class SorbetStatusProvider implements Disposable {
    * @param newStatus Status to report.
    */
   public async stopSorbet(newStatus: ServerStatus): Promise<void> {
-    // Use property-setter to ensure proper clean-up.
+    const oldClient = this.activeLanguageClient;
     this.activeLanguageClient = undefined;
+    if (oldClient) {
+      this.fireOnStatusChanged({ status: ServerStatus.STOPPING, stopped: true });
+      await oldClient.stop();
+    }
     this.fireOnStatusChanged({ status: newStatus, stopped: true });
   }
 }

--- a/vscode_extension/src/test/commands/showSorbetActions.test.ts
+++ b/vscode_extension/src/test/commands/showSorbetActions.test.ts
@@ -37,6 +37,13 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
       Action.ConfigureSorbet,
     ]);
 
+    assert.deepStrictEqual(getAvailableActions(ServerStatus.STOPPING), [
+      Action.ViewOutput,
+      Action.RestartSorbet,
+      Action.DisableSorbet,
+      Action.ConfigureSorbet,
+    ]);
+
     assert.deepStrictEqual(getAvailableActions(ServerStatus.INITIALIZING), [
       Action.ViewOutput,
       Action.RestartSorbet,

--- a/vscode_extension/src/test/sorbetStatusProvider.test.ts
+++ b/vscode_extension/src/test/sorbetStatusProvider.test.ts
@@ -35,6 +35,7 @@ suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
     const startSorbetStub = sinon.stub(provider, "startSorbet").resolves();
     const stopped = createDeferredPromise();
     const fakeClient = <any>{
+      dispose: sinon.stub(),
       stop: sinon.stub().returns(stopped.promise),
       status: ServerStatus.RUNNING,
     };

--- a/vscode_extension/src/test/sorbetStatusProvider.test.ts
+++ b/vscode_extension/src/test/sorbetStatusProvider.test.ts
@@ -1,0 +1,57 @@
+import * as assert from "assert";
+import * as path from "path";
+import * as sinon from "sinon";
+import { SorbetExtensionContext } from "../sorbetExtensionContext";
+import { SorbetStatusProvider } from "../sorbetStatusProvider";
+import { RestartReason, ServerStatus } from "../types";
+import { createLogStub } from "./testUtils";
+
+function createDeferredPromise(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve = () => {};
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+suite(`Test Suite: ${path.basename(__filename, ".test.js")}`, () => {
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test("restartSorbet waits for the active client to stop before starting", async () => {
+    const context = <SorbetExtensionContext>(<unknown>{
+      log: createLogStub(),
+      metrics: {
+        emitCountMetric: sinon.stub().resolves(),
+      },
+    });
+    const provider = new SorbetStatusProvider(context);
+    const startSorbetStub = sinon.stub(provider, "startSorbet").resolves();
+    const stopped = createDeferredPromise();
+    const fakeClient = <any>{
+      stop: sinon.stub().returns(stopped.promise),
+      status: ServerStatus.RUNNING,
+    };
+
+    (<any>provider).wrappedActiveLanguageClient = fakeClient;
+    (<any>provider).disposables.push(fakeClient);
+
+    const restartPromise = provider.restartSorbet(RestartReason.CONFIG_CHANGE);
+    await Promise.resolve();
+
+    sinon.assert.calledOnce(fakeClient.stop);
+    sinon.assert.notCalled(startSorbetStub);
+    assert.strictEqual(provider.activeLanguageClient, undefined);
+    assert.strictEqual(provider.serverStatus, ServerStatus.STOPPING);
+    assert.ok(!(<any>provider).disposables.includes(fakeClient));
+
+    stopped.resolve();
+    await restartPromise;
+
+    sinon.assert.calledOnce(startSorbetStub);
+  });
+});

--- a/vscode_extension/src/test/sorbetStatusProvider.test.ts
+++ b/vscode_extension/src/test/sorbetStatusProvider.test.ts
@@ -6,10 +6,12 @@ import { SorbetStatusProvider } from "../sorbetStatusProvider";
 import { RestartReason, ServerStatus } from "../types";
 import { createLogStub } from "./testUtils";
 
-function createDeferredPromise(): {
+interface DeferredPromise {
   promise: Promise<void>;
   resolve: () => void;
-} {
+}
+
+function createDeferredPromise(): DeferredPromise {
   let resolve = () => {};
   const promise = new Promise<void>((res) => {
     resolve = res;

--- a/vscode_extension/src/types.ts
+++ b/vscode_extension/src/types.ts
@@ -32,6 +32,8 @@ export enum RestartReason {
 export const enum ServerStatus {
   // The language client is disabled.
   DISABLED,
+  // The language client is stopping.
+  STOPPING,
   // The language client is restarting.
   RESTARTING,
   // The language client is initializing.


### PR DESCRIPTION
This PR splits out the VS Code process group improvements from https://github.com/sorbet/sorbet/pull/10128 and is based on top of https://github.com/sorbet/sorbet/pull/10280 as requested for an easier revert.

Incremental compare link: https://github.com/thatch-health/sorbet/compare/fix-vscode-watchman-vscode-lifecycle...fix-vscode-watchman-process-group

### Motivation
Fix issues with lingering Watchman processes.

### Test plan

Manual testing by restarting the extension and force killing VS Code.