### PR TITLE
Track if an LSPFileUpdates will modify the package DB

### DIFF
--- a/main/lsp/LSPFileUpdates.h
+++ b/main/lsp/LSPFileUpdates.h
@@ -56,6 +56,9 @@ public:
     // (Used in tests) Ensures that a slow path typecheck on these updates waits until it gets cancelled.
     bool cancellationExpected = false;
 
+    // True if this edit modifies the package database by adding, removing, or modifying a __package.rb.
+    bool modifiesPackageDB = false;
+
     /**
      * Merges the given (and older) LSPFileUpdates object into this LSPFileUpdates object.
      *

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -103,7 +103,37 @@ LSPIndexer::getTypecheckingPathInternal(const vector<shared_ptr<core::File>> &ch
         return result;
     }
 
+    if (this->gs->packageDB().enabled()) {
+        // NOTE: it would be really nice to partition `changedFiles` by `hasPackageRbPath`, but we must not change the
+        // order of its elements as there's a parallel vector of FileRefs that it needs to remain consistent with.
+        for (auto &f : changedFiles) {
+            if (!f->hasPackageRbPath()) {
+                continue;
+            }
+
+            // We don't yet have a content hash that works for package files yet. Instead, we check if the package file
+            // source text has changed at all. If it does, we take the slow path.
+            // Only relevant in `--sorbet-packages` mode. This prevents LSP editing features like autocomplete from
+            // working in `__package.rb` since every edit causes a slow path.
+            // Note: We don't use File::isPackage because we have not necessarily set the packager options on initialGS
+            // yet
+            auto fref = gs->findFileByPath(f->path());
+            if (!fref.exists() || f->source() != getOldFile(fref, *gs, evictedFiles).source()) {
+                logger.debug("Taking slow path because {} is a package file", f->path());
+                prodCategoryCounterInc("lsp.slow_path_reason", "package_file");
+                timeit.setTag("path_chosen", "slow");
+                result.modifiesPackageDB = true;
+                return result;
+            }
+        }
+    }
+
     for (auto &f : changedFiles) {
+        // We processed all __package.rb files above
+        if (this->config->opts.cacheSensitiveOptions.sorbetPackages && f->hasPackageRbPath()) {
+            continue;
+        }
+
         auto fref = gs->findFileByPath(f->path());
         if (!fref.exists()) {
             logger.debug("Taking slow path because {} is a new file", f->path());
@@ -113,18 +143,6 @@ LSPIndexer::getTypecheckingPathInternal(const vector<shared_ptr<core::File>> &ch
         }
 
         const auto &oldFile = getOldFile(fref, *gs, evictedFiles);
-        // We don't yet have a content hash that works for package files yet. Instead, we check if the package file
-        // source text has changed at all. If it does, we take the slow path.
-        // Only relevant in `--sorbet-packages` mode. This prevents LSP editing features like autocomplete from
-        // working in `__package.rb` since every edit causes a slow path.
-        // Note: We don't use File::isPackage because we have not necessarily set the packager options on initialGS yet
-        if (this->config->opts.cacheSensitiveOptions.sorbetPackages && oldFile.hasPackageRbPath() &&
-            oldFile.source() != f->source()) {
-            logger.debug("Taking slow path because {} is a package file", f->path());
-            prodCategoryCounterInc("lsp.slow_path_reason", "package_file");
-            timeit.setTag("path_chosen", "slow");
-            return result;
-        }
         ENFORCE(oldFile.getFileHash() != nullptr);
         ENFORCE(f->getFileHash() != nullptr);
         const auto &oldHash = *oldFile.getFileHash();
@@ -237,19 +255,22 @@ LSPIndexer::getTypecheckingPath(LSPFileUpdates &edit,
         return TypecheckingPath::Slow;
     }
 
-    auto [path, result] = getTypecheckingPathInternal(edit.updatedFiles, evictedFiles);
-    switch (path) {
+    auto result = getTypecheckingPathInternal(edit.updatedFiles, evictedFiles);
+    switch (result.path) {
         case TypecheckingPath::Fast: {
-            edit.fastPathUseIncrementalNamer = result.useIncrementalNamer;
-            edit.fastPathExtraFiles = std::move(result.extraFiles);
+            ENFORCE(!result.modifiesPackageDB);
+            edit.fastPathUseIncrementalNamer = result.files.useIncrementalNamer;
+            edit.fastPathExtraFiles = std::move(result.files.extraFiles);
             break;
         }
 
-        case TypecheckingPath::Slow:
+        case TypecheckingPath::Slow: {
+            edit.modifiesPackageDB = result.modifiesPackageDB;
             break;
+        }
     }
 
-    return path;
+    return result.path;
 }
 
 TypecheckingPath LSPIndexer::getTypecheckingPath(const vector<shared_ptr<core::File>> &changedFiles) const {
@@ -267,8 +288,8 @@ TypecheckingPath LSPIndexer::getTypecheckingPath(const vector<shared_ptr<core::F
     // Ensure all files have computed hashes.
     computeFileHashes(changedFiles);
 
-    auto [path, result] = getTypecheckingPathInternal(changedFiles, emptyMap);
-    return path;
+    auto result = getTypecheckingPathInternal(changedFiles, emptyMap);
+    return result.path;
 }
 
 void LSPIndexer::transferInitializeState(InitializedTask &task) {

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -56,6 +56,7 @@ class LSPIndexer final {
 
     struct TypecheckingPathResult {
         TypecheckingPath path = TypecheckingPath::Slow;
+        bool modifiesPackageDB = false;
         LSPFileUpdates::FastPathFilesToTypecheckResult files;
     };
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This PR restructures `LSPIndexer::getTypecheckingPathInternal` to process all `__package.rb` files first, so that it's possible to determine if an edit will modify the package graph in any significant way.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Prework for restarting the slow path in the middle of the package graph.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Refactoring only, no changes expected.
