### PR TITLE
don't build temporary strings for autocorrect titles

### DIFF
--- a/core/AutocorrectSuggestion.h
+++ b/core/AutocorrectSuggestion.h
@@ -20,7 +20,8 @@ struct AutocorrectSuggestion {
 
     bool hideEdit;
 
-    AutocorrectSuggestion(std::string title, std::vector<Edit> edits, bool isDidYouMean = false, bool hideEdit = false)
+    AutocorrectSuggestion(std::string_view title, std::vector<Edit> edits, bool isDidYouMean = false,
+                          bool hideEdit = false)
         : title(title), edits(edits), isDidYouMean(isDidYouMean), hideEdit(hideEdit) {}
 
     // Reads all the files to be edited, and then accumulates all the edits that need to be applied

--- a/core/Error.h
+++ b/core/Error.h
@@ -194,7 +194,7 @@ public:
     void addAutocorrect(AutocorrectSuggestion &&autocorrect);
     void maybeAddAutocorrect(std::optional<AutocorrectSuggestion> &&autocorrect);
     template <typename... Args>
-    void replaceWith(const std::string &title, Loc loc, fmt::format_string<Args...> replacement, Args &&...args) {
+    void replaceWith(std::string_view title, Loc loc, fmt::format_string<Args...> replacement, Args &&...args) {
         std::string formatted = fmt::format(replacement, std::forward<Args>(args)...);
         addAutocorrect(AutocorrectSuggestion{title, {AutocorrectSuggestion::Edit{loc, std::move(formatted)}}});
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This commit is cherry-picked from #8466 and is required to make that PR work, but has no behavioral changes under C++17.

The reason it's necessary is a bunch of C++ and compiler nonsense.  With C++20 enabled prior to this PR, we were getting ASan errors everywhere that looked like:

```
[2026-05-20T14:07:21Z] ==466195==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7fb35d86e8a0 at pc 0x5638938e0e77 bp 0x7ffc4f8ebed0 sp 0x7ffc4f8ebec8
[2026-05-20T14:07:21Z] READ of size 1 at 0x7fb35d86e8a0 thread T0
[2026-05-20T14:07:21Z]     #0 0x5638938e0e76 in sorbet::parser::(anonymous namespace)::reportDiagnostics(sorbet::core::GlobalState&, sorbet::core::FileRef, std::__1::vector<ruby_parser::diagnostic, std::__1::allocator<ruby_parser::diagnostic>>, bool) Parser.cc
[2026-05-20T14:07:21Z]     #1 0x5638938deb36 in sorbet::parser::Parser::run(sorbet::core::GlobalState&, sorbet::core::FileRef, sorbet::parser::Parser::Settings, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>) (/usr/local/var/bazelcache/output-bases/test-static-sanitized/execroot/com_stripe_ruby_typer/bazel-out/k8-dbg/bin/test/lsp_test_runner+0x4115b36) (BuildId: 5764eb81f12c25f4034e832bbecb8db9)
[2026-05-20T14:07:21Z]     #2 0x563892fa8895 in sorbet::realmain::pipeline::(anonymous namespace)::runParser(sorbet::core::GlobalState&, sorbet::core::FileRef, sorbet::realmain::options::Printers const&, bool, bool) pipeline.cc
[...rest of the stack elided...]
[2026-05-20T14:07:21Z]
[2026-05-20T14:07:21Z] Address 0x7fb35d86e8a0 is located in stack of thread T0 at offset 160 in frame
[2026-05-20T14:07:21Z]     #0 0x5638938e00b6 in sorbet::parser::(anonymous namespace)::reportDiagnostics(sorbet::core::GlobalState&, sorbet::core::FileRef, std::__1::vector<ruby_parser::diagnostic, std::__1::allocator<ruby_parser::diagnostic>>, bool) Parser.cc
[2026-05-20T14:07:21Z]
[2026-05-20T14:07:21Z]   This frame has 14 object(s):
[2026-05-20T14:07:21Z]     [32, 48) '__sv.i.i'
[2026-05-20T14:07:21Z]     [64, 76) 'loc.i'
[2026-05-20T14:07:21Z]     [96, 120) 'ref.tmp.i'
[2026-05-20T14:07:21Z]     [160, 184) 'ref.tmp11.i' <== Memory access at offset 160 is inside this variable
[2026-05-20T14:07:21Z]     [224, 248) 'source.i'
[2026-05-20T14:07:21Z]     [288, 312) 'replacement.i'
[2026-05-20T14:07:21Z]     [352, 376) 'ref.tmp64.i'
[2026-05-20T14:07:21Z]     [416, 424) '__begin2'
[2026-05-20T14:07:21Z]     [448, 456) '__end2'
[2026-05-20T14:07:21Z]     [480, 484) 'errorClass'
[2026-05-20T14:07:21Z]     [496, 600) 'e'
[2026-05-20T14:07:21Z]     [640, 664) 'ref.tmp'
[2026-05-20T14:07:21Z]     [704, 720) 'ref.tmp66'
[2026-05-20T14:07:21Z]     [736, 808) 'agg.tmp94'
[2026-05-20T14:07:21Z] HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
[2026-05-20T14:07:21Z]       (longjmp and C++ exceptions *are* supported)
[2026-05-20T14:07:21Z] SUMMARY: AddressSanitizer: stack-use-after-scope Parser.cc in sorbet::parser::(anonymous namespace)::reportDiagnostics(sorbet::core::GlobalState&, sorbet::core::FileRef, std::__1::vector<ruby_parser::diagnostic, std::__1::allocator<ruby_parser::diagnostic>>, bool)
[2026-05-20T14:07:21Z] Shadow bytes around the buggy address:
[2026-05-20T14:07:21Z]   0x0ff6ebb05cc0: 00 00 00 f2 f2 f2 f2 f2 f8 f8 f8 f8 f8 f8 f8 f8
[2026-05-20T14:07:21Z]   0x0ff6ebb05cd0: f8 f8 f2 f2 f2 f2 f8 f2 f2 f2 f8 f2 f2 f2 f8 f2
[2026-05-20T14:07:21Z]   0x0ff6ebb05ce0: f2 f2 f8 f2 f2 f2 f8 f8 f8 f8 f8 f2 f2 f2 f2 f2
[2026-05-20T14:07:21Z]   0x0ff6ebb05cf0: 00 00 f2 f2 00 00 00 f3 f3 f3 f3 f3 00 00 00 00
[2026-05-20T14:07:21Z]   0x0ff6ebb05d00: f1 f1 f1 f1 f8 f8 f2 f2 00 04 f2 f2 f8 f8 f8 f2
[2026-05-20T14:07:21Z] =>0x0ff6ebb05d10: f2 f2 f2 f2[f8]f8 f8 f2 f2 f2 f2 f2 f8 f8 f8 f2
[2026-05-20T14:07:21Z]   0x0ff6ebb05d20: f2 f2 f2 f2 f8 f8 f8 f2 f2 f2 f2 f2 f8 f8 f8 f2
[2026-05-20T14:07:21Z]   0x0ff6ebb05d30: f2 f2 f2 f2 00 f2 f2 f2 00 f2 f2 f2 04 f2 00 00
[2026-05-20T14:07:21Z]   0x0ff6ebb05d40: 00 00 00 00 00 00 00 00 00 00 00 f2 f2 f2 f2 f2
[2026-05-20T14:07:21Z]   0x0ff6ebb05d50: f8 f8 f8 f2 f2 f2 f2 f2 f8 f8 f2 f2 00 00 00 00
[2026-05-20T14:07:21Z]   0x0ff6ebb05d60: 00 00 00 00 00 f3 f3 f3 f3 f3 f3 f3 00 00 00 00
[2026-05-20T14:07:21Z] Shadow byte legend (one shadow byte represents 8 application bytes):
[2026-05-20T14:07:21Z]   Addressable:           00
[2026-05-20T14:07:21Z]   Partially addressable: 01 02 03 04 05 06 07
[2026-05-20T14:07:21Z]   Heap left redzone:       fa
[2026-05-20T14:07:21Z]   Freed heap region:       fd
[2026-05-20T14:07:21Z]   Stack left redzone:      f1
[2026-05-20T14:07:21Z]   Stack mid redzone:       f2
[2026-05-20T14:07:21Z]   Stack right redzone:     f3
[2026-05-20T14:07:21Z]   Stack after return:      f5
[2026-05-20T14:07:21Z]   Stack use after scope:   f8
[2026-05-20T14:07:21Z]   Global redzone:          f9
[2026-05-20T14:07:21Z]   Global init order:       f6
[2026-05-20T14:07:21Z]   Poisoned by user:        f7
[2026-05-20T14:07:21Z]   Container overflow:      fc
[2026-05-20T14:07:21Z]   Array cookie:            ac
[2026-05-20T14:07:21Z]   Intra object redzone:    bb
[2026-05-20T14:07:21Z]   ASan internal:           fe
[2026-05-20T14:07:21Z]   Left alloca redzone:     ca
[2026-05-20T14:07:21Z]   Right alloca redzone:    cb
[2026-05-20T14:07:21Z] ==466195==ABORTING
```

But if you look at the function that's causing the error, there is nothing obviously wrong:

https://github.com/sorbet/sorbet/blob/2e6be14eb5ab1ac79d645636d7da368889ebe308/parser/Parser.cc#L82-L103

e.g. there's basically nothing being destructed?  What is going wrong?

It turns out if you look at the assembly, what's happening here is partially explained by `explainError` getting inlined -- `explainError` is a single-use function in this file, lives in an anonymous namespace, and doesn't escape outside this file, so a great candidate for inlining.  That function is a little more interesting:

https://github.com/sorbet/sorbet/blob/2e6be14eb5ab1ac79d645636d7da368889ebe308/parser/Parser.cc#L49-L80

OK, so we have some `replaceWith` calls happening:

https://github.com/sorbet/sorbet/blob/2e6be14eb5ab1ac79d645636d7da368889ebe308/core/Error.h#L196-L200

and those calls take a `const std::string &` for `title`, so we obviously have to construct a `std::string` object from the string literals getting passed in each branch.

But again, those temporary string objects should only live as long as the end of the statement in which they're used...they're copied everywhere that matters, e.g. passing `title` to `Autocorrect` suggestion copies the string:

https://github.com/sorbet/sorbet/blob/2e6be14eb5ab1ac79d645636d7da368889ebe308/core/AutocorrectSuggestion.h#L23-L24

If they _weren't_ copied and we held actual references somewhere, presumably we would be seeing ASan errors already.  But we're not holding actual references somewhere, so what's going on?

In C++20 and with `-Os`, which is our CI configuration:

https://github.com/sorbet/sorbet/blob/2e6be14eb5ab1ac79d645636d7da368889ebe308/.bazelrc#L197

it looks like clang will actually sink the destructors for the string temporaries generated by the `replaceWith` calls in the `IfInsteadOfItForTest`, `MissingCommanBetweenKwargs`, and `CurlyBracesAroundBlocks` into the common block after the `switch`.  This is done for codesize reasons; no sense in calling a destructor three times when you can just call it once!

The problem is that common block doesn't guard the destructor call with "has the temporary been initialized?"  This is actually not a bad thing without ASan enabled, because the compiler is able to see enough of the code to realize that the destructor has no visible effects and what's left of the destructor after inlining is harmless.  I _think_ this is because `~basic_string` is `constexpr` in C++20: https://github.com/llvm/llvm-project/blob/4b93c1be7ea580ca0b92cc1b266060c6f691981f/libcxx/include/string#L1165  Since we're passing constant strings to the constructor, clang can make various bits of things go away, e.g. magic like https://github.com/llvm/llvm-project/blob/4b93c1be7ea580ca0b92cc1b266060c6f691981f/libcxx/include/string#L2082-L2087

But this is _not_ OK with ASan enabled: the function prologue will poison the memory for the temporary before the `switch`.  (For reasons I do not completely understand, there _is_ valid stuff stored there, so the memory is initialized, but the temporary has no lifetime prior to the `switch`, so ASan considers it poisoned.)  The `case` branches all unpoison the memory and then re-poison the memory, and then in the merged block for the shared destructor, ASan will insert "is this memory poisoned" prior to the actual, previously harmless read.  And that leads to the cryptic-looking error message above.

This does feel like a compiler bug, but searching around the internet doesn't turn up anything that suggests this has been addressed.  https://github.com/llvm/llvm-project/issues/60249 is...kind of the same thing, but with constructors instead of destructors.  I think we are possibly unusual in compiling with ASan and with `-Os`, rather than `-O2` (I don't remember what Firefox did when you were building with ASan; Firefox compiles with `-Os` normally, but it's entirely possible that the settings for ASan are a bit different, because you're willing to try and get a little more speed out of ASan builds for fuzzing purposes.): the destructor sinking might not happen at `-O2`?

Ideally the above should explain _why_ this PR fixes the problem: using `string_view` in `replaceWith` and all the way down the call stack as far as possible means that we're not constructing any temporaries with non-trivial destructors.  So even if there's destructor sinking happening, there's no code to run anyway.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
