### PR TITLE
Handle payload static field and type member namespace collisions

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1703,6 +1703,41 @@ void GlobalState::mangleRenameMethod(MethodRef what, NameRef origName) {
     what.data(*this)->name = name;
 }
 
+void GlobalState::mangleRenameStaticField(FieldRef what, NameRef origName) {
+    ENFORCE_NO_TIMER(!symbolTableFrozen);
+    ENFORCE_NO_TIMER(what.data(*this)->flags.isStaticField);
+    auto owner = what.data(*this)->owner;
+    auto ownerData = owner.data(*this);
+    auto &ownerMembers = ownerData->members();
+    auto fnd = ownerMembers.find(origName);
+    ENFORCE_NO_TIMER(fnd != ownerMembers.end());
+    ENFORCE_NO_TIMER(fnd->second == what);
+    ENFORCE_NO_TIMER(what.data(*this)->name == origName);
+    NameRef name = nextMangledName(owner, origName);
+    ENFORCE(!ownerData->findMember(*this, name).exists(), "would overwrite the Symbol with name {}",
+            name.showRaw(*this));
+    ownerMembers.erase(fnd);
+    ownerMembers[name] = what;
+    what.data(*this)->name = name;
+}
+
+void GlobalState::mangleRenameTypeMember(TypeMemberRef what, NameRef origName) {
+    ENFORCE_NO_TIMER(!symbolTableFrozen);
+    auto owner = what.data(*this)->owner.asClassOrModuleRef();
+    auto ownerData = owner.data(*this);
+    auto &ownerMembers = ownerData->members();
+    auto fnd = ownerMembers.find(origName);
+    ENFORCE_NO_TIMER(fnd != ownerMembers.end());
+    ENFORCE_NO_TIMER(fnd->second == what);
+    ENFORCE_NO_TIMER(what.data(*this)->name == origName);
+    NameRef name = nextMangledName(owner, origName);
+    ENFORCE(!ownerData->findMember(*this, name).exists(), "would overwrite the Symbol with name {}",
+            name.showRaw(*this));
+    ownerMembers.erase(fnd);
+    ownerMembers[name] = what;
+    what.data(*this)->name = name;
+}
+
 // This method should be used sparingly, because using it correctly is tricky.
 // Consider using mangleRenameMethod (or defining a new constant with a name produced by nextMangledName)
 // instead, unless you absolutely know that you must use this method.

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -443,6 +443,8 @@ public:
 
     NameRef nextMangledName(ClassOrModuleRef owner, NameRef origName);
     void mangleRenameMethod(MethodRef what, NameRef origName);
+    void mangleRenameStaticField(FieldRef what, NameRef origName);
+    void mangleRenameTypeMember(TypeMemberRef what, NameRef origName);
     // NOTE: You likely want to use mangleRenameMethod not deleteMethodSymbol, unless you know what you're doing.
     // See the comment on the implementation for more.
     void deleteMethodSymbol(MethodRef what);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1205,10 +1205,21 @@ private:
             symbol = ctx.owner.asClassOrModuleRef().data(ctx)->singletonClass(ctx);
         } else {
             auto owner = getOwnerSymbol(state, klass.owner);
-            auto member = owner.data(ctx)->findMember(ctx, klass.name);
+            auto member = owner.data(ctx)->findMemberNoDealias(klass.name);
             if (member.exists()) {
-                // If member exists with this name, it must be a class or module, because we never mangle-rename them.
-                symbol = member.asClassOrModuleRef();
+                if (member.isClassOrModule()) {
+                    symbol = member.asClassOrModuleRef();
+                } else if (member.isStaticField(ctx)) {
+                    // This can happen when the payload already defines a static field that user code
+                    // later treats as a namespace, like `DATA::A`.
+                    ctx.state.mangleRenameStaticField(member.asFieldRef(), klass.name);
+                    symbol = ctx.state.enterClassSymbol(ctx.locAt(klass.declLoc), owner, klass.name);
+                } else if (member.isTypeMember()) {
+                    ctx.state.mangleRenameTypeMember(member.asTypeMemberRef(), klass.name);
+                    symbol = ctx.state.enterClassSymbol(ctx.locAt(klass.declLoc), owner, klass.name);
+                } else {
+                    ENFORCE(false, "Unexpected non-class member kind in class namespace: {}", member.show(ctx));
+                }
             } else {
                 auto newClass = ctx.state.enterClassSymbol(ctx.locAt(klass.declLoc), owner, klass.name);
                 symbol = newClass;

--- a/test/testdata/namer/payload_static_field_namespace.rb
+++ b/test/testdata/namer/payload_static_field_namespace.rb
@@ -1,0 +1,13 @@
+# typed: true
+
+class DATA::A
+end
+
+class Sorbet::Private::Static::IOLike::A
+end
+
+class Queue::A
+end
+
+class Bundler::EndpointSpecification::Elem::A
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
See the linked issue. Existing assumption: 

https://github.com/sorbet/sorbet/blob/5ae1eebe3866a046044f1c126ea48b847b57ee4e/namer/namer.cc#L1210-L1211

However, payload symbols are not handled here, so any static field from any payload .rbi file causes collision if the user then attempts to use it as a prefix... This change handles them in the same way Sorbet mangles methods, so such input does not cause a crash.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes https://github.com/sorbet/sorbet/issues/10130

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

4 new test cases that can reproduce the state.

See included automated tests.
