### PR TITLE
gen-packages mode: Don't add an `export` for a constant if it comes from a package that was imported with ` uses_internals`

### DIFF
--- a/packager/GenPackages.cc
+++ b/packager/GenPackages.cc
@@ -45,6 +45,15 @@ void exportClassOrModule(const core::GlobalState &gs,
             continue;
         }
 
+        if (packageForF.exists()) {
+            auto &referencingPkgInfo = gs.packageDB().getPackageInfo(packageForF);
+            auto *imp = referencingPkgInfo.importsPackage(owningPackage);
+            if (imp != nullptr && imp->usesInternals) {
+                ENFORCE(gs.packageDB().testPackages());
+                continue;
+            }
+        }
+
         if (ownerWillBeExported(gs, toExport[owningPackage], data->owner)) {
             // No need to check the rest of referencingFiles, we're already going to export the owner
             break;
@@ -68,6 +77,15 @@ void exportField(const core::GlobalState &gs,
         auto packageForF = gs.packageDB().getPackageNameForFile(f);
         if (packageForF == owningPackage || gs.packageDB().allowRelaxedPackagerChecksFor(packageForF)) {
             continue;
+        }
+
+        if (packageForF.exists()) {
+            auto &referencingPkgInfo = gs.packageDB().getPackageInfo(packageForF);
+            auto *imp = referencingPkgInfo.importsPackage(owningPackage);
+            if (imp != nullptr && imp->usesInternals) {
+                ENFORCE(gs.packageDB().testPackages());
+                continue;
+            }
         }
 
         if (ownerWillBeExported(gs, toExport[owningPackage], data->owner)) {

--- a/test/cli/package-gen-packages-test-packages/D/constants.rb
+++ b/test/cli/package-gen-packages-test-packages/D/constants.rb
@@ -15,4 +15,7 @@ module D
       OtherVariant = new
     end
   end
+
+  class ShouldNotBeExported
+  end
 end

--- a/test/cli/package-gen-packages-test-packages/D/test/test_constants.rb
+++ b/test/cli/package-gen-packages-test-packages/D/test/test_constants.rb
@@ -2,4 +2,5 @@
 
 module Test::D
   puts E::CONSTANT_FROM_E
+  puts D::ShouldNotBeExported
 end

--- a/test/cli/package-gen-packages-test-packages/test.out
+++ b/test/cli/package-gen-packages-test-packages/test.out
@@ -80,8 +80,7 @@ D/__package.rb:3: `D` is missing exports https://srb.help/3734
   Autocorrect: Done
     D/__package.rb:8: Inserted `export D::CONSTANT_FROM_D
       export D::ClassFromD
-      export D::EnumFromD
-      export D::ShouldNotBeExported`
+      export D::EnumFromD`
      8 |  export D::AlreadyExportedClass
                                         ^
 
@@ -145,7 +144,6 @@ class D < PackageSpec
   export D::CONSTANT_FROM_D
   export D::ClassFromD
   export D::EnumFromD
-  export D::ShouldNotBeExported
 end
 
 ###### cat E/__package.rb ######
@@ -235,8 +233,7 @@ D/__package.rb:3: `D` is missing exports https://srb.help/3734
   Autocorrect: Done
     D/__package.rb:8: Inserted `export D::CONSTANT_FROM_D
       export D::ClassFromD
-      export D::EnumFromD
-      export D::ShouldNotBeExported`
+      export D::EnumFromD`
      8 |  export D::AlreadyExportedClass
                                         ^
 
@@ -313,7 +310,6 @@ class D < PackageSpec
   export D::CONSTANT_FROM_D
   export D::ClassFromD
   export D::EnumFromD
-  export D::ShouldNotBeExported
 end
 
 ###### cat E/__package.rb ######

--- a/test/cli/package-gen-packages-test-packages/test.out
+++ b/test/cli/package-gen-packages-test-packages/test.out
@@ -80,7 +80,8 @@ D/__package.rb:3: `D` is missing exports https://srb.help/3734
   Autocorrect: Done
     D/__package.rb:8: Inserted `export D::CONSTANT_FROM_D
       export D::ClassFromD
-      export D::EnumFromD`
+      export D::EnumFromD
+      export D::ShouldNotBeExported`
      8 |  export D::AlreadyExportedClass
                                         ^
 
@@ -144,6 +145,7 @@ class D < PackageSpec
   export D::CONSTANT_FROM_D
   export D::ClassFromD
   export D::EnumFromD
+  export D::ShouldNotBeExported
 end
 
 ###### cat E/__package.rb ######
@@ -233,7 +235,8 @@ D/__package.rb:3: `D` is missing exports https://srb.help/3734
   Autocorrect: Done
     D/__package.rb:8: Inserted `export D::CONSTANT_FROM_D
       export D::ClassFromD
-      export D::EnumFromD`
+      export D::EnumFromD
+      export D::ShouldNotBeExported`
      8 |  export D::AlreadyExportedClass
                                         ^
 
@@ -310,6 +313,7 @@ class D < PackageSpec
   export D::CONSTANT_FROM_D
   export D::ClassFromD
   export D::EnumFromD
+  export D::ShouldNotBeExported
 end
 
 ###### cat E/__package.rb ######

--- a/test/cli/package-gen-packages/D/constants.rb
+++ b/test/cli/package-gen-packages/D/constants.rb
@@ -15,4 +15,7 @@ module D
       OtherVariant = new
     end
   end
+
+  class ShouldNotBeExported
+  end
 end

--- a/test/cli/package-gen-packages/D/test/test_constants.rb
+++ b/test/cli/package-gen-packages/D/test/test_constants.rb
@@ -2,4 +2,5 @@
 
 module Test::D
   puts E::CONSTANT_FROM_E
+  puts D::ShouldNotBeExported
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The importing package is allowed to used unexported constants if the target package is imported with `uses_internals`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
