### PR TITLE
Implement Prism support for splats in `rescue` clauses

### DIFF
--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -2087,7 +2087,9 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             bool hasPredicate = (caseNode->predicate != nullptr);
 
             if (hasPredicate) {
-                predicateLoc = predicate.loc();
+                // Use the Prism node's loc directly (not the desugared expr's loc) so that
+                // e.g. `case (1)` retains the parens-inclusive loc rather than collapsing to `1`.
+                predicateLoc = translateLoc(caseNode->predicate->location);
                 tempName = nextUniqueDesugarName(core::Names::assignTemp());
             } else {
                 tempName = core::NameRef::noName();

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -4881,8 +4881,24 @@ ast::Rescue::RESCUE_CASE_store Desugarer::desugarRescueCases(pm_rescue_node *fir
         // Build exception store from exceptions being rescued
         ast::RescueCase::EXCEPTION_store exceptions;
         auto exceptionsNodes = absl::MakeSpan(rescueNode->exceptions.nodes, rescueNode->exceptions.size);
-        for (auto *ex : exceptionsNodes) {
-            exceptions.emplace_back(desugar(ex));
+
+        bool hasSplat = absl::c_any_of(exceptionsNodes, [](auto *ex) { return isa_node<pm_splat_node>(ex); });
+        if (hasSplat) {
+            // When there's a splat, desugar the entire list as an array with concatenations.
+            // This produces: [A].concat(<splat>(B)).concat([C]) for `rescue A, *B, C`
+            ast::Array::ENTRY_store exceptionElements;
+            exceptionElements.reserve(exceptionsNodes.size());
+            for (auto *ex : exceptionsNodes) {
+                exceptionElements.emplace_back(desugar(ex));
+            }
+            auto exceptionsLoc =
+                translateLoc(exceptionsNodes.front()->location.start, exceptionsNodes.back()->location.end);
+            auto concatenatedExceptions = desugarArray(exceptionsLoc, exceptionsNodes, move(exceptionElements));
+            exceptions.emplace_back(move(concatenatedExceptions));
+        } else {
+            for (auto *ex : exceptionsNodes) {
+                exceptions.emplace_back(desugar(ex));
+            }
         }
 
         // Desugar the rescue body

--- a/test/BUILD
+++ b/test/BUILD
@@ -469,7 +469,6 @@ pipeline_tests(
 
             # Prism desugared tree doesn't match legacy desugared tree (desugar differences)
             "testdata/desugar/destructure_rest.rb",
-            "testdata/desugar/splat.rb",
             "testdata/desugar/star_in_block_arg.rb",
             "testdata/infer/generics/validator.rb",
             "testdata/lsp/fast_path/alias_stub_module__*.rb",


### PR DESCRIPTION
### Motivation

Part of #9065.

Implement support for syntax like `rescue => *array`.

### Test plan

Fixes `//test:test_PrismPosTests/testdata/desugar/splat`
