### PR TITLE
add an LSP test for alias scopes

### DIFF
--- a/test/testdata/lsp/alias_scopes.rb
+++ b/test/testdata/lsp/alias_scopes.rb
@@ -1,0 +1,39 @@
+# typed: true
+
+class Bar
+    # ^ def: Bar 1 not-def-of-self
+  Cnst = 1
+  # ^ def: Cnst
+end
+
+module Foo
+  Alias = Bar
+  # ^ def: Alias
+  #       ^ go-to-def-special: Bar
+
+  module Other
+         # ^ def: Other 1 not-def-of-self
+    Alias = Bar
+    # ^ def: OtherAlias_Inner
+    #       ^ go-to-def-special: Bar
+  end
+
+  OtherAlias = Other
+  # ^ def: OtherAlias
+  #             ^ go-to-def-special: Other
+
+  DeepAlias = OtherAlias::Alias
+  # ^ def: DeepAlias
+  #           ^ usage: OtherAlias
+  #                       ^ usage: OtherAlias_Inner
+end
+
+module Foo
+  Alias::Cnst
+  # ^ usage: Alias
+  #      ^ usage: Cnst
+
+  DeepAlias::Cnst
+  # ^ usage: DeepAlias
+  #           ^ usage: Cnst
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This PR adds a test similar to `test/cli/autogen_print_alias_scopes`, but running in LSP.

Offline discussion for #9971 suggested that LSP ought to have a test that fails due to how #9971 was originally conceived (a single `SymbolRef` being sufficient to represent a resolved constant; scopes are implicitly tracked through `owner()`), but we only had a CLI test that failed.  CLI tests are kind of annoying to run, and a LSP test is easier to debug.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Test-only changes, if the build is green, we are good.  I verified that this test fails on a current-ish iteration of #9971.