### PR TITLE
Add missing `reserve` call

### DIFF
--- a/ast/ParamParsing.cc
+++ b/ast/ParamParsing.cc
@@ -71,6 +71,8 @@ ExpressionPtr getDefaultValue(ExpressionPtr param) {
 
 vector<core::ParsedParam> ParamParsing::parseParams(const ast::MethodDef::PARAMS_store &params) {
     vector<core::ParsedParam> parsedParams;
+    parsedParams.reserve(params.size());
+
     for (auto &param : params) {
         if (!ast::isa_reference(param)) {
             Exception::raise("Must be a reference!");


### PR DESCRIPTION
### Motivation

Less allocations more betterer.

### Test plan

None.