### PR TITLE
Elide temp var when `case` is given a local var

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -2328,15 +2328,30 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     return;
                 }
 
-                ExpressionPtr assign;
-                auto temp = core::NameRef::noName();
-                core::LocOffsets cloc;
+                bool hasCondition = case_->condition != nullptr;
 
-                if (case_->condition != nullptr) {
+                core::LocOffsets cloc;
+                ExpressionPtr condition;
+                // If the predicate is already reference-like (local, ivar, self, etc.), reading it is side-effect-free,
+                // so we can read it directly in each `===`, skipping the synthetic `<assignTemp>` local.
+                bool needsTempLocal = false;
+                auto temp = core::NameRef::noName();
+                ExpressionPtr assign;
+                if (hasCondition) {
                     cloc = case_->condition->loc;
-                    temp = dctx.freshNameUnique(core::Names::assignTemp());
-                    assign = MK::Assign(cloc, temp, node2TreeImpl(dctx, case_->condition));
+                    condition = node2TreeImpl(dctx, case_->condition);
+                    needsTempLocal = !isa_reference(condition);
+                    if (needsTempLocal) {
+                        temp = dctx.freshNameUnique(core::Names::assignTemp());
+                        assign = MK::Assign(cloc, temp, move(condition));
+                    }
                 }
+
+                // Build an AST node that reads the case's condition.
+                auto makeConditionRead = [&]() -> ExpressionPtr {
+                    return needsTempLocal ? MK::Local(cloc, temp) : MK::cpRef(condition);
+                };
+
                 ExpressionPtr res = node2TreeImpl(dctx, case_->else_);
                 for (auto it = case_->whens.rbegin(); it != case_->whens.rend(); ++it) {
                     auto when = parser::cast_node<parser::When>(it->get());
@@ -2345,22 +2360,20 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     for (auto &cnode : when->patterns) {
                         ExpressionPtr test;
                         if (parser::isa_node<parser::Splat>(cnode.get())) {
-                            ENFORCE(temp.exists(), "splats need something to test against");
+                            ENFORCE(hasCondition, "splats need something to test against");
                             auto recv = MK::Magic(loc);
-                            auto local = MK::Local(cloc, temp);
                             // TODO(froydnj): use the splat's var directly so we can elide the
                             // coercion to an array where possible.
                             auto splat = node2TreeImpl(dctx, cnode);
                             auto patternloc = splat.loc();
                             test = MK::Send2(patternloc, move(recv), core::Names::checkMatchArray(),
-                                             patternloc.copyWithZeroLength(), move(local), move(splat));
+                                             patternloc.copyWithZeroLength(), makeConditionRead(), move(splat));
                         } else {
                             auto ctree = node2TreeImpl(dctx, cnode);
-                            if (temp.exists()) {
-                                auto local = MK::Local(cloc, temp);
+                            if (hasCondition) {
                                 auto patternloc = ctree.loc();
                                 test = MK::Send1(patternloc, move(ctree), core::Names::tripleEq(),
-                                                 patternloc.copyWithZeroLength(), move(local));
+                                                 patternloc.copyWithZeroLength(), makeConditionRead());
                             } else {
                                 test = move(ctree);
                             }
@@ -2375,9 +2388,11 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     }
                     res = MK::If(when->loc, move(cond), node2TreeImpl(dctx, when->body), move(res));
                 }
+
                 if (assign != nullptr) {
                     res = MK::InsSeq1(loc, move(assign), move(res));
                 }
+
                 result = move(res);
             },
             [&](parser::Splat *splat) {

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -2080,20 +2080,30 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                                 move(args));
             }
 
-            core::NameRef tempName;
             core::LocOffsets predicateLoc;
             // Check if the prism node has a predicate, not the desugared result,
             // because desugarNullable returns EmptyTree (not nullptr) for null nodes.
             bool hasPredicate = (caseNode->predicate != nullptr);
 
+            // If the predicate is already reference-like (local, ivar, self, etc.), reading it is side-effect-free,
+            // so we can read it directly in each `===`, skipping the synthetic `<assignTemp>` local.
+            bool needsTempLocal = hasPredicate && !ast::isa_reference(predicate);
+
+            core::NameRef tempName = core::NameRef::noName();
             if (hasPredicate) {
                 // Use the Prism node's loc directly (not the desugared expr's loc) so that
                 // e.g. `case (1)` retains the parens-inclusive loc rather than collapsing to `1`.
                 predicateLoc = translateLoc(caseNode->predicate->location);
-                tempName = nextUniqueDesugarName(core::Names::assignTemp());
-            } else {
-                tempName = core::NameRef::noName();
+
+                if (needsTempLocal) {
+                    tempName = nextUniqueDesugarName(core::Names::assignTemp());
+                }
             }
+
+            // Build an AST node that reads the case's predicate.
+            auto makePredicateRead = [&]() -> ExpressionPtr {
+                return needsTempLocal ? MK::Local(predicateLoc, tempName) : MK::cpRef(predicate);
+            };
 
             // The if/else ladder for the entire case statement, starting with the else clause as the final `else` when
             // building backwards
@@ -2117,17 +2127,15 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                     if (isa_node<pm_splat_node>(prismPattern)) {
                         // splat pattern in when clause, predicate is required, `case a when *others`
                         ENFORCE(hasPredicate, "splats need something to test against");
-                        auto local = MK::Local(predicateLoc, tempName);
                         // Desugar `case x when *patterns` to `::Magic.<check-match-array>(x, patterns)`,
                         // which behaves like `patterns.any?(x)`
                         testExpr = MK::Send2(patternLoc, MK::Magic(location), core::Names::checkMatchArray(),
-                                             patternLoc.copyWithZeroLength(), move(local), move(pattern));
+                                             patternLoc.copyWithZeroLength(), makePredicateRead(), move(pattern));
                     } else if (hasPredicate) {
                         // regular pattern when case predicate is present, `case a when 1`
-                        auto local = MK::Local(predicateLoc, tempName);
                         // Desugar `case x when 1` to `1 === x`
                         testExpr = MK::Send1(patternLoc, move(pattern), core::Names::tripleEq(),
-                                             patternLoc.copyWithZeroLength(), move(local));
+                                             patternLoc.copyWithZeroLength(), makePredicateRead());
                     } else {
                         // regular pattern when case predicate is not present, `case when 1 then "one" end`
                         // case # no predicate present
@@ -2164,8 +2172,11 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                 nextClauseLoc = core::LocOffsets{lineStart, whenLoc.endPos()};
             }
 
-            if (hasPredicate) {
+            if (needsTempLocal) {
+                // <assignTemp>$1 = predicate
                 auto assignExpr = MK::Assign(predicateLoc, tempName, move(predicate));
+
+                // Prepend the assignment to the `if`/`else` ladder we built.
                 resultExpr = MK::InsSeq1(location, move(assignExpr), move(resultExpr));
             }
 

--- a/test/testdata/desugar/case.rb
+++ b/test/testdata/desugar/case.rb
@@ -19,4 +19,60 @@ class Test
       :b
     end
   end
+
+  @@cvar = T.let(123, T.nilable(Integer))
+
+  # Test when Sorbet synthesizes a temporary variable, vs. when it skips it.
+  def test_when_temporary_variables_are_used
+    # Method calls can have side-effects. Extract the result to a synthetic local variable.
+    case to_s()
+    when 1
+    when 2
+    end
+
+    # Reading from `self` is side-effect-free, so we can elide the synthetic local variable.
+    T.bind(self, T.nilable(Integer))
+    case self
+    when Integer
+    else T.absurd(self)
+    #    ^^^^^^^^^^^^^^ error: Control flow could reach `T.absurd` because the type `NilClass` wasn't handled
+    end
+
+    # Local variables are ... already local variables. We can elide the synthetic local variable.
+    lvar = T.let(123, T.nilable(Integer))
+    case lvar
+    when Integer
+    else T.absurd(lvar)
+    #    ^^^^^^^^^^^^^^ error: Control flow could reach `T.absurd` because the type `NilClass` wasn't handled
+    end
+
+    @ivar  = T.let(123, T.nilable(Integer))
+    case @ivar
+    when Integer
+    else T.absurd(@ivar)
+    #    ^^^^^^^^^^^^^^^ error: Control flow could reach `T.absurd` because the type `NilClass` wasn't handled
+    end
+
+    case @@cvar
+    when Integer
+    else T.absurd(@@cvar)
+    #    ^^^^^^^^^^^^^^^^ error: Control flow could reach `T.absurd` because the type `NilClass` wasn't handled
+    end
+
+    $gvar = T.let(123, T.nilable(Integer))
+    case $gvar
+    when Integer
+    else T.absurd($gvar)
+    #    ^^^^^^^^^^^^^^^ error: Control flow could reach `T.absurd` because the type `NilClass` wasn't handled
+    end
+
+    # Incorrect Desugar tree until https://github.com/sorbet/sorbet/pull/10020 is merged.
+    # tap do |_; block_local_var|
+    #   block_local_var = T.let(123, T.nilable(Integer))
+    #   case block_local_var
+    #   when Integer
+    #   when 2
+    #   end
+    # end
+  end
 end

--- a/test/testdata/desugar/case.rb
+++ b/test/testdata/desugar/case.rb
@@ -1,5 +1,7 @@
-# typed: false
+# typed: true
+
 class Test
+  attr_reader :a, :foo1, :foo2, :foo3, :test1, :test2, :test3
   def test_case
     case a
     when foo1

--- a/test/testdata/desugar/case.rb.desugar-tree.exp
+++ b/test/testdata/desugar/case.rb.desugar-tree.exp
@@ -53,48 +53,33 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           end
         end
         <emptyTree>::<C T>.bind(<self>, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
-        begin
-          <assignTemp>$3 = <self>
-          if <emptyTree>::<C Integer>.===(<assignTemp>$3)
-            <emptyTree>
-          else
-            <emptyTree>::<C T>.absurd(<self>)
-          end
+        if <emptyTree>::<C Integer>.===(<self>)
+          <emptyTree>
+        else
+          <emptyTree>::<C T>.absurd(<self>)
         end
         lvar = <emptyTree>::<C T>.let(123, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
-        begin
-          <assignTemp>$4 = lvar
-          if <emptyTree>::<C Integer>.===(<assignTemp>$4)
-            <emptyTree>
-          else
-            <emptyTree>::<C T>.absurd(lvar)
-          end
+        if <emptyTree>::<C Integer>.===(lvar)
+          <emptyTree>
+        else
+          <emptyTree>::<C T>.absurd(lvar)
         end
         @ivar = <emptyTree>::<C T>.let(123, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
-        begin
-          <assignTemp>$5 = @ivar
-          if <emptyTree>::<C Integer>.===(<assignTemp>$5)
-            <emptyTree>
-          else
-            <emptyTree>::<C T>.absurd(@ivar)
-          end
+        if <emptyTree>::<C Integer>.===(@ivar)
+          <emptyTree>
+        else
+          <emptyTree>::<C T>.absurd(@ivar)
         end
-        begin
-          <assignTemp>$6 = @@cvar
-          if <emptyTree>::<C Integer>.===(<assignTemp>$6)
-            <emptyTree>
-          else
-            <emptyTree>::<C T>.absurd(@@cvar)
-          end
+        if <emptyTree>::<C Integer>.===(@@cvar)
+          <emptyTree>
+        else
+          <emptyTree>::<C T>.absurd(@@cvar)
         end
         $gvar = <emptyTree>::<C T>.let(123, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
-        begin
-          <assignTemp>$7 = $gvar
-          if <emptyTree>::<C Integer>.===(<assignTemp>$7)
-            <emptyTree>
-          else
-            <emptyTree>::<C T>.absurd($gvar)
-          end
+        if <emptyTree>::<C Integer>.===($gvar)
+          <emptyTree>
+        else
+          <emptyTree>::<C T>.absurd($gvar)
         end
       end
     end

--- a/test/testdata/desugar/case.rb.desugar-tree.exp
+++ b/test/testdata/desugar/case.rb.desugar-tree.exp
@@ -35,5 +35,68 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         end
       end
     end
+
+    @@cvar = <emptyTree>::<C T>.let(123, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
+
+    def test_when_temporary_variables_are_used<<todo method>>(&<blk>)
+      begin
+        begin
+          <assignTemp>$2 = <self>.to_s()
+          if 1.===(<assignTemp>$2)
+            <emptyTree>
+          else
+            if 2.===(<assignTemp>$2)
+              <emptyTree>
+            else
+              <emptyTree>
+            end
+          end
+        end
+        <emptyTree>::<C T>.bind(<self>, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
+        begin
+          <assignTemp>$3 = <self>
+          if <emptyTree>::<C Integer>.===(<assignTemp>$3)
+            <emptyTree>
+          else
+            <emptyTree>::<C T>.absurd(<self>)
+          end
+        end
+        lvar = <emptyTree>::<C T>.let(123, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
+        begin
+          <assignTemp>$4 = lvar
+          if <emptyTree>::<C Integer>.===(<assignTemp>$4)
+            <emptyTree>
+          else
+            <emptyTree>::<C T>.absurd(lvar)
+          end
+        end
+        @ivar = <emptyTree>::<C T>.let(123, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
+        begin
+          <assignTemp>$5 = @ivar
+          if <emptyTree>::<C Integer>.===(<assignTemp>$5)
+            <emptyTree>
+          else
+            <emptyTree>::<C T>.absurd(@ivar)
+          end
+        end
+        begin
+          <assignTemp>$6 = @@cvar
+          if <emptyTree>::<C Integer>.===(<assignTemp>$6)
+            <emptyTree>
+          else
+            <emptyTree>::<C T>.absurd(@@cvar)
+          end
+        end
+        $gvar = <emptyTree>::<C T>.let(123, <emptyTree>::<C T>.nilable(<emptyTree>::<C Integer>))
+        begin
+          <assignTemp>$7 = $gvar
+          if <emptyTree>::<C Integer>.===(<assignTemp>$7)
+            <emptyTree>
+          else
+            <emptyTree>::<C T>.absurd($gvar)
+          end
+        end
+      end
+    end
   end
 end

--- a/test/testdata/desugar/case.rb.desugar-tree.exp
+++ b/test/testdata/desugar/case.rb.desugar-tree.exp
@@ -1,5 +1,7 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Test><<C <todo sym>>> < (::<todo sym>)
+    <self>.attr_reader(:a, :foo1, :foo2, :foo3, :test1, :test2, :test3)
+
     def test_case<<todo method>>(&<blk>)
       begin
         begin

--- a/test/testdata/infer/case.rb
+++ b/test/testdata/infer/case.rb
@@ -8,4 +8,30 @@ class TestCase
       T.assert_type!(x, T.any(T::Array[T.untyped], T::Hash[T.untyped, T.untyped]))
     end
   end
+
+  def test_narrowing_subclass_after_lambda
+    x = T.let("", Object)
+
+    case x
+    when ->(y) { false }
+    when String
+      # Fails to narrow to `String` because of the mere presence of the `-> (y) { false }` lambda above.
+      T.reveal_type(x)
+    # ^^^^^^^^^^^^^^^^ error: Revealed type: `Object`
+    end
+  end
+
+  def test_narrowing_union_after_lambda
+    x = T.let(123, T.any(Integer, String))
+
+    case x
+    when ->(y) { false }
+    when String
+    when Integer
+      # Fails to narrow to `Integer` because of the mere presence of the `-> (y) { false }` lambda above.
+      T.reveal_type(x)
+    # ^^^^^^^^^^^^^^^^ error: Revealed type: `T.any(Integer, String)`
+    else T.absurd(x)
+    end
+  end
 end

--- a/test/testdata/infer/case.rb
+++ b/test/testdata/infer/case.rb
@@ -15,9 +15,9 @@ class TestCase
     case x
     when ->(y) { false }
     when String
-      # Fails to narrow to `String` because of the mere presence of the `-> (y) { false }` lambda above.
+      # Narrows correctly even with the `-> (y) { false }` lambda above.
       T.reveal_type(x)
-    # ^^^^^^^^^^^^^^^^ error: Revealed type: `Object`
+    # ^^^^^^^^^^^^^^^^ error: Revealed type: `String`
     end
   end
 
@@ -28,9 +28,9 @@ class TestCase
     when ->(y) { false }
     when String
     when Integer
-      # Fails to narrow to `Integer` because of the mere presence of the `-> (y) { false }` lambda above.
+      # Narrows correctly even with the `-> (y) { false }` lambda above.
       T.reveal_type(x)
-    # ^^^^^^^^^^^^^^^^ error: Revealed type: `T.any(Integer, String)`
+    # ^^^^^^^^^^^^^^^^ error: Revealed type: `Integer`
     else T.absurd(x)
     end
   end

--- a/test/testdata/infer/huge_unions.rb.cfg-text.exp
+++ b/test/testdata/infer/huge_unions.rb.cfg-text.exp
@@ -396,9 +396,9 @@ method ::<Class:A>#send_beta_invitation {
 bb0[firstDead=-1]():
     <self>: T.class_of(A) = cast(<self>: NilClass, T.class_of(A));
     invite: T.untyped = load_arg(invite)
-    <statTemp>$6: Integer(1) = 1
-    <ifTemp>$5: T::Boolean = <statTemp>$6: Integer(1).===(invite: T.untyped)
-    <ifTemp>$5 -> (T::Boolean ? bb2 : bb3)
+    <statTemp>$5: Integer(1) = 1
+    <ifTemp>$4: T::Boolean = <statTemp>$5: Integer(1).===(invite: T.untyped)
+    <ifTemp>$4 -> (T::Boolean ? bb2 : bb3)
 
 # backedges
 # - bb61
@@ -409,281 +409,281 @@ bb1[firstDead=-1](<returnMethodTemp>$2):
 # backedges
 # - bb0
 bb2[firstDead=-1]():
-    <cfgAlias>$8: T.class_of(C1) = alias <C C1>
-    r: T.class_of(C1) = <cfgAlias>$8
+    <cfgAlias>$7: T.class_of(C1) = alias <C C1>
+    r: T.class_of(C1) = <cfgAlias>$7
     <unconditional> -> bb61
 
 # backedges
 # - bb0
 bb3[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
-    <statTemp>$10: Integer(2) = 2
-    <ifTemp>$9: T::Boolean = <statTemp>$10: Integer(2).===(invite: T.untyped)
-    <ifTemp>$9 -> (T::Boolean ? bb4 : bb5)
+    <statTemp>$9: Integer(2) = 2
+    <ifTemp>$8: T::Boolean = <statTemp>$9: Integer(2).===(invite: T.untyped)
+    <ifTemp>$8 -> (T::Boolean ? bb4 : bb5)
 
 # backedges
 # - bb3
 bb4[firstDead=-1]():
-    <cfgAlias>$12: T.class_of(C2) = alias <C C2>
-    r: T.class_of(C2) = <cfgAlias>$12
+    <cfgAlias>$11: T.class_of(C2) = alias <C C2>
+    r: T.class_of(C2) = <cfgAlias>$11
     <unconditional> -> bb61
 
 # backedges
 # - bb3
 bb5[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
-    <statTemp>$14: Integer(3) = 3
-    <ifTemp>$13: T::Boolean = <statTemp>$14: Integer(3).===(invite: T.untyped)
-    <ifTemp>$13 -> (T::Boolean ? bb6 : bb7)
+    <statTemp>$13: Integer(3) = 3
+    <ifTemp>$12: T::Boolean = <statTemp>$13: Integer(3).===(invite: T.untyped)
+    <ifTemp>$12 -> (T::Boolean ? bb6 : bb7)
 
 # backedges
 # - bb5
 bb6[firstDead=-1]():
-    <cfgAlias>$16: T.class_of(C3) = alias <C C3>
-    r: T.class_of(C3) = <cfgAlias>$16
+    <cfgAlias>$15: T.class_of(C3) = alias <C C3>
+    r: T.class_of(C3) = <cfgAlias>$15
     <unconditional> -> bb61
 
 # backedges
 # - bb5
 bb7[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
-    <statTemp>$18: Integer(4) = 4
-    <ifTemp>$17: T::Boolean = <statTemp>$18: Integer(4).===(invite: T.untyped)
-    <ifTemp>$17 -> (T::Boolean ? bb8 : bb9)
+    <statTemp>$17: Integer(4) = 4
+    <ifTemp>$16: T::Boolean = <statTemp>$17: Integer(4).===(invite: T.untyped)
+    <ifTemp>$16 -> (T::Boolean ? bb8 : bb9)
 
 # backedges
 # - bb7
 bb8[firstDead=-1]():
-    <cfgAlias>$20: T.class_of(C4) = alias <C C4>
-    r: T.class_of(C4) = <cfgAlias>$20
+    <cfgAlias>$19: T.class_of(C4) = alias <C C4>
+    r: T.class_of(C4) = <cfgAlias>$19
     <unconditional> -> bb61
 
 # backedges
 # - bb7
 bb9[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
-    <statTemp>$22: Integer(5) = 5
-    <ifTemp>$21: T::Boolean = <statTemp>$22: Integer(5).===(invite: T.untyped)
-    <ifTemp>$21 -> (T::Boolean ? bb10 : bb11)
+    <statTemp>$21: Integer(5) = 5
+    <ifTemp>$20: T::Boolean = <statTemp>$21: Integer(5).===(invite: T.untyped)
+    <ifTemp>$20 -> (T::Boolean ? bb10 : bb11)
 
 # backedges
 # - bb9
 bb10[firstDead=-1]():
-    <cfgAlias>$24: T.class_of(C5) = alias <C C5>
-    r: T.class_of(C5) = <cfgAlias>$24
+    <cfgAlias>$23: T.class_of(C5) = alias <C C5>
+    r: T.class_of(C5) = <cfgAlias>$23
     <unconditional> -> bb61
 
 # backedges
 # - bb9
 bb11[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
-    <statTemp>$26: Integer(6) = 6
-    <ifTemp>$25: T::Boolean = <statTemp>$26: Integer(6).===(invite: T.untyped)
-    <ifTemp>$25 -> (T::Boolean ? bb12 : bb13)
+    <statTemp>$25: Integer(6) = 6
+    <ifTemp>$24: T::Boolean = <statTemp>$25: Integer(6).===(invite: T.untyped)
+    <ifTemp>$24 -> (T::Boolean ? bb12 : bb13)
 
 # backedges
 # - bb11
 bb12[firstDead=-1]():
-    <cfgAlias>$28: T.class_of(C6) = alias <C C6>
-    r: T.class_of(C6) = <cfgAlias>$28
+    <cfgAlias>$27: T.class_of(C6) = alias <C C6>
+    r: T.class_of(C6) = <cfgAlias>$27
     <unconditional> -> bb61
 
 # backedges
 # - bb11
 bb13[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
-    <statTemp>$30: Integer(7) = 7
-    <ifTemp>$29: T::Boolean = <statTemp>$30: Integer(7).===(invite: T.untyped)
-    <ifTemp>$29 -> (T::Boolean ? bb14 : bb15)
+    <statTemp>$29: Integer(7) = 7
+    <ifTemp>$28: T::Boolean = <statTemp>$29: Integer(7).===(invite: T.untyped)
+    <ifTemp>$28 -> (T::Boolean ? bb14 : bb15)
 
 # backedges
 # - bb13
 bb14[firstDead=-1]():
-    <cfgAlias>$32: T.class_of(C7) = alias <C C7>
-    r: T.class_of(C7) = <cfgAlias>$32
+    <cfgAlias>$31: T.class_of(C7) = alias <C C7>
+    r: T.class_of(C7) = <cfgAlias>$31
     <unconditional> -> bb61
 
 # backedges
 # - bb13
 bb15[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
-    <statTemp>$34: Integer(8) = 8
-    <ifTemp>$33: T::Boolean = <statTemp>$34: Integer(8).===(invite: T.untyped)
-    <ifTemp>$33 -> (T::Boolean ? bb16 : bb17)
+    <statTemp>$33: Integer(8) = 8
+    <ifTemp>$32: T::Boolean = <statTemp>$33: Integer(8).===(invite: T.untyped)
+    <ifTemp>$32 -> (T::Boolean ? bb16 : bb17)
 
 # backedges
 # - bb15
 bb16[firstDead=-1]():
-    <cfgAlias>$36: T.class_of(C8) = alias <C C8>
-    r: T.class_of(C8) = <cfgAlias>$36
+    <cfgAlias>$35: T.class_of(C8) = alias <C C8>
+    r: T.class_of(C8) = <cfgAlias>$35
     <unconditional> -> bb61
 
 # backedges
 # - bb15
 bb17[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
-    <statTemp>$38: Integer(9) = 9
-    <ifTemp>$37: T::Boolean = <statTemp>$38: Integer(9).===(invite: T.untyped)
-    <ifTemp>$37 -> (T::Boolean ? bb18 : bb19)
+    <statTemp>$37: Integer(9) = 9
+    <ifTemp>$36: T::Boolean = <statTemp>$37: Integer(9).===(invite: T.untyped)
+    <ifTemp>$36 -> (T::Boolean ? bb18 : bb19)
 
 # backedges
 # - bb17
 bb18[firstDead=-1]():
-    <cfgAlias>$40: T.class_of(C9) = alias <C C9>
-    r: T.class_of(C9) = <cfgAlias>$40
+    <cfgAlias>$39: T.class_of(C9) = alias <C C9>
+    r: T.class_of(C9) = <cfgAlias>$39
     <unconditional> -> bb61
 
 # backedges
 # - bb17
 bb19[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
-    <statTemp>$42: Integer(10) = 10
-    <ifTemp>$41: T::Boolean = <statTemp>$42: Integer(10).===(invite: T.untyped)
-    <ifTemp>$41 -> (T::Boolean ? bb20 : bb21)
+    <statTemp>$41: Integer(10) = 10
+    <ifTemp>$40: T::Boolean = <statTemp>$41: Integer(10).===(invite: T.untyped)
+    <ifTemp>$40 -> (T::Boolean ? bb20 : bb21)
 
 # backedges
 # - bb19
 bb20[firstDead=-1]():
-    <cfgAlias>$44: T.class_of(C10) = alias <C C10>
-    r: T.class_of(C10) = <cfgAlias>$44
+    <cfgAlias>$43: T.class_of(C10) = alias <C C10>
+    r: T.class_of(C10) = <cfgAlias>$43
     <unconditional> -> bb61
 
 # backedges
 # - bb19
 bb21[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
-    <statTemp>$46: Integer(11) = 11
-    <ifTemp>$45: T::Boolean = <statTemp>$46: Integer(11).===(invite: T.untyped)
-    <ifTemp>$45 -> (T::Boolean ? bb22 : bb23)
+    <statTemp>$45: Integer(11) = 11
+    <ifTemp>$44: T::Boolean = <statTemp>$45: Integer(11).===(invite: T.untyped)
+    <ifTemp>$44 -> (T::Boolean ? bb22 : bb23)
 
 # backedges
 # - bb21
 bb22[firstDead=-1]():
-    <cfgAlias>$48: T.class_of(C11) = alias <C C11>
-    r: T.class_of(C11) = <cfgAlias>$48
+    <cfgAlias>$47: T.class_of(C11) = alias <C C11>
+    r: T.class_of(C11) = <cfgAlias>$47
     <unconditional> -> bb61
 
 # backedges
 # - bb21
 bb23[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
-    <statTemp>$50: Integer(12) = 12
-    <ifTemp>$49: T::Boolean = <statTemp>$50: Integer(12).===(invite: T.untyped)
-    <ifTemp>$49 -> (T::Boolean ? bb24 : bb25)
+    <statTemp>$49: Integer(12) = 12
+    <ifTemp>$48: T::Boolean = <statTemp>$49: Integer(12).===(invite: T.untyped)
+    <ifTemp>$48 -> (T::Boolean ? bb24 : bb25)
 
 # backedges
 # - bb23
 bb24[firstDead=-1]():
-    <cfgAlias>$52: T.class_of(C12) = alias <C C12>
-    r: T.class_of(C12) = <cfgAlias>$52
+    <cfgAlias>$51: T.class_of(C12) = alias <C C12>
+    r: T.class_of(C12) = <cfgAlias>$51
     <unconditional> -> bb61
 
 # backedges
 # - bb23
 bb25[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
-    <statTemp>$54: Integer(13) = 13
-    <ifTemp>$53: T::Boolean = <statTemp>$54: Integer(13).===(invite: T.untyped)
-    <ifTemp>$53 -> (T::Boolean ? bb26 : bb27)
+    <statTemp>$53: Integer(13) = 13
+    <ifTemp>$52: T::Boolean = <statTemp>$53: Integer(13).===(invite: T.untyped)
+    <ifTemp>$52 -> (T::Boolean ? bb26 : bb27)
 
 # backedges
 # - bb25
 bb26[firstDead=-1]():
-    <cfgAlias>$56: T.class_of(C13) = alias <C C13>
-    r: T.class_of(C13) = <cfgAlias>$56
+    <cfgAlias>$55: T.class_of(C13) = alias <C C13>
+    r: T.class_of(C13) = <cfgAlias>$55
     <unconditional> -> bb61
 
 # backedges
 # - bb25
 bb27[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
-    <statTemp>$58: Integer(14) = 14
-    <ifTemp>$57: T::Boolean = <statTemp>$58: Integer(14).===(invite: T.untyped)
-    <ifTemp>$57 -> (T::Boolean ? bb28 : bb29)
+    <statTemp>$57: Integer(14) = 14
+    <ifTemp>$56: T::Boolean = <statTemp>$57: Integer(14).===(invite: T.untyped)
+    <ifTemp>$56 -> (T::Boolean ? bb28 : bb29)
 
 # backedges
 # - bb27
 bb28[firstDead=-1]():
-    <cfgAlias>$60: T.class_of(C14) = alias <C C14>
-    r: T.class_of(C14) = <cfgAlias>$60
+    <cfgAlias>$59: T.class_of(C14) = alias <C C14>
+    r: T.class_of(C14) = <cfgAlias>$59
     <unconditional> -> bb61
 
 # backedges
 # - bb27
 bb29[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
-    <statTemp>$62: Integer(15) = 15
-    <ifTemp>$61: T::Boolean = <statTemp>$62: Integer(15).===(invite: T.untyped)
-    <ifTemp>$61 -> (T::Boolean ? bb30 : bb31)
+    <statTemp>$61: Integer(15) = 15
+    <ifTemp>$60: T::Boolean = <statTemp>$61: Integer(15).===(invite: T.untyped)
+    <ifTemp>$60 -> (T::Boolean ? bb30 : bb31)
 
 # backedges
 # - bb29
 bb30[firstDead=-1]():
-    <cfgAlias>$64: T.class_of(C15) = alias <C C15>
-    r: T.class_of(C15) = <cfgAlias>$64
+    <cfgAlias>$63: T.class_of(C15) = alias <C C15>
+    r: T.class_of(C15) = <cfgAlias>$63
     <unconditional> -> bb61
 
 # backedges
 # - bb29
 bb31[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
-    <statTemp>$66: Integer(16) = 16
-    <ifTemp>$65: T::Boolean = <statTemp>$66: Integer(16).===(invite: T.untyped)
-    <ifTemp>$65 -> (T::Boolean ? bb32 : bb33)
+    <statTemp>$65: Integer(16) = 16
+    <ifTemp>$64: T::Boolean = <statTemp>$65: Integer(16).===(invite: T.untyped)
+    <ifTemp>$64 -> (T::Boolean ? bb32 : bb33)
 
 # backedges
 # - bb31
 bb32[firstDead=-1]():
-    <cfgAlias>$68: T.class_of(C16) = alias <C C16>
-    r: T.class_of(C16) = <cfgAlias>$68
+    <cfgAlias>$67: T.class_of(C16) = alias <C C16>
+    r: T.class_of(C16) = <cfgAlias>$67
     <unconditional> -> bb61
 
 # backedges
 # - bb31
 bb33[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
-    <statTemp>$70: Integer(17) = 17
-    <ifTemp>$69: T::Boolean = <statTemp>$70: Integer(17).===(invite: T.untyped)
-    <ifTemp>$69 -> (T::Boolean ? bb34 : bb35)
+    <statTemp>$69: Integer(17) = 17
+    <ifTemp>$68: T::Boolean = <statTemp>$69: Integer(17).===(invite: T.untyped)
+    <ifTemp>$68 -> (T::Boolean ? bb34 : bb35)
 
 # backedges
 # - bb33
 bb34[firstDead=-1]():
-    <cfgAlias>$72: T.class_of(C17) = alias <C C17>
-    r: T.class_of(C17) = <cfgAlias>$72
+    <cfgAlias>$71: T.class_of(C17) = alias <C C17>
+    r: T.class_of(C17) = <cfgAlias>$71
     <unconditional> -> bb61
 
 # backedges
 # - bb33
 bb35[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
-    <statTemp>$74: Integer(18) = 18
-    <ifTemp>$73: T::Boolean = <statTemp>$74: Integer(18).===(invite: T.untyped)
-    <ifTemp>$73 -> (T::Boolean ? bb36 : bb37)
+    <statTemp>$73: Integer(18) = 18
+    <ifTemp>$72: T::Boolean = <statTemp>$73: Integer(18).===(invite: T.untyped)
+    <ifTemp>$72 -> (T::Boolean ? bb36 : bb37)
 
 # backedges
 # - bb35
 bb36[firstDead=-1]():
-    <cfgAlias>$76: T.class_of(C18) = alias <C C18>
-    r: T.class_of(C18) = <cfgAlias>$76
+    <cfgAlias>$75: T.class_of(C18) = alias <C C18>
+    r: T.class_of(C18) = <cfgAlias>$75
     <unconditional> -> bb61
 
 # backedges
 # - bb35
 bb37[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
-    <statTemp>$78: Integer(19) = 19
-    <ifTemp>$77: T::Boolean = <statTemp>$78: Integer(19).===(invite: T.untyped)
-    <ifTemp>$77 -> (T::Boolean ? bb38 : bb39)
+    <statTemp>$77: Integer(19) = 19
+    <ifTemp>$76: T::Boolean = <statTemp>$77: Integer(19).===(invite: T.untyped)
+    <ifTemp>$76 -> (T::Boolean ? bb38 : bb39)
 
 # backedges
 # - bb37
 bb38[firstDead=-1]():
-    <cfgAlias>$80: T.class_of(C19) = alias <C C19>
-    r: T.class_of(C19) = <cfgAlias>$80
+    <cfgAlias>$79: T.class_of(C19) = alias <C C19>
+    r: T.class_of(C19) = <cfgAlias>$79
     <unconditional> -> bb61
 
 # backedges
 # - bb37
 bb39[firstDead=-1](<self>: T.class_of(A), invite: T.untyped):
-    <statTemp>$82: Integer(20) = 20
-    <ifTemp>$81: T::Boolean = <statTemp>$82: Integer(20).===(invite: T.untyped)
-    <ifTemp>$81 -> (T::Boolean ? bb40 : bb41)
+    <statTemp>$81: Integer(20) = 20
+    <ifTemp>$80: T::Boolean = <statTemp>$81: Integer(20).===(invite: T.untyped)
+    <ifTemp>$80 -> (T::Boolean ? bb40 : bb41)
 
 # backedges
 # - bb39
 bb40[firstDead=-1]():
-    <cfgAlias>$84: T.class_of(C20) = alias <C C20>
-    r: T.class_of(C20) = <cfgAlias>$84
+    <cfgAlias>$83: T.class_of(C20) = alias <C C20>
+    r: T.class_of(C20) = <cfgAlias>$83
     <unconditional> -> bb61
 
 # backedges
 # - bb39
 bb41[firstDead=2](<self>: T.class_of(A)):
-    <statTemp>$86: String("Bla bla bla") = "Bla bla bla"
-    <statTemp>$3: T.noreturn = <self>: T.class_of(A).raise(<statTemp>$86: String("Bla bla bla"))
+    <statTemp>$85: String("Bla bla bla") = "Bla bla bla"
+    <statTemp>$3: T.noreturn = <self>: T.class_of(A).raise(<statTemp>$85: String("Bla bla bla"))
     <unconditional> -> bb61
 
 # backedges

--- a/test/testdata/infer/isa_generic.rb.cfg-text.exp
+++ b/test/testdata/infer/isa_generic.rb.cfg-text.exp
@@ -83,9 +83,9 @@ method ::Object#f {
 bb0[firstDead=-1]():
     <self>: Object = cast(<self>: NilClass, Object);
     x: T.any(Concrete, Other) = load_arg(x)
-    <cfgAlias>$7: T.class_of(Concrete) = alias <C Concrete>
-    <ifTemp>$5: T::Boolean = <cfgAlias>$7: T.class_of(Concrete).===(x: T.any(Concrete, Other))
-    <ifTemp>$5 -> (T::Boolean ? bb2 : bb3)
+    <cfgAlias>$6: T.class_of(Concrete) = alias <C Concrete>
+    <ifTemp>$4: T::Boolean = <cfgAlias>$6: T.class_of(Concrete).===(x: T.any(Concrete, Other))
+    <ifTemp>$4 -> (T::Boolean ? bb2 : bb3)
 
 # backedges
 # - bb13
@@ -95,28 +95,28 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 bb2[firstDead=-1](x: Concrete):
-    <cfgAlias>$10: T.class_of(Concrete) = alias <C Concrete>
-    keep_for_ide$9: T.class_of(Concrete) = <cfgAlias>$10
-    keep_for_ide$9: T.untyped = <keep-alive> keep_for_ide$9
-    <castTemp>$11: Concrete = x
-    <statTemp>$3: Concrete = cast(<castTemp>$11: Concrete, Concrete);
+    <cfgAlias>$9: T.class_of(Concrete) = alias <C Concrete>
+    keep_for_ide$8: T.class_of(Concrete) = <cfgAlias>$9
+    keep_for_ide$8: T.untyped = <keep-alive> keep_for_ide$8
+    <castTemp>$10: Concrete = x
+    <statTemp>$3: Concrete = cast(<castTemp>$10: Concrete, Concrete);
     <unconditional> -> bb7
 
 # backedges
 # - bb0
 bb3[firstDead=-1](x: Other):
-    <cfgAlias>$14: T.class_of(Other) = alias <C Other>
-    <ifTemp>$12: TrueClass = <cfgAlias>$14: T.class_of(Other).===(x: Other)
-    <ifTemp>$12 -> (TrueClass ? bb4 : bb7)
+    <cfgAlias>$13: T.class_of(Other) = alias <C Other>
+    <ifTemp>$11: TrueClass = <cfgAlias>$13: T.class_of(Other).===(x: Other)
+    <ifTemp>$11 -> (TrueClass ? bb4 : bb7)
 
 # backedges
 # - bb3
 bb4[firstDead=-1](x: Other):
-    <cfgAlias>$17: T.class_of(Other) = alias <C Other>
-    keep_for_ide$16: T.class_of(Other) = <cfgAlias>$17
-    keep_for_ide$16: T.untyped = <keep-alive> keep_for_ide$16
-    <castTemp>$18: Other = x
-    <statTemp>$3: Other = cast(<castTemp>$18: Other, Other);
+    <cfgAlias>$16: T.class_of(Other) = alias <C Other>
+    keep_for_ide$15: T.class_of(Other) = <cfgAlias>$16
+    keep_for_ide$15: T.untyped = <keep-alive> keep_for_ide$15
+    <castTemp>$17: Other = x
+    <statTemp>$3: Other = cast(<castTemp>$17: Other, Other);
     <unconditional> -> bb7
 
 # backedges
@@ -124,27 +124,27 @@ bb4[firstDead=-1](x: Other):
 # - bb3
 # - bb4
 bb7[firstDead=-1](x: T.any(Concrete, Other)):
-    <cfgAlias>$23: T.class_of(Concrete) = alias <C Concrete>
-    <ifTemp>$20: T::Boolean = x: T.any(Concrete, Other).is_a?(<cfgAlias>$23: T.class_of(Concrete))
-    <ifTemp>$20 -> (T::Boolean ? bb8 : bb10)
+    <cfgAlias>$22: T.class_of(Concrete) = alias <C Concrete>
+    <ifTemp>$19: T::Boolean = x: T.any(Concrete, Other).is_a?(<cfgAlias>$22: T.class_of(Concrete))
+    <ifTemp>$19 -> (T::Boolean ? bb8 : bb10)
 
 # backedges
 # - bb7
 bb8[firstDead=-1](x: Concrete):
-    <cfgAlias>$25: T.class_of(Concrete) = alias <C Concrete>
-    keep_for_ide$24: T.class_of(Concrete) = <cfgAlias>$25
-    keep_for_ide$24: T.untyped = <keep-alive> keep_for_ide$24
-    <castTemp>$26: Concrete = x
-    <statTemp>$19: Concrete = cast(<castTemp>$26: Concrete, Concrete);
+    <cfgAlias>$24: T.class_of(Concrete) = alias <C Concrete>
+    keep_for_ide$23: T.class_of(Concrete) = <cfgAlias>$24
+    keep_for_ide$23: T.untyped = <keep-alive> keep_for_ide$23
+    <castTemp>$25: Concrete = x
+    <statTemp>$18: Concrete = cast(<castTemp>$25: Concrete, Concrete);
     <unconditional> -> bb10
 
 # backedges
 # - bb7
 # - bb8
 bb10[firstDead=-1](x: T.any(Other, Concrete)):
-    <cfgAlias>$30: T.class_of(Other) = alias <C Other>
-    <ifTemp>$27: T::Boolean = x: T.any(Other, Concrete).is_a?(<cfgAlias>$30: T.class_of(Other))
-    <ifTemp>$27 -> (T::Boolean ? bb11 : bb12)
+    <cfgAlias>$29: T.class_of(Other) = alias <C Other>
+    <ifTemp>$26: T::Boolean = x: T.any(Other, Concrete).is_a?(<cfgAlias>$29: T.class_of(Other))
+    <ifTemp>$26 -> (T::Boolean ? bb11 : bb12)
 
 # backedges
 # - bb10
@@ -155,11 +155,11 @@ bb11[firstDead=-1]():
 # backedges
 # - bb10
 bb12[firstDead=-1](x: Concrete):
-    <cfgAlias>$32: T.class_of(Concrete) = alias <C Concrete>
-    keep_for_ide$31: T.class_of(Concrete) = <cfgAlias>$32
-    keep_for_ide$31: T.untyped = <keep-alive> keep_for_ide$31
-    <castTemp>$33: Concrete = x
-    <returnMethodTemp>$2: Concrete = cast(<castTemp>$33: Concrete, Concrete);
+    <cfgAlias>$31: T.class_of(Concrete) = alias <C Concrete>
+    keep_for_ide$30: T.class_of(Concrete) = <cfgAlias>$31
+    keep_for_ide$30: T.untyped = <keep-alive> keep_for_ide$30
+    <castTemp>$32: Concrete = x
+    <returnMethodTemp>$2: Concrete = cast(<castTemp>$32: Concrete, Concrete);
     <unconditional> -> bb13
 
 # backedges

--- a/test/testdata/lsp/completion/case_1.rb.desugar-tree.exp
+++ b/test/testdata/lsp/completion/case_1.rb.desugar-tree.exp
@@ -9,13 +9,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.test1<<todo method>>(x, &<blk>)
       begin
         <self>.puts("before")
-        begin
-          <assignTemp>$2 = x
-          if <emptyTree>::<C <ErrorNode>>.===(<assignTemp>$2)
-            <emptyTree>
-          else
-            <emptyTree>
-          end
+        if <emptyTree>::<C <ErrorNode>>.===(x)
+          <emptyTree>
+        else
+          <emptyTree>
         end
       end
     end
@@ -23,13 +20,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.test2<<todo method>>(x, &<blk>)
       begin
         <self>.puts("before")
-        begin
-          <assignTemp>$2 = x
-          if <emptyTree>::<C MethodCompletion>.puts("hello").===(<assignTemp>$2)
-            <emptyTree>
-          else
-            <emptyTree>
-          end
+        if <emptyTree>::<C MethodCompletion>.puts("hello").===(x)
+          <emptyTree>
+        else
+          <emptyTree>
         end
       end
     end
@@ -37,13 +31,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.test3<<todo method>>(x, &<blk>)
       begin
         <self>.puts("before")
-        begin
-          <assignTemp>$2 = x
-          if <emptyTree>::<C MethodCompletion>.Opus()::<C Log>.info("hello").===(<assignTemp>$2)
-            <emptyTree>
-          else
-            <emptyTree>
-          end
+        if <emptyTree>::<C MethodCompletion>.Opus()::<C Log>.info("hello").===(x)
+          <emptyTree>
+        else
+          <emptyTree>
         end
       end
     end
@@ -51,13 +42,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.test4<<todo method>>(x, &<blk>)
       begin
         <self>.puts("before")
-        begin
-          <assignTemp>$2 = x
-          if <emptyTree>::<C MethodCompletion>.y=(nil).===(<assignTemp>$2)
-            <emptyTree>
-          else
-            <emptyTree>
-          end
+        if <emptyTree>::<C MethodCompletion>.y=(nil).===(x)
+          <emptyTree>
+        else
+          <emptyTree>
         end
       end
     end

--- a/test/testdata/lsp/completion/case_2.rb.desugar-tree.exp
+++ b/test/testdata/lsp/completion/case_2.rb.desugar-tree.exp
@@ -13,13 +13,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.test1<<todo method>>(x, &<blk>)
       begin
         <self>.puts("before")
-        begin
-          <assignTemp>$2 = x
-          if <emptyTree>::<C ConstantCompletion>::<C <ConstantNameMissing>>.===(<assignTemp>$2)
-            <self>.puts("hello")
-          else
-            <emptyTree>
-          end
+        if <emptyTree>::<C ConstantCompletion>::<C <ConstantNameMissing>>.===(x)
+          <self>.puts("hello")
+        else
+          <emptyTree>
         end
       end
     end
@@ -27,13 +24,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.test2<<todo method>>(x, &<blk>)
       begin
         <self>.puts("before")
-        begin
-          <assignTemp>$2 = x
-          if <emptyTree>::<C ConstantCompletion>.puts("hello").===(<assignTemp>$2)
-            <emptyTree>
-          else
-            <emptyTree>
-          end
+        if <emptyTree>::<C ConstantCompletion>.puts("hello").===(x)
+          <emptyTree>
+        else
+          <emptyTree>
         end
       end
     end
@@ -41,13 +35,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.test3<<todo method>>(x, &<blk>)
       begin
         <self>.puts("before")
-        begin
-          <assignTemp>$2 = x
-          if <emptyTree>::<C ConstantCompletion>::<C Opus>::<C Log>.info("hello").===(<assignTemp>$2)
-            <emptyTree>
-          else
-            <emptyTree>
-          end
+        if <emptyTree>::<C ConstantCompletion>::<C Opus>::<C Log>.info("hello").===(x)
+          <emptyTree>
+        else
+          <emptyTree>
         end
       end
     end
@@ -55,13 +46,10 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     def self.test4<<todo method>>(x, &<blk>)
       begin
         <self>.puts("before")
-        begin
-          <assignTemp>$2 = x
-          if <emptyTree>::<C ConstantCompletion>.y=(nil).===(<assignTemp>$2)
-            <emptyTree>
-          else
-            <emptyTree>
-          end
+        if <emptyTree>::<C ConstantCompletion>.y=(nil).===(x)
+          <emptyTree>
+        else
+          <emptyTree>
         end
       end
     end


### PR DESCRIPTION
### Motivation

Simplify the desugaring of `case` expressions.

They would always introduce a synthetic local variable, even if the discriminant was already a local variable.

E.g.

```ruby
x = 123

case x
when 1
when 2
when 3
else
end
```

Before:

```
begin
  <assignTemp>$2 = x
  if 1.===(<assignTemp>$2)
    <emptyTree>
  else
    if 2.===(<assignTemp>$2)
      <emptyTree>
    else
      if 3.===(<assignTemp>$2)
        <emptyTree>
      else
        <emptyTree>
      end
    end
  end
end
```

After:

```
if 1.===(x)
  <emptyTree>
else
  if 2.===(x)
    <emptyTree>
  else
    if 3.===(x)
      <emptyTree>
    else
      <emptyTree>
    end
  end
end
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
