### PR TITLE
Overwrite `current_declaration.mod` to store the real mod

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -228,6 +228,8 @@ module T::Private::Methods
             "to `sig` is immediately followed by a method definition on the same " \
             "class/module."
     end
+    # Overwrite the DeclarationBlock mod with `mod`, which is the Module that owns the method.
+    current_declaration.mod = mod
 
     original_method = mod.instance_method(method_name)
     sig_block = lambda do

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -23,7 +23,7 @@ module Opus::Types::Test
       mod.fn(1) # executes the sig block
 
       assert(builder)
-      assert_equal(mod, builder.decl.mod)
+      assert_equal(mod.singleton_class, builder.decl.mod)
       assert_equal({x: Integer}, builder.decl.params)
       assert_equal(String, builder.decl.returns)
       assert_nil(builder.decl.checked)


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`hook_mod` is fake. It's just the mod that happened to trigger the
`sig`, and is only used to match up the `sig` and the `_on_method_added`
hook. Once that's done, the only module that matters is the actual
`mod`, which is where the instance method is owned.

In my `final def` change, we need to be able to have the `mod`, but all
we have is the `hook_mod` via `current_declaration.mod`. Rather than
storing a new field, let's just overwrite what we store in this field,
because it's all we need.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests, Stripe's codebase.

http://go/builds/bui_Ue1kNQ7GsygJj0

This is a no-op until the changes in #10276 land (again).