### PR TITLE
Use C++20 default member initializers for Flags bit-fields

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -834,12 +834,12 @@ public:
         // True if the receiver was self (either implicit like `foo()` or explicit like `self.foo()`)
         //   - Prior to Ruby 2.7, it was illegal to call a private method with an explicit receiver.
         //   - As of Ruby 2.7, it became legal to call private methods on self, e.g. `self.foo()`.
-        bool isPrivateOk : 1;
-        bool isRewriterSynthesized : 1;
-        bool hasBlock : 1;
+        bool isPrivateOk : 1 {false};
+        bool isRewriterSynthesized : 1 {false};
+        bool hasBlock : 1 {false};
 
-        // In C++20 we can replace this with bit field initialzers
-        Flags() : isPrivateOk(false), isRewriterSynthesized(false), hasBlock(false) {}
+        
+        Flags()  = default;
 
         bool operator==(const Flags &other) const noexcept = default;
         bool operator!=(const Flags &other) const noexcept = default;


### PR DESCRIPTION
### Motivation
Addresses a portion of #9142. This PR modernizes the `Flags` struct in `ast/Trees.h` to use C++20 default member initializers for bit-fields, making the code cleaner and removing the clunky manual constructor initialization.

### Test Plan
See included automated tests. The change updates standard type initializations which will be verified by the existing CI test suite.