### PR TITLE
Cut 8 bytes out of LSPFileUpdates::FastPathjfilesToTypecheckResult

### DIFF
--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -77,7 +77,7 @@ public:
 
     struct FastPathFilesToTypecheckResult {
         // The number of files that would be checked in the fast path.
-        size_t totalChanged = 0;
+        uint32_t totalChanged = 0;
 
         // True when we should use the incremental namer, which happens if a symbol name changed and we brought in
         // additional related files to check.


### PR DESCRIPTION
We never needed a full `size_t` here, `uint32_t` is what we store the configuration option as already. Switching to `uint32_t` avoids us needing an additional 8 bytes to fit the boolean between the number of files and the vector.

### Motivation
Meager savings.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavioral changes expected.
