### PR TITLE
Replace `|| true` in CLI tests with louder failure

### DIFF
--- a/test/cli/at/test.sh
+++ b/test/cli/at/test.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 main/sorbet --censor-for-snapshot-tests --silence-dev-message @test/cli/at/at.input 2>&1
 
-main/sorbet --censor-for-snapshot-tests --silence-dev-message @does_not_exist 2>&1 || true
+if main/sorbet --censor-for-snapshot-tests --silence-dev-message @does_not_exist 2>&1; then
+  echo "Expected to fail!"
+  exit 1
+fi

--- a/test/cli/backtrace/test.sh
+++ b/test/cli/backtrace/test.sh
@@ -17,7 +17,11 @@ then
  exit 0;
 fi
 
-main/sorbet --silence-dev-message --simulate-crash  &> "$outfile" || true
+if main/sorbet --silence-dev-message --simulate-crash  &> "$outfile"; then
+  echo "Expected to fail!"
+  exit 1
+fi
+
 if grep -q "realmain" "$outfile"
 then
     echo "$PASS_TEXT"

--- a/test/cli/errors-skip-cache/test.sh
+++ b/test/cli/errors-skip-cache/test.sh
@@ -10,11 +10,15 @@ trap cleanup EXIT
 mkdir "$dir/cache"
 
 run_sorbet() {
-  main/sorbet --censor-for-snapshot-tests \
+  if main/sorbet --censor-for-snapshot-tests \
     --silence-dev-message \
     --cache-dir "$dir"/cache \
     test/cli/errors-skip-cache/"$1" \
-    2>&1 || true
+    2>&1
+  then
+    echo "Expected to fail!"
+    exit 1
+  fi
 }
 
 run_twice() {

--- a/test/cli/files-dirs/test.sh
+++ b/test/cli/files-dirs/test.sh
@@ -11,7 +11,10 @@ main/sorbet --silence-dev-message -p file-table-json --no-stdlib foo.rb
 rm foo.rb
 
 echo '------------------------------------------------------------------------'
-main/sorbet --silence-dev-message -p file-table-json --no-stdlib --dir . --ignore external 2>&1 || true
+if main/sorbet --silence-dev-message -p file-table-json --no-stdlib --dir . --ignore external 2>&1; then
+  echo "Expected to fail!"
+  exit 1
+fi
 
 echo '------------------------------------------------------------------------'
 touch foo.rb

--- a/test/cli/no-stdlib-caching/test.sh
+++ b/test/cli/no-stdlib-caching/test.sh
@@ -7,6 +7,13 @@ trap 'rm -rf "$dir"' EXIT
 
 cp ./test/cli/no-stdlib-caching/test.rb "$dir"
 
-main/sorbet --silence-dev-message --cache-dir="$dir/cache" "$dir" 2>&1 || true
-main/sorbet --silence-dev-message --no-stdlib --cache-dir="$dir/cache" "$dir" 2>&1 || true
+if main/sorbet --silence-dev-message --cache-dir="$dir/cache" "$dir" 2>&1; then
+  echo "Expected to fail!"
+  exit 1
+fi
+
+if main/sorbet --silence-dev-message --no-stdlib --cache-dir="$dir/cache" "$dir" 2>&1; then
+  echo "Expected to fail!"
+  exit 1
+fi
 

--- a/test/cli/track-untyped/test.sh
+++ b/test/cli/track-untyped/test.sh
@@ -11,10 +11,19 @@ args=(
 )
 
 echo --- implicit 'everywhere' ---
-main/sorbet "${args[@]}" --track-untyped 2>&1 || true
+if main/sorbet "${args[@]}" --track-untyped 2>&1; then
+  echo "Expected to fail!"
+  exit 1
+fi
 
 echo --- explicit 'nowhere' ---
-main/sorbet "${args[@]}" --track-untyped=nowhere 2>&1 || true
+if main/sorbet "${args[@]}" --track-untyped=nowhere 2>&1; then
+  echo "Expected to fail!"
+  exit 1
+fi
 
 echo --- explicit 'everywhere' ---
-main/sorbet "${args[@]}" --track-untyped=everywhere 2>&1 || true
+if main/sorbet "${args[@]}" --track-untyped=everywhere 2>&1; then
+  echo "Expected to fail!"
+  exit 1
+fi


### PR DESCRIPTION
### Motivation

Inspired by [Jake's comment](https://github.com/sorbet/sorbet/pull/10285#discussion_r3326057465). Applies the much more common `echo "Expected to fail!"` pattern used in other tests.

### Test plan

None.