### PR TITLE
Delete `visible_to`s that refer to constants/packages that don't exist

### DIFF
--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -198,11 +198,8 @@ optional<core::AutocorrectSuggestion> PackageInfo::addImport(const core::GlobalS
                     // edit to delete the existing line, and then use the regular logic for adding an import to
                     // insert the `import`.
                     auto importLoc = core::Loc(fullLoc().file(), import.loc);
-                    auto [lineStart, numWhitespace] = importLoc.findStartOfIndentation(gs);
-                    // -numWhitespace - 1 for the indentation and previous new line
-                    auto beginPos = lineStart.adjust(gs, -numWhitespace - 1, 0).beginPos();
-                    auto endPos = importLoc.endPos();
-                    core::Loc replaceLoc(importLoc.file(), beginPos, endPos);
+                    auto startDetail = importLoc.toDetails(gs).first;
+                    auto replaceLoc = importLoc.adjust(gs, -startDetail.column, 0);
 
                     deleteTestImportEdit = {replaceLoc, ""};
 
@@ -213,7 +210,7 @@ optional<core::AutocorrectSuggestion> PackageInfo::addImport(const core::GlobalS
                     // tricky
 
                     if (importType == ImportType::TestHelper) {
-                        insertionLoc = {importLoc.file(), beginPos - 1, beginPos - 1};
+                        insertionLoc = {importLoc.file(), replaceLoc.beginPos() - 1, replaceLoc.beginPos() - 1};
                         break;
                     }
                 } else {
@@ -619,11 +616,8 @@ std::optional<core::AutocorrectSuggestion> PackageInfo::aggregateMissingImports(
             // is used somewhere, then we're going to add an import to the correct name just below, so we can delete
             // this line.
             auto importLoc = core::Loc(fullLoc().file(), import.loc);
-            auto [lineStart, numWhitespace] = importLoc.findStartOfIndentation(gs);
-            // -numWhitespace - 1 for the indentation and previous new line
-            auto beginPos = lineStart.adjust(gs, -numWhitespace - 1, 0).beginPos();
-            auto endPos = importLoc.endPos();
-            core::Loc replaceLoc(importLoc.file(), beginPos, endPos);
+            auto startDetail = importLoc.toDetails(gs).first;
+            auto replaceLoc = importLoc.adjust(gs, -startDetail.column, 0);
             core::AutocorrectSuggestion::Edit deleteEdit = {replaceLoc, ""};
             allEdits.push_back(deleteEdit);
         }
@@ -677,11 +671,8 @@ PackageInfo::aggregateMissingExports(const core::GlobalState &gs, vector<core::S
         // trying to export is used somewhere, then we're going to add the correct export just below, so we can delete
         // this line.
         auto exportLoc = core::Loc(fullLoc().file(), export_.loc);
-        auto [lineStart, numWhitespace] = exportLoc.findStartOfIndentation(gs);
-        // -numWhitespace - 1 for the indentation and previous new line
-        auto beginPos = lineStart.adjust(gs, -numWhitespace - 1, 0).beginPos();
-        auto endPos = exportLoc.endPos();
-        core::Loc replaceLoc(exportLoc.file(), beginPos, endPos);
+        auto startDetail = exportLoc.toDetails(gs).first;
+        auto replaceLoc = exportLoc.adjust(gs, -startDetail.column, 0);
         core::AutocorrectSuggestion::Edit deleteEdit = {replaceLoc, ""};
         allEdits.push_back(deleteEdit);
     }
@@ -725,11 +716,8 @@ std::optional<core::AutocorrectSuggestion> PackageInfo::aggregateMissingVisibleT
     for (auto &v : visibleTo_) {
         if (!v.mangledName.owner.exists()) {
             auto visibleToLoc = core::Loc(file, v.loc);
-            auto [lineStart, numWhitespace] = visibleToLoc.findStartOfIndentation(gs);
-            // -numWhitespace - 1 for the indentation and previous new line
-            auto beginPos = lineStart.adjust(gs, -numWhitespace - 1, 0).beginPos();
-            auto endPos = visibleToLoc.endPos();
-            core::Loc replaceLoc(visibleToLoc.file(), beginPos, endPos);
+            auto startDetail = visibleToLoc.toDetails(gs).first;
+            auto replaceLoc = visibleToLoc.adjust(gs, -startDetail.column, 0);
             core::AutocorrectSuggestion::Edit deleteEdit = {replaceLoc, ""};
             allEdits.push_back(deleteEdit);
         }

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -720,6 +720,21 @@ PackageInfo::aggregateMissingExports(const core::GlobalState &gs, vector<core::S
 std::optional<core::AutocorrectSuggestion> PackageInfo::aggregateMissingVisibleTo(
     const core::GlobalState &gs, UnorderedSet<core::packages::MangledName> &visibleTos, bool visibleToTests) const {
     std::vector<core::AutocorrectSuggestion::Edit> allEdits;
+
+    // Delete `visible_to`s that refer to constants/packages that don't exist
+    for (auto &v : visibleTo_) {
+        if (!v.mangledName.owner.exists()) {
+            auto visibleToLoc = core::Loc(file, v.loc);
+            auto [lineStart, numWhitespace] = visibleToLoc.findStartOfIndentation(gs);
+            // -numWhitespace - 1 for the indentation and previous new line
+            auto beginPos = lineStart.adjust(gs, -numWhitespace - 1, 0).beginPos();
+            auto endPos = visibleToLoc.endPos();
+            core::Loc replaceLoc(visibleToLoc.file(), beginPos, endPos);
+            core::AutocorrectSuggestion::Edit deleteEdit = {replaceLoc, ""};
+            allEdits.push_back(deleteEdit);
+        }
+    }
+
     for (auto &pkgName : visibleTos) {
         auto autocorrect = addVisibleTo(gs, pkgName);
         if (autocorrect.has_value()) {

--- a/packager/GenPackages.cc
+++ b/packager/GenPackages.cc
@@ -236,10 +236,12 @@ void GenPackages::run(core::GlobalState &gs) {
         // over all files, and it doesn't make sense to rerun the loop for each package, so we do this work upfront
         auto exportsAutocorrect = pkgInfo.aggregateMissingExports(gs, toExport[pkgName]);
         // Similar idea for visible_to.
-        auto visibleToAutocorrect =
-            gs.packageDB().updateVisibilityFor(pkgName)
-                ? pkgInfo.aggregateMissingVisibleTo(gs, neededVisibleTo[pkgName], neededVisibleToTests[pkgName])
-                : nullopt;
+        // We always call aggregateMissingVisibleTo so that visible_to entries referencing non-existent packages
+        // get deleted, even if we're not adding new visible_to entries for this package.
+        auto emptyVisibleTos = UnorderedSet<core::packages::MangledName>{};
+        auto visibleToAutocorrect = pkgInfo.aggregateMissingVisibleTo(
+            gs, gs.packageDB().updateVisibilityFor(pkgName) ? neededVisibleTo[pkgName] : emptyVisibleTos,
+            gs.packageDB().updateVisibilityFor(pkgName) && neededVisibleToTests[pkgName]);
 
         auto autocorrects = vector<core::AutocorrectSuggestion>{};
         auto missingTypes = vector<string>{};

--- a/test/cli/package-gen-packages-test-packages/C/__package.rb
+++ b/test/cli/package-gen-packages-test-packages/C/__package.rb
@@ -7,4 +7,7 @@ class C < PackageSpec
   import A
   import AnotherPack
   import D
+
+  visible_to DoesNotExist
+  visible_to AlsoDoesNotExist::*
 end

--- a/test/cli/package-gen-packages-test-packages/E/__package.rb
+++ b/test/cli/package-gen-packages-test-packages/E/__package.rb
@@ -5,4 +5,7 @@ class E < PackageSpec
   layer 'util'
 
   export E::CONSTANT_FROM_E
+
+  visible_to DoesNotExis
+  visible_to AlsoDoesNotExist::*
 end

--- a/test/cli/package-gen-packages-test-packages/test.out
+++ b/test/cli/package-gen-packages-test-packages/test.out
@@ -50,7 +50,7 @@ C/__package.rb:7: Layering violation: cannot import `A` (in layer `app`) from `C
      5 |  layer 'app'
                 ^^^^^
 
-C/__package.rb:3: `C` is missing imports https://srb.help/3734
+C/__package.rb:3: `C` is missing imports and `visible_to`s https://srb.help/3734
      3 |class C < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -65,11 +65,23 @@ C/__package.rb:3: `C` is missing imports https://srb.help/3734
       import E`
      9 |  import D
                   ^
+    C/__package.rb:11: Deleted
+    11 |  visible_to DoesNotExist
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
+    C/__package.rb:12: Deleted
+    12 |  visible_to AlsoDoesNotExist::*
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
      3 |class E < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
+    E/__package.rb:9: Deleted
+     9 |  visible_to DoesNotExis
+        ^^^^^^^^^^^^^^^^^^^^^^^^
+    E/__package.rb:10: Deleted
+    10 |  visible_to AlsoDoesNotExist::*
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     E/__package.rb:10: Inserted `visible_to 'tests'
       visible_to C`
     10 |  visible_to AlsoDoesNotExist::*
@@ -155,8 +167,6 @@ class C < PackageSpec
   import D::ANestedPackage
   import E
 
-  visible_to DoesNotExist
-  visible_to AlsoDoesNotExist::*
 end
 
 ###### cat D/__package.rb ######
@@ -191,8 +201,6 @@ class E < PackageSpec
 
   export E::CONSTANT_FROM_E
 
-  visible_to DoesNotExis
-  visible_to AlsoDoesNotExist::*
   visible_to 'tests'
   visible_to C
 end
@@ -250,7 +258,7 @@ C/__package.rb:7: Layering violation: cannot import `A` (in layer `app`) from `C
      5 |  layer 'app'
                 ^^^^^
 
-C/__package.rb:3: `C` is missing imports https://srb.help/3734
+C/__package.rb:3: `C` is missing imports and `visible_to`s https://srb.help/3734
      3 |class C < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -265,11 +273,23 @@ C/__package.rb:3: `C` is missing imports https://srb.help/3734
       import E`
      9 |  import D
                   ^
+    C/__package.rb:11: Deleted
+    11 |  visible_to DoesNotExist
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
+    C/__package.rb:12: Deleted
+    12 |  visible_to AlsoDoesNotExist::*
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
      3 |class E < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
+    E/__package.rb:9: Deleted
+     9 |  visible_to DoesNotExis
+        ^^^^^^^^^^^^^^^^^^^^^^^^
+    E/__package.rb:10: Deleted
+    10 |  visible_to AlsoDoesNotExist::*
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     E/__package.rb:10: Inserted `visible_to 'tests'
       visible_to C`
     10 |  visible_to AlsoDoesNotExist::*
@@ -368,8 +388,6 @@ class C < PackageSpec
   import D::ANestedPackage
   import E
 
-  visible_to DoesNotExist
-  visible_to AlsoDoesNotExist::*
 end
 
 ###### cat D/__package.rb ######
@@ -404,8 +422,6 @@ class E < PackageSpec
 
   export E::CONSTANT_FROM_E
 
-  visible_to DoesNotExis
-  visible_to AlsoDoesNotExist::*
   visible_to 'tests'
   visible_to C
 end

--- a/test/cli/package-gen-packages-test-packages/test.out
+++ b/test/cli/package-gen-packages-test-packages/test.out
@@ -70,10 +70,10 @@ E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
      3 |class E < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    E/__package.rb:7: Inserted `visible_to 'tests'
+    E/__package.rb:10: Inserted `visible_to 'tests'
       visible_to C`
-     7 |  export E::CONSTANT_FROM_E
-                                   ^
+    10 |  visible_to AlsoDoesNotExist::*
+                                        ^
 
 D/test/__package.rb:3: `Test::D` is missing imports https://srb.help/3734
      3 |class Test::D < PackageSpec
@@ -154,6 +154,9 @@ class C < PackageSpec
   import D
   import D::ANestedPackage
   import E
+
+  visible_to DoesNotExist
+  visible_to AlsoDoesNotExist::*
 end
 
 ###### cat D/__package.rb ######
@@ -187,6 +190,9 @@ class E < PackageSpec
   layer 'util'
 
   export E::CONSTANT_FROM_E
+
+  visible_to DoesNotExis
+  visible_to AlsoDoesNotExist::*
   visible_to 'tests'
   visible_to C
 end
@@ -264,10 +270,10 @@ E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
      3 |class E < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    E/__package.rb:7: Inserted `visible_to 'tests'
+    E/__package.rb:10: Inserted `visible_to 'tests'
       visible_to C`
-     7 |  export E::CONSTANT_FROM_E
-                                   ^
+    10 |  visible_to AlsoDoesNotExist::*
+                                        ^
 
 D/test/__package.rb:3: `Test::D` is missing imports https://srb.help/3734
      3 |class Test::D < PackageSpec
@@ -361,6 +367,9 @@ class C < PackageSpec
   import D
   import D::ANestedPackage
   import E
+
+  visible_to DoesNotExist
+  visible_to AlsoDoesNotExist::*
 end
 
 ###### cat D/__package.rb ######
@@ -394,6 +403,9 @@ class E < PackageSpec
   layer 'util'
 
   export E::CONSTANT_FROM_E
+
+  visible_to DoesNotExis
+  visible_to AlsoDoesNotExist::*
   visible_to 'tests'
   visible_to C
 end

--- a/test/cli/package-gen-packages/C/__package.rb
+++ b/test/cli/package-gen-packages/C/__package.rb
@@ -7,4 +7,7 @@ class C < PackageSpec
   import A
   import AnotherPack
   import D
+
+  visible_to DoesNotExist
+  visible_to AlsoDoesNotExist::*
 end

--- a/test/cli/package-gen-packages/E/__package.rb
+++ b/test/cli/package-gen-packages/E/__package.rb
@@ -5,4 +5,7 @@ class E < PackageSpec
   layer 'util'
 
   export E::CONSTANT_FROM_E
+
+  visible_to DoesNotExis
+  visible_to AlsoDoesNotExist::*
 end

--- a/test/cli/package-gen-packages/test.out
+++ b/test/cli/package-gen-packages/test.out
@@ -50,7 +50,7 @@ C/__package.rb:7: Layering violation: cannot import `A` (in layer `app`) from `C
      5 |  layer 'app'
                 ^^^^^
 
-C/__package.rb:3: `C` is missing imports https://srb.help/3734
+C/__package.rb:3: `C` is missing imports and `visible_to`s https://srb.help/3734
      3 |class C < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -65,11 +65,23 @@ C/__package.rb:3: `C` is missing imports https://srb.help/3734
       import E`
      9 |  import D
                   ^
+    C/__package.rb:11: Deleted
+    11 |  visible_to DoesNotExist
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
+    C/__package.rb:12: Deleted
+    12 |  visible_to AlsoDoesNotExist::*
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
      3 |class E < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
+    E/__package.rb:9: Deleted
+     9 |  visible_to DoesNotExis
+        ^^^^^^^^^^^^^^^^^^^^^^^^
+    E/__package.rb:10: Deleted
+    10 |  visible_to AlsoDoesNotExist::*
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     E/__package.rb:10: Inserted `visible_to 'tests'
       visible_to C`
     10 |  visible_to AlsoDoesNotExist::*
@@ -150,8 +162,6 @@ class C < PackageSpec
   import D::ANestedPackage
   import E
 
-  visible_to DoesNotExist
-  visible_to AlsoDoesNotExist::*
 end
 
 ###### cat D/__package.rb ######
@@ -187,8 +197,6 @@ class E < PackageSpec
 
   export E::CONSTANT_FROM_E
 
-  visible_to DoesNotExis
-  visible_to AlsoDoesNotExist::*
   visible_to 'tests'
   visible_to C
 end
@@ -233,7 +241,7 @@ C/__package.rb:7: Layering violation: cannot import `A` (in layer `app`) from `C
      5 |  layer 'app'
                 ^^^^^
 
-C/__package.rb:3: `C` is missing imports https://srb.help/3734
+C/__package.rb:3: `C` is missing imports and `visible_to`s https://srb.help/3734
      3 |class C < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -248,11 +256,23 @@ C/__package.rb:3: `C` is missing imports https://srb.help/3734
       import E`
      9 |  import D
                   ^
+    C/__package.rb:11: Deleted
+    11 |  visible_to DoesNotExist
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
+    C/__package.rb:12: Deleted
+    12 |  visible_to AlsoDoesNotExist::*
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
      3 |class E < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
+    E/__package.rb:9: Deleted
+     9 |  visible_to DoesNotExis
+        ^^^^^^^^^^^^^^^^^^^^^^^^
+    E/__package.rb:10: Deleted
+    10 |  visible_to AlsoDoesNotExist::*
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     E/__package.rb:10: Inserted `visible_to 'tests'
       visible_to C`
     10 |  visible_to AlsoDoesNotExist::*
@@ -352,8 +372,6 @@ class C < PackageSpec
   import D::ANestedPackage
   import E
 
-  visible_to DoesNotExist
-  visible_to AlsoDoesNotExist::*
 end
 
 ###### cat D/__package.rb ######
@@ -389,8 +407,6 @@ class E < PackageSpec
 
   export E::CONSTANT_FROM_E
 
-  visible_to DoesNotExis
-  visible_to AlsoDoesNotExist::*
   visible_to 'tests'
   visible_to C
 end

--- a/test/cli/package-gen-packages/test.out
+++ b/test/cli/package-gen-packages/test.out
@@ -70,10 +70,10 @@ E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
      3 |class E < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    E/__package.rb:7: Inserted `visible_to 'tests'
+    E/__package.rb:10: Inserted `visible_to 'tests'
       visible_to C`
-     7 |  export E::CONSTANT_FROM_E
-                                   ^
+    10 |  visible_to AlsoDoesNotExist::*
+                                        ^
 
 D/__package.rb:3: `D` is missing imports and exports https://srb.help/3734
      3 |class D < PackageSpec
@@ -149,6 +149,9 @@ class C < PackageSpec
   import D
   import D::ANestedPackage
   import E
+
+  visible_to DoesNotExist
+  visible_to AlsoDoesNotExist::*
 end
 
 ###### cat D/__package.rb ######
@@ -183,6 +186,9 @@ class E < PackageSpec
   layer 'util'
 
   export E::CONSTANT_FROM_E
+
+  visible_to DoesNotExis
+  visible_to AlsoDoesNotExist::*
   visible_to 'tests'
   visible_to C
 end
@@ -247,10 +253,10 @@ E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
      3 |class E < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    E/__package.rb:7: Inserted `visible_to 'tests'
+    E/__package.rb:10: Inserted `visible_to 'tests'
       visible_to C`
-     7 |  export E::CONSTANT_FROM_E
-                                   ^
+    10 |  visible_to AlsoDoesNotExist::*
+                                        ^
 
 D/__package.rb:3: `D` is missing imports and exports https://srb.help/3734
      3 |class D < PackageSpec
@@ -345,6 +351,9 @@ class C < PackageSpec
   import D
   import D::ANestedPackage
   import E
+
+  visible_to DoesNotExist
+  visible_to AlsoDoesNotExist::*
 end
 
 ###### cat D/__package.rb ######
@@ -379,6 +388,9 @@ class E < PackageSpec
   layer 'util'
 
   export E::CONSTANT_FROM_E
+
+  visible_to DoesNotExis
+  visible_to AlsoDoesNotExist::*
   visible_to 'tests'
   visible_to C
 end

--- a/test/testdata/packager/visibility/foo/__package.rb
+++ b/test/testdata/packager/visibility/foo/__package.rb
@@ -13,6 +13,8 @@ class Foo < PackageSpec
            # ^^^^^^^^^^^^^^^^^^^^ error: Argument to `visible_to` must be a constant or
 
   visible_to Nested::*
+  visible_to Quux::*
+           # ^^^^ error: Unable to resolve constant `Quux`
 
   visible_to Nested::*(0)
            # ^^^^^^^^^^^^ error: Argument to `visible_to` must be a constant or


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Review commit-by-commit.

Similar to #10225 and #10229

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Delete `visible_to`s that are causing an error. Unlike the import and export case, we won't always automatically add the correct one, but we will if the user passes in `--update-visibility-for`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
