### PR TITLE
prework: Factor `validate_non_override_mode` to not need signature

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -249,7 +249,7 @@ class T::Private::Methods::Signature
     self.class.method_desc(@method, @method_name)
   end
 
-  def self.method_desc(method, method_name, source_loc = method.source_location)
+  def self.method_desc(method, method_name, source_loc=method.source_location)
     loc = if source_loc
       source_loc.join(':')
     else

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -246,12 +246,16 @@ class T::Private::Methods::Signature
   end
 
   def method_desc
-    loc = if (source_loc = @method.source_location)
+    self.class.method_desc(@method, @method_name)
+  end
+
+  def self.method_desc(method, method_name, source_loc = method.source_location)
+    loc = if source_loc
       source_loc.join(':')
     else
       "<unknown location>"
     end
-    "#{@method.owner}##{@method_name} at #{loc}"
+    "#{method.owner}##{method_name} at #{loc}"
   end
 
   def force_type_init

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rbi
@@ -119,6 +119,9 @@ class T::Private::Methods::Signature
   sig {returns(String)}
   def method_desc; end
 
+  sig {params(method: UnboundMethod, method_name: Symbol, source_loc: T.nilable([String, Integer])).returns(String)}
+  def self.method_desc(method, method_name, source_loc = method.source_location); end
+
   sig {void}
   def force_type_init; end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
@@ -98,9 +98,9 @@ module T::Private::Methods::SignatureValidation
 
   private_class_method def self.pretty_mode(mode)
     if mode == Modes.overridable_override
-      '.overridable.override'
+      'overridable.override'
     else
-      ".#{mode}"
+      mode
     end
   end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
@@ -138,7 +138,7 @@ module T::Private::Methods::SignatureValidation
     end
   end
 
-  def self.validate_non_override_mode(mode, method_name, method, source_loc = method.source_location)
+  def self.validate_non_override_mode(mode, method_name, method, source_loc=method.source_location)
     case mode
     when Modes.override
       if method_name == :each && method.owner < Enumerable

--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
@@ -92,15 +92,15 @@ module T::Private::Methods::SignatureValidation
         validate_override_visibility(signature, super_signature)
       end
     else
-      validate_non_override_mode(signature)
+      validate_non_override_mode(signature.mode, signature.method_name, signature.method)
     end
   end
 
-  private_class_method def self.pretty_mode(signature)
-    if signature.mode == Modes.overridable_override
+  private_class_method def self.pretty_mode(mode)
+    if mode == Modes.overridable_override
       '.overridable.override'
     else
-      ".#{signature.mode}"
+      ".#{mode}"
     end
   end
 
@@ -138,10 +138,10 @@ module T::Private::Methods::SignatureValidation
     end
   end
 
-  def self.validate_non_override_mode(signature)
-    case signature.mode
+  def self.validate_non_override_mode(mode, method_name, method, source_loc = method.source_location)
+    case mode
     when Modes.override
-      if signature.method_name == :each && signature.method.owner < Enumerable
+      if method_name == :each && method.owner < Enumerable
         # Enumerable#each is the only method in Sorbet's RBI payload that defines an abstract method.
         # Enumerable#each does not actually exist at runtime, but it is required to be implemented by
         # any class which includes Enumerable. We want to declare Enumerable#each as abstract so that
@@ -151,25 +151,25 @@ module T::Private::Methods::SignatureValidation
         # This is a one-off hack, and we should think carefully before adding more methods here.
         nil
       else
-        raise "You marked `#{signature.method_name}` as #{pretty_mode(signature)}, but that method doesn't already exist in this class/module to be overridden.\n" \
+        raise "You marked `#{method_name}` as #{pretty_mode(mode)}, but that method doesn't already exist in this class/module to be overridden.\n" \
           "  Either check for typos and for missing includes or super classes to make the parent method shows up\n" \
-          "  ... or remove #{pretty_mode(signature)} here: #{signature.method_desc}\n"
+          "  ... or remove #{pretty_mode(mode)} here: #{T::Private::Methods::Signature.method_desc(method, method_name, source_loc)}\n"
       end
     when Modes.standard, *Modes::NON_OVERRIDE_MODES
       # Peaceful
       nil
     else
-      raise "Unexpected mode: #{signature.mode}. Please report this bug at https://github.com/sorbet/sorbet/issues"
+      raise "Unexpected mode: #{mode}. Please report this bug at https://github.com/sorbet/sorbet/issues"
     end
 
     # Given a singleton class, we can check if it belongs to a
     # module by looking at its superclass; given `module M`,
     # `M.singleton_class.superclass == Module`, which is not true
     # for any class.
-    owner = signature.method.owner
-    if (signature.mode == Modes.abstract || Modes::OVERRIDABLE_MODES.include?(signature.mode)) &&
+    owner = method.owner
+    if (mode == Modes.abstract || Modes::OVERRIDABLE_MODES.include?(mode)) &&
         owner.singleton_class? && Class === owner && owner.superclass == Module
-      raise "Defining an overridable class method (via #{pretty_mode(signature)}) " \
+      raise "Defining an overridable class method (via #{pretty_mode(mode)}) " \
             "on a module is not allowed. Class methods on " \
             "modules do not get inherited and thus cannot be overridden."
     end

--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rbi
@@ -5,14 +5,22 @@ module T::Private::Methods
     sig {params(signature: Signature).void}
     def self.validate(signature); end
 
-    sig {params(signature: Signature).returns(String)}
-    private_class_method def self.pretty_mode(signature); end
+    sig {params(mode: String).returns(String)}
+    private_class_method def self.pretty_mode(mode); end
 
     sig {params(signature: Signature, super_signature: Signature).void}
     def self.validate_override_mode(signature, super_signature); end
 
-    sig {params(signature: Signature).void}
-    def self.validate_non_override_mode(signature); end
+    sig do
+      params(
+        mode: String,
+        method_name: Symbol,
+        method: UnboundMethod,
+        source_loc: T.nilable([String, Integer]),
+      )
+        .void
+    end
+    def self.validate_non_override_mode(mode, method_name, method, source_loc = method.source_location); end
 
     sig {params(signature: Signature, super_signature: Signature).void}
     def self.validate_override_shape(signature, super_signature); end

--- a/gems/sorbet-runtime/test/types/abstract_validation.rb
+++ b/gems/sorbet-runtime/test/types/abstract_validation.rb
@@ -50,7 +50,7 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
 
     assert_includes(
       err.message,
-      "Defining an overridable class method (via .abstract) on a module is not allowed.",
+      "Defining an overridable class method (via abstract) on a module is not allowed.",
     )
   end
 

--- a/gems/sorbet-runtime/test/types/configuration.rb
+++ b/gems/sorbet-runtime/test/types/configuration.rb
@@ -187,7 +187,7 @@ module Opus::Types::Test
           end
           assert_includes(
             ex.message,
-            "You marked `foo` as .override, but that method doesn't already exist"
+            "You marked `foo` as override, but that method doesn't already exist"
           )
         end
       end
@@ -205,7 +205,7 @@ module Opus::Types::Test
 
         it 'handles a sig build error' do
           CustomReceiver.expects(:receive).once.with do |error, opts|
-            error.message.include?("You marked `foo` as .override, but that method doesn't already exist") &&
+            error.message.include?("You marked `foo` as override, but that method doesn't already exist") &&
               error.is_a?(RuntimeError) &&
               opts.is_a?(Hash) &&
               opts[:method].is_a?(UnboundMethod) &&

--- a/gems/sorbet-runtime/test/types/method_modes.rb
+++ b/gems/sorbet-runtime/test/types/method_modes.rb
@@ -184,7 +184,7 @@ class Opus::Types::Test::MethodModesTest < Critic::Unit::UnitTest
 
       assert_includes(
         err.message,
-        "You marked `foo` as .override, but that method doesn't already exist"
+        "You marked `foo` as override, but that method doesn't already exist"
       )
     end
 
@@ -202,7 +202,7 @@ class Opus::Types::Test::MethodModesTest < Critic::Unit::UnitTest
 
       assert_includes(
         err.message,
-        "You marked `foo` as .override, but that method doesn't already exist in this class/module to be overridden"
+        "You marked `foo` as override, but that method doesn't already exist in this class/module to be overridden"
       )
     end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I want to be able to call this method from the `override def` syntax.

Also: Remove the leading `.` in the error. Most of the time, these methods are
actually leading (`override.void`). Soon, they're going to be `override def
foo`, with no dot at all.

I wanted to change the definition of `Modes.overridable_override` from
`"overridable_override"` to `"overridable.override"` and then just delete this
`pretty_method`, but it seems that there are lots of calleres in the wider
Sorbet ecosystem expecting to see `"overridable_override"` instead of using
`Modes.overridable_override`, which makes sense because technically that is a
method in a `Private` module.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.