### PR TITLE
Better support for `sig` with `let` methods in RSpec

### DIFF
--- a/gems/sorbet-runtime/lib/types/compatibility_patches.rb
+++ b/gems/sorbet-runtime/lib/types/compatibility_patches.rb
@@ -51,6 +51,36 @@ if defined? ::RSpec::Mocks
   end
 end
 
+# Allow using `sig {...}` on top of a `let`-defined method in an RSpec example group
+if defined? ::RSpec::Core::MemoizedHelpers::ClassMethods
+  module T
+    module CompatibilityPatches
+      module RSpecCompatibility
+        module MemoizedHelpers
+          def let(name, &block)
+            current_declaration = T::Private::DeclState.current.active_declaration
+            return super unless current_declaration
+
+            # Make sure that our method_added hook will fire
+            let_definitions = ::RSpec::Core::MemoizedHelpers.module_for(self)
+            return super unless let_definitions.is_a?(T::Private::Methods::MethodHooks)
+
+            # Make it behave like the `sig` had been written inside the
+            # `LetDefinitions` module, so that the runtime wrapping happens on
+            # the inner method (the one that's not memoized), so that the
+            # runtime type validation only happens once, not every time that
+            # the `let`-defined method is called.
+            current_declaration.mod = let_definitions
+
+            super
+          end
+        end
+        ::RSpec::Core::MemoizedHelpers::ClassMethods.prepend(MemoizedHelpers)
+      end
+    end
+  end
+end
+
 # Work around for sorbet-runtime wrapped methods.
 #
 # When a sig is defined, sorbet-runtime will replace the sigged method

--- a/gems/sorbet-runtime/lib/types/compatibility_patches.rb
+++ b/gems/sorbet-runtime/lib/types/compatibility_patches.rb
@@ -57,6 +57,8 @@ if defined? ::RSpec::Core::MemoizedHelpers::ClassMethods
     module CompatibilityPatches
       module RSpecCompatibility
         module MemoizedHelpers
+          # `let!`, `subject`, and `subject!` are implemented by dispatching to
+          # `let`, so this should cover those methods too.
           def let(name, &block)
             current_declaration = T::Private::DeclState.current.active_declaration
             return super unless current_declaration

--- a/gems/sorbet-runtime/lib/types/compatibility_patches.rb
+++ b/gems/sorbet-runtime/lib/types/compatibility_patches.rb
@@ -60,21 +60,31 @@ if defined? ::RSpec::Core::MemoizedHelpers::ClassMethods
           # `let!`, `subject`, and `subject!` are implemented by dispatching to
           # `let`, so this should cover those methods too.
           def let(name, &block)
+            # TODO(jez) This will need to use consume!
+
             current_declaration = T::Private::DeclState.current.active_declaration
             return super unless current_declaration
+            T::Private::DeclState.current.reset!
 
-            # Make sure that our method_added hook will fire
-            let_definitions = ::RSpec::Core::MemoizedHelpers.module_for(self)
-            return super unless let_definitions.is_a?(T::Private::Methods::MethodHooks)
-
-            # Make it behave like the `sig` had been written inside the
-            # `LetDefinitions` module, so that the runtime wrapping happens on
-            # the inner method (the one that's not memoized), so that the
-            # runtime type validation only happens once, not every time that
-            # the `let`-defined method is called.
-            current_declaration.mod = let_definitions
-
+            # Allow the `let`-defined methods to be defined
             super
+
+            # Stash the sig and re-define the method RSpec just defined. This
+            # ensures that the `sig` attaches to the outer method, not any
+            # method inside the LetDefinitions module.
+            #
+            # Unfortunately, this means that the runtime checks are not
+            # memoized (but they never were).
+            #
+            # (An alternative approach of pretending that the `sig` was actually
+            # written inside the `LetDefinitions` module didn't work, because
+            # things like `sig {override}` broke: the `LetDefinitions` module
+            # has no ancestors and thus does not override anything)
+
+            method = instance_method(name)
+            remove_method(name)
+            T::Private::DeclState.current.active_declaration = current_declaration
+            define_method(name, method)
           end
         end
         ::RSpec::Core::MemoizedHelpers::ClassMethods.prepend(MemoizedHelpers)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #10315

~~This solves two problems:~~

- ~~The changes in #10262 affected users who monkey patch `T::Sig` into
  `Module`, preventing them from using `sig` on `let`-defined methods.~~

- ~~Even before that change, it was the case that the runtime wrapped
  method would be the outer method (the one that does the memoization
  check) instead of the inner method (the one that holds the true method
  implementation). The runtime checks should also be subject to
  memoization, so that we don't pay the cost of them all the time.~~

~~This change makes it look like a `sig` that precedes a `let`-defined
method was actually written atop the inner, `LetDefinitions` module that
RSpec creates if we know that our `method_added` hook will fire.~~

This solves a problem introduced in #10262, affecting users who monkey patch `T::Sig` into `Module`. That PR prevented them from using `sig` on `let`-defined methods in RSpec.

I had originally hoped to take the opportunity to improve the state of things even further, by making `sig` respect the intent of `let` (e.g. to memoize a helper in a test) such that the runtime type checks are themselves memoized. I was not able to get that to work (see the commit history for the change which backs it out), because my strategy was to "lie" in a way that turned out to be meaningful (e.g. I tried to lie and treat the `sig` definition as if it happened inside RSpec's `LetDefinitions` module that it creates to hold the original methods passed to `let`, which is subjected to the memoization machinery, but that lie was visible via things like runtime override checking when a signature is built).

As such, this only solves the immediate problem.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

We do not have automated tests for these compatibility patches, because we don't
have `rspec` as a dependency in `sorbet-runtime`.

I tested this manually in a few ways:

With a global `T::Sig` monkey patch:

```ruby
require_relative '/Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/sorbet-runtime'

Module.include(T::Sig)

RSpec.describe "hello" do
  sig { returns(Integer) }
  let(:foo) { "not an integer" }

  it "fails with a type error" do
    foo
  end
end
```

and with a local `extend T::Sig` in the describe block:

```ruby
require_relative '/Users/jez/stripe/sorbet/gems/sorbet-runtime/lib/sorbet-runtime'

RSpec.describe "hello" do
  extend T::Sig
  sig { returns(Integer) }
  let(:foo) { "not an integer" }

  it "fails with a type error" do
    foo
  end
end
```

In both cases, the old behavior (before #10262) was that `bundle exec rspec
foo.rb` fails with a sorbet-runtime `TypeError` about `"not an integer"` not
being an `Integer`.

After #10262, the first snippet changed in behavior (reporting an exception
about the `sig` and `def` being on different modules).

After the changes in this PR, the behavior of both snippets is once again to
fail with a type error.

Another test case, which passes using the updated strategy:

```ruby
# typed: true

class Module
  include T::Sig
end

RSpec.describe "hello" do
  sig { returns(Integer) }
  let(:foo) { "not an integer" }

  describe "inner" do
    sig { override.returns(Integer) }
    let(:foo) { "also not an integer" }

    it "fails with a type error" do
      foo
    end
  end
end
```