### PR TITLE
Skip clang-tidy on macOS

### DIFF
--- a/.buildkite/test-static-sanitized.sh
+++ b/.buildkite/test-static-sanitized.sh
@@ -84,23 +84,27 @@ fi
 
 # Run clang-tidy even if tests failed (reuses the same build config for cache hits)
 clang_tidy_err=0
-./bazel build \
-  --keep_going \
-  --config=clang-tidy \
-  "${build_args[@]}" \
-  --experimental_generate_json_trace_profile \
-  --profile=_out_/clang_tidy_profile.json \
-  //... \
-  || clang_tidy_err=$?
 
-if [ "$clang_tidy_err" -ne 0 ]; then
-  {
-    echo 'There were clang-tidy errors. To reproduce locally:'
-    echo
-    echo '```bash'
-    echo './bazel build --keep_going --config=clang-tidy --config=dbg //...'
-    echo '```'
-  } | buildkite-agent annotate --context "clang-tidy" --style error --append
+# ... but only run clang-tidy on linux (there's only one macOS runner)
+if [[ "mac" != "$platform" ]]; then
+  ./bazel build \
+    --keep_going \
+    --config=clang-tidy \
+    "${build_args[@]}" \
+    --experimental_generate_json_trace_profile \
+    --profile=_out_/clang_tidy_profile.json \
+    //... \
+    || clang_tidy_err=$?
+
+  if [ "$clang_tidy_err" -ne 0 ]; then
+    {
+      echo 'There were clang-tidy errors. To reproduce locally:'
+      echo
+      echo '```bash'
+      echo './bazel build --keep_going --config=clang-tidy --config=dbg //...'
+      echo '```'
+    } | buildkite-agent annotate --context "clang-tidy" --style error --append
+  fi
 fi
 
 if [ "$err" -ne 0 ]; then


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

clang-tidy is a little slow, and there's only one macOS machine. I don't
think we're likely to see clang-tidy bugs that only manifest on macOS so
I'm going to skip them to make the macOS runner a little less contended.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Will check the buildkite logs on the branch and on master to make sure that
clang-tidy is still running on linux and skipped on master on macOS.