### PR TITLE
Rewrite RBS `nil` type to a resolved `::NilClass`

### DIFF
--- a/parser/prism/Factory.cc
+++ b/parser/prism/Factory.cc
@@ -337,6 +337,10 @@ pm_node_t *Factory::Call(core::LocOffsets loc, pm_node_t *receiver, string_view 
     return up_cast(createCallNode(receiver, methodId, up_cast(arguments), tinyLoc, fullLoc, tinyLoc, block));
 }
 
+pm_node_t *Factory::NilClass(core::LocOffsets loc) const {
+    return ConstantReadNode("NilClass"sv, loc);
+}
+
 pm_node_t *Factory::T(core::LocOffsets loc) const {
     return ConstantPathNode(loc, nullptr, "T");
 }

--- a/parser/prism/Factory.cc
+++ b/parser/prism/Factory.cc
@@ -338,7 +338,7 @@ pm_node_t *Factory::Call(core::LocOffsets loc, pm_node_t *receiver, string_view 
 }
 
 pm_node_t *Factory::NilClass(core::LocOffsets loc) const {
-    return ConstantReadNode("NilClass"sv, loc);
+    return parser.markResolved(ConstantReadNode("NilClass"sv, loc), core::Symbols::NilClass());
 }
 
 pm_node_t *Factory::T(core::LocOffsets loc) const {

--- a/parser/prism/Factory.h
+++ b/parser/prism/Factory.h
@@ -78,6 +78,9 @@ public:
     pm_node_t *SorbetPrivateStaticVoid(core::LocOffsets loc) const;
     pm_node_t *TSigWithoutRuntime(core::LocOffsets loc) const;
 
+    // Standard library types
+    pm_node_t *NilClass(core::LocOffsets loc) const;
+
     // T constant and method helpers
     pm_node_t *T(core::LocOffsets loc) const;
     pm_node_t *THelpers(core::LocOffsets loc) const;

--- a/rbs/prism/TypeToParserNodePrism.cc
+++ b/rbs/prism/TypeToParserNodePrism.cc
@@ -369,7 +369,7 @@ pm_node_t *TypeToParserNodePrism::toPrismNode(const rbs_node_t *node, const RBSD
         case RBS_TYPES_BASES_INSTANCE:
             return prism.TAttachedClass(nodeLoc);
         case RBS_TYPES_BASES_NIL:
-            return prism.ConstantReadNode("NilClass"sv, nodeLoc);
+            return prism.NilClass(nodeLoc);
         case RBS_TYPES_BASES_SELF:
             return prism.TSelfType(nodeLoc);
         case RBS_TYPES_BASES_TOP:

--- a/test/BUILD
+++ b/test/BUILD
@@ -626,6 +626,7 @@ pipeline_tests(
             "testdata/rbs/assertions_heredoc.rb",
 
             # Prism output differs from legacy for constant resolution.
+            "testdata/rbs/annotations_literal_types.rb",
             "testdata/rbs/signatures_types.rb",
         ],
     ),

--- a/test/BUILD
+++ b/test/BUILD
@@ -624,11 +624,6 @@ pipeline_tests(
         exclude = [
             # Specific test for the legacy pipeline. Prism has its own `testdata/rbs/assertions_heredoc_modified.rb`.
             "testdata/rbs/assertions_heredoc.rb",
-
-            # Prism output differs from legacy for constant resolution.
-            "testdata/rbs/annotations_literal_types.rb",
-            "testdata/rbs/signatures_types.rb",
-            "testdata/rbs/annotations_literal_types.rb",
         ],
     ),
     "PrismPosTests",

--- a/test/BUILD
+++ b/test/BUILD
@@ -628,6 +628,7 @@ pipeline_tests(
             # Prism output differs from legacy for constant resolution.
             "testdata/rbs/annotations_literal_types.rb",
             "testdata/rbs/signatures_types.rb",
+            "testdata/rbs/annotations_literal_types.rb",
         ],
     ),
     "PrismPosTests",

--- a/test/testdata/rbs/annotations_literal_types.rb
+++ b/test/testdata/rbs/annotations_literal_types.rb
@@ -1,0 +1,4 @@
+# typed: true
+# enable-experimental-rbs-comments: true
+
+n = nil #: nil

--- a/test/testdata/rbs/annotations_literal_types.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/annotations_literal_types.rb.rewrite-tree.exp
@@ -1,0 +1,3 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  n = <cast:let>(nil, <todo sym>, ::NilClass)
+end

--- a/test/testdata/rbs/signatures_types.rb
+++ b/test/testdata/rbs/signatures_types.rb
@@ -13,6 +13,13 @@ module Foo
   end
 end
 
+#: -> nil
+def returns_nil = nil;
+T.reveal_type(returns_nil) # error: Revealed type: `NilClass`
+
+#: (nil) -> void
+def takes_nil(n) = T.reveal_type(n) # error: Revealed type: `NilClass`
+
 # Class instance types
 
 #: -> Foo

--- a/test/testdata/rbs/signatures_types.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_types.rb.rewrite-tree.exp
@@ -1,5 +1,21 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.returns(::NilClass)
+  end
+
+  def returns_nil<<todo method>>(&<blk>)
+    nil
+  end
+
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.params(:n, ::NilClass).void()
+  end
+
+  def takes_nil<<todo method>>(n, &<blk>)
+    <emptyTree>::<C T>.reveal_type(n)
+  end
+
+  ::T::Sig::WithoutRuntime.sig() do ||
     <self>.returns(<emptyTree>::<C Foo>)
   end
 
@@ -532,6 +548,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
   end
+
+  <runtime method definition of returns_nil>
+
+  <emptyTree>::<C T>.reveal_type(<self>.returns_nil())
+
+  <runtime method definition of takes_nil>
 
   <runtime method definition of class_instance_type1>
 


### PR DESCRIPTION
### Motivation

Prior to #10283, it was difficult to emit resolved constants out of the Prism based rewriter.

The legacy RBS rewriter emitted resolved constants (since it was post-desugar, it was easy to do so), and now the Prism-based RBS rewriter matches.

### Test plan

Fixes the last remaining discrepancy in `//test:test_PrismPosTests/testdata/rbs/signatures_types`, which can now be un-excluded.