### PR TITLE
sorbet-runtime: allow sig followed by method added on an ancestor module

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -208,6 +208,26 @@ module T::Private::Methods
     if current_declaration.nil?
       return
     end
+
+    # Leave the declaration intact if the hook fired on a module unrelated
+    # to the pending sig; the next adjacent definition can consume it.
+    match_kind = sig_target_match_kind(hook_mod, current_declaration.mod)
+    if match_kind.nil?
+      return
+    end
+
+    # On the ancestor path, require same-file adjacency to catch a stray
+    # sig being silently consumed by a `define_method` defined elsewhere.
+    if match_kind == :ancestor
+      sig_loc = current_declaration.loc
+      method_path = mod.instance_method(method_name).source_location&.first
+      if sig_loc && method_path && sig_loc.path != method_path
+        T::Private::DeclState.current.reset!
+        raise "`sig` at #{sig_loc.path}:#{sig_loc.lineno} would be applied to " \
+              "`#{method_name}` on #{hook_mod} (#{method_path}), which is in a different file."
+      end
+    end
+
     T::Private::DeclState.current.reset!
 
     if method_name == :method_added || method_name == :singleton_method_added
@@ -342,20 +362,20 @@ module T::Private::Methods
     decl
   end
 
+  # Returns :exact, :singleton, :top_self, :ancestor, or nil. The :ancestor
+  # case covers patterns like RSpec `let`, where the method is added on an
+  # included helper module rather than the declared class itself.
+  def self.sig_target_match_kind(hook_mod, declaration_mod)
+    return :exact if hook_mod == declaration_mod
+    return :singleton if hook_mod.singleton_class == declaration_mod
+    return :top_self if declaration_mod == TOP_SELF
+    return :ancestor if declaration_mod.is_a?(Module) && declaration_mod.ancestors.include?(hook_mod)
+
+    nil
+  end
+
   def self.build_sig(hook_mod, method_name, original_method, current_declaration)
     begin
-      # We allow `sig` in the current module's context (normal case) and
-      if hook_mod != current_declaration.mod &&
-         # inside `class << self`, and
-         hook_mod.singleton_class != current_declaration.mod &&
-         # on `self` at the top level of a file
-         current_declaration.mod != TOP_SELF
-        raise "A method (#{method_name}) is being added on a different class/module (#{hook_mod}) than the " \
-              "last call to `sig` (#{current_declaration.mod}). Make sure each call " \
-              "to `sig` is immediately followed by a method definition on the same " \
-              "class/module."
-      end
-
       signature = Signature.new(
         method: original_method,
         method_name: method_name,

--- a/gems/sorbet-runtime/test/types/method_validation.rb
+++ b/gems/sorbet-runtime/test/types/method_validation.rb
@@ -11,6 +11,10 @@ module Opus::Types::Test
       end
     end
 
+    after do
+      T::Private::DeclState.current.reset!
+    end
+
     private def check_alloc_counts
       @check_alloc_counts = Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0')
     end
@@ -94,7 +98,7 @@ module Opus::Types::Test
         )
       end
 
-      it "raises an error when adding a method to a different module than the last declaration" do
+      it "silently preserves the declaration when a method is added on an unrelated module" do
         mod2 = Module.new do
           extend T::Sig
           sig { returns(String) }
@@ -102,17 +106,119 @@ module Opus::Types::Test
         end
 
         @mod.sig { returns(Symbol) }
+        refute_nil(T::Private::DeclState.current.active_declaration)
+
+        def mod2.bar; :bar; end
+        assert_equal(:bar, mod2.bar)
+        refute_nil(T::Private::DeclState.current.active_declaration)
+
+        # Integer return violates `returns(Symbol)`, proving the sig bound.
+        def @mod.qux; 42; end
+        assert_nil(T::Private::DeclState.current.active_declaration)
+        assert_raises(TypeError) { @mod.qux }
+      end
+
+      it "raises on a second `sig` if a method was added on an unrelated module in between" do
+        mod2 = Module.new { extend T::Sig }
+
+        @mod.sig { returns(Symbol) }
         def mod2.bar; end
+
         err = assert_raises(RuntimeError) do
-          mod2.bar
+          @mod.sig { returns(Symbol) }
+        end
+        assert_equal("You called sig twice without declaring a method in between", err.message)
+      end
+
+      it "accepts a method added on an included ancestor module of the declaration target" do
+        helper_module = Module.new
+        T::Private::Methods.install_hooks(helper_module)
+
+        consumer = Class.new do
+          extend T::Sig
+          include helper_module
         end
 
-        assert_equal(
-          "A method (bar) is being added on a different class/module (#{mod2}) than the last call to " \
-          "`sig` (#{@mod}). Make sure each call to `sig` is immediately " \
-          "followed by a method definition on the same class/module.",
-          err.message
-        )
+        consumer.sig { returns(Integer) }
+        helper_module.send(:define_method, :foo) { 42 }
+
+        assert_equal(42, consumer.new.foo)
+      end
+
+      it "accepts a method added on a prepended ancestor module of the declaration target" do
+        helper_module = Module.new
+        T::Private::Methods.install_hooks(helper_module)
+
+        consumer = Class.new do
+          extend T::Sig
+          prepend helper_module
+        end
+
+        consumer.sig { returns(Integer) }
+        helper_module.send(:define_method, :foo) { 42 }
+
+        assert_equal(42, consumer.new.foo)
+      end
+
+      it "accepts a method added on a transitive ancestor module of the declaration target" do
+        inner_helper = Module.new
+        T::Private::Methods.install_hooks(inner_helper)
+
+        outer_helper = Module.new do
+          include inner_helper
+        end
+
+        consumer = Class.new do
+          extend T::Sig
+          include outer_helper
+        end
+
+        consumer.sig { returns(Integer) }
+        inner_helper.send(:define_method, :foo) { 42 }
+
+        assert_equal(42, consumer.new.foo)
+      end
+
+      it "accepts an ancestor-path sig when hooks are installed via `extend T::Sig`" do
+        helper_module = Module.new do
+          extend T::Sig
+        end
+
+        consumer = Class.new do
+          extend T::Sig
+          include helper_module
+        end
+
+        consumer.sig { returns(Integer) }
+        helper_module.send(:define_method, :foo) { :wrong_type }
+
+        assert_raises(TypeError) { consumer.new.foo }
+      end
+
+      it "raises when an ancestor-path method is added from a different file than the sig" do
+        helper_module = Module.new
+        T::Private::Methods.install_hooks(helper_module)
+
+        consumer = Class.new do
+          extend T::Sig
+          include helper_module
+        end
+
+        # rubocop:disable Style/EvalWithLocation
+        far_away_block = eval("proc { 42 }", binding, "/tmp/some_other_file.rb", 1)
+        # rubocop:enable Style/EvalWithLocation
+
+        consumer.sig { returns(Integer) }
+        err = assert_raises(RuntimeError) do
+          helper_module.send(:define_method, :foo, &far_away_block)
+        end
+        assert_match(/different file/, err.message)
+        assert_match(/`foo`/, err.message)
+        assert_match(%r{/tmp/some_other_file\.rb}, err.message)
+
+        consumer.sig { returns(Integer) }
+        helper_module.send(:define_method, :bar) { 7 }
+        assert_equal(7, consumer.new.bar)
       end
 
       it "gives a helpful error if you order optional kwargs after required" do

--- a/website/docs/sigs.md
+++ b/website/docs/sigs.md
@@ -314,6 +314,8 @@ end
 
 Since every singleton class descends from `Module`, this will make the `sig` method available in every class body.
 
+With this monkey patch in place, `sig` is also accepted when the method lands on an ancestor module of the declaring class (e.g. RSpec's `let` and `subject`), as long as the method body lives in the same source file as the `sig`.
+
 This involves a monkey patch, and is **not** required to use Sorbet. But the most earnest users of Sorbet all eventually add this monkey patch, because `extend T::Sig` ends up getting written into almost every class.
 
 We recommend putting this monkeypatch in the same file that


### PR DESCRIPTION
Allow `sig` followed by a method added on an ancestor module of the declaring class, so the `LetDefinitions`-style RSpec `let`/`subject` pattern stops raising spuriously after #10262.

### Motivation

Fixes #10315.

After #10262, `T::Sig::MethodHooks` is included into `T::Sig` itself, so `method_added` now fires for every `define_method` across the process when callers opt-in globally via `Module.include(T::Sig)` (a documented pattern from the [Sorbet docs](https://sorbet.org/docs/sigs#can-i-skip-writing-extend-tsig-everywhere)) — including helper modules the caller never directly typed.

The adjacency check in `Methods.build_sig` was written assuming the hook only fires on the same module where `sig` was called, so it raises spuriously for the common RSpec pattern where `sig` is declared on the example group but `let` defines the method on an anonymous `LetDefinitions` module included into the group:

```ruby
RSpec.describe Foo do
  sig { returns(Bar) }
  let(:bar) { Bar.new }   # raises after #10262 with Module.include(T::Sig)
end
```

### Changes

- Move the adjacency check from `build_sig` (lazy, on first method invocation) up into `_on_method_added` (at definition time).
- Convert it from an unconditional raise to a non-consuming silent skip when the method landed on a module unrelated to the pending sig. The pending declaration is left intact so the next adjacent method definition can consume it; the existing "called sig twice without a method in between" guard still catches typos.
- Extract the matching predicate to `sig_target_match_kind`, returning `:exact`, `:singleton`, `:top_self`, `:ancestor`, or `nil`. The new `:ancestor` case is the RSpec/`LetDefinitions` shape — the method is visible on the declared class via Ruby's normal dispatch, so it isn't leaking onto an unrelated class.
- On the `:ancestor` path, require the method's `source_location` to live in the same file as the `sig`'s `caller_location`. This catches a stray `sig` that would otherwise be silently consumed by an unrelated `define_method` defined elsewhere (e.g. inside a gem), while still allowing the RSpec case where the user's block lives in the same spec file as the `sig`.
- Document the relaxation and same-file constraint in `website/docs/sigs.md`.

### Test plan

New automated tests cover:

- The motivating ancestor cases: `include`, `prepend`, and a depth-2 transitive ancestor.
- The realistic install path via `extend T::Sig` on the helper (same `MethodHooks` chain `Module.include(T::Sig)` activates globally).
- Silent-skip when the hook fires on an unrelated module, with direct `DeclState.active_declaration` assertions and a `TypeError` on a wrong-typed return to prove the sig is bound by the next adjacent def (not silently dropped).
- The two-sigs-without-a-method guard still raises if no def follows.
- The same-file proximity guard: a `define_method` whose block reports a fake `source_location` raises with both source locations in the message.

An `after` block resets `DeclState` between tests so a leaked declaration cannot poison the next test.
