### PR TITLE
Faster slow path restarts in package-directed mode

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2192,6 +2192,67 @@ GlobalState::copyForSlowPath(const vector<string> &extraPackageFilesDirectoryUnd
     return result;
 }
 
+bool GlobalState::copySymbolTableFrom(const GlobalState &other, packages::Stratum toStratum) {
+    // Exit early if there's nothing to copy.
+    if (!other.packageDB().enabled() || toStratum == packages::Stratum(0) ||
+        toStratum.rawId() >= other.symbolOffsets.size()) {
+        return false;
+    }
+
+    this->packageDB_ = other.packageDB().deepCopy();
+
+    this->symbolOffsets.clear();
+    this->symbolOffsets.insert(this->symbolOffsets.begin(), other.symbolOffsets.begin(),
+                               other.symbolOffsets.begin() + toStratum.rawId() + 1);
+
+    auto offsets = other.symbolOffsets[toStratum.rawId()];
+
+    ENFORCE(this->classAndModules.empty());
+    for (auto i = 0; i < offsets.classAndModulesOffset; ++i) {
+        this->classAndModules.emplace_back(other.classAndModules[i].deepCopy(*this));
+    }
+
+    // TODO(trevor): multiplex this with the worker pool
+    for (auto &sym : this->classAndModules) {
+        absl::erase_if(sym.members(), [offsets](pair<NameRef, SymbolRef> e) {
+            auto sym = e.second;
+            switch (sym.kind()) {
+                case SymbolRef::Kind::ClassOrModule:
+                    return sym.asClassOrModuleRef().id() >= offsets.classAndModulesOffset;
+                case SymbolRef::Kind::Method:
+                    return sym.asMethodRef().id() >= offsets.methodsOffset;
+                case SymbolRef::Kind::FieldOrStaticField:
+                    return sym.asFieldRef().id() >= offsets.fieldsOffset;
+                case SymbolRef::Kind::TypeParameter:
+                case SymbolRef::Kind::TypeMember:
+                    return false;
+            }
+        });
+    }
+
+    ENFORCE(this->methods.empty());
+    for (auto i = 0; i < offsets.methodsOffset; ++i) {
+        this->methods.emplace_back(other.methods[i].deepCopy(*this));
+    }
+
+    ENFORCE(this->fields.empty());
+    for (auto i = 0; i < offsets.fieldsOffset; ++i) {
+        this->fields.emplace_back(other.fields[i].deepCopy(*this));
+    }
+
+    ENFORCE(this->typeParameters.empty());
+    for (auto i = 0; i < offsets.typeParametersOffset; ++i) {
+        this->typeParameters.emplace_back(other.typeParameters[i].deepCopy(*this));
+    }
+
+    ENFORCE(this->typeMembers.empty());
+    for (auto i = 0; i < offsets.typeMembersOffset; ++i) {
+        this->typeMembers.emplace_back(other.typeMembers[i].deepCopy(*this));
+    }
+
+    return true;
+}
+
 string_view GlobalState::getPrintablePath(string_view path) const {
     // Only strip the path prefix if the path has it.
     if (path.substr(0, pathPrefix.length()) == pathPrefix) {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2144,15 +2144,15 @@ unique_ptr<GlobalState> GlobalState::copyForLSPTypechecker(
 
     return result;
 }
-unique_ptr<GlobalState>
-GlobalState::copyForSlowPath(const vector<string> &extraPackageFilesDirectoryUnderscorePrefixes,
-                             const vector<string> &extraPackageFilesDirectorySlashDeprecatedPrefixes,
-                             const vector<string> &extraPackageFilesDirectorySlashPrefixes,
-                             const vector<string> &packageSkipRBIExportEnforcementDirs,
-                             const vector<string> &allowRelaxedPackagerChecksFor,
-                             const vector<string> &updateVisibilityFor, const vector<string> &packagerLayers,
-                             string errorHint, packages::GenPackagesMode genPackagesMode,
-                             bool allowRelaxingTestVisibility, bool packageAttributedErrors, bool testPackages) const {
+
+pair<unique_ptr<GlobalState>, bool> GlobalState::copyForSlowPath(
+    const vector<string> &extraPackageFilesDirectoryUnderscorePrefixes,
+    const vector<string> &extraPackageFilesDirectorySlashDeprecatedPrefixes,
+    const vector<string> &extraPackageFilesDirectorySlashPrefixes,
+    const vector<string> &packageSkipRBIExportEnforcementDirs, const vector<string> &allowRelaxedPackagerChecksFor,
+    const vector<string> &updateVisibilityFor, const vector<string> &packagerLayers, string errorHint,
+    packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility, bool packageAttributedErrors,
+    bool testPackages, core::packages::Stratum toStratum) const {
     auto result = make_unique<GlobalState>(this->errorQueue, this->epochManager);
 
     // We omit a call to `initEmpty` here, as the only intended use of this function is to have its symbol table
@@ -2179,29 +2179,41 @@ GlobalState::copyForSlowPath(const vector<string> &extraPackageFilesDirectoryUnd
     result->typeParameters.reserve(this->typeParameters.capacity());
     result->typeMembers.reserve(this->typeMembers.capacity());
 
+    bool copiedSymbolTablePrefix = false;
     if (packageDB().enabled()) {
-        core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*result);
-        core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = result->unfreezePackages();
-        result->setPackagerOptions(extraPackageFilesDirectoryUnderscorePrefixes,
-                                   extraPackageFilesDirectorySlashDeprecatedPrefixes,
-                                   extraPackageFilesDirectorySlashPrefixes, packageSkipRBIExportEnforcementDirs,
-                                   allowRelaxedPackagerChecksFor, updateVisibilityFor, packagerLayers, errorHint,
-                                   genPackagesMode, allowRelaxingTestVisibility, packageAttributedErrors, testPackages);
+        {
+            core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*result);
+            core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = result->unfreezePackages();
+            result->setPackagerOptions(
+                extraPackageFilesDirectoryUnderscorePrefixes, extraPackageFilesDirectorySlashDeprecatedPrefixes,
+                extraPackageFilesDirectorySlashPrefixes, packageSkipRBIExportEnforcementDirs,
+                allowRelaxedPackagerChecksFor, updateVisibilityFor, packagerLayers, errorHint, genPackagesMode,
+                allowRelaxingTestVisibility, packageAttributedErrors, testPackages);
+        }
+
+        copiedSymbolTablePrefix = result->copySymbolTableFrom(*this, toStratum);
     }
 
-    return result;
+    return {move(result), copiedSymbolTablePrefix};
 }
 
 bool GlobalState::copySymbolTableFrom(const GlobalState &other, packages::Stratum toStratum) {
-    // Exit early if there's nothing to copy.
-    if (!other.packageDB().enabled() || toStratum == packages::Stratum(0) ||
-        toStratum.rawId() >= other.symbolOffsets.size()) {
+    // Copying a prefix of the symbol tables assumes that this global state derives from `other`.
+    ENFORCE(this->files->size() == other.files->size());
+    ENFORCE(this->constantNames.size() == other.constantNames.size());
+    ENFORCE(this->uniqueNames.size() == other.uniqueNames.size());
+    ENFORCE(this->namesByHash.size() == other.namesByHash.size());
+    ENFORCE(other.packageDB().enabled(), "Copying a prefix of the symbol table requires --sorbet-packages");
+
+    // Exit early if there's nothing to copy, or if we don't have information about the stratum specified.
+    if (toStratum == packages::Stratum(0) || toStratum.rawId() >= other.symbolOffsets.size()) {
         return false;
     }
 
     this->packageDB_ = other.packageDB().deepCopy();
 
     this->symbolOffsets.clear();
+    this->symbolOffsets.reserve(other.symbolOffsets.size());
     this->symbolOffsets.insert(this->symbolOffsets.begin(), other.symbolOffsets.begin(),
                                other.symbolOffsets.begin() + toStratum.rawId() + 1);
 
@@ -2224,8 +2236,9 @@ bool GlobalState::copySymbolTableFrom(const GlobalState &other, packages::Stratu
                 case SymbolRef::Kind::FieldOrStaticField:
                     return sym.asFieldRef().id() >= offsets.fieldsOffset;
                 case SymbolRef::Kind::TypeParameter:
+                    return sym.asTypeParameterRef().id() >= offsets.typeParametersOffset;
                 case SymbolRef::Kind::TypeMember:
-                    return false;
+                    return sym.asTypeMemberRef().id() >= offsets.typeMembersOffset;
             }
         });
     }

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -287,6 +287,8 @@ GlobalState::GlobalState(shared_ptr<ErrorQueue> errorQueue, shared_ptr<lsp::Type
     int namesByHashSize = nextPowerOfTwo(
         2 * (PAYLOAD_MAX_UTF8_NAME_COUNT + PAYLOAD_MAX_CONSTANT_NAME_COUNT + PAYLOAD_MAX_UNIQUE_NAME_COUNT));
     namesByHash.resize(namesByHashSize);
+
+    this->symbolOffsets.emplace_back();
 }
 
 unique_ptr<GlobalState> GlobalState::makeEmptyGlobalStateForHashing(spdlog::logger &logger) {

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -698,7 +698,7 @@ public:
 
     // Symbol table offset information for the current stratum of files.
     const SymbolTableOffsets &newSymbols() const {
-        return this->symbolOffsets;
+        return this->symbolOffsets.back();
     }
 
     // ClassOrModules that have been introduced in the current stratum of files.
@@ -726,8 +726,13 @@ public:
         return this->newSymbols().typeParameterRefs(*this);
     }
 
+    // Reserve space for internal structures, under the assumption that we'll see `len` strata.
+    void preallocateForStrata(size_t len) {
+        this->symbolOffsets.reserve(len);
+    }
+
     void updateSymbolTableOffsets() {
-        this->symbolOffsets = SymbolTableOffsets(*this);
+        this->symbolOffsets.emplace_back(SymbolTableOffsets(*this));
     }
 
 private:
@@ -774,7 +779,8 @@ private:
     bool symbolTableFrozen = true;
     bool fileTableFrozen = true;
 
-    SymbolTableOffsets symbolOffsets;
+    // Symbol table offsets for each stratum of the package graph traversal.
+    std::vector<SymbolTableOffsets> symbolOffsets;
 
     // Copy options over from another GlobalState. Private, as it's only meant to be used as a helper to implement other
     // copying strategies.

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -13,6 +13,7 @@
 #include "core/lsp/Query.h"
 #include "core/packages/PackageDB.h"
 #include "core/packages/PackageInfo.h"
+#include "core/packages/Stratum.h"
 #include "main/pipeline/semantic_extension/SemanticExtension.h"
 #include <memory>
 
@@ -282,6 +283,8 @@ public:
 
 // A snapshot of the size of all of GlobalState's symbol tables at a point in time.
 class SymbolTableOffsets {
+    friend class GlobalState;
+
     // The defaults of `1` are because all of our symbol tables reserve index `0` for the invalid entry, so all valid
     // indices will start at offset `1` into their respective vector.
     unsigned int classAndModulesOffset = 1;
@@ -590,6 +593,10 @@ public:
                     const std::vector<std::string> &updateVisibilityFor, const std::vector<std::string> &packagerLayers,
                     std::string errorHint, packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility,
                     bool packageAttributedErrors, bool testPackages) const;
+
+    // Copy the symbol table from other, planning to start typechecking at the given stratum. Returns `true` if the copy
+    // took place, or `false` if the symbol table was left un-initialized.
+    bool copySymbolTableFrom(const GlobalState &other, packages::Stratum toStratum);
 
     // Contains a path prefix that should be stripped from all printed paths.
     std::string pathPrefix;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -581,10 +581,10 @@ public:
         std::string errorHint, packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility,
         bool testPackages) const;
 
-    // Copy the name table, file table and other parts of GlobalState that are required to start the slow path.
-    // NOTE: this very intentionally will not copy the symbol table, and the expectation is that the symbol table will
-    // be overwritten by immediately deserializaing the payload over it.
-    std::unique_ptr<GlobalState>
+    // Copy the name table, file table and other parts of GlobalState that are required to start the slow path. If the
+    // `toStratum` value is passed as something other than the `0` stratum, the prefix of the symbol table leading up to
+    // that stratum will be copied over as well.
+    std::pair<std::unique_ptr<GlobalState>, bool>
     copyForSlowPath(const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
                     const std::vector<std::string> &extraPackageFilesDirectorySlashDeprecatedPrefixes,
                     const std::vector<std::string> &extraPackageFilesDirectorySlashPrefixes,
@@ -592,11 +592,7 @@ public:
                     const std::vector<std::string> &allowRelaxedPackagerChecksFor,
                     const std::vector<std::string> &updateVisibilityFor, const std::vector<std::string> &packagerLayers,
                     std::string errorHint, packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility,
-                    bool packageAttributedErrors, bool testPackages) const;
-
-    // Copy the symbol table from other, planning to start typechecking at the given stratum. Returns `true` if the copy
-    // took place, or `false` if the symbol table was left un-initialized.
-    bool copySymbolTableFrom(const GlobalState &other, packages::Stratum toStratum);
+                    bool packageAttributedErrors, bool testPackages, core::packages::Stratum toStratum) const;
 
     // Contains a path prefix that should be stripped from all printed paths.
     std::string pathPrefix;
@@ -801,6 +797,13 @@ private:
                                    SymbolRef defaultReturnValue, bool ignoreKind = false) const;
 
     std::string toStringWithOptions(bool showFull, bool showRaw) const;
+
+    // Copy the symbol table from other, planning to start typechecking at the given stratum. Returns `true` if the copy
+    // took place, or `false` if the symbol table was left un-initialized.
+    //
+    // This method requires that `this` be derived from `other`, as the copied symbol table prefix will assume that
+    // their name tables and file tables to match.
+    bool copySymbolTableFrom(const GlobalState &other, packages::Stratum toStratum);
 };
 // CheckSize(GlobalState, 152, 8);
 // Historically commented out because size of unordered_map was different between different versions of stdlib

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -453,7 +453,9 @@ core::packages::Stratum determineStartingStratum(const core::GlobalState &gs,
             ENFORCE(info.file.id() < fileToStratum.size());
             fileStratum = fileToStratum[info.file.id()];
         } else {
-            // We can't keep any part of the symbol table if the package file has changed.
+            // We can't keep any part of the symbol table if the package file has changed. The byte-for-byte comparison
+            // is a little expensive here, but we could refactor LSPIndexer::getTypecheckingPathInternal to cache the
+            // results of this check on the LSPFileUpdates so that we could avoid the additional check here.
             if (file->hasPackageRbPath() && fref.data(gs).source() != file->source()) {
                 return core::packages::Stratum(0);
             }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -33,10 +33,11 @@ using namespace std;
 namespace {
 
 void sendTypecheckInfo(const LSPConfiguration &config, const core::GlobalState &gs, SorbetTypecheckRunStatus status,
-                       TypecheckingPath typecheckingPath, vector<core::FileRef> filesTypechecked) {
+                       TypecheckingPath typecheckingPath, vector<core::FileRef> filesTypechecked,
+                       core::packages::Stratum startingStratum) {
     if (config.getClientConfig().enableTypecheckInfo) {
-        auto sorbetTypecheckInfo =
-            make_unique<SorbetTypecheckRunInfo>(status, typecheckingPath, config.frefsToPaths(gs, filesTypechecked));
+        auto sorbetTypecheckInfo = make_unique<SorbetTypecheckRunInfo>(
+            status, typecheckingPath, config.frefsToPaths(gs, filesTypechecked), startingStratum.rawId());
         config.output->write(make_unique<LSPMessage>(
             make_unique<NotificationMessage>("2.0", LSPMethod::SorbetTypecheckRunInfo, move(sorbetTypecheckInfo))));
     }
@@ -147,7 +148,7 @@ void LSPTypechecker::initialize(TaskQueue &queue, unique_ptr<core::GlobalState> 
         ErrorEpoch epoch(*errorReporter, updates.epoch, isIncremental, {});
         auto errorFlusher = make_shared<ErrorFlusherLSP>(updates.epoch, errorReporter);
         auto handler = InitKVStoreStrategy::build(*this->gs, std::move(kvstore));
-        auto committed = runSlowPath(updates, handler, workers, errorFlusher, SlowPathMode::Init);
+        auto [committed, _startingStratum] = runSlowPath(updates, handler, workers, errorFlusher, SlowPathMode::Init);
         ENFORCE(committed);
         epoch.committed = true;
     }
@@ -205,8 +206,9 @@ bool LSPTypechecker::typecheck(unique_ptr<LSPFileUpdates> updates, WorkerPool &w
 
     vector<core::FileRef> filesTypechecked;
     bool committed = true;
+    core::packages::Stratum startingStratum;
     const bool isFastPath = updates->typecheckingPath == TypecheckingPath::Fast;
-    sendTypecheckInfo(*config, *gs, SorbetTypecheckRunStatus::Started, updates->typecheckingPath, {});
+    sendTypecheckInfo(*config, *gs, SorbetTypecheckRunStatus::Started, updates->typecheckingPath, {}, startingStratum);
     {
         ErrorEpoch epoch(*errorReporter, updates->epoch, isFastPath, move(diagnosticLatencyTimers));
 
@@ -227,7 +229,8 @@ bool LSPTypechecker::typecheck(unique_ptr<LSPFileUpdates> updates, WorkerPool &w
             prodCategoryCounterInc("lsp.updates", "fastpath");
         } else {
             SessionKVStoreStrategy kvstore(this->sessionCache.get(), *this->config);
-            committed = runSlowPath(*updates, kvstore, workers, errorFlusher, SlowPathMode::Cancelable);
+            std::tie(committed, startingStratum) =
+                runSlowPath(*updates, kvstore, workers, errorFlusher, SlowPathMode::Cancelable);
         }
         epoch.committed = committed;
     }
@@ -239,7 +242,7 @@ bool LSPTypechecker::typecheck(unique_ptr<LSPFileUpdates> updates, WorkerPool &w
     }
 
     sendTypecheckInfo(*config, *gs, committed ? SorbetTypecheckRunStatus::Ended : SorbetTypecheckRunStatus::Cancelled,
-                      updates->typecheckingPath, move(filesTypechecked));
+                      updates->typecheckingPath, move(filesTypechecked), startingStratum);
     return committed;
 }
 
@@ -541,8 +544,10 @@ void applyFileTableUpdates(core::GlobalState &gs, vector<core::FileRef> &workspa
 }
 } // namespace
 
-bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, KVStoreStrategy &kvstore, WorkerPool &workers,
-                                 shared_ptr<core::ErrorFlusher> errorFlusher, LSPTypechecker::SlowPathMode mode) {
+pair<bool, core::packages::Stratum> LSPTypechecker::runSlowPath(LSPFileUpdates &updates, KVStoreStrategy &kvstore,
+                                                                WorkerPool &workers,
+                                                                shared_ptr<core::ErrorFlusher> errorFlusher,
+                                                                LSPTypechecker::SlowPathMode mode) {
     ENFORCE(this_thread::get_id() == typecheckerThreadId,
             "runSlowPath can only be called from the typechecker thread.");
 
@@ -561,7 +566,6 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, KVStoreStrategy &kvsto
         timeit.setTag("cancelable", "true");
 
         startingStratum = determineStartingStratum(*this->gs, this->fileToStratum, this->lastStratum, updates);
-        config->logger->error("Starting from stratum {}", startingStratum.rawId());
 
         auto savedGS =
             std::exchange(this->gs, pipeline::copyForSlowPath(*this->gs, this->config->opts, startingStratum));
@@ -898,7 +902,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, KVStoreStrategy &kvsto
         logger->debug("[Typechecker] Typecheck run for epoch {} was canceled.", updates.epoch);
     }
 
-    return committed;
+    return {committed, startingStratum};
 }
 
 void LSPTypechecker::cacheUpdatedFiles(absl::Span<const ast::ParsedFile> indexed,

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -645,8 +645,10 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, KVStoreStrategy &kvsto
         int stratumIx = -1;
 
         auto strata = pipeline::computePackageStrata(*this->gs, packageIndexed, workspaceFilesSpan, this->config->opts);
+        const auto numStrata = strata.strata.size();
         this->fileToStratum = move(strata.fileToStratum);
-        this->lastStratum = core::packages::Stratum(strata.strata.size() - 1);
+        this->lastStratum = core::packages::Stratum(numStrata - 1);
+        this->gs->preallocateForStrata(numStrata);
 
         // Determine which stratum this edit will be checked at, so that we have a good reference for when to switch
         // to the SlowPathNonBlocking status. This isn't exactly correct, as you could switch to editing a file in an

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -554,12 +554,17 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, KVStoreStrategy &kvsto
     ENFORCE(updates.typecheckingPath != TypecheckingPath::Fast || config->disableFastPath);
     logger->debug("Taking slow path");
 
+    core::packages::Stratum startingStratum(0);
     UnorderedSet<core::FileRef> openFiles;
     ENFORCE(this->cancellationUndoState == nullptr);
     if (cancelable) {
         timeit.setTag("cancelable", "true");
 
-        auto savedGS = std::exchange(this->gs, pipeline::copyForSlowPath(*this->gs, this->config->opts));
+        startingStratum = determineStartingStratum(*this->gs, this->fileToStratum, this->lastStratum, updates);
+        config->logger->error("Starting from stratum {}", startingStratum.rawId());
+
+        auto savedGS =
+            std::exchange(this->gs, pipeline::copyForSlowPath(*this->gs, this->config->opts, startingStratum));
 
         // Seed open files with the previous set from `indexedFinalGS`
         for (auto &entry : this->indexedFinalGS) {
@@ -692,11 +697,6 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, KVStoreStrategy &kvsto
                                      workers);
         }
 
-        // This is cast to a uint16_t everywhere it's used. This seems bad, but it should be fine because:
-        // 1. we increment in the beginning of the loop before any use
-        // 2. overflowing a uint16_t would mean that we have a chain of dependencies that's >65535 packages long
-        int stratumIx = -1;
-
         auto strata = pipeline::computePackageStrata(*this->gs, packageIndexed, workspaceFilesSpan, this->config->opts);
         const auto numStrata = strata.strata.size();
         this->fileToStratum = move(strata.fileToStratum);
@@ -707,13 +707,15 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, KVStoreStrategy &kvsto
         // to the SlowPathNonBlocking status. This isn't exactly correct, as you could switch to editing a file in an
         // earlier stratum and see requests handled by preemption before the status changes, or edit a file in a later
         // stratum and see `Loading...` despite the status.
-        auto editStratum = updatedFileRefs.empty() ? this->lastStratum
-                                                   : this->getFileStratumMapping().getStratumForFiles(updatedFileRefs);
+        auto editStratum =
+            updatedFileRefs.empty()
+                ? this->lastStratum
+                : std::max(startingStratum, this->getFileStratumMapping().getStratumForFiles(updatedFileRefs));
 
-        for (auto &stratum : strata.strata) {
+        for (auto stratumIx = startingStratum.rawId(); stratumIx < numStrata; ++stratumIx) {
+            auto &stratum = strata.strata[stratumIx];
+            core::packages::Stratum currentStratum(stratumIx);
             vector<ast::ParsedFile> stratumFiles, nonPackagedIndexed;
-
-            core::packages::Stratum currentStratum(++stratumIx);
 
             // When we unpartition the package and non-package files, we'll realloc stratumFiles to hold everything.
             stratumFiles.reserve(stratum.packageFiles.size() + stratum.sourceFiles.size());
@@ -873,7 +875,7 @@ bool LSPTypechecker::runSlowPath(LSPFileUpdates &updates, KVStoreStrategy &kvsto
             Exception::raise("Slow path failed to handle all expected preemptions");
         }
 
-        return core::packages::Stratum(stratumIx);
+        return this->lastStratum;
     });
 
     gs->lspQuery = core::lsp::Query::noQuery();

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -414,6 +414,59 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
 
 namespace {
 
+// Determine how much of the symbol table we can copy when starting a slow path edit: any __package.rb modification
+// means that we can't reuse the symbol table.
+core::packages::Stratum determineStartingStratum(const core::GlobalState &gs,
+                                                 const vector<core::packages::Stratum> &fileToStratum,
+                                                 const core::packages::Stratum lastStratum,
+                                                 const LSPFileUpdates &update) {
+    // We start by assuming we can copy the whole previous symbol table.
+    auto editStratum = lastStratum;
+
+    int ix = -1;
+    for (auto &file : update.updatedFiles) {
+        ++ix;
+
+        auto fref = update.updatedFileRefs[ix];
+
+        core::packages::Stratum fileStratum;
+
+        // If this is a new file, we can still copy a prefix if we can determine what package it would belong to.
+        if (fref.id() >= fileToStratum.size()) {
+            // We can't keep any part of the symbol table if we see a new package file
+            if (file->hasPackageRbPath()) {
+                return core::packages::Stratum(0);
+            }
+
+            auto pkg = gs.packageDB().findPackageByPath(gs, *file);
+            if (!pkg.exists()) {
+                return core::packages::Stratum(0);
+            }
+
+            auto &info = gs.packageDB().getPackageInfo(pkg);
+            ENFORCE(info.exists());
+
+            // We have already checked for new package files above, so this should always be true.
+            ENFORCE(info.file.id() < fileToStratum.size());
+            fileStratum = fileToStratum[info.file.id()];
+        } else {
+            // We can't keep any part of the symbol table if the package file has changed.
+            if (file->hasPackageRbPath() && fref.data(gs).source() != file->source()) {
+                return core::packages::Stratum(0);
+            }
+
+            fileStratum = fileToStratum[fref.id()];
+        }
+
+        // We need to find the earliest stratum involved in this edit to know what prefix of the symbol table will not
+        // be affected by it. This is the opposite of what we do for preemption, as in that case we need to know the
+        // point at which an edit's dependencies will all have been satisfied.
+        editStratum = std::min(editStratum, fileStratum);
+    }
+
+    return editStratum;
+}
+
 // Determine which files we need to copy into the open files cache (indexedFinalGS), and update the file table to point
 // to the updated files.
 void applyFileTableUpdates(core::GlobalState &gs, vector<core::FileRef> &workspaceFiles, const LSPConfiguration &config,

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -113,8 +113,10 @@ class LSPTypechecker final {
 
     /** Conservatively reruns entire pipeline without caching any trees. Returns 'true' if committed, 'false' if
      * canceled. */
-    bool runSlowPath(LSPFileUpdates &updates, KVStoreStrategy &kvstore, WorkerPool &workers,
-                     std::shared_ptr<core::ErrorFlusher> errorFlusher, SlowPathMode mode);
+    std::pair<bool, core::packages::Stratum> runSlowPath(LSPFileUpdates &updates, KVStoreStrategy &kvstore,
+                                                         WorkerPool &workers,
+                                                         std::shared_ptr<core::ErrorFlusher> errorFlusher,
+                                                         SlowPathMode mode);
 
     struct FastPathResult {
         // All of the files that we typechecked during the fast path.

--- a/main/lsp/tools/make_lsp_types.cc
+++ b/main/lsp/tools/make_lsp_types.cc
@@ -1349,6 +1349,7 @@ void makeLSPTypes(vector<shared_ptr<JSONClassType>> &enumTypes, vector<shared_pt
                                                  makeField("status", SorbetTypecheckRunStatus),
                                                  makeField("typecheckingPath", TypecheckingPath),
                                                  makeField("filesTypechecked", makeArray(JSONString)),
+                                                 makeField("startingStratum", JSONInt),
                                              },
                                              classTypes);
 

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -116,7 +116,8 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
 #endif
 }
 
-unique_ptr<core::GlobalState> copyForSlowPath(const core::GlobalState &from, const options::Options &opts) {
+unique_ptr<core::GlobalState> copyForSlowPath(const core::GlobalState &from, const options::Options &opts,
+                                              core::packages::Stratum forStratum) {
     if (opts.cacheSensitiveOptions.noStdlib) {
         auto result = make_unique<core::GlobalState>(from.errorQueue, from.epochManager);
         result->initEmpty();
@@ -129,7 +130,10 @@ unique_ptr<core::GlobalState> copyForSlowPath(const core::GlobalState &from, con
         opts.allowRelaxedPackagerChecksFor, opts.updateVisibilityFor, opts.packagerLayers, opts.sorbetPackagesHint,
         opts.genPackagesMode, opts.allowRelaxingTestVisibility, opts.packageAttributedErrors, opts.testPackages);
 
-    core::serialize::Serializer::loadSymbolTable(*result, PAYLOAD_SYMBOL_TABLE);
+    // Fall back on initializing from the payload if we're not copying part of from's symbol table.
+    if (!result->copySymbolTableFrom(from, forStratum)) {
+        core::serialize::Serializer::loadSymbolTable(*result, PAYLOAD_SYMBOL_TABLE);
+    }
 
     return result;
 }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -124,18 +124,19 @@ unique_ptr<core::GlobalState> copyForSlowPath(const core::GlobalState &from, con
         return result;
     }
 
-    auto result = from.copyForSlowPath(
+    auto [result, symbolTableInitialized] = from.copyForSlowPath(
         opts.extraPackageFilesDirectoryUnderscorePrefixes, opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
         opts.extraPackageFilesDirectorySlashPrefixes, opts.packageSkipRBIExportEnforcementDirs,
         opts.allowRelaxedPackagerChecksFor, opts.updateVisibilityFor, opts.packagerLayers, opts.sorbetPackagesHint,
-        opts.genPackagesMode, opts.allowRelaxingTestVisibility, opts.packageAttributedErrors, opts.testPackages);
+        opts.genPackagesMode, opts.allowRelaxingTestVisibility, opts.packageAttributedErrors, opts.testPackages,
+        forStratum);
 
     // Fall back on initializing from the payload if we're not copying part of from's symbol table.
-    if (!result->copySymbolTableFrom(from, forStratum)) {
+    if (!symbolTableInitialized) {
         core::serialize::Serializer::loadSymbolTable(*result, PAYLOAD_SYMBOL_TABLE);
     }
 
-    return result;
+    return move(result);
 }
 
 vector<core::FileRef> reserveFiles(core::GlobalState &gs, const vector<string> &files) {

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -121,7 +121,8 @@ void printUntypedBlames(const core::GlobalState &gs, const UnorderedMap<long, lo
                         const options::Options &opts);
 
 // Create a copy of `from` that has its symbol table reset to the payload.
-std::unique_ptr<core::GlobalState> copyForSlowPath(const core::GlobalState &from, const options::Options &opts);
+std::unique_ptr<core::GlobalState> copyForSlowPath(const core::GlobalState &from, const options::Options &opts,
+                                                   core::packages::Stratum forStratum);
 
 // Sort files by size, so that larger files appear earlier than smaller files.
 //

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -650,6 +650,7 @@ int realmain(int argc, char *argv[]) {
         vector<ast::ParsedFile> stratumFiles;
         int currentStratum = -1;
         auto strata = pipeline::computePackageStrata(*gs, packageIndexed, inputFilesSpan, opts);
+        gs->preallocateForStrata(strata.strata.size());
         for (auto &stratum : strata.strata) {
             ++currentStratum;
 

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -1190,4 +1190,402 @@ TEST_CASE_FIXTURE(ProtocolTest, "ShowOperationPackaged") {
     }
 }
 
+// Exercise cases where the slow path can reuse parts of the previous global state, and also show that any changes to
+// the package graph currently disable that optimization.
+TEST_CASE_FIXTURE(ProtocolTest, "SlowPathRestarts") {
+    auto initOpts = make_shared<realmain::options::Options>();
+    initOpts->cacheSensitiveOptions.sorbetPackages = true;
+    initOpts->packageDirected = true;
+    resetState(initOpts);
+
+    vector<pair<string, string>> files = {
+        {"__package.rb", PackageTextBuilder().withName("Root").withExports({"Root::A"}).build()},
+        {"a.rb", "# typed: true\n"
+                 "module Root\n"
+                 "  class A\n"
+                 "    def fun\n"
+                 "    end\n"
+                 "  end\n"
+                 "end\n"},
+        {"foo/__package.rb",
+         PackageTextBuilder().withName("Root::Foo").withExports({"Root::Foo::A"}).withImports({"Root"}).build()},
+        {"foo/a.rb", "# typed: true\n"
+                     "module Root::Foo\n"
+                     "  class A\n"
+                     "    def foo\n"
+                     "      Root::A.new()\n"
+                     "    end\n"
+                     "  end\n"
+                     "end\n"},
+    };
+
+    writeFilesToFS(files);
+
+    for (auto &[path, _] : files) {
+        this->lspWrapper->opts->inputFileNames.emplace_back(fmt::format("{}/{}", this->rootPath, path));
+    }
+
+    auto supportsMarkdown = true;
+    auto supportsCodeActionResolve = true;
+    auto opts = make_unique<SorbetInitializationOptions>();
+    opts->enableTypecheckInfo = true;
+
+    // The initial slow path.
+    assertErrorDiagnostics(initializeLSP(supportsMarkdown, supportsCodeActionResolve, move(opts)), {});
+
+    SUBCASE("NewFile") {
+        // Add a new file, kicking off a slow path
+        auto resps = send(*openFile("foo/b.rb", "# typed: true\n"
+                                                "module Root::Foo\n"
+                                                "  class B\n"
+                                                "  end\n"
+                                                "end\n"));
+
+        // We should see a starting and ending slow path message, with the end message indicating that the slow path
+        // started from stratum 1
+        REQUIRE_EQ(resps.size(), 2);
+        REQUIRE(absl::c_all_of(resps, [](auto &resp) { return resp->isNotification(); }));
+        REQUIRE(absl::c_all_of(
+            resps, [](auto &resp) { return resp->asNotification().method == LSPMethod::SorbetTypecheckRunInfo; }));
+
+        {
+            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps[0]->asNotification().params);
+            CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
+            CHECK_EQ(params->status, SorbetTypecheckRunStatus::Started);
+        }
+
+        {
+            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps[1]->asNotification().params);
+            CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
+            CHECK_EQ(params->status, SorbetTypecheckRunStatus::Ended);
+
+            // We're modifying package `Root::Foo`, which means we don't need to typecheck `Root` again.
+            CHECK_EQ(params->startingStratum, 1);
+        }
+    }
+
+    SUBCASE("ExistingFile") {
+        assertErrorDiagnostics(send(*openFile(files[3].first, files[3].second)), {});
+
+        // Make a slow path modification to an existing file.
+        auto resps = send(*changeFile(files[3].first,
+                                      "# typed: true\n"
+                                      "module Root::Foo\n"
+                                      "  class A\n"
+                                      "    module Foo\n"
+                                      "    end\n"
+                                      "\n"
+                                      "    def foo\n"
+                                      "      Root::A.new()\n"
+                                      "    end\n"
+                                      "  end\n"
+                                      "end\n",
+                                      2));
+
+        // We should see a starting and ending slow path message, with the end message indicating that the slow path
+        // started from stratum 1
+        REQUIRE_EQ(resps.size(), 2);
+        REQUIRE(absl::c_all_of(resps, [](auto &resp) { return resp->isNotification(); }));
+        REQUIRE(absl::c_all_of(
+            resps, [](auto &resp) { return resp->asNotification().method == LSPMethod::SorbetTypecheckRunInfo; }));
+
+        {
+            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps[0]->asNotification().params);
+            CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
+            CHECK_EQ(params->status, SorbetTypecheckRunStatus::Started);
+        }
+
+        {
+            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps[1]->asNotification().params);
+            CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
+            CHECK_EQ(params->status, SorbetTypecheckRunStatus::Ended);
+
+            // We're modifying package `Root::Foo`, which means we don't need to typecheck `Root` again.
+            CHECK_EQ(params->startingStratum, 1);
+        }
+    }
+
+    SUBCASE("AddPackage") {
+        // Add a new file, kicking off a slow path
+        auto resps = send(
+            *openFile("bar/__package.rb", PackageTextBuilder().withName("Root::Bar").withImports({"Root"}).build()));
+
+        // We should see a starting and ending slow path message, with the end message indicating that the slow path
+        // started from stratum 1
+        REQUIRE_EQ(resps.size(), 2);
+        REQUIRE(absl::c_all_of(resps, [](auto &resp) { return resp->isNotification(); }));
+        REQUIRE(absl::c_all_of(
+            resps, [](auto &resp) { return resp->asNotification().method == LSPMethod::SorbetTypecheckRunInfo; }));
+
+        {
+            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps[0]->asNotification().params);
+            CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
+            CHECK_EQ(params->status, SorbetTypecheckRunStatus::Started);
+        }
+
+        {
+            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps[1]->asNotification().params);
+            CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
+            CHECK_EQ(params->status, SorbetTypecheckRunStatus::Ended);
+
+            // We're modifying the package graph, which means we rebuild everything.
+            CHECK_EQ(params->startingStratum, 0);
+        }
+    }
+
+    SUBCASE("ModifyPackage") {
+        assertErrorDiagnostics(send(*openFile(files[2].first, files[2].second)), {});
+
+        // Remove the exports from Root::Foo's __package.rb, forcing a complete slow path
+        auto resps = send(
+            *changeFile(files[2].first, PackageTextBuilder().withName("Root::Foo").withImports({"Root"}).build(), 2));
+
+        // We should see a starting and ending slow path message, with the end message indicating that the slow path
+        // started from stratum 1
+        REQUIRE_EQ(resps.size(), 2);
+        REQUIRE(absl::c_all_of(resps, [](auto &resp) { return resp->isNotification(); }));
+        REQUIRE(absl::c_all_of(
+            resps, [](auto &resp) { return resp->asNotification().method == LSPMethod::SorbetTypecheckRunInfo; }));
+
+        {
+            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps[0]->asNotification().params);
+            CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
+            CHECK_EQ(params->status, SorbetTypecheckRunStatus::Started);
+        }
+
+        {
+            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps[1]->asNotification().params);
+            CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
+            CHECK_EQ(params->status, SorbetTypecheckRunStatus::Ended);
+
+            // We're modifying the package graph, which means we rebuild everything.
+            CHECK_EQ(params->startingStratum, 0);
+        }
+    }
+}
+
+// Tests that fast path operations on an earlier stratum work after a slow path reused that portion of the symbol table.
+TEST_CASE_FIXTURE(ProtocolTest, "FastPathAfterSlowPathRestarts") {
+    auto initOpts = make_shared<realmain::options::Options>();
+    initOpts->cacheSensitiveOptions.sorbetPackages = true;
+    initOpts->packageDirected = true;
+    resetState(initOpts);
+
+    vector<pair<string, string>> files = {
+        {"__package.rb", PackageTextBuilder().withName("Root").withExports({"Root::A"}).build()},
+        {"a.rb", "# typed: true\n"
+                 "module Root\n"
+                 "  class A\n"
+                 "    def fun\n"
+                 "    end\n"
+                 "  end\n"
+                 "end\n"},
+        {"foo/__package.rb",
+         PackageTextBuilder().withName("Root::Foo").withExports({"Root::Foo::A"}).withImports({"Root"}).build()},
+        {"foo/a.rb", "# typed: true\n"
+                     "module Root::Foo\n"
+                     "  class A\n"
+                     "    def foo\n"
+                     "      Root::A.new()\n"
+                     "    end\n"
+                     "  end\n"
+                     "end\n"},
+    };
+
+    writeFilesToFS(files);
+
+    for (auto &[path, _] : files) {
+        this->lspWrapper->opts->inputFileNames.emplace_back(fmt::format("{}/{}", this->rootPath, path));
+    }
+
+    auto supportsMarkdown = true;
+    auto supportsCodeActionResolve = true;
+    auto opts = make_unique<SorbetInitializationOptions>();
+    opts->enableTypecheckInfo = true;
+
+    // The initial slow path.
+    assertErrorDiagnostics(initializeLSP(supportsMarkdown, supportsCodeActionResolve, move(opts)), {});
+
+    // Make a slow path edit to Root::Foo::A
+    {
+        assertErrorDiagnostics(send(*openFile(files[1].first, files[1].second)), {});
+        assertErrorDiagnostics(send(*openFile(files[3].first, files[3].second)), {});
+
+        // Make a slow path modification to an existing file.
+        auto resps = send(*changeFile(files[3].first,
+                                      "# typed: true\n"
+                                      "module Root::Foo\n"
+                                      "  class A\n"
+                                      "    module Foo\n"
+                                      "    end\n"
+                                      "\n"
+                                      "    def foo\n"
+                                      "      Root::A.new()\n"
+                                      "    end\n"
+                                      "  end\n"
+                                      "end\n",
+                                      2));
+
+        // We should see a starting and ending slow path message, with the end message indicating that the slow path
+        // started from stratum 1
+        REQUIRE_EQ(resps.size(), 2);
+        REQUIRE(absl::c_all_of(resps, [](auto &resp) { return resp->isNotification(); }));
+        REQUIRE(absl::c_all_of(
+            resps, [](auto &resp) { return resp->asNotification().method == LSPMethod::SorbetTypecheckRunInfo; }));
+
+        {
+            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps[0]->asNotification().params);
+            CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
+            CHECK_EQ(params->status, SorbetTypecheckRunStatus::Started);
+        }
+
+        {
+            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps[1]->asNotification().params);
+            CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
+            CHECK_EQ(params->status, SorbetTypecheckRunStatus::Ended);
+
+            // We're modifying package `Root::Foo`, which means we don't need to typecheck `Root` again.
+            CHECK_EQ(params->startingStratum, 1);
+        }
+    }
+
+    // The following cases all happen in stratum 0 to ensure that the copied prefix is functioning as we would expect.
+
+    SUBCASE("HoverInRoot") {
+        auto resps = send(*hover(files[1].first, 2, 9));
+
+        REQUIRE_EQ(resps.size(), 1);
+        REQUIRE(resps.front()->isResponse());
+        REQUIRE_EQ(resps.front()->asResponse().requestMethod, LSPMethod::TextDocumentHover);
+    }
+
+    SUBCASE("FastPathErrorInRoot") {
+        auto resps = send(*changeFile(files[1].first,
+                                      "# typed: true\n"
+                                      "module Root\n"
+                                      "  class A\n"
+                                      "    def fun\n"
+                                      "      1 + :type_error\n"
+                                      "    end\n"
+                                      "  end\n"
+                                      "end\n",
+                                      2));
+
+        REQUIRE_EQ(resps.size(), 3);
+
+        REQUIRE(resps[0]->isNotification());
+        REQUIRE_EQ(resps[0]->asNotification().method, LSPMethod::SorbetTypecheckRunInfo);
+        REQUIRE_EQ(TypecheckingPath::Fast,
+                   get<unique_ptr<SorbetTypecheckRunInfo>>(resps[0]->asNotification().params)->typecheckingPath);
+
+        REQUIRE(resps[2]->isNotification());
+        REQUIRE_EQ(resps[2]->asNotification().method, LSPMethod::SorbetTypecheckRunInfo);
+        REQUIRE_EQ(TypecheckingPath::Fast,
+                   get<unique_ptr<SorbetTypecheckRunInfo>>(resps[2]->asNotification().params)->typecheckingPath);
+
+        assertErrorDiagnostics(move(resps), {{files[1].first, 4, "Expected `Integer`"}});
+    }
+}
+
+// Tests that fast path operations on an earlier stratum work after a slow path reused that portion of the symbol table.
+TEST_CASE_FIXTURE(ProtocolTest, "ErrorsRemainAfterSlowPathRestart") {
+    auto initOpts = make_shared<realmain::options::Options>();
+    initOpts->cacheSensitiveOptions.sorbetPackages = true;
+    initOpts->packageDirected = true;
+    resetState(initOpts);
+
+    vector<pair<string, string>> files = {
+        {"__package.rb", PackageTextBuilder().withName("Root").withExports({"Root::A"}).build()},
+        {"a.rb", "# typed: true\n"
+                 "module Root\n"
+                 "  class A\n"
+                 "    def fun\n"
+                 "    end\n"
+                 "  end\n"
+                 "end\n"},
+        {"foo/__package.rb",
+         PackageTextBuilder().withName("Root::Foo").withExports({"Root::Foo::A"}).withImports({"Root"}).build()},
+        {"foo/a.rb", "# typed: true\n"
+                     "module Root::Foo\n"
+                     "  class A\n"
+                     "    def foo\n"
+                     "      Root::A.new()\n"
+                     "    end\n"
+                     "  end\n"
+                     "end\n"},
+    };
+
+    writeFilesToFS(files);
+
+    for (auto &[path, _] : files) {
+        this->lspWrapper->opts->inputFileNames.emplace_back(fmt::format("{}/{}", this->rootPath, path));
+    }
+
+    auto supportsMarkdown = true;
+    auto supportsCodeActionResolve = true;
+    auto opts = make_unique<SorbetInitializationOptions>();
+    opts->enableTypecheckInfo = true;
+
+    // The initial slow path.
+    assertErrorDiagnostics(initializeLSP(supportsMarkdown, supportsCodeActionResolve, move(opts)), {});
+
+    // Add a fast-path error in a.rb
+    assertErrorDiagnostics(send(*openFile(files[1].first, files[1].second)), {});
+    assertErrorDiagnostics(send(*changeFile(files[1].first,
+                                            "# typed: true\n"
+                                            "module Root\n"
+                                            "  class A\n"
+                                            "    def fun\n"
+                                            "      1 + :type_error\n"
+                                            "    end\n"
+                                            "  end\n"
+                                            "end\n",
+                                            2)),
+                           {{files[1].first, 4, "Expected `Integer`"}});
+
+    // Make a slow path edit to Root::Foo::A
+    {
+        assertErrorDiagnostics(send(*openFile(files[3].first, files[3].second)),
+                               {{files[1].first, 4, "Expected `Integer`"}});
+
+        // Make a slow path modification to an existing file.
+        auto resps = send(*changeFile(files[3].first,
+                                      "# typed: true\n"
+                                      "module Root::Foo\n"
+                                      "  class A\n"
+                                      "    module Foo\n"
+                                      "    end\n"
+                                      "\n"
+                                      "    def foo\n"
+                                      "      Root::A.new() + :type_error\n"
+                                      "    end\n"
+                                      "  end\n"
+                                      "end\n",
+                                      2));
+
+        // We should see a starting and ending slow path message, with the end message indicating that the slow path
+        // started from stratum 1
+        REQUIRE_EQ(resps.size(), 3);
+        {
+            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps[0]->asNotification().params);
+            CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
+            CHECK_EQ(params->status, SorbetTypecheckRunStatus::Started);
+        }
+
+        {
+            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps[2]->asNotification().params);
+            CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
+            CHECK_EQ(params->status, SorbetTypecheckRunStatus::Ended);
+
+            // We're modifying package `Root::Foo`, which means we don't need to typecheck `Root` again.
+            CHECK_EQ(params->startingStratum, 1);
+        }
+
+        assertErrorDiagnostics(move(resps), {
+                                                {files[1].first, 4, "Expected `Integer`"},
+                                                {files[3].first, 7, "Method `+` does not exist"},
+                                            });
+    }
+}
+
 } // namespace sorbet::test::lsp


### PR DESCRIPTION
Now that our LSP implementation supports `--experimental-package-directed`, we can speed up the slow path by determining how much of the previous symbol table wouldn't be affected by the edit, copying that prefix into our new `GlobalState`, and skipping those files. Pairing this with the changes to support preemption when in package-directed mode means that the worst-case latency for changes to non-package files should now be tied to the size of the largest stratum, instead of the whole codebase.

The important changes here are:

1. We now track the `SymbolTableOffsets` for every stratum, holding onto them in a vector in `GlobalState`. These entries are what we use to determine how much of the previous symbol tables we can copy when starting the slow path.
2. This optimization can't handle changes to the PackageDB currently, as packages enter symbols into the `classOrModules` symbol table; adding or removing packages would mean that all `ClassOrModule` symbol refs after the region that holds package symbols would become invalid.


### Motivation
Slow path performance.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included tests.