### PR TITLE
Derive comparisons now that we have c++20

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -198,16 +198,11 @@ public:
         return ptr != 0;
     }
 
-    bool operator==(const ExpressionPtr &other) const noexcept {
-        return ptr == other.ptr;
-    }
+    bool operator==(const ExpressionPtr &other) const noexcept = default;
+    bool operator!=(const ExpressionPtr &other) const noexcept = default;
 
     bool operator==(std::nullptr_t) const noexcept {
         return ptr == 0;
-    }
-
-    bool operator!=(const ExpressionPtr &other) const noexcept {
-        return ptr != other.ptr;
     }
 
     bool operator!=(std::nullptr_t) const noexcept {
@@ -845,14 +840,9 @@ public:
 
         // In C++20 we can replace this with bit field initialzers
         Flags() : isPrivateOk(false), isRewriterSynthesized(false), hasBlock(false) {}
-        bool operator==(const Flags &other) const noexcept {
-            return isPrivateOk == other.isPrivateOk && isRewriterSynthesized == other.isRewriterSynthesized &&
-                   hasBlock == other.hasBlock;
-        }
 
-        bool operator!=(const Flags &other) const noexcept {
-            return !(*this == other);
-        }
+        bool operator==(const Flags &other) const noexcept = default;
+        bool operator!=(const Flags &other) const noexcept = default;
     };
     CheckSize(Flags, 1, 1);
 

--- a/cfg/LocalRef.cc
+++ b/cfg/LocalRef.cc
@@ -42,14 +42,6 @@ string LocalRef::showRaw(const core::GlobalState &gs, const CFG &cfg) const {
     return this->data(cfg).showRaw(gs);
 }
 
-bool LocalRef::operator==(const LocalRef &rhs) const {
-    return this->_id == rhs._id;
-}
-
-bool LocalRef::operator!=(const LocalRef &rhs) const {
-    return this->_id != rhs._id;
-}
-
 // Note: The special ID values below are validated in CFG.cc in the CFG constructor.
 
 LocalRef LocalRef::noVariable() {

--- a/cfg/LocalRef.h
+++ b/cfg/LocalRef.h
@@ -28,8 +28,9 @@ public:
     bool isSyntheticTemporary(const CFG &cfg) const;
     std::string toString(const core::GlobalState &gs, const CFG &cfg) const;
     std::string showRaw(const core::GlobalState &gs, const CFG &cfg) const;
-    bool operator==(const LocalRef &rhs) const;
-    bool operator!=(const LocalRef &rhs) const;
+
+    bool operator==(const LocalRef &rhs) const noexcept = default;
+    bool operator!=(const LocalRef &rhs) const noexcept = default;
 
     static LocalRef noVariable();
     static LocalRef blockCall();

--- a/core/ArityHash.h
+++ b/core/ArityHash.h
@@ -2,6 +2,7 @@
 #define SORBET_ARITY_HASH_H
 
 #include "common/common.h"
+#include <compare>
 
 namespace sorbet::core {
 
@@ -33,18 +34,22 @@ public:
         return _hashValue == ALIAS_METHOD;
     }
 
-    inline bool operator==(const ArityHash &rhs) const noexcept {
+    auto operator<=>(const ArityHash &rhs) const noexcept {
         ENFORCE(isDefined());
         ENFORCE(rhs.isDefined());
-        return _hashValue == rhs._hashValue;
+        return _hashValue <=> rhs._hashValue;
     }
 
-    inline bool operator!=(const ArityHash &rhs) const noexcept {
-        return !(rhs == *this);
+    bool operator==(const ArityHash &rhs) const noexcept {
+        return std::is_eq(*this <=> rhs);
     }
 
-    inline bool operator<(const ArityHash &rhs) const noexcept {
-        return this->_hashValue < rhs._hashValue;
+    bool operator!=(const ArityHash &rhs) const noexcept {
+        return std::is_neq(*this <=> rhs);
+    }
+
+    bool operator<(const ArityHash &rhs) const noexcept {
+        return std::is_lt(*this <=> rhs);
     }
 
     // Pseudo-private, only public for serialization

--- a/core/Error.h
+++ b/core/Error.h
@@ -17,13 +17,8 @@ public:
     constexpr ErrorClass(uint16_t code, StrictLevel minLevel) : code(code), minLevel(minLevel){};
     ErrorClass(const ErrorClass &rhs) = default;
 
-    bool operator==(const ErrorClass &rhs) const {
-        return code == rhs.code;
-    }
-
-    bool operator!=(const ErrorClass &rhs) const {
-        return !(*this == rhs);
-    }
+    bool operator==(const ErrorClass &rhs) const noexcept = default;
+    bool operator!=(const ErrorClass &rhs) const noexcept = default;
 };
 
 class ErrorColors {

--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -2,6 +2,8 @@
 #define RUBY_TYPER_FILE_HASH_H
 #include "common/common.h"
 #include "core/ArityHash.h"
+#include <compare>
+
 namespace sorbet::core {
 class NameRef;
 class GlobalState;
@@ -19,18 +21,23 @@ public:
     }
     WithoutUniqueNameHash(const WithoutUniqueNameHash &nm) noexcept = default;
     WithoutUniqueNameHash() noexcept : _hashValue(0){};
-    inline bool operator==(const WithoutUniqueNameHash &rhs) const noexcept {
+
+    auto operator<=>(const WithoutUniqueNameHash &rhs) const noexcept {
         ENFORCE_NO_TIMER(isDefined());
         ENFORCE_NO_TIMER(rhs.isDefined());
-        return _hashValue == rhs._hashValue;
+        return _hashValue <=> rhs._hashValue;
     }
 
-    inline bool operator!=(const WithoutUniqueNameHash &rhs) const noexcept {
-        return !(rhs == *this);
+    bool operator==(const WithoutUniqueNameHash &rhs) const noexcept {
+        return std::is_eq(*this <=> rhs);
     }
 
-    inline bool operator<(const WithoutUniqueNameHash &rhs) const noexcept {
-        return this->_hashValue < rhs._hashValue;
+    bool operator!=(const WithoutUniqueNameHash &rhs) const noexcept {
+        return std::is_neq(*this <=> rhs);
+    }
+
+    bool operator<(const WithoutUniqueNameHash &rhs) const noexcept {
+        return std::is_lt(*this <=> rhs);
     }
 
     uint32_t _hashValue;
@@ -51,18 +58,23 @@ public:
     }
     FullNameHash(const FullNameHash &nm) noexcept = default;
     FullNameHash() noexcept : _hashValue(0){};
-    inline bool operator==(const FullNameHash &rhs) const noexcept {
+
+    inline auto operator<=>(const FullNameHash &rhs) const noexcept {
         ENFORCE_NO_TIMER(isDefined());
         ENFORCE_NO_TIMER(rhs.isDefined());
-        return _hashValue == rhs._hashValue;
+        return _hashValue <=> rhs._hashValue;
     }
 
-    inline bool operator!=(const FullNameHash &rhs) const noexcept {
-        return !(rhs == *this);
+    bool operator==(const FullNameHash &rhs) const noexcept {
+        return std::is_eq(*this <=> rhs);
     }
 
-    inline bool operator<(const FullNameHash &rhs) const noexcept {
-        return this->_hashValue < rhs._hashValue;
+    bool operator!=(const FullNameHash &rhs) const noexcept {
+        return std::is_neq(*this <=> rhs);
+    }
+
+    bool operator<(const FullNameHash &rhs) const noexcept {
+        return std::is_lt(*this <=> rhs);
     }
 
     uint32_t _hashValue;
@@ -87,10 +99,7 @@ struct SymbolHash {
     SymbolHash(WithoutUniqueNameHash nameHash, uint32_t symbolHash) noexcept
         : nameHash(nameHash), symbolHash(symbolHash) {}
 
-    inline bool operator<(const SymbolHash &h) const noexcept {
-        // Take advantage of lexicographic ordering with std::tie
-        return std::tie(this->nameHash, this->symbolHash) < std::tie(h.nameHash, h.symbolHash);
-    }
+    auto operator<=>(const SymbolHash &h) const noexcept = default;
 };
 CheckSize(SymbolHash, 8, 4);
 

--- a/core/FileRef.h
+++ b/core/FileRef.h
@@ -18,21 +18,7 @@ public:
     FileRef &operator=(const FileRef &f) = default;
     FileRef &operator=(FileRef &&f) = default;
 
-    bool operator==(const FileRef &rhs) const {
-        return _id == rhs._id;
-    }
-
-    bool operator!=(const FileRef &rhs) const {
-        return !(rhs == *this);
-    }
-
-    bool operator<(const FileRef &rhs) const {
-        return _id < rhs._id;
-    }
-
-    bool operator>(const FileRef &rhs) const {
-        return _id > rhs._id;
-    }
+    auto operator<=>(const FileRef &rhs) const = default;
 
     inline unsigned int id() const {
         return _id;

--- a/core/Loc.cc
+++ b/core/Loc.cc
@@ -269,14 +269,6 @@ string LocOffsets::showRaw() const {
     return fmt::format("LocOffsets {{beginPos={}, endPos={}}}", beginPos(), endPos());
 }
 
-bool LocOffsets::operator==(const LocOffsets &rhs) const {
-    return this->beginLoc == rhs.beginLoc && this->endLoc == rhs.endLoc;
-}
-
-bool LocOffsets::operator!=(const LocOffsets &rhs) const {
-    return !(rhs == *this);
-}
-
 string Loc::showRaw(const GlobalState &gs) const {
     string_view path;
     if (file().exists()) {
@@ -356,14 +348,6 @@ bool Loc::contains(const Loc &other) const {
     ENFORCE_NO_TIMER(this->exists());
     ENFORCE_NO_TIMER(other.exists());
     return file() == other.file() && offsets().contains(other.offsets());
-}
-
-bool Loc::operator==(const Loc &rhs) const {
-    return storage.offsets == rhs.storage.offsets && storage.fileRef == rhs.storage.fileRef;
-}
-
-bool Loc::operator!=(const Loc &rhs) const {
-    return !(rhs == *this);
 }
 
 Loc Loc::adjust(const GlobalState &gs, int32_t beginAdjust, int32_t endAdjust) const {

--- a/core/Loc.h
+++ b/core/Loc.h
@@ -13,10 +13,14 @@ class Context;
 class MutableContext;
 
 class Loc final {
-    struct {
+    struct storage {
         LocOffsets offsets;
         core::FileRef fileRef;
+
+        bool operator==(const storage &other) const noexcept = default;
+        bool operator!=(const storage &other) const noexcept = default;
     } storage;
+
     template <typename H> friend H AbslHashValue(H h, const Loc &m);
     friend class sorbet::core::serialize::SerializerImpl;
 
@@ -96,9 +100,9 @@ public:
     std::string filePosToString(const GlobalState &gs, bool showFull = false) const;
     std::optional<std::string_view> source(const GlobalState &gs) const;
 
-    bool operator==(const Loc &rhs) const;
+    bool operator==(const Loc &rhs) const noexcept = default;
+    bool operator!=(const Loc &rhs) const noexcept = default;
 
-    bool operator!=(const Loc &rhs) const;
     static std::optional<uint32_t> detail2Pos(const File &file, Detail detail);
     static Detail pos2Detail(const File &file, uint32_t off);
     static std::optional<Loc> fromDetails(const GlobalState &gs, FileRef fileRef, Detail begin, Detail end);

--- a/core/LocOffsets.h
+++ b/core/LocOffsets.h
@@ -58,9 +58,8 @@ struct LocOffsets {
     std::string showRaw(const GlobalState &gs, const FileRef file) const;
     std::string showRaw() const;
 
-    bool operator==(const LocOffsets &rhs) const;
-
-    bool operator!=(const LocOffsets &rhs) const;
+    bool operator==(const LocOffsets &rhs) const noexcept = default;
+    bool operator!=(const LocOffsets &rhs) const noexcept = default;
 };
 CheckSize(LocOffsets, 8, 4);
 

--- a/core/LocalVariable.cc
+++ b/core/LocalVariable.cc
@@ -36,14 +36,6 @@ bool LocalVariable::isAliasForGlobal(const GlobalState &gs) const {
     return _name == Names::cfgAlias();
 }
 
-bool LocalVariable::operator==(const LocalVariable &rhs) const {
-    return this->_name == rhs._name && this->unique == rhs.unique;
-}
-
-bool LocalVariable::operator!=(const LocalVariable &rhs) const {
-    return !this->operator==(rhs);
-}
-
 string LocalVariable::showRaw(const GlobalState &gs) const {
     if (unique == 0) {
         return this->_name.showRaw(gs);

--- a/core/LocalVariable.h
+++ b/core/LocalVariable.h
@@ -34,19 +34,7 @@ public:
 
     LocalVariable &operator=(const LocalVariable &) = default;
 
-    bool operator==(const LocalVariable &rhs) const;
-
-    bool operator!=(const LocalVariable &rhs) const;
-
-    inline bool operator<(const LocalVariable &rhs) const {
-        if (this->_name.rawId() < rhs._name.rawId()) {
-            return true;
-        }
-        if (this->_name.rawId() > rhs._name.rawId()) {
-            return false;
-        }
-        return this->unique < rhs.unique;
-    }
+    auto operator<=>(const LocalVariable &rhs) const noexcept = default;
 
     static inline LocalVariable noVariable() {
         return LocalVariable(NameRef::noName(), 0);

--- a/core/NameRef.h
+++ b/core/NameRef.h
@@ -2,6 +2,8 @@
 #define RUBY_TYPER_NAMEREF_H
 #include "common/common.h"
 #include "core/DebugOnlyCheck.h"
+#include <compare>
+
 namespace sorbet::core {
 class GlobalState;
 class NameSubstitution;
@@ -134,12 +136,15 @@ public:
 
     NameRef &operator=(const NameRef &rhs) = default;
 
-    bool operator==(const NameRef &rhs) const {
-        return _id == rhs._id;
+    auto operator<=>(const NameRef &rhs) const noexcept {
+        return this->_id <=> rhs._id;
     }
 
-    bool operator!=(const NameRef &rhs) const {
-        return !(rhs == *this);
+    inline bool operator==(const NameRef &rhs) const noexcept {
+        return std::is_eq(*this <=> rhs);
+    }
+    inline bool operator!=(const NameRef &rhs) const noexcept {
+        return std::is_neq(*this <=> rhs);
     }
 
     constexpr uint32_t rawId() const {

--- a/core/SymbolRef.h
+++ b/core/SymbolRef.h
@@ -147,8 +147,8 @@ public:
     ConstClassOrModuleData data(const GlobalState &gs) const;
     ConstClassOrModuleData dataAllowingNone(const GlobalState &gs) const;
 
-    bool operator==(const ClassOrModuleRef &rhs) const;
-    bool operator!=(const ClassOrModuleRef &rhs) const;
+    bool operator==(const ClassOrModuleRef &rhs) const noexcept = default;
+    bool operator!=(const ClassOrModuleRef &rhs) const noexcept = default;
 
     std::string toString(const GlobalState &gs) const {
         bool showFull = false;
@@ -242,9 +242,8 @@ public:
     };
     std::string show(const GlobalState &gs, ShowOptions options) const;
 
-    bool operator==(const MethodRef &rhs) const;
-
-    bool operator!=(const MethodRef &rhs) const;
+    bool operator==(const MethodRef &rhs) const noexcept = default;
+    bool operator!=(const MethodRef &rhs) const noexcept = default;
 };
 CheckSize(MethodRef, 4, 4);
 
@@ -287,9 +286,8 @@ public:
     };
     std::string show(const GlobalState &gs, ShowOptions options) const;
 
-    bool operator==(const FieldRef &rhs) const;
-
-    bool operator!=(const FieldRef &rhs) const;
+    bool operator==(const FieldRef &rhs) const noexcept = default;
+    bool operator!=(const FieldRef &rhs) const noexcept = default;
 };
 CheckSize(FieldRef, 4, 4);
 
@@ -331,9 +329,8 @@ public:
     };
     std::string show(const GlobalState &gs, ShowOptions options) const;
 
-    bool operator==(const TypeMemberRef &rhs) const;
-
-    bool operator!=(const TypeMemberRef &rhs) const;
+    bool operator==(const TypeMemberRef &rhs) const noexcept = default;
+    bool operator!=(const TypeMemberRef &rhs) const noexcept = default;
 };
 CheckSize(TypeMemberRef, 4, 4);
 
@@ -376,9 +373,8 @@ public:
     };
     std::string show(const GlobalState &gs, ShowOptions options) const;
 
-    bool operator==(const TypeParameterRef &rhs) const;
-
-    bool operator!=(const TypeParameterRef &rhs) const;
+    bool operator==(const TypeParameterRef &rhs) const noexcept = default;
+    bool operator!=(const TypeParameterRef &rhs) const noexcept = default;
 };
 CheckSize(TypeParameterRef, 4, 4);
 
@@ -531,9 +527,8 @@ public:
     }
 
 public:
-    bool operator==(const SymbolRef &rhs) const;
-
-    bool operator!=(const SymbolRef &rhs) const;
+    bool operator==(const SymbolRef &rhs) const noexcept = default;
+    bool operator!=(const SymbolRef &rhs) const noexcept = default;
 
     // TODO(jvilk): Remove as many of these methods as possible in favor of callsites using .data on the more specific
     // symbol *Ref classes (e.g., ClassOrModuleRef). These were introduced to wean the codebase from calling

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -38,54 +38,6 @@ string showInternal(const GlobalState &gs, core::SymbolRef owner, core::NameRef 
 }
 } // namespace
 
-bool SymbolRef::operator==(const SymbolRef &rhs) const {
-    return _id == rhs._id;
-}
-
-bool SymbolRef::operator!=(const SymbolRef &rhs) const {
-    return !(rhs == *this);
-}
-
-bool ClassOrModuleRef::operator==(const ClassOrModuleRef &rhs) const {
-    return rhs._id == this->_id;
-}
-
-bool ClassOrModuleRef::operator!=(const ClassOrModuleRef &rhs) const {
-    return rhs._id != this->_id;
-}
-
-bool MethodRef::operator==(const MethodRef &rhs) const {
-    return rhs._id == this->_id;
-}
-
-bool MethodRef::operator!=(const MethodRef &rhs) const {
-    return rhs._id != this->_id;
-}
-
-bool FieldRef::operator==(const FieldRef &rhs) const {
-    return rhs._id == this->_id;
-}
-
-bool FieldRef::operator!=(const FieldRef &rhs) const {
-    return rhs._id != this->_id;
-}
-
-bool TypeMemberRef::operator==(const TypeMemberRef &rhs) const {
-    return rhs._id == this->_id;
-}
-
-bool TypeMemberRef::operator!=(const TypeMemberRef &rhs) const {
-    return rhs._id != this->_id;
-}
-
-bool TypeParameterRef::operator==(const TypeParameterRef &rhs) const {
-    return rhs._id == this->_id;
-}
-
-bool TypeParameterRef::operator!=(const TypeParameterRef &rhs) const {
-    return rhs._id != this->_id;
-}
-
 vector<TypePtr> ClassOrModule::selfTypeArgs(const GlobalState &gs) const {
     vector<TypePtr> targs;
     for (auto tm : typeMembers()) {

--- a/core/packages/MangledName.h
+++ b/core/packages/MangledName.h
@@ -29,13 +29,8 @@ public:
     // (might not exist)
     static MangledName lookupMangledName(const core::GlobalState &gs, const std::vector<std::string> &parts);
 
-    bool operator==(const MangledName &rhs) const {
-        return owner == rhs.owner;
-    }
-
-    bool operator!=(const MangledName &rhs) const {
-        return !(rhs == *this);
-    }
+    bool operator==(const MangledName &rhs) const noexcept = default;
+    bool operator!=(const MangledName &rhs) const noexcept = default;
 
     bool exists() const {
         return this->owner.exists();

--- a/core/packages/Stratum.h
+++ b/core/packages/Stratum.h
@@ -1,6 +1,7 @@
 #ifndef SORBET_CORE_PACKAGES_STRATUM_H
 #define SORBET_CORE_PACKAGES_STRATUM_H
 
+#include <compare>
 #include <cstdint>
 
 namespace sorbet::core::packages {
@@ -21,29 +22,7 @@ public:
         return this->stratum;
     }
 
-    constexpr bool operator==(Stratum other) const {
-        return this->stratum == other.stratum;
-    }
-
-    constexpr bool operator!=(Stratum other) const {
-        return this->stratum != other.stratum;
-    }
-
-    constexpr bool operator<(Stratum other) const {
-        return this->stratum < other.stratum;
-    }
-
-    constexpr bool operator<=(Stratum other) const {
-        return this->stratum <= other.stratum;
-    }
-
-    constexpr bool operator>(Stratum other) const {
-        return this->stratum > other.stratum;
-    }
-
-    constexpr bool operator>=(Stratum other) const {
-        return this->stratum >= other.stratum;
-    }
+    constexpr auto operator<=>(const Stratum &other) const noexcept = default;
 };
 
 } // namespace sorbet::core::packages


### PR DESCRIPTION
Now that we have c++20 available, we can derive most of our comparison method implementations.

### Motivation
Simplifying code, and getting better comparison implementations by deriving `operator<=>` when possible.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Refactoring, no changes expected.
