### PR TITLE
fix def/ref information for exception variables

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1221,17 +1221,31 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 //   of `self`
                 // * if the RHS is `<exceptionValue>` we inherit the RHS to propagate locations that include `rescue`
                 //   and enables more targeted advice when reporting pinning errors below.
+                const bool rhsExceptionValue = i.what.data(inWhat)._name == core::Names::exceptionValue();
                 if (bind.bind.variable.isSyntheticTemporary(inWhat) ||
-                    bind.bind.variable == cfg::LocalRef::selfVariable() ||
-                    i.what.data(inWhat)._name == core::Names::exceptionValue()) {
+                    bind.bind.variable == cfg::LocalRef::selfVariable() || rhsExceptionValue) {
                     tp.origins = typeAndOrigin.origins;
                 } else {
                     tp.origins.emplace_back(ctx.locAt(bind.loc));
                 }
 
                 if (lspQueryMatch && !bind.value.isSynthetic()) {
+                    // Don't let `<exceptionValue>` propagate out into LSP.  Use the real thing.
+                    auto responseRef = rhsExceptionValue ? bind.bind.variable : i.what;
+                    // Similarly, don't let the weird loc of `rescue` make its way out.
+                    auto responseTp = tp;
+                    auto &origins = responseTp.origins;
+                    origins.erase(std::remove_if(origins.begin(), origins.end(),
+                                                 [&ctx](auto loc) {
+                                                     auto src = loc.source(ctx);
+                                                     if (src && *src == "rescue") {
+                                                         return true;
+                                                     }
+                                                     return false;
+                                                 }),
+                                  origins.end());
                     core::lsp::QueryResponse::pushQueryResponse(
-                        ctx, core::lsp::IdentResponse(ctx.locAt(bind.loc), i.what.data(inWhat), tp,
+                        ctx, core::lsp::IdentResponse(ctx.locAt(bind.loc), responseRef.data(inWhat), responseTp,
                                                       ctx.owner.asMethodRef(), ctx.locAt(inWhat.loc)));
                 }
 

--- a/test/testdata/lsp/definitions_and_usages.rb
+++ b/test/testdata/lsp/definitions_and_usages.rb
@@ -51,6 +51,15 @@ class TestClass
     # ^^^ usage: var
     end
   end
+  def method_with_rescue_var
+    begin
+      puts("hi")
+    rescue => err
+            # ^^^ def: err
+      puts(err)
+         # ^^^ usage: err
+    end
+  end
 end
 
 # Introduced to avoid awkward indenting.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Reported by @qaisjp.

I do not love the hack around avoiding `rescue` locs, but the version(s) before this were even worse, and this at least keeps things scoped to cfg + infer.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
