### PR TITLE
In gen-package mode, treat `typed: ignore` files as `typed: false`

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -195,6 +195,13 @@ core::StrictLevel decideStrictLevel(const core::GlobalState &gs, const core::Fil
         level = core::StrictLevel::False;
     }
 
+    if (gs.packageDB().genPackagesMode() != core::packages::GenPackagesMode::Disabled &&
+        level < core::StrictLevel::False) {
+        // In gen-packages mode, we want to ensure we see all definitions and references, even if they're in
+        // # typed: ignore files, so that we can generate accurate __package.rb files
+        level = core::StrictLevel::False;
+    }
+
     return level;
 }
 

--- a/test/cli/package-gen-packages-test-packages/PackageWithIgnore/__package.rb
+++ b/test/cli/package-gen-packages-test-packages/PackageWithIgnore/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+class PackageWithIgnore < PackageSpec
+  strict_dependencies 'false'
+  layer 'util'
+end

--- a/test/cli/package-gen-packages-test-packages/PackageWithIgnore/ignore_file.rb
+++ b/test/cli/package-gen-packages-test-packages/PackageWithIgnore/ignore_file.rb
@@ -1,0 +1,5 @@
+# typed: ignore
+
+module PackageWithIgnore
+  puts F::CONSTANT_FROM_F
+end

--- a/test/cli/package-gen-packages-test-packages/test.out
+++ b/test/cli/package-gen-packages-test-packages/test.out
@@ -32,15 +32,6 @@ B/__package.rb:3: `B` is missing `visible_to`s https://srb.help/3734
      9 |  visible_to A
                       ^
 
-E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
-     3 |class E < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    E/__package.rb:7: Inserted `visible_to 'tests'
-      visible_to C`
-     7 |  export E::CONSTANT_FROM_E
-                                   ^
-
 C/__package.rb:7: Layering violation: cannot import `A` (in layer `app`) from `C` (in layer `util`) https://srb.help/3726
      7 |  import A
           ^^^^^^^^
@@ -67,6 +58,15 @@ C/__package.rb:3: `C` is missing imports https://srb.help/3734
      9 |  import D
                   ^
 
+E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
+     3 |class E < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    E/__package.rb:7: Inserted `visible_to 'tests'
+      visible_to C`
+     7 |  export E::CONSTANT_FROM_E
+                                   ^
+
 D/test/__package.rb:3: `Test::D` is missing imports https://srb.help/3734
      3 |class Test::D < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -74,6 +74,14 @@ D/test/__package.rb:3: `Test::D` is missing imports https://srb.help/3734
     D/test/__package.rb:9: Inserted `import E`
      9 |  import D, uses_internals: true
                                         ^
+
+D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://srb.help/3734
+     3 |class D::ANestedPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    D/ANestedPackage/__package.rb:5: Inserted `export D::ANestedPackage::Foo`
+     5 |  layer 'util'
+                      ^
 
 D/__package.rb:3: `D` is missing exports https://srb.help/3734
      3 |class D < PackageSpec
@@ -90,14 +98,6 @@ D/__package.rb:3: `D` is missing exports https://srb.help/3734
       export D::EnumFromD`
      9 |  export D::ANestedPackage::Foo
                                        ^
-
-D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://srb.help/3734
-     3 |class D::ANestedPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    D/ANestedPackage/__package.rb:5: Inserted `export D::ANestedPackage::Foo`
-     5 |  layer 'util'
-                      ^
 
 C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
      8 |      puts F::CONSTANT_FROM_F
@@ -196,6 +196,13 @@ class Test::D < PackageSpec
   import E
 end
 
+###### cat PackageWithIgnore/__package.rb ######
+# typed: strict
+
+class PackageWithIgnore < PackageSpec
+  strict_dependencies 'false'
+  layer 'util'
+end
 ##############################
 ###### Package directed ######
 ##############################
@@ -209,15 +216,6 @@ B/__package.rb:3: `B` is missing `visible_to`s https://srb.help/3734
       visible_to D`
      9 |  visible_to A
                       ^
-
-E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
-     3 |class E < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    E/__package.rb:7: Inserted `visible_to 'tests'
-      visible_to C`
-     7 |  export E::CONSTANT_FROM_E
-                                   ^
 
 C/__package.rb:7: Layering violation: cannot import `A` (in layer `app`) from `C` (in layer `util`) https://srb.help/3726
      7 |  import A
@@ -245,6 +243,15 @@ C/__package.rb:3: `C` is missing imports https://srb.help/3734
      9 |  import D
                   ^
 
+E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
+     3 |class E < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    E/__package.rb:7: Inserted `visible_to 'tests'
+      visible_to C`
+     7 |  export E::CONSTANT_FROM_E
+                                   ^
+
 D/test/__package.rb:3: `Test::D` is missing imports https://srb.help/3734
      3 |class Test::D < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -252,6 +259,14 @@ D/test/__package.rb:3: `Test::D` is missing imports https://srb.help/3734
     D/test/__package.rb:9: Inserted `import E`
      9 |  import D, uses_internals: true
                                         ^
+
+D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://srb.help/3734
+     3 |class D::ANestedPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    D/ANestedPackage/__package.rb:5: Inserted `export D::ANestedPackage::Foo`
+     5 |  layer 'util'
+                      ^
 
 D/__package.rb:3: `D` is missing exports https://srb.help/3734
      3 |class D < PackageSpec
@@ -268,14 +283,6 @@ D/__package.rb:3: `D` is missing exports https://srb.help/3734
       export D::EnumFromD`
      9 |  export D::ANestedPackage::Foo
                                        ^
-
-D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://srb.help/3734
-     3 |class D::ANestedPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    D/ANestedPackage/__package.rb:5: Inserted `export D::ANestedPackage::Foo`
-     5 |  layer 'util'
-                      ^
 
 A/constants.rb:5: Unable to resolve constant `G` https://srb.help/5002
      5 |  puts G::ANOTHER_CONSTANT_FROM_G
@@ -385,4 +392,12 @@ class Test::D < PackageSpec
 
   import D, uses_internals: true
   import E
+end
+
+###### cat PackageWithIgnore/__package.rb ######
+# typed: strict
+
+class PackageWithIgnore < PackageSpec
+  strict_dependencies 'false'
+  layer 'util'
 end

--- a/test/cli/package-gen-packages-test-packages/test.out
+++ b/test/cli/package-gen-packages-test-packages/test.out
@@ -15,6 +15,14 @@ A/__package.rb:3: `A` is missing imports https://srb.help/3734
      5 |  layer 'app'
                      ^
 
+PackageWithIgnore/__package.rb:3: `PackageWithIgnore` is missing imports https://srb.help/3734
+     3 |class PackageWithIgnore < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    PackageWithIgnore/__package.rb:5: Inserted `import F`
+     5 |  layer 'util'
+                      ^
+
 G/__package.rb:3: `G` is missing exports https://srb.help/3734
      3 |class G < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
@@ -116,7 +124,7 @@ C/app.rb:9: Package `G` includes explicit visibility modifiers and cannot be imp
                    ^^^^^^^^^^^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
-Errors: 11
+Errors: 12
 
 ###### cat B/__package.rb ######
 # typed: strict
@@ -202,12 +210,21 @@ end
 class PackageWithIgnore < PackageSpec
   strict_dependencies 'false'
   layer 'util'
+  import F
 end
 ##############################
 ###### Package directed ######
 ##############################
 
 ###### Running gen-packages ######
+PackageWithIgnore/__package.rb:3: `PackageWithIgnore` is missing imports https://srb.help/3734
+     3 |class PackageWithIgnore < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    PackageWithIgnore/__package.rb:5: Inserted `import F`
+     5 |  layer 'util'
+                      ^
+
 B/__package.rb:3: `B` is missing `visible_to`s https://srb.help/3734
      3 |class B < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
@@ -314,7 +331,7 @@ C/app.rb:9: Package `G` includes explicit visibility modifiers and cannot be imp
                    ^^^^^^^^^^^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
-Errors: 10
+Errors: 11
 
 ###### cat B/__package.rb ######
 # typed: strict
@@ -400,4 +417,5 @@ end
 class PackageWithIgnore < PackageSpec
   strict_dependencies 'false'
   layer 'util'
+  import F
 end

--- a/test/cli/package-gen-packages-test-packages/test.sh
+++ b/test/cli/package-gen-packages-test-packages/test.sh
@@ -52,6 +52,9 @@ echo "###### cat D/test/__package.rb ######"
 cat D/test/__package.rb
 
 echo
+echo "###### cat PackageWithIgnore/__package.rb ######"
+cat PackageWithIgnore/__package.rb
+
 echo "##############################"
 echo "###### Package directed ######"
 echo "##############################"
@@ -93,3 +96,7 @@ cat E/__package.rb
 echo
 echo "###### cat D/test/__package.rb ######"
 cat D/test/__package.rb
+
+echo
+echo "###### cat PackageWithIgnore/__package.rb ######"
+cat PackageWithIgnore/__package.rb

--- a/test/cli/package-gen-packages/PackageWithIgnore/__package.rb
+++ b/test/cli/package-gen-packages/PackageWithIgnore/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+class PackageWithIgnore < PackageSpec
+  strict_dependencies 'false'
+  layer 'util'
+end

--- a/test/cli/package-gen-packages/PackageWithIgnore/ignore_file.rb
+++ b/test/cli/package-gen-packages/PackageWithIgnore/ignore_file.rb
@@ -1,0 +1,5 @@
+# typed: ignore
+
+module PackageWithIgnore
+  puts F::CONSTANT_FROM_F
+end

--- a/test/cli/package-gen-packages/test.out
+++ b/test/cli/package-gen-packages/test.out
@@ -32,15 +32,6 @@ B/__package.rb:3: `B` is missing `visible_to`s https://srb.help/3734
      9 |  visible_to A
                       ^
 
-E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
-     3 |class E < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    E/__package.rb:7: Inserted `visible_to 'tests'
-      visible_to C`
-     7 |  export E::CONSTANT_FROM_E
-                                   ^
-
 C/__package.rb:7: Layering violation: cannot import `A` (in layer `app`) from `C` (in layer `util`) https://srb.help/3726
      7 |  import A
           ^^^^^^^^
@@ -66,6 +57,15 @@ C/__package.rb:3: `C` is missing imports https://srb.help/3734
       import E`
      9 |  import D
                   ^
+
+E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
+     3 |class E < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    E/__package.rb:7: Inserted `visible_to 'tests'
+      visible_to C`
+     7 |  export E::CONSTANT_FROM_E
+                                   ^
 
 D/__package.rb:3: `D` is missing imports and exports https://srb.help/3734
      3 |class D < PackageSpec
@@ -178,6 +178,14 @@ class E < PackageSpec
   visible_to 'tests'
   visible_to C
 end
+
+###### cat PackageWithIgnore/__package.rb ######
+# typed: strict
+
+class PackageWithIgnore < PackageSpec
+  strict_dependencies 'false'
+  layer 'util'
+end
 ##############################
 ###### Package directed ######
 ##############################
@@ -191,15 +199,6 @@ B/__package.rb:3: `B` is missing `visible_to`s https://srb.help/3734
       visible_to D`
      9 |  visible_to A
                       ^
-
-E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
-     3 |class E < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    E/__package.rb:7: Inserted `visible_to 'tests'
-      visible_to C`
-     7 |  export E::CONSTANT_FROM_E
-                                   ^
 
 C/__package.rb:7: Layering violation: cannot import `A` (in layer `app`) from `C` (in layer `util`) https://srb.help/3726
      7 |  import A
@@ -226,6 +225,15 @@ C/__package.rb:3: `C` is missing imports https://srb.help/3734
       import E`
      9 |  import D
                   ^
+
+E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
+     3 |class E < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    E/__package.rb:7: Inserted `visible_to 'tests'
+      visible_to C`
+     7 |  export E::CONSTANT_FROM_E
+                                   ^
 
 D/__package.rb:3: `D` is missing imports and exports https://srb.help/3734
      3 |class D < PackageSpec
@@ -356,4 +364,12 @@ class E < PackageSpec
   export E::CONSTANT_FROM_E
   visible_to 'tests'
   visible_to C
+end
+
+###### cat PackageWithIgnore/__package.rb ######
+# typed: strict
+
+class PackageWithIgnore < PackageSpec
+  strict_dependencies 'false'
+  layer 'util'
 end

--- a/test/cli/package-gen-packages/test.out
+++ b/test/cli/package-gen-packages/test.out
@@ -15,6 +15,14 @@ A/__package.rb:3: `A` is missing imports https://srb.help/3734
      5 |  layer 'app'
                      ^
 
+PackageWithIgnore/__package.rb:3: `PackageWithIgnore` is missing imports https://srb.help/3734
+     3 |class PackageWithIgnore < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    PackageWithIgnore/__package.rb:5: Inserted `import F`
+     5 |  layer 'util'
+                      ^
+
 G/__package.rb:3: `G` is missing exports https://srb.help/3734
      3 |class G < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
@@ -111,7 +119,7 @@ C/app.rb:9: Package `G` includes explicit visibility modifiers and cannot be imp
                    ^^^^^^^^^^^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
-Errors: 10
+Errors: 11
 
 ###### cat B/__package.rb ######
 # typed: strict
@@ -185,12 +193,21 @@ end
 class PackageWithIgnore < PackageSpec
   strict_dependencies 'false'
   layer 'util'
+  import F
 end
 ##############################
 ###### Package directed ######
 ##############################
 
 ###### Running gen-packages ######
+PackageWithIgnore/__package.rb:3: `PackageWithIgnore` is missing imports https://srb.help/3734
+     3 |class PackageWithIgnore < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    PackageWithIgnore/__package.rb:5: Inserted `import F`
+     5 |  layer 'util'
+                      ^
+
 B/__package.rb:3: `B` is missing `visible_to`s https://srb.help/3734
      3 |class B < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
@@ -298,7 +315,7 @@ C/app.rb:9: Package `G` includes explicit visibility modifiers and cannot be imp
                    ^^^^^^^^^^^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
-Errors: 9
+Errors: 10
 
 ###### cat B/__package.rb ######
 # typed: strict
@@ -372,4 +389,5 @@ end
 class PackageWithIgnore < PackageSpec
   strict_dependencies 'false'
   layer 'util'
+  import F
 end

--- a/test/cli/package-gen-packages/test.sh
+++ b/test/cli/package-gen-packages/test.sh
@@ -47,7 +47,9 @@ echo
 echo "###### cat E/__package.rb ######"
 cat E/__package.rb
 
-
+echo
+echo "###### cat PackageWithIgnore/__package.rb ######"
+cat PackageWithIgnore/__package.rb
 
 echo "##############################"
 echo "###### Package directed ######"
@@ -86,3 +88,7 @@ cat D/ANestedPackage/__package.rb
 echo
 echo "###### cat E/__package.rb ######"
 cat E/__package.rb
+
+echo
+echo "###### cat PackageWithIgnore/__package.rb ######"
+cat PackageWithIgnore/__package.rb


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Similar to what we do in the autogen right above.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

For gen-packages mode, we need to see references to all constants used in a package so that we generate the right imports and exports. If a reference to a certain package is only in a `typed: ignore` file, we'll generate incomplete imports.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
