### PR TITLE
Allow searching for a package path in a File

### DIFF
--- a/core/packages/PackageDB.cc
+++ b/core/packages/PackageDB.cc
@@ -88,6 +88,10 @@ MangledName PackageDB::findPackageByPath(const core::GlobalState &gs, core::File
     // See https://github.com/sorbet/sorbet/pull/5291 for more information.
     auto &fileData = file.dataAllowingUnsafe(gs);
 
+    return this->findPackageByPath(gs, fileData);
+}
+
+MangledName PackageDB::findPackageByPath(const core::GlobalState &gs, const core::File &fileData) const {
     string_view path = fileData.path();
     int curPrefixPos = path.find_last_of('/');
     while (curPrefixPos > 0) {

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -43,6 +43,8 @@ public:
     void setPackageNameForFile(FileRef file, MangledName mangledName);
 
     MangledName findPackageByPath(const core::GlobalState &gs, core::FileRef file) const;
+    MangledName findPackageByPath(const core::GlobalState &gs, const core::File &fileData) const;
+
     const PackageInfo &getPackageInfo(MangledName mangledName) const;
     PackageInfo *getPackageInfoNonConst(MangledName mangledName);
 


### PR DESCRIPTION
When looking up package files for new `File` values that come from an edit in lsp, it's convenient to allow package lookups without a `FileRef`.

### Motivation
Prework for faster slow path restarts.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Refactoring only.
