### PR TITLE
Support `true` and `false` RBS literals

### DIFF
--- a/parser/prism/Factory.cc
+++ b/parser/prism/Factory.cc
@@ -89,6 +89,11 @@ pm_node_t *Factory::ConstantWriteNode(core::LocOffsets loc, pm_constant_id_t nam
     return up_cast(node);
 }
 
+// @param parent If nullptr, creates a fully qualifier constant reference to `name`,
+//                 * e.g. ConstantPathNode(loc, nullptr, "A") -> `::A`
+//                 * To create non-qualified constants, use `ConstantReadNode()` instead.
+//               If non-null, creates a nested constant under `parent`
+//                 * e.g. ConstantPathNode(loc, ConstantReadNode("A"), "B") -> `A::B`
 pm_node_t *Factory::ConstantPathNode(core::LocOffsets loc, pm_node_t *parent, string_view name) const {
     pm_constant_id_t nameId = addConstantToPool(name);
     pm_location_t pmLoc = parser.convertLocOffsets(loc);
@@ -339,6 +344,14 @@ pm_node_t *Factory::Call(core::LocOffsets loc, pm_node_t *receiver, string_view 
 
 pm_node_t *Factory::NilClass(core::LocOffsets loc) const {
     return parser.markResolved(ConstantReadNode("NilClass"sv, loc), core::Symbols::NilClass());
+}
+
+pm_node_t *Factory::TrueClass(core::LocOffsets loc) const {
+    return parser.markResolved(ConstantPathNode(loc, nullptr, "TrueClass"sv), core::Symbols::TrueClass());
+}
+
+pm_node_t *Factory::FalseClass(core::LocOffsets loc) const {
+    return parser.markResolved(ConstantPathNode(loc, nullptr, "FalseClass"sv), core::Symbols::FalseClass());
 }
 
 pm_node_t *Factory::T(core::LocOffsets loc) const {

--- a/parser/prism/Factory.h
+++ b/parser/prism/Factory.h
@@ -80,6 +80,8 @@ public:
 
     // Standard library types
     pm_node_t *NilClass(core::LocOffsets loc) const;
+    pm_node_t *TrueClass(core::LocOffsets loc) const;
+    pm_node_t *FalseClass(core::LocOffsets loc) const;
 
     // T constant and method helpers
     pm_node_t *T(core::LocOffsets loc) const;

--- a/rbs/prism/TypeToParserNodePrism.cc
+++ b/rbs/prism/TypeToParserNodePrism.cc
@@ -393,10 +393,25 @@ pm_node_t *TypeToParserNodePrism::toPrismNode(const rbs_node_t *node, const RBSD
         case RBS_TYPES_INTERSECTION:
             return intersectionType((rbs_types_intersection_t *)node, nodeLoc, declaration);
         case RBS_TYPES_LITERAL: {
-            if (auto e = ctx.beginIndexerError(nodeLoc, core::errors::Rewriter::RBSUnsupported)) {
-                e.setHeader("RBS literal types are not supported");
+            rbs_types_literal_t *literalNode = rbs_down_cast<rbs_types_literal_t>(const_cast<rbs_node_t *>(node));
+
+            switch (literalNode->literal->type) {
+                case RBS_AST_BOOL: { // Boolean literals used in type positions, like `(false) -> true`
+                    auto *boolNode = rbs_down_cast<rbs_ast_bool_t>(literalNode->literal);
+
+                    // Sorbet doesn't support literal bool types. Rewrite them to their corresponding classes instead:
+                    // * `true` -> `TrueClass`
+                    // * `false` -> `FalseClass`
+                    return boolNode->value ? prism.TrueClass(nodeLoc) : prism.FalseClass(nodeLoc);
+                }
+                default: {
+                    // We don't have a good way to represent other literal types, so we just return T.untyped for them.
+                    if (auto e = ctx.beginIndexerError(nodeLoc, core::errors::Rewriter::RBSUnsupported)) {
+                        e.setHeader("RBS literal types are not supported");
+                    }
+                    return prism.TUntyped(nodeLoc);
+                }
             }
-            return prism.TUntyped(nodeLoc);
         }
         case RBS_TYPES_OPTIONAL:
             return optionalType((rbs_types_optional_t *)node, nodeLoc, declaration);

--- a/rbs/rbs_common.h
+++ b/rbs/rbs_common.h
@@ -39,10 +39,12 @@ template <typename Type> struct RBSNodeTypeHelper {
         static constexpr enum rbs_node_type TypeID = type_enum; \
     }
 
+DEF_RBS_TYPE_HELPER(rbs_ast_bool_t, RBS_AST_BOOL);
 DEF_RBS_TYPE_HELPER(rbs_ast_symbol_t, RBS_AST_SYMBOL);
 DEF_RBS_TYPE_HELPER(rbs_ast_type_param_t, RBS_AST_TYPE_PARAM);
 DEF_RBS_TYPE_HELPER(rbs_types_function_t, RBS_TYPES_FUNCTION);
 DEF_RBS_TYPE_HELPER(rbs_types_function_param_t, RBS_TYPES_FUNCTION_PARAM);
+DEF_RBS_TYPE_HELPER(rbs_types_literal_t, RBS_TYPES_LITERAL);
 
 #undef DEF_RBS_TYPE_HELPER
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -533,6 +533,11 @@ pipeline_tests(
         # todo(gdritter): fix this!
         exclude = [
             "testdata/packager/directed-*/**/*",
+
+            # These test require support for RBS boolean literal types,
+            # which will not be back-ported to the whitequark-based RBS rewriter.
+            "testdata/rbs/annotations_literal_types.rb",
+            "testdata/rbs/signatures_types.rb",
         ],
     ),
     "LSPTests",
@@ -609,6 +614,11 @@ pipeline_tests(
         exclude = [
             # Specific test that is modified for Prism, contains minor differences in the exp file
             "testdata/rbs/assertions_heredoc_modified.rb",
+
+            # These test require support for RBS boolean literal types,
+            # which will not be back-ported to the whitequark-based RBS rewriter.
+            "testdata/rbs/annotations_literal_types.rb",
+            "testdata/rbs/signatures_types.rb",
         ],
     ),
     "PosTests",

--- a/test/testdata/rbs/annotations_literal_types.rb
+++ b/test/testdata/rbs/annotations_literal_types.rb
@@ -2,3 +2,5 @@
 # enable-experimental-rbs-comments: true
 
 n = nil #: nil
+t = true #: true
+f = false #: false

--- a/test/testdata/rbs/annotations_literal_types.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/annotations_literal_types.rb.rewrite-tree.exp
@@ -1,3 +1,7 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   n = <cast:let>(nil, <todo sym>, ::NilClass)
+
+  t = <cast:let>(true, <todo sym>, ::TrueClass)
+
+  f = <cast:let>(false, <todo sym>, ::FalseClass)
 end

--- a/test/testdata/rbs/signatures_types.rb
+++ b/test/testdata/rbs/signatures_types.rb
@@ -20,6 +20,20 @@ T.reveal_type(returns_nil) # error: Revealed type: `NilClass`
 #: (nil) -> void
 def takes_nil(n) = T.reveal_type(n) # error: Revealed type: `NilClass`
 
+#: -> false
+def returns_false = false;
+T.reveal_type(returns_false) # error: Revealed type: `FalseClass`
+
+#: (false) -> void
+def takes_false(f) = T.reveal_type(f) # error: Revealed type: `FalseClass`
+
+#: -> true
+def returns_true = true;
+T.reveal_type(returns_true) # error: Revealed type: `TrueClass`
+
+#: (true) -> void
+def takes_true(t) = T.reveal_type(t) # error: Revealed type: `TrueClass`
+
 # Class instance types
 
 #: -> Foo

--- a/test/testdata/rbs/signatures_types.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_types.rb.rewrite-tree.exp
@@ -16,6 +16,38 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.returns(::FalseClass)
+  end
+
+  def returns_false<<todo method>>(&<blk>)
+    false
+  end
+
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.params(:f, ::FalseClass).void()
+  end
+
+  def takes_false<<todo method>>(f, &<blk>)
+    <emptyTree>::<C T>.reveal_type(f)
+  end
+
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.returns(::TrueClass)
+  end
+
+  def returns_true<<todo method>>(&<blk>)
+    true
+  end
+
+  ::T::Sig::WithoutRuntime.sig() do ||
+    <self>.params(:t, ::TrueClass).void()
+  end
+
+  def takes_true<<todo method>>(t, &<blk>)
+    <emptyTree>::<C T>.reveal_type(t)
+  end
+
+  ::T::Sig::WithoutRuntime.sig() do ||
     <self>.returns(<emptyTree>::<C Foo>)
   end
 
@@ -554,6 +586,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(<self>.returns_nil())
 
   <runtime method definition of takes_nil>
+
+  <runtime method definition of returns_false>
+
+  <emptyTree>::<C T>.reveal_type(<self>.returns_false())
+
+  <runtime method definition of takes_false>
+
+  <runtime method definition of returns_true>
+
+  <emptyTree>::<C T>.reveal_type(<self>.returns_true())
+
+  <runtime method definition of takes_true>
 
   <runtime method definition of class_instance_type1>
 


### PR DESCRIPTION
### Motivation

Using `TrueClass` and `FalseClass` is not idiomatic in RBS, which has `true` and `false` literals.

This PR implements support for them, rewriting them to the classes that Sorbet can understand.

### Test plan

Expanded the existing tests.