### PR TITLE
Rewriter: hoist nested shared_examples for define_derived_metadata and local_context patterns

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -294,6 +294,8 @@ NameDef names[] = {
     {"includeContext", "include_context"},
     {"itBehavesLike", "it_behaves_like"},
     {"localContext", "local_context"},
+    {"configure"},
+    {"defineDerivedMetadata", "define_derived_metadata"},
     {"RSpec", "RSpec", true},
     {"Core", "Core", true},
     {"ExampleGroup", "ExampleGroup", true},

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -1263,9 +1263,18 @@ vector<ast::ExpressionPtr> Minitest::run(core::MutableContext ctx, bool isClass,
         return stats;
     }
 
-    // Handle RSpec.local_context do ... end: scan the body for RSpec.shared_examples /
-    // shared_context / shared_examples_for calls and hoist them to the top-level scope,
-    // making them resolvable via include_examples / include_context in any describe block.
+    // Handle RSpec.local_context do ... end: scan the body for shared_examples /
+    // shared_context / shared_examples_for calls (bare or RSpec.-prefixed) and hoist them
+    // to the top-level scope, making them resolvable via include_examples / include_context
+    // in any describe block.
+    //
+    // At runtime `RSpec.local_context` registers the block body to be re-evaluated inside
+    // each consumer's example group, so any shared_examples-family call defined inside it
+    // (bare or RSpec.-prefixed) ends up registered in the RSpec global / consumer registry.
+    // We pass `insideDescribe=true` for bare shared_examples-family calls so they pass
+    // `runSingle`'s `!insideDescribe && !recvIsRSpec` gate. Other bare sends (e.g. `let`,
+    // `before`, `it`) keep being dropped on purpose -- they would otherwise emit method
+    // defs at root scope.
     if (ctx.state.cacheSensitiveOptions.rspecRewriterEnabled && send->fun == core::Names::localContext() &&
         isRSpec(ctx, send->recv) && send->hasBlock()) {
         auto *block = send->block();
@@ -1273,12 +1282,18 @@ vector<ast::ExpressionPtr> Minitest::run(core::MutableContext ctx, bool isClass,
         // Note: only direct Send children of the block body are scanned.
         // Shared examples nested inside conditionals or other blocks are not hoisted.
         auto processStmt = [&](ast::ExpressionPtr &stmt) {
-            if (auto bodySend = ast::cast_tree<ast::Send>(stmt)) {
-                auto result = runSingle(ctx, /* isClass */ false, /* maybeSharedExamplesName */ nullptr, bodySend,
-                                        /* insideDescribe */ false);
-                if (result != nullptr) {
-                    stats.emplace_back(std::move(result));
-                }
+            auto bodySend = ast::cast_tree<ast::Send>(stmt);
+            if (bodySend == nullptr) {
+                return;
+            }
+            // Only treat bare shared_examples-family calls as if we were inside a describe.
+            // For anything else (including bare `let`/`before`/`it`), keep `insideDescribe=false`
+            // so `runSingle` drops it instead of emitting root-scoped pollution.
+            bool isBareSharedExamples = bodySend->recv.isSelfReference() && isSharedExamplesName(bodySend->fun);
+            auto result = runSingle(ctx, /* isClass */ false, /* maybeSharedExamplesName */ nullptr, bodySend,
+                                    /* insideDescribe */ isBareSharedExamples);
+            if (result != nullptr) {
+                stats.emplace_back(std::move(result));
             }
         };
 

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -1094,8 +1094,7 @@ std::optional<core::NameRef> asSymbolLiteral(const ast::ExpressionPtr &expr) {
 //   config.include_context 'NAME', :TAG
 //   config.define_derived_metadata(...) do |m|; m[:TAG] = true; end
 // Adds each matching context NAME to `out`.
-void collectAutoIncludedFromConfigure(core::MutableContext ctx, ast::Block *block,
-                                      UnorderedSet<core::NameRef> &out) {
+void collectAutoIncludedFromConfigure(core::MutableContext ctx, ast::Block *block, UnorderedSet<core::NameRef> &out) {
     if (block == nullptr) {
         return;
     }
@@ -1128,8 +1127,8 @@ void collectAutoIncludedFromConfigure(core::MutableContext ctx, ast::Block *bloc
 
             forEachBlockBodyStmt(inner->body, [&](ast::ExpressionPtr &innerStmt) {
                 auto assign = ast::cast_tree<ast::Send>(innerStmt);
-                if (assign == nullptr || assign->fun != core::Names::squareBracketsEq() ||
-                    assign->numPosArgs() != 2 || assign->hasBlock()) {
+                if (assign == nullptr || assign->fun != core::Names::squareBracketsEq() || assign->numPosArgs() != 2 ||
+                    assign->hasBlock()) {
                     return;
                 }
                 auto tagOpt = asSymbolLiteral(assign->getPosArg(0));
@@ -1180,8 +1179,8 @@ ast::ExpressionPtr cloneAsRSpecPrefixed(core::MutableContext ctx, ast::Send *sen
         newFlags.hasBlock = true;
     }
 
-    return ast::MK::Send(send->loc, std::move(rspecRecv), send->fun, send->funLoc, numPosArgs,
-                         std::move(newArgs), newFlags);
+    return ast::MK::Send(send->loc, std::move(rspecRecv), send->fun, send->funLoc, numPosArgs, std::move(newArgs),
+                         newFlags);
 }
 
 } // namespace

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -2,11 +2,13 @@
 #include "ast/Helpers.h"
 #include "ast/ast.h"
 #include "ast/treemap/treemap.h"
+#include "common/common.h"
 #include "core/Context.h"
 #include "core/Names.h"
 #include "core/core.h"
 #include "core/errors/rewriter.h"
 #include "rewriter/rewriter.h"
+#include <optional>
 
 using namespace std;
 
@@ -991,8 +993,16 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::
 
         case core::Names::includeExamples().rawId():
         case core::Names::includeContext().rawId(): {
-            if (!ctx.state.cacheSensitiveOptions.rspecRewriterEnabled || block != nullptr ||
-                !send->recv.isSelfReference() || !insideDescribe || send->numPosArgs() < 1) {
+            // `include_context 'name'` (no block) maps to a synthetic include of the
+            // `<shared_examples 'name'>` module. The with-block forms
+            // `include_context 'name' do ... end` (and `include_examples 'name' do ... end`)
+            // add setup specific to the consumer's example group; the most important effect
+            // for type checking is still the include, so we emit the include and drop the
+            // block body. (The block can shadow `let`/`before` from the included context
+            // with local overrides, but those are evaluated as RSpec example-group methods
+            // that Sorbet already approximates loosely.)
+            if (!ctx.state.cacheSensitiveOptions.rspecRewriterEnabled || !send->recv.isSelfReference() ||
+                !insideDescribe || send->numPosArgs() < 1) {
                 return nullptr;
             }
 
@@ -1048,7 +1058,205 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::
     return nullptr;
 }
 
+// Iterates over each top-level statement of a block body. Block bodies are either an `InsSeq`
+// (multi-statement) or a single ExpressionPtr (one statement); the caller usually wants to
+// treat both shapes uniformly.
+template <typename F> void forEachBlockBodyStmt(ast::ExpressionPtr &body, F &&fn) {
+    if (auto bodySeq = ast::cast_tree<ast::InsSeq>(body)) {
+        for (auto &exp : bodySeq->stats) {
+            fn(exp);
+        }
+        fn(bodySeq->expr);
+    } else {
+        fn(body);
+    }
+}
+
+// Returns the underlying NameRef of a string-literal arg, or nullopt otherwise.
+std::optional<core::NameRef> asStringLiteral(const ast::ExpressionPtr &expr) {
+    auto lit = ast::cast_tree<ast::Literal>(expr);
+    if (lit == nullptr || !lit->isString()) {
+        return std::nullopt;
+    }
+    return lit->asString();
+}
+
+// Returns the underlying NameRef of a symbol-literal arg, or nullopt otherwise.
+std::optional<core::NameRef> asSymbolLiteral(const ast::ExpressionPtr &expr) {
+    auto lit = ast::cast_tree<ast::Literal>(expr);
+    if (lit == nullptr || !lit->isSymbol()) {
+        return std::nullopt;
+    }
+    return lit->asSymbol();
+}
+
+// Scans one `RSpec.configure do |config| ... end` block body for the pairing:
+//   config.include_context 'NAME', :TAG
+//   config.define_derived_metadata(...) do |m|; m[:TAG] = true; end
+// Adds each matching context NAME to `out`.
+void collectAutoIncludedFromConfigure(core::MutableContext ctx, ast::Block *block,
+                                      UnorderedSet<core::NameRef> &out) {
+    if (block == nullptr) {
+        return;
+    }
+
+    UnorderedMap<core::NameRef, core::NameRef> nameByTag; // :tag -> 'name'
+    UnorderedSet<core::NameRef> tagsAutoApplied;
+
+    forEachBlockBodyStmt(block->body, [&](ast::ExpressionPtr &stmt) {
+        auto send = ast::cast_tree<ast::Send>(stmt);
+        if (send == nullptr) {
+            return;
+        }
+
+        // config.include_context 'NAME', :TAG, ... (any extra args are accepted)
+        if (send->fun == core::Names::includeContext() && send->numPosArgs() >= 2 && !send->hasBlock()) {
+            auto nameOpt = asStringLiteral(send->getPosArg(0));
+            auto tagOpt = asSymbolLiteral(send->getPosArg(1));
+            if (nameOpt.has_value() && tagOpt.has_value()) {
+                nameByTag[*tagOpt] = *nameOpt;
+            }
+            return;
+        }
+
+        // config.define_derived_metadata(...) do |metadata|; metadata[:TAG] = true; end
+        if (send->fun == core::Names::defineDerivedMetadata() && send->hasBlock()) {
+            auto inner = send->block();
+            if (inner == nullptr || inner->params.size() != 1) {
+                return;
+            }
+
+            forEachBlockBodyStmt(inner->body, [&](ast::ExpressionPtr &innerStmt) {
+                auto assign = ast::cast_tree<ast::Send>(innerStmt);
+                if (assign == nullptr || assign->fun != core::Names::squareBracketsEq() ||
+                    assign->numPosArgs() != 2 || assign->hasBlock()) {
+                    return;
+                }
+                auto tagOpt = asSymbolLiteral(assign->getPosArg(0));
+                if (!tagOpt.has_value()) {
+                    return;
+                }
+                auto valLit = ast::cast_tree<ast::Literal>(assign->getPosArg(1));
+                if (valLit == nullptr || !valLit->isTrue(ctx.state)) {
+                    return;
+                }
+                tagsAutoApplied.insert(*tagOpt);
+            });
+        }
+    });
+
+    for (auto tag : tagsAutoApplied) {
+        auto it = nameByTag.find(tag);
+        if (it != nameByTag.end()) {
+            out.insert(it->second);
+        }
+    }
+}
+
+// Clones a bare-receiver Send (e.g. `shared_examples 'foo' do ... end`) as the equivalent
+// `RSpec.<fun>(args) do ... end`, deep-copying positional args and the block. Used to hoist
+// nested bare shared_examples from an auto-included `RSpec.shared_context` to top level so
+// the per-statement rewriter emits a root-scoped synthetic module.
+ast::ExpressionPtr cloneAsRSpecPrefixed(core::MutableContext ctx, ast::Send *send) {
+    ENFORCE(send != nullptr);
+
+    auto recvLoc = send->recv.loc();
+    auto rspecRecv = ast::MK::UnresolvedConstantParts(recvLoc, {core::Names::Constants::RSpec()});
+
+    auto numPosArgs = send->numPosArgs();
+    ast::Send::ARGS_store newArgs;
+    for (uint16_t i = 0; i < numPosArgs; ++i) {
+        newArgs.emplace_back(send->getPosArg(i).deepCopy());
+    }
+
+    ast::Send::Flags newFlags;
+    newFlags.isRewriterSynthesized = true;
+    if (send->hasBlock()) {
+        // Send stores the block as the last entry in `args`. We need to deep-copy that whole
+        // entry (the `ast::Block` tree) into our new send.
+        auto *blockExpr = send->rawBlock();
+        ENFORCE(blockExpr != nullptr);
+        newArgs.emplace_back(blockExpr->deepCopy());
+        newFlags.hasBlock = true;
+    }
+
+    return ast::MK::Send(send->loc, std::move(rspecRecv), send->fun, send->funLoc, numPosArgs,
+                         std::move(newArgs), newFlags);
+}
+
 } // namespace
+
+void Minitest::runOnClassDef(core::MutableContext ctx, ast::ClassDef *classDef) {
+    if (!ctx.state.cacheSensitiveOptions.rspecRewriterEnabled) {
+        return;
+    }
+    if (ctx.state.cacheSensitiveOptions.runningUnderAutogen) {
+        return;
+    }
+    if (classDef == nullptr) {
+        return;
+    }
+
+    // Pass 1: scan top-level RSpec.configure blocks for the auto-include pairing.
+    UnorderedSet<core::NameRef> autoIncludedNames;
+    for (auto &stat : classDef->rhs) {
+        auto send = ast::cast_tree<ast::Send>(stat);
+        if (send == nullptr || !send->hasBlock()) {
+            continue;
+        }
+        if (send->fun != core::Names::configure() || !isRSpec(ctx, send->recv)) {
+            continue;
+        }
+        collectAutoIncludedFromConfigure(ctx, send->block(), autoIncludedNames);
+    }
+    if (autoIncludedNames.empty()) {
+        return;
+    }
+
+    // Pass 2: for each `RSpec.shared_context 'NAME', :TAG do ... end` where NAME is auto-included,
+    // clone its direct-child bare shared_examples/shared_context/shared_examples_for sends as
+    // top-level `RSpec.<fun>` sends. The per-statement pass below will then emit root-scoped
+    // synthetic modules for each.
+    std::vector<ast::ExpressionPtr> hoisted;
+    for (auto &stat : classDef->rhs) {
+        auto send = ast::cast_tree<ast::Send>(stat);
+        if (send == nullptr || !send->hasBlock()) {
+            continue;
+        }
+        if (!isRSpec(ctx, send->recv) || send->fun != core::Names::sharedContext() || send->numPosArgs() < 1) {
+            continue;
+        }
+        auto nameOpt = asStringLiteral(send->getPosArg(0));
+        if (!nameOpt.has_value() || autoIncludedNames.count(*nameOpt) == 0) {
+            continue;
+        }
+
+        auto *block = send->block();
+        if (block == nullptr) {
+            continue;
+        }
+
+        forEachBlockBodyStmt(block->body, [&](ast::ExpressionPtr &innerStmt) {
+            auto innerSend = ast::cast_tree<ast::Send>(innerStmt);
+            if (innerSend == nullptr || !innerSend->hasBlock()) {
+                return;
+            }
+            if (!innerSend->recv.isSelfReference() || !isSharedExamplesName(innerSend->fun) ||
+                innerSend->numPosArgs() < 1) {
+                return;
+            }
+
+            auto cloned = cloneAsRSpecPrefixed(ctx, innerSend);
+            if (cloned != nullptr) {
+                hoisted.emplace_back(std::move(cloned));
+            }
+        });
+    }
+
+    for (auto &h : hoisted) {
+        classDef->rhs.emplace_back(std::move(h));
+    }
+}
 
 vector<ast::ExpressionPtr> Minitest::run(core::MutableContext ctx, bool isClass, ast::Send *send) {
     vector<ast::ExpressionPtr> stats;

--- a/rewriter/Minitest.h
+++ b/rewriter/Minitest.h
@@ -34,6 +34,17 @@ class Minitest final {
 public:
     static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, bool isClass, ast::Send *send);
 
+    // Class-level pass. Looks for `RSpec.configure do |config| ... end` blocks containing the
+    // pairing `config.include_context 'NAME', :TAG` + `config.define_derived_metadata(...) do |m|
+    // m[:TAG] = true end`. For each `NAME` so identified, finds the matching
+    // `RSpec.shared_context 'NAME', :TAG do ... end` in the same file and clones its
+    // direct-child bare `shared_examples`/`shared_context`/`shared_examples_for` calls as
+    // top-level `RSpec.`-prefixed sends. The per-statement `run` pass then emits these as
+    // root-scoped synthetic modules so consumers that pull the outer in via
+    // `define_derived_metadata` (instead of an explicit lexical `include_context`) can still
+    // resolve them.
+    static void runOnClassDef(core::MutableContext ctx, ast::ClassDef *classDef);
+
     Minitest() = delete;
 };
 

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -52,6 +52,7 @@ public:
         TypeMembers::run(ctx, classDef);
         Concern::run(ctx, classDef);
         TestCase::run(ctx, classDef);
+        Minitest::runOnClassDef(ctx, classDef);
 
         PackageSpec::run(ctx, classDef);
 

--- a/test/testdata/rewriter/rspec_shared_examples_in_derived_metadata_context.rb
+++ b/test/testdata/rewriter/rspec_shared_examples_in_derived_metadata_context.rb
@@ -1,0 +1,151 @@
+# typed: true
+# enable-experimental-rspec: true
+
+module RSpec
+  module Core
+    class ExampleGroup
+    end
+  end
+
+  def self.configure
+    yield self
+  end
+  def self.include_context(_name, _tag); end
+  def self.define_derived_metadata(*); yield({}); end
+end
+
+# Bare `shared_examples` defined inside an `RSpec.shared_context` whose tag is
+# auto-applied via `RSpec.configure { config.include_context 'NAME', :TAG;
+# config.define_derived_metadata(...) { |m| m[:TAG] = true } }` should be hoisted to
+# root scope so consumers that pick up the outer context via derived_metadata (rather
+# than an explicit lexical `include_context`) can still resolve them via
+# `it_behaves_like` / `include_examples`.
+#
+# This mirrors zenpayroll's `packs/technical_services/auth/authorization/spec/support/
+# shared_contexts/admin_abilities.rb` pattern, where a sibling `RSpec.configure`
+# block wires the outer context to every spec under a file_path regex.
+
+RSpec.shared_context 'outer auto included', :auto_tag do
+  shared_examples 'an action that requires permission' do |action, permission|
+    it 'works' do
+    end
+  end
+
+  shared_examples 'an unauthorized action' do |action|
+    it 'fails' do
+    end
+  end
+
+  shared_examples_for 'a permitted operation' do |operation|
+    it 'is permitted' do
+    end
+  end
+
+  shared_context 'a nested context' do
+    let(:foo) { 42 }
+  end
+end
+
+RSpec.configure do |config|
+  config.include_context 'outer auto included', :auto_tag
+  config.define_derived_metadata(file_path: %r{/some/path/}) do |metadata|
+    metadata[:auto_tag] = true
+  end
+end
+
+# Consumer with no lexical `include_context` — at runtime RSpec applies the include via
+# `define_derived_metadata`. The hoisted root-scoped synthetic modules let Sorbet
+# resolve the references without needing a `RSpec.shared_examples` RBI shim.
+RSpec.describe 'metadata-driven consumer' do
+  it_behaves_like 'an action that requires permission', :create, :read
+  it_behaves_like 'an unauthorized action', :delete
+  include_examples 'a permitted operation', :update
+  include_context 'a nested context'
+end
+
+# `include_context 'name' do ... end` (with a block) — RSpec runtime adds the block
+# body as consumer-local setup on top of the include. The rewriter previously
+# returned nullptr on this shape (dropping the include entirely); now we emit the
+# include and ignore the block body, so the consumer's class still has the outer
+# context in its ancestor chain for resolving sibling `it_behaves_like` references.
+RSpec.shared_context 'with block context' do
+  shared_examples 'block-form sibling examples' do
+    it 'sibling works' do
+    end
+  end
+end
+
+RSpec.describe 'with-block include_context consumer' do
+  include_context 'with block context' do
+    let(:override) { :consumer_local }
+  end
+  it_behaves_like 'block-form sibling examples'
+end
+
+# Negative case: a tag that is NOT paired with `define_derived_metadata` should
+# leave its nested shared_examples enclosing-scoped (the post-#10273 default).
+# A consumer without an explicit `include_context` should NOT resolve the nested
+# names — error expected.
+RSpec.shared_context 'outer not auto included', :manual_only_tag do
+  shared_examples 'manually included only' do
+    it 'works only when explicitly included' do
+    end
+  end
+end
+
+RSpec.describe 'consumer that does not include outer' do
+  it_behaves_like 'manually included only'
+  #                ^^^^^^^^^^^^^^^^^^^^^^^ error-with-dupes: Unable to resolve constant `<shared_examples 'manually included only'>`
+end
+
+# -----------------------------------------------------------------------------
+# TODO(sorbet/sorbet): consumer-of-consumer chains across `include_context` ----
+# -----------------------------------------------------------------------------
+#
+# When an outer `RSpec.shared_context` uses `include_context 'inner'` to pull in
+# another shared_context, AND defines a nested `shared_examples` that references
+# the inner's nested `shared_examples` via `include_examples`, the inner
+# reference fails to resolve.
+#
+# At runtime RSpec inlines the inner context's body into the outer at each
+# include site, so the inner's nested shared_examples gets re-registered in the
+# outer's example group. Sorbet currently models `include_context` as a plain
+# Ruby `include`, and Ruby's constant lookup does NOT walk a lexical parent's
+# includes for inherited nested constants -- the same lookup fails in plain
+# Ruby too:
+#
+#     module Outer; module Inner; end; end
+#     class Container
+#       include Outer
+#       class Nested
+#         p Inner   # NameError: uninitialized constant Container::Nested::Inner
+#       end
+#     end
+#
+# To fix: teach the rewriter that `include_context 'name'` inside an
+# `RSpec.shared_context` body should inline the included context's nested
+# `shared_examples` definitions (or otherwise expose them at root scope at the
+# include site), rather than emitting a plain `include`. Mirrors zenpayroll's
+# `packs/product_services/payroll/pufferfish/spec/support/shared_behaviors/
+# individual_eft_debit.rb` pattern.
+
+RSpec.shared_context 'inner ctx' do
+  shared_examples 'inner shared examples' do
+    it 'inner works' do
+    end
+  end
+end
+
+RSpec.shared_context 'outer ctx that includes inner' do
+  include_context 'inner ctx'
+
+  shared_examples 'outer shared examples that consumes inner' do
+    it 'outer works' do
+    end
+
+    # TODO(sorbet/sorbet): should resolve via runtime inline-body semantics.
+    include_examples 'inner shared examples'
+    #                ^^^^^^^^^^^^^^^^^^^^^^^ error-with-dupes: Unable to resolve constant `<shared_examples 'inner shared examples'>`
+  end
+end
+

--- a/test/testdata/rewriter/rspec_shared_examples_in_derived_metadata_context.rb
+++ b/test/testdata/rewriter/rspec_shared_examples_in_derived_metadata_context.rb
@@ -95,7 +95,7 @@ end
 
 RSpec.describe 'consumer that does not include outer' do
   it_behaves_like 'manually included only'
-  #                ^^^^^^^^^^^^^^^^^^^^^^^ error-with-dupes: Unable to resolve constant `<shared_examples 'manually included only'>`
+  #               ^^^^^^^^^^^^^^^^^^^^^^^^ error-with-dupes: Unable to resolve constant `<shared_examples 'manually included only'>`
 end
 
 # -----------------------------------------------------------------------------
@@ -118,7 +118,7 @@ end
 #     class Container
 #       include Outer
 #       class Nested
-#         p Inner   # NameError: uninitialized constant Container::Nested::Inner
+#         p Inner   # raises uninitialized constant Container::Nested::Inner
 #       end
 #     end
 #

--- a/test/testdata/rewriter/rspec_shared_examples_in_derived_metadata_context.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_shared_examples_in_derived_metadata_context.rb.rewrite-tree.exp
@@ -1,0 +1,186 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C RSpec><<C <todo sym>>> < ()
+    def self.configure<<todo method>>(&<implicit yield>)
+      <implicit yield>.call(<self>)
+    end
+
+    def self.include_context<<todo method>>(_name, _tag, &<blk>)
+      <emptyTree>
+    end
+
+    def self.define_derived_metadata<<todo method>>(**, &<implicit yield>)
+      <implicit yield>.call({})
+    end
+
+    module <emptyTree>::<C Core><<C <todo sym>>> < ()
+      class <emptyTree>::<C ExampleGroup><<C <todo sym>>> < (::<todo sym>)
+      end
+    end
+
+    <runtime method definition of self.configure>
+
+    <runtime method definition of self.include_context>
+
+    <runtime method definition of self.define_derived_metadata>
+  end
+
+  module ::<root>::<C <shared_examples 'outer auto included'>><<C <todo sym>>> < ()
+    module <emptyTree>::<C <shared_examples 'an action that requires permission'>><<C <todo sym>>> < ()
+      def <it 'works'><<todo method>>(&<blk>)
+        [::T.unsafe(nil)].each() do |action, permission|
+          <emptyTree>
+        end
+      end
+
+      <runtime method definition of <it 'works'>>
+    end
+
+    module <emptyTree>::<C <shared_examples 'an unauthorized action'>><<C <todo sym>>> < ()
+      def <it 'fails'><<todo method>>(&<blk>)
+        [::T.unsafe(nil)].each() do |action|
+          <emptyTree>
+        end
+      end
+
+      <runtime method definition of <it 'fails'>>
+    end
+
+    module <emptyTree>::<C <shared_examples 'a permitted operation'>><<C <todo sym>>> < ()
+      def <it 'is permitted'><<todo method>>(&<blk>)
+        [::T.unsafe(nil)].each() do |operation|
+          <emptyTree>
+        end
+      end
+
+      <runtime method definition of <it 'is permitted'>>
+    end
+
+    module <emptyTree>::<C <shared_examples 'a nested context'>><<C <todo sym>>> < ()
+      def foo<<todo method>>(&<blk>)
+        42
+      end
+
+      <runtime method definition of foo>
+    end
+  end
+
+  <emptyTree>::<C RSpec>.configure() do |config|
+    begin
+      config.include_context("outer auto included", :auto_tag)
+      config.define_derived_metadata(:file_path, ::Regexp.new("/some/path/", 0)) do |metadata|
+        metadata.[]=(:auto_tag, true)
+      end
+    end
+  end
+
+  begin
+    "metadata-driven consumer"
+    class <emptyTree>::<C <describe 'metadata-driven consumer'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      class <emptyTree>::<C <it_behaves_like 'an action that requires permission'>><<C <todo sym>>> < (<self>)
+        <self>.include(<emptyTree>::<C <shared_examples 'an action that requires permission'>>)
+      end
+
+      class <emptyTree>::<C <it_behaves_like 'an unauthorized action'>><<C <todo sym>>> < (<self>)
+        <self>.include(<emptyTree>::<C <shared_examples 'an unauthorized action'>>)
+      end
+
+      <self>.include(<emptyTree>::<C <shared_examples 'a permitted operation'>>)
+
+      <self>.include(<emptyTree>::<C <shared_examples 'a nested context'>>)
+    end
+  end
+
+  module ::<root>::<C <shared_examples 'with block context'>><<C <todo sym>>> < ()
+    module <emptyTree>::<C <shared_examples 'block-form sibling examples'>><<C <todo sym>>> < ()
+      def <it 'sibling works'><<todo method>>(&<blk>)
+        <emptyTree>
+      end
+    end
+  end
+
+  begin
+    "with-block include_context consumer"
+    class <emptyTree>::<C <describe 'with-block include_context consumer'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      <self>.include(<emptyTree>::<C <shared_examples 'with block context'>>)
+
+      class <emptyTree>::<C <it_behaves_like 'block-form sibling examples'>><<C <todo sym>>> < (<self>)
+        <self>.include(<emptyTree>::<C <shared_examples 'block-form sibling examples'>>)
+      end
+    end
+  end
+
+  module ::<root>::<C <shared_examples 'outer not auto included'>><<C <todo sym>>> < ()
+    module <emptyTree>::<C <shared_examples 'manually included only'>><<C <todo sym>>> < ()
+      def <it 'works only when explicitly included'><<todo method>>(&<blk>)
+        <emptyTree>
+      end
+    end
+  end
+
+  begin
+    "consumer that does not include outer"
+    class <emptyTree>::<C <describe 'consumer that does not include outer'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      class <emptyTree>::<C <it_behaves_like 'manually included only'>><<C <todo sym>>> < (<self>)
+        <self>.include(<emptyTree>::<C <shared_examples 'manually included only'>>)
+      end
+    end
+  end
+
+  module ::<root>::<C <shared_examples 'inner ctx'>><<C <todo sym>>> < ()
+    module <emptyTree>::<C <shared_examples 'inner shared examples'>><<C <todo sym>>> < ()
+      def <it 'inner works'><<todo method>>(&<blk>)
+        <emptyTree>
+      end
+    end
+  end
+
+  module ::<root>::<C <shared_examples 'outer ctx that includes inner'>><<C <todo sym>>> < ()
+    <self>.include(<emptyTree>::<C <shared_examples 'inner ctx'>>)
+
+    module <emptyTree>::<C <shared_examples 'outer shared examples that consumes inner'>><<C <todo sym>>> < ()
+      def <it 'outer works'><<todo method>>(&<blk>)
+        <emptyTree>
+      end
+
+      <self>.include(<emptyTree>::<C <shared_examples 'inner shared examples'>>)
+    end
+  end
+
+  module ::<root>::<C <shared_examples 'an action that requires permission'>><<C <todo sym>>> < ()
+    def <it 'works'><<todo method>>(&<blk>)
+      [::T.unsafe(nil)].each() do |action, permission|
+        <emptyTree>
+      end
+    end
+
+    <runtime method definition of <it 'works'>>
+  end
+
+  module ::<root>::<C <shared_examples 'an unauthorized action'>><<C <todo sym>>> < ()
+    def <it 'fails'><<todo method>>(&<blk>)
+      [::T.unsafe(nil)].each() do |action|
+        <emptyTree>
+      end
+    end
+
+    <runtime method definition of <it 'fails'>>
+  end
+
+  module ::<root>::<C <shared_examples 'a permitted operation'>><<C <todo sym>>> < ()
+    def <it 'is permitted'><<todo method>>(&<blk>)
+      [::T.unsafe(nil)].each() do |operation|
+        <emptyTree>
+      end
+    end
+
+    <runtime method definition of <it 'is permitted'>>
+  end
+
+  module ::<root>::<C <shared_examples 'a nested context'>><<C <todo sym>>> < ()
+    def foo<<todo method>>(&<blk>)
+      42
+    end
+
+    <runtime method definition of foo>
+  end
+end

--- a/test/testdata/rewriter/rspec_shared_examples_in_local_context.rb
+++ b/test/testdata/rewriter/rspec_shared_examples_in_local_context.rb
@@ -8,9 +8,12 @@ module RSpec
   end
 end
 
-# RSpec.shared_examples/shared_context/shared_examples_for defined inside a
-# RSpec.local_context block should be registered as root-scoped constants and
-# be resolvable via include_context / include_examples in any describe block.
+# shared_examples/shared_context/shared_examples_for defined inside an
+# RSpec.local_context block — bare or RSpec.-prefixed — should be hoisted to the
+# top-level scope so consumers can resolve them via include_context /
+# include_examples in any describe block. At runtime RSpec.local_context
+# re-evaluates the block body in each consumer's example group, so any
+# shared_examples-family call inside (regardless of receiver) ends up registered.
 RSpec.local_context do
   RSpec.shared_context 'nested context inside local context' do
     let(:value) { 42 }
@@ -25,10 +28,29 @@ RSpec.local_context do
     it 'also works' do
     end
   end
+
+  # Bare-receiver forms should be hoisted alongside the RSpec.-prefixed ones.
+  shared_context 'bare nested context inside local context' do
+    let(:value) { 42 }
+  end
+
+  shared_examples 'bare nested examples inside local context' do
+    it 'works' do
+    end
+  end
+
+  shared_examples_for 'bare nested examples_for inside local context' do
+    it 'also works' do
+    end
+  end
 end
 
 RSpec.describe 'consumer' do
   include_context 'nested context inside local context'
   include_examples 'nested examples inside local context'
   include_examples 'nested examples_for inside local context'
+
+  include_context 'bare nested context inside local context'
+  include_examples 'bare nested examples inside local context'
+  include_examples 'bare nested examples_for inside local context'
 end

--- a/test/testdata/rewriter/rspec_shared_examples_in_local_context.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_shared_examples_in_local_context.rb.rewrite-tree.exp
@@ -26,6 +26,26 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
+  module <emptyTree>::<C <shared_examples 'bare nested context inside local context'>><<C <todo sym>>> < ()
+    def value<<todo method>>(&<blk>)
+      42
+    end
+
+    <runtime method definition of value>
+  end
+
+  module <emptyTree>::<C <shared_examples 'bare nested examples inside local context'>><<C <todo sym>>> < ()
+    def <it 'works'><<todo method>>(&<blk>)
+      <emptyTree>
+    end
+  end
+
+  module <emptyTree>::<C <shared_examples 'bare nested examples_for inside local context'>><<C <todo sym>>> < ()
+    def <it 'also works'><<todo method>>(&<blk>)
+      <emptyTree>
+    end
+  end
+
   begin
     "consumer"
     class <emptyTree>::<C <describe 'consumer'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
@@ -34,6 +54,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.include(<emptyTree>::<C <shared_examples 'nested examples inside local context'>>)
 
       <self>.include(<emptyTree>::<C <shared_examples 'nested examples_for inside local context'>>)
+
+      <self>.include(<emptyTree>::<C <shared_examples 'bare nested context inside local context'>>)
+
+      <self>.include(<emptyTree>::<C <shared_examples 'bare nested examples inside local context'>>)
+
+      <self>.include(<emptyTree>::<C <shared_examples 'bare nested examples_for inside local context'>>)
     end
   end
 end


### PR DESCRIPTION
## Motivation

In large RSpec codebases (e.g. zenpayroll), shared_examples are often defined nested inside an outer construct — an `RSpec.shared_context` wired in via `RSpec.configure` + `define_derived_metadata`, or an `RSpec.local_context` block consumed via a project-specific helper. After #10273, these nested definitions are correctly scoped to their enclosing synthetic module for consumers that lexically `include_context` the outer; but for the two patterns below the rewriter does not see the include, so every `it_behaves_like` / `include_examples` becomes `Unable to resolve constant`. The workaround is a growing RBI shim file that re-declares the names at root scope.

This PR teaches the rewriter both patterns. Validated end-to-end against zenpayroll: with the patched sorbet, **20 of 31 currently-required shim entries** become unnecessary (4 of 8 newly-added derived_metadata-driven entries; 16 of 23 long-standing `local_context`-nested entries).

## Changes

### 1. `Minitest::runOnClassDef`: hoist on `define_derived_metadata` pairing

A new class-level pass:

1. Scans top-level `RSpec.configure { … }` blocks for the pairing of `config.include_context 'NAME', :TAG` and `config.define_derived_metadata(...) { metadata[:TAG] = true }`.
2. For each `NAME` so identified, finds the matching `RSpec.shared_context 'NAME', :TAG do … end` in the same file.
3. For each direct-child bare `shared_examples` / `shared_context` / `shared_examples_for` call, synthesizes an equivalent `RSpec.<fun> 'X' do … end` top-level send.

The existing per-statement `Minitest::run` pass then emits the synthesized sends as root-scoped synthetic modules. Cleanly composes with #10273's enclosing-scope behavior for the explicit-`include_context` case.

### 2. Hoist bare shared_examples-family calls inside `RSpec.local_context`

The existing `local_context` handler called `runSingle` with `insideDescribe=false`, which gates bare shared_examples-family calls out (`!insideDescribe && !recvIsRSpec` → nullptr). Only `RSpec.`-prefixed forms survived. At RSpec runtime there is no semantic difference: the local_context block body is re-evaluated in each consumer's example group, so both forms get registered.

Now the handler passes `insideDescribe=true` only for bare shared_examples-family sends, while keeping `let` / `before` / `it` / etc. dropped to avoid root-scope pollution.

### 3. Allow `include_context` / `include_examples` with a block

Previously the rewriter dropped any `include_context 'name' do … end` (or `include_examples 'name' do … end`) entirely. The runtime semantics are "include the context AND apply the block as consumer-local setup"; static type checking primarily benefits from the include. Emit the synthetic include and drop the block body, consistent with how Sorbet already approximates RSpec setup methods loosely.

### 4. Names

Two new entries in `core::Names`: `configure`, `defineDerivedMetadata`.

## Testing

- **New fixture** `test/testdata/rewriter/rspec_shared_examples_in_derived_metadata_context.rb` (with regenerated `.rewrite-tree.exp`): positive case (derived_metadata-driven hoist), with-block `include_context`, negative case (`:manual_only_tag` without paired `define_derived_metadata` stays enclosing-scoped), and a `TODO(sorbet/sorbet)` case.
- **Existing fixture** `test/testdata/rewriter/rspec_shared_examples_in_local_context.rb` extended with bare-receiver siblings of the existing `RSpec.`-prefixed cases, consumed via both `include_context` and `include_examples`. `.rewrite-tree.exp` regenerated.
- All 2277 PosTests pass locally; clang-tidy clean on `//rewriter` and `//core`.

## Known TODO

One case remains documented in the new fixture but unaddressed: a nested `shared_examples` inside an outer `shared_context` that itself `include_context`s another `shared_context`, with the nested examples referencing the inner's nested examples via `include_examples`. RSpec inlines the included body at runtime; Sorbet models `include_context` as a plain Ruby `include`, and Ruby's constant lookup does not inherit nested constants through a lexical parent's includes (the same lookup raises `NameError` in plain Ruby). Fixing this would require modeling RSpec's inline-the-body semantics rather than mapping to plain `include` — separate follow-up.

## Status

Draft — feedback welcome on (a) the choice of a class-level pre-pass for the configure-block scan and (b) the targeted gating in the local_context handler.