### PR TITLE
Eagerly report sig+module mismatch problems

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -217,6 +217,18 @@ module T::Private::Methods
       )
     end
 
+    # We allow `sig` in the current module's context (normal case) and
+    if hook_mod != current_declaration.mod &&
+       # inside `class << self`, and
+       hook_mod.singleton_class != current_declaration.mod &&
+       # on `self` at the top level of a file
+       current_declaration.mod != TOP_SELF
+      raise "A method (#{method_name}) is being added on a different class/module (#{hook_mod}) than the " \
+            "last call to `sig` (#{current_declaration.mod}). Make sure each call " \
+            "to `sig` is immediately followed by a method definition on the same " \
+            "class/module."
+    end
+
     original_method = mod.instance_method(method_name)
     sig_block = lambda do
       T::Private::Methods.run_sig(hook_mod, method_name, original_method, current_declaration)
@@ -344,18 +356,6 @@ module T::Private::Methods
 
   def self.build_sig(hook_mod, method_name, original_method, current_declaration)
     begin
-      # We allow `sig` in the current module's context (normal case) and
-      if hook_mod != current_declaration.mod &&
-         # inside `class << self`, and
-         hook_mod.singleton_class != current_declaration.mod &&
-         # on `self` at the top level of a file
-         current_declaration.mod != TOP_SELF
-        raise "A method (#{method_name}) is being added on a different class/module (#{hook_mod}) than the " \
-              "last call to `sig` (#{current_declaration.mod}). Make sure each call " \
-              "to `sig` is immediately followed by a method definition on the same " \
-              "class/module."
-      end
-
       signature = Signature.new(
         method: original_method,
         method_name: method_name,

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -231,7 +231,7 @@ module T::Private::Methods
 
     original_method = mod.instance_method(method_name)
     sig_block = lambda do
-      T::Private::Methods.run_sig(hook_mod, method_name, original_method, current_declaration)
+      T::Private::Methods.run_sig(method_name, original_method, current_declaration)
     end
 
     # Always replace the original method with this wrapper,
@@ -310,7 +310,7 @@ module T::Private::Methods
 
   # Executes the `sig` block, and converts the resulting Declaration
   # to a Signature.
-  def self.run_sig(hook_mod, method_name, original_method, declaration_block)
+  def self.run_sig(method_name, original_method, declaration_block)
     current_declaration =
       begin
         run_builder(declaration_block)
@@ -324,7 +324,7 @@ module T::Private::Methods
 
     signature =
       if current_declaration
-        build_sig(hook_mod, method_name, original_method, current_declaration)
+        build_sig(method_name, original_method, current_declaration)
       else
         Signature.new_untyped(method: original_method)
       end
@@ -354,7 +354,7 @@ module T::Private::Methods
     decl
   end
 
-  def self.build_sig(hook_mod, method_name, original_method, current_declaration)
+  def self.build_sig(method_name, original_method, current_declaration)
     begin
       signature = Signature.new(
         method: original_method,

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
@@ -65,14 +65,14 @@ module T::Private::Methods
   sig {params(receiver: Object, original_method: UnboundMethod, callee: Symbol).returns(T::Private::Methods::Signature)}
   def self._handle_missing_method_signature(receiver, original_method, callee); end
 
-  sig {params(hook_mod: Module, method_name: Symbol, original_method: UnboundMethod, declaration_block: DeclarationBlock).returns(T::Private::Methods::Signature)}
-  def self.run_sig(hook_mod, method_name, original_method, declaration_block); end
+  sig {params(method_name: Symbol, original_method: UnboundMethod, declaration_block: DeclarationBlock).returns(T::Private::Methods::Signature)}
+  def self.run_sig(method_name, original_method, declaration_block); end
 
   sig {params(declaration_block: DeclarationBlock).returns(T::Private::Methods::Declaration)}
   def self.run_builder(declaration_block); end
 
-  sig {params(hook_mod: Module, method_name: Symbol, original_method: UnboundMethod, current_declaration: T::Private::Methods::Declaration).returns(T::Private::Methods::Signature)}
-  def self.build_sig(hook_mod, method_name, original_method, current_declaration); end
+  sig {params(method_name: Symbol, original_method: UnboundMethod, current_declaration: T::Private::Methods::Declaration).returns(T::Private::Methods::Signature)}
+  def self.build_sig(method_name, original_method, current_declaration); end
 
   sig {params(method: T.any(Method, UnboundMethod)).returns(T.nilable(T::Private::Methods::Signature))}
   def self.signature_for_method(method); end

--- a/gems/sorbet-runtime/test/types/method_validation.rb
+++ b/gems/sorbet-runtime/test/types/method_validation.rb
@@ -102,9 +102,8 @@ module Opus::Types::Test
         end
 
         @mod.sig { returns(Symbol) }
-        def mod2.bar; end
         err = assert_raises(RuntimeError) do
-          mod2.bar
+          def mod2.bar; end
         end
 
         assert_equal(


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

If a `sig` is defined and then a method is defined after it in a different
module, this reports the error eagerly, instead of lazily on first call.

This lets us remove a usage of `hook_mod` in the declaration of `run_sig`.
`hook_mod` is a bit of a lie that causes problems for the changes in #10276 to
add `override` as a DSL method (`hook_mod` represents "the module where the
`sig` method was called" which is almost never what the code actually wants--the
code normally wants to operate on `mod`, which is the actual owner of a given
instance method).

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests and Stripe's codebase.

http://go/builds/bui_Ue1GOIhhk24dMN

There were a few errors in Stripe's codebase, but they were fixed by either
deleting or re-arranging bad signatures.