### PR TITLE
Narrow down what `isa_reference()` checks for

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -136,7 +136,10 @@ public:
         return make_expression<UnresolvedIdent>(loc, UnresolvedIdent::Kind::Instance, name);
     }
 
+    // Create a new "read" node for the given reference read node.
     static ExpressionPtr cpRef(ExpressionPtr &name) {
+        ENFORCE(isa_reference(name), "Can only copy reference-like nodes with cpRef");
+
         if (auto nm = cast_tree<UnresolvedIdent>(name)) {
             return make_expression<UnresolvedIdent>(nm->loc, nm->kind, nm->name);
         } else if (auto nm = cast_tree<ast::Local>(name)) {
@@ -144,7 +147,8 @@ public:
         } else if (auto self = cast_tree<ast::Self>(name)) {
             return make_expression<ast::Self>(self->loc);
         }
-        Exception::notImplemented();
+
+        unreachable("MK::cpRef should handle every type that passes `isa_reference()`.");
     }
 
     static ExpressionPtr Assign(core::LocOffsets loc, ExpressionPtr lhs, ExpressionPtr rhs) {

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -685,8 +685,8 @@ public:
                 [&](const class BlockParam &blk) { cursor = &blk.expr; },
                 [&](const class ShadowArg &shadow) { cursor = &shadow.expr; },
                 // ENFORCES are last so that we don't pay the price of casting in the fast path.
-                [&](const ast::Local &opt) { ENFORCE(false, "Should only be called before local_vars.cc"); },
-                [&](const ExpressionPtr &expr) { ENFORCE(false, "Unexpected node type in parameter position."); });
+                [&](const ast::Local &opt) { unreachable("Should only be called before local_vars.cc"); },
+                [&](const ExpressionPtr &expr) { unreachable("Unexpected node type in parameter position."); });
         }
     }
 
@@ -706,8 +706,8 @@ public:
                 [&](const class BlockParam &blk) { cursor = &blk.expr; },
                 [&](const class ShadowArg &shadow) { cursor = &shadow.expr; },
                 // ENFORCES are last so that we don't pay the price of casting in the fast path.
-                [&](const UnresolvedIdent &opt) { ENFORCE(false, "Namer should have created a Local for this arg."); },
-                [&](const ExpressionPtr &expr) { ENFORCE(false, "Unexpected node type in parameter position."); });
+                [&](const UnresolvedIdent &opt) { unreachable("Namer should have created a Local for this arg."); },
+                [&](const ExpressionPtr &expr) { unreachable("Unexpected node type in parameter position."); });
         }
     }
 };

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -686,7 +686,7 @@ public:
                 [&](const class ShadowArg &shadow) { cursor = &shadow.expr; },
                 // ENFORCES are last so that we don't pay the price of casting in the fast path.
                 [&](const ast::Local &opt) { ENFORCE(false, "Should only be called before local_vars.cc"); },
-                [&](const ExpressionPtr &expr) { ENFORCE(false, "Unexpected node type in argument position."); });
+                [&](const ExpressionPtr &expr) { ENFORCE(false, "Unexpected node type in parameter position."); });
         }
     }
 
@@ -707,7 +707,7 @@ public:
                 [&](const class ShadowArg &shadow) { cursor = &shadow.expr; },
                 // ENFORCES are last so that we don't pay the price of casting in the fast path.
                 [&](const UnresolvedIdent &opt) { ENFORCE(false, "Namer should have created a Local for this arg."); },
-                [&](const ExpressionPtr &expr) { ENFORCE(false, "Unexpected node type in argument position."); });
+                [&](const ExpressionPtr &expr) { ENFORCE(false, "Unexpected node type in parameter position."); });
         }
     }
 };

--- a/ast/ParamParsing.cc
+++ b/ast/ParamParsing.cc
@@ -39,7 +39,8 @@ core::ParsedParam parseParam(const ast::ExpressionPtr &param) {
                 parsedParam.local = local.localVariable;
                 parsedParam.loc = local.loc;
                 cursor = nullptr;
-            });
+            },
+            [&](const ast::ExpressionPtr &expr) { ENFORCE(false, "Unexpected node type in argument position."); });
     }
 
     return parsedParam;
@@ -74,9 +75,6 @@ vector<core::ParsedParam> ParamParsing::parseParams(const ast::MethodDef::PARAMS
     parsedParams.reserve(params.size());
 
     for (auto &param : params) {
-        if (!ast::isa_reference(param)) {
-            Exception::raise("Must be a reference!");
-        }
         parsedParams.emplace_back(parseParam(param));
     }
 

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -153,10 +153,10 @@ void ExpressionPtr::resetToEmpty(EmptyTree *expr) noexcept {
     resetTagged(tagPtr(ExpressionToTag<EmptyTree>::value, expr));
 }
 
+// Returns true for nodes that are a pure read, like from a local variable, instance variable, `self`, etc.
+// These can be copied with `MK::cpRef`.
 bool isa_reference(const ExpressionPtr &what) {
-    return isa_tree<Local>(what) || isa_tree<UnresolvedIdent>(what) || isa_tree<RestParam>(what) ||
-           isa_tree<KeywordArg>(what) || isa_tree<OptionalParam>(what) || isa_tree<BlockParam>(what) ||
-           isa_tree<ShadowArg>(what) || isa_tree<Self>(what);
+    return isa_tree<Local>(what) || isa_tree<UnresolvedIdent>(what) || isa_tree<Self>(what);
 }
 
 /** https://git.corp.stripe.com/gist/nelhage/51564501674174da24822e60ad770f64

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -108,7 +108,8 @@ class LocalNameInserter {
                     named.flags.shadow = true;
                     cursor = &shadow.expr;
                 },
-                [&](const ast::Local &local) { Exception::raise("Local variable found in argument list"); });
+                [&](const ast::Local &local) { unreachable("Local variable found in argument list"); },
+                [&](const ast::ExpressionPtr &expr) { unreachable("Unexpected node type in parameter position."); });
         }
 
         named.expr = move(arg);
@@ -120,10 +121,6 @@ class LocalNameInserter {
         int pos = -1;
         for (auto &param : methodParams) {
             ++pos;
-
-            if (!ast::isa_reference(param)) {
-                Exception::raise("Must be a reference!");
-            }
             auto named = nameArg(ctx, namedParams, move(param), pos);
             namedParams.emplace_back(move(named));
         }


### PR DESCRIPTION
### Motivation

It's living a double life, and in both contexts its used, most of the things it checks for can't occur (worse: they would be invalid to be there).

* On one hand, it's used to find out "reference-like" things that can be read from, without side-effects (thus letting you skip a synthetic local variable), like for `@a ||= 1`.

* On the other, it's used to validate that methods' parameter lists only contain parameters.

These two cases are basically mutually exclusive (except `ast::Local`, which describes both local variables and required positional parameters). We can just make them into two functions, and limit how many checks we do for each.

### Test plan

Pure refactor.