### PR TITLE
When computing the `fileToStratum` mapping in `--test-packages` mode, always use `applicationStratum`

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -904,7 +904,7 @@ PackageStrata computePackageStrata(const core::GlobalState &gs, vector<ast::Pars
             ENFORCE(stratumMapping.find(pkgName) != stratumMapping.end(),
                     "All packages must be present in the condensation graph");
             auto &info = stratumMapping[pkgName];
-            if (file->isPackagedTest() || file->isPackagedTestHelper()) {
+            if (!db.testPackages() && (file->isPackagedTest() || file->isPackagedTestHelper())) {
                 ENFORCE(info.testStratum < USHRT_MAX);
                 result.fileToStratum[ix] = core::packages::Stratum(info.testStratum);
             } else {

--- a/test/cli/test-packages-package-directed/app/__package.rb
+++ b/test/cli/test-packages-package-directed/app/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+class App < PackageSpec
+  import Base
+  export App::MyClass
+end

--- a/test/cli/test-packages-package-directed/app/my_class.rb
+++ b/test/cli/test-packages-package-directed/app/my_class.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+module App
+  class MyClass
+  end
+end

--- a/test/cli/test-packages-package-directed/app/test/__package.rb
+++ b/test/cli/test-packages-package-directed/app/test/__package.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+class Test::App < PackageSpec
+  test!
+
+  import App
+end

--- a/test/cli/test-packages-package-directed/app/test/app_test.rb
+++ b/test/cli/test-packages-package-directed/app/test/app_test.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module Test::App
+  puts App::MyClass
+end

--- a/test/cli/test-packages-package-directed/base/__package.rb
+++ b/test/cli/test-packages-package-directed/base/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Base < PackageSpec
+  export Base::Util
+end

--- a/test/cli/test-packages-package-directed/base/util.rb
+++ b/test/cli/test-packages-package-directed/base/util.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+module Base
+  class Util
+  end
+end

--- a/test/cli/test-packages-package-directed/test.out
+++ b/test/cli/test-packages-package-directed/test.out
@@ -1,11 +1,1 @@
-app/test/app_test.rb:4: Unable to resolve constant `App` https://srb.help/5002
-     4 |  puts App::MyClass
-               ^^^
-  Did you mean `Test::App`? Use `-a` to autocorrect
-    app/test/app_test.rb:4: Replace with `Test::App`
-     4 |  puts App::MyClass
-               ^^^
-    app/test/app_test.rb:3: `Test::App` defined here
-     3 |module Test::App
-        ^^^^^^^^^^^^^^^^
-Errors: 1
+No errors! Great job.

--- a/test/cli/test-packages-package-directed/test.out
+++ b/test/cli/test-packages-package-directed/test.out
@@ -1,0 +1,11 @@
+app/test/app_test.rb:4: Unable to resolve constant `App` https://srb.help/5002
+     4 |  puts App::MyClass
+               ^^^
+  Did you mean `Test::App`? Use `-a` to autocorrect
+    app/test/app_test.rb:4: Replace with `Test::App`
+     4 |  puts App::MyClass
+               ^^^
+    app/test/app_test.rb:3: `Test::App` defined here
+     3 |module Test::App
+        ^^^^^^^^^^^^^^^^
+Errors: 1

--- a/test/cli/test-packages-package-directed/test.sh
+++ b/test/cli/test-packages-package-directed/test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+root="$PWD"
+
+cd test/cli/test-packages-package-directed || ( echo "Failed to cd!"; exit 1 )
+
+"$root/main/sorbet" \
+  --censor-for-snapshot-tests --silence-dev-message --max-threads=0 \
+  --sorbet-packages --experimental-test-packages --experimental-package-directed . 2>&1


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Explanation of bug: In `--test-packages` mode, all SCCs are considered as "regular"/non-test SCCs, so the `testStratum` field was be unset. However, when assigning the file its stratum, we would treat it as a test SCC because of the file name, and assign it the unset stratum value of 0 (which also happens to be the first stratum). This means that the `Test::App` package would be in an earlier stratum from `App`, even though `Test::App` imports `App`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
