### PR TITLE
PackageDB::deepCopy should copy fileToPackage_ as well

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -208,6 +208,9 @@ PackageDB PackageDB::deepCopy() const {
     // This assumes that the GlobalState this PackageDB is getting copied into also has these
     // interned mangledName NameRefs at the same IDs as the current PackageDB.
     result.mangledNames = this->mangledNames;
+    // Likewise, this assumes that the GlobalState this PackageDB is getting copied into also has
+    // the same set of files available.
+    result.packageForFile_ = this->packageForFile_;
 
     // --- options ---
     result.enabled_ = this->enabled_;


### PR DESCRIPTION
`PackageDB::deepCopy` was missing `packageForFile_`.

### Motivation
Prework for copying a prefix of the symbol table.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

We don't have any tests for `PackageDB` copying.
