### PR TITLE
pass format string + args to `Exception::raise` directly

### DIFF
--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -1154,8 +1154,7 @@ ast::ExpressionPtr Desugarer::translateOpAssignment(PrismAssignmentNode *node, c
         return lhs;
     }
 
-    auto s = fmt::format("the LHS has been desugared to something we haven't expected: {}", lhs.toString(ctx));
-    Exception::raise(s);
+    Exception::raise("the LHS has been desugared to something we haven't expected: {}", lhs.toString(ctx));
 }
 
 // Desugar &&= or ||= for a simple reference LHS (local, instance, class, global variable).


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Trying to poke at #8466 again revealed that we need this to compile, since `fmt` is a bit stricter about non-constant format strings when C++20 is enabled.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
