### PR TITLE
Also serialize abstract-ness for subclasses in autogen

### DIFF
--- a/main/autogen/subclasses.cc
+++ b/main/autogen/subclasses.cc
@@ -162,7 +162,7 @@ vector<string> Subclasses::serializeSubclassMap(const core::GlobalState &gs, con
 
         string parentName = parentRef.show(gs);
 
-        auto type = children.classKind == ClassKind::Class ? "class" : "module";
+        auto type = children.classKind == ClassKind::Class ? "c" : "m";
         descendantsMapSerialized.emplace_back(fmt::format("{} {}", type, parentName));
 
         auto subclassesStart = descendantsMapSerialized.size();
@@ -170,8 +170,9 @@ vector<string> Subclasses::serializeSubclassMap(const core::GlobalState &gs, con
             auto loc = info.defining_ref.value_or(childRef.data(gs)->loc());
             string_view path = gs.getPrintablePath(loc.file().data(gs).path());
             string childName = childRef.show(gs);
-            auto type = childRef.data(gs)->isClass() ? "class" : "module";
-            descendantsMapSerialized.emplace_back(fmt::format(" {} {} {}", type, childName, path));
+            auto type = childRef.data(gs)->isClass() ? "c" : "m";
+            auto abstract = childRef.data(gs)->flags.isAbstract ? "a" : "c";
+            descendantsMapSerialized.emplace_back(fmt::format(" {} {} {} {}", type, childName, path, abstract));
         }
 
         fast_sort_range(descendantsMapSerialized.begin() + subclassesStart, descendantsMapSerialized.end());

--- a/test/cli/autogen-subclasses-ignore/test.out
+++ b/test/cli/autogen-subclasses-ignore/test.out
@@ -1,5 +1,5 @@
 --- autogen-subclasses-ignore-absolute ---
 
 --- autogen-subclasses-ignore-relative ---
-class Opus::Parent
- class Opus::Child test/cli/autogen-subclasses-ignore/not-ignored/not-ignored.rb
+c Opus::Parent
+ c Opus::Child test/cli/autogen-subclasses-ignore/not-ignored/not-ignored.rb c

--- a/test/cli/autogen-subclasses/abstract_child.rb
+++ b/test/cli/autogen-subclasses/abstract_child.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+require_relative './parent'
+
+module Bopus
+  class AbstractChild < Parent
+    abstract!
+  end
+end

--- a/test/cli/autogen-subclasses/child_of_abstract_child.rb
+++ b/test/cli/autogen-subclasses/child_of_abstract_child.rb
@@ -1,0 +1,11 @@
+# typed: true
+
+require_relative './child'
+
+module Bopus
+  AbstractChildAlias = AbstractChild
+  class ChildOfAbstractChild1 < AbstractChild
+    abstract!
+  end
+  class ChildOfAbstractChild2 < AbstractChildAlias; end
+end

--- a/test/cli/autogen-subclasses/test.out
+++ b/test/cli/autogen-subclasses/test.out
@@ -1,15 +1,18 @@
 --- autogen-subclasses ---
-class Bopus::Parent
- class Bopus::Child child.rb
- class Bopus::ChildAgain child_again.rb
- class Bopus::ChildOfChild1 child_of_child.rb
- class Bopus::ChildOfChild2 child_of_child.rb
-module MyMixin
- class MyClass a.rb
-module Opus::Mixin
- class Opus::Mixed a.rb
- class Opus::MixedDescendant a.rb
- module Opus::MixedModule a.rb
-class Opus::Parent
- class Opus::Child a.rb
- class Opus::DupChild a.rb
+c Bopus::Parent
+ c Bopus::AbstractChild abstract_child.rb a
+ c Bopus::Child child.rb c
+ c Bopus::ChildAgain child_again.rb c
+ c Bopus::ChildOfAbstractChild1 child_of_abstract_child.rb a
+ c Bopus::ChildOfAbstractChild2 child_of_abstract_child.rb c
+ c Bopus::ChildOfChild1 child_of_child.rb c
+ c Bopus::ChildOfChild2 child_of_child.rb c
+m MyMixin
+ c MyClass a.rb c
+m Opus::Mixin
+ c Opus::Mixed a.rb c
+ c Opus::MixedDescendant a.rb c
+ m Opus::MixedModule a.rb c
+c Opus::Parent
+ c Opus::Child a.rb c
+ c Opus::DupChild a.rb c


### PR DESCRIPTION
This changes the serialization format to include whether or not a class is abstract. At the same time, this also changes the format to reduce the strings `class` and `module` down to `c` and `m`: because the resulting file is so big (more than 400,000 lines) simply cutting out four characters per line drops the file size down about 1.65 MB. Not mind-blowing, but it makes up for the extra size added by the extra two characters per line we're adding here.

### Motivation
We end up checking for abstract-ness a _lot_ in code that uses the results of this step, so this folds it in directly.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
