### PR TITLE
Remove now-incorrect paragraph from generics docs

### DIFF
--- a/website/docs/generics.md
+++ b/website/docs/generics.md
@@ -327,8 +327,6 @@ Covariant type variables preserve the subtyping relationship. Specifically, if t
 Child <: Parent  ==>  M[Child] <: M[Parent]
 ```
 
-Note that only a Ruby `module` (not a `class`) may have a covariant `type_member`. (See the docs for error code [5016](error-reference.md#5016) for more information.) Note that since `type_template` creates a type variable scoped to a singleton class, `type_template` can never be covariant (because all singleton classes are classes, even singleton classes of modules).
-
 Here's an example of a module that has a covariant type member:
 
 ```ruby


### PR DESCRIPTION
Remove a now-inaccurate note about variance and classes.

### Motivation
This doc hasn't been updated to reflect #6721, which means the paragraph I'm removing here is incorrect now. I considered replacing it with a note about older versions, but I think at this point it's been long enough since the change merged that we can just describe the current state and elide this paragraph entirely.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
