### PR TITLE
gen-packages mode: Don't add an `export` for a constant if it comes from a package that was imported with ` uses_internals`

### DIFF
--- a/packager/GenPackages.cc
+++ b/packager/GenPackages.cc
@@ -45,6 +45,15 @@ void exportClassOrModule(const core::GlobalState &gs,
             continue;
         }
 
+        if (packageForF.exists()) {
+            auto &referencingPkgInfo = gs.packageDB().getPackageInfo(packageForF);
+            auto *imp = referencingPkgInfo.importsPackage(owningPackage);
+            if (imp != nullptr && imp->usesInternals) {
+                ENFORCE(gs.packageDB().testPackages());
+                continue;
+            }
+        }
+
         if (ownerWillBeExported(gs, toExport[owningPackage], data->owner)) {
             // No need to check the rest of referencingFiles, we're already going to export the owner
             break;
@@ -68,6 +77,15 @@ void exportField(const core::GlobalState &gs,
         auto packageForF = gs.packageDB().getPackageNameForFile(f);
         if (packageForF == owningPackage || gs.packageDB().allowRelaxedPackagerChecksFor(packageForF)) {
             continue;
+        }
+
+        if (packageForF.exists()) {
+            auto &referencingPkgInfo = gs.packageDB().getPackageInfo(packageForF);
+            auto *imp = referencingPkgInfo.importsPackage(owningPackage);
+            if (imp != nullptr && imp->usesInternals) {
+                ENFORCE(gs.packageDB().testPackages());
+                continue;
+            }
         }
 
         if (ownerWillBeExported(gs, toExport[owningPackage], data->owner)) {

--- a/test/cli/package-gen-packages-test-packages/D/constants.rb
+++ b/test/cli/package-gen-packages-test-packages/D/constants.rb
@@ -15,4 +15,7 @@ module D
       OtherVariant = new
     end
   end
+
+  class ShouldNotBeExported
+  end
 end

--- a/test/cli/package-gen-packages-test-packages/D/test/test_constants.rb
+++ b/test/cli/package-gen-packages-test-packages/D/test/test_constants.rb
@@ -2,4 +2,5 @@
 
 module Test::D
   puts E::CONSTANT_FROM_E
+  puts D::ShouldNotBeExported
 end

--- a/test/cli/package-gen-packages-test-packages/test.out
+++ b/test/cli/package-gen-packages-test-packages/test.out
@@ -90,6 +90,9 @@ D/__package.rb:3: `D` is missing exports https://srb.help/3734
       export D::EnumFromD`
      9 |  export D::ANestedPackage::Foo
                                        ^
+    D/__package.rb:10: Inserted `export D::ShouldNotBeExported`
+    10 |  export D::EnumFromD::Variant
+                                      ^
 
 D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://srb.help/3734
      3 |class D::ANestedPackage < PackageSpec
@@ -160,6 +163,7 @@ class D < PackageSpec
   export D::CONSTANT_FROM_D
   export D::ClassFromD
   export D::EnumFromD
+  export D::ShouldNotBeExported
 end
 
 ###### cat D/ANestedPackage/__package.rb ######
@@ -268,6 +272,9 @@ D/__package.rb:3: `D` is missing exports https://srb.help/3734
       export D::EnumFromD`
      9 |  export D::ANestedPackage::Foo
                                        ^
+    D/__package.rb:10: Inserted `export D::ShouldNotBeExported`
+    10 |  export D::EnumFromD::Variant
+                                      ^
 
 D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://srb.help/3734
      3 |class D::ANestedPackage < PackageSpec
@@ -351,6 +358,7 @@ class D < PackageSpec
   export D::CONSTANT_FROM_D
   export D::ClassFromD
   export D::EnumFromD
+  export D::ShouldNotBeExported
 end
 
 ###### cat D/ANestedPackage/__package.rb ######

--- a/test/cli/package-gen-packages-test-packages/test.out
+++ b/test/cli/package-gen-packages-test-packages/test.out
@@ -90,9 +90,6 @@ D/__package.rb:3: `D` is missing exports https://srb.help/3734
       export D::EnumFromD`
      9 |  export D::ANestedPackage::Foo
                                        ^
-    D/__package.rb:10: Inserted `export D::ShouldNotBeExported`
-    10 |  export D::EnumFromD::Variant
-                                      ^
 
 D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://srb.help/3734
      3 |class D::ANestedPackage < PackageSpec
@@ -163,7 +160,6 @@ class D < PackageSpec
   export D::CONSTANT_FROM_D
   export D::ClassFromD
   export D::EnumFromD
-  export D::ShouldNotBeExported
 end
 
 ###### cat D/ANestedPackage/__package.rb ######
@@ -272,9 +268,6 @@ D/__package.rb:3: `D` is missing exports https://srb.help/3734
       export D::EnumFromD`
      9 |  export D::ANestedPackage::Foo
                                        ^
-    D/__package.rb:10: Inserted `export D::ShouldNotBeExported`
-    10 |  export D::EnumFromD::Variant
-                                      ^
 
 D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://srb.help/3734
      3 |class D::ANestedPackage < PackageSpec
@@ -358,7 +351,6 @@ class D < PackageSpec
   export D::CONSTANT_FROM_D
   export D::ClassFromD
   export D::EnumFromD
-  export D::ShouldNotBeExported
 end
 
 ###### cat D/ANestedPackage/__package.rb ######

--- a/test/cli/package-gen-packages/D/constants.rb
+++ b/test/cli/package-gen-packages/D/constants.rb
@@ -15,4 +15,7 @@ module D
       OtherVariant = new
     end
   end
+
+  class ShouldNotBeExported
+  end
 end

--- a/test/cli/package-gen-packages/D/test/test_constants.rb
+++ b/test/cli/package-gen-packages/D/test/test_constants.rb
@@ -2,4 +2,5 @@
 
 module Test::D
   puts E::CONSTANT_FROM_E
+  puts D::ShouldNotBeExported
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

(same as #10293, I merged the stacked PR in the wrong order so it ended up in the wrong merge base)

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The importing package is allowed to used unexported constants if the target package is imported with `uses_internals`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
