### PR TITLE
Add a `consume!` API for getting the `active_declaration`

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/decl_state.rb
+++ b/gems/sorbet-runtime/lib/types/private/decl_state.rb
@@ -12,9 +12,17 @@ class T::Private::DeclState
 
   attr_accessor :active_declaration
   attr_accessor :skip_on_method_added
+  attr_accessor :previous_declaration
 
   def reset!
     self.active_declaration = nil
+    @previous_declaration = nil
+  end
+
+  def consume!
+    @previous_declaration = self.active_declaration
+    self.active_declaration = nil
+    @previous_declaration
   end
 
   def without_on_method_added

--- a/gems/sorbet-runtime/lib/types/private/decl_state.rbi
+++ b/gems/sorbet-runtime/lib/types/private/decl_state.rbi
@@ -8,19 +8,10 @@ class T::Private::DeclState
   def self.current=(other); end
 
   sig {returns(T.nilable(T::Private::Methods::DeclarationBlock))}
-  def active_declaration; end
-
-  sig do
-    params(active_declaration: T.nilable(T::Private::Methods::DeclarationBlock))
-      .returns(T.nilable(T::Private::Methods::DeclarationBlock))
-  end
-  def active_declaration=(active_declaration); end
+  attr_accessor :active_declaration
 
   sig {returns(T.nilable(TrueClass))}
-  def skip_on_method_added; end
-
-  sig {params(skip_on_method_added: T.nilable(TrueClass)).returns(T.nilable(TrueClass))}
-  def skip_on_method_added=(skip_on_method_added); end
+  attr_accessor :skip_on_method_added
 
   sig {void}
   def reset!; end

--- a/gems/sorbet-runtime/lib/types/private/decl_state.rbi
+++ b/gems/sorbet-runtime/lib/types/private/decl_state.rbi
@@ -13,8 +13,14 @@ class T::Private::DeclState
   sig {returns(T.nilable(TrueClass))}
   attr_accessor :skip_on_method_added
 
+  sig { returns(T.nilable(T::Private::Methods::DeclarationBlock)) }
+  attr_accessor :previous_declaration
+
   sig {void}
   def reset!; end
+
+  sig { returns(T.nilable(T::Private::Methods::DeclarationBlock)) }
+  def consume!; end
 
   sig do
     type_parameters(:U)

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -478,6 +478,10 @@ module T::Private::Methods
       key, = first_wrapper
       run_sig_block_for_key(key, force_type_init: force_type_init)
     end
+
+    # Make sure that there are no lingering declaration blocks being kept alive
+    # (so we're not retaining any extra references for a possible GC)
+    T::Private::DeclState.current.reset!
   end
 
   def self.all_checked_tests_sigs

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -472,6 +472,12 @@ module T::Private::Methods
   end
 
   def self.run_all_sig_blocks(force_type_init: true)
+    current_declaration = T::Private::DeclState.current.active_declaration
+    if !current_declaration.nil?
+      T::Private::DeclState.current.reset!
+      raise "Cannot call `run_all_sig_blocks` while there is a pending `sig` block in #{current_declaration.mod} at #{current_declaration.loc}"
+    end
+
     loop do
       first_wrapper = @sig_wrappers.first
       break unless first_wrapper

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -194,8 +194,7 @@ module T::Private::Methods
       return
     end
 
-    current_declaration = T::Private::DeclState.current.active_declaration
-    T::Private::DeclState.current.reset!
+    current_declaration = T::Private::DeclState.current.consume!
 
     if T::Private::Final.final_module?(mod) && (current_declaration.nil? || !current_declaration.final)
       raise "#{mod} was declared as final but its method `#{method_name}` was not declared as final"

--- a/gems/sorbet-runtime/test/types/utils.rb
+++ b/gems/sorbet-runtime/test/types/utils.rb
@@ -58,5 +58,18 @@ module Opus::Types::Test
         end
       end
     end
+
+    describe 'run_all_sig_blocks' do
+      it 'raises if pending sigs' do
+        Module.new do
+          extend T::Sig
+          sig { void }
+        end
+        exn = assert_raises(RuntimeError) do
+          T::Utils.run_all_sig_blocks
+        end
+        assert_match(/pending `sig` block in/, exn.message)
+      end
+    end
   end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

In a future change we want to preserve the `previous_declaration`, so that
things like `override def foo; end` can use it.

This makes the changes necessary to support that feature.

I originally included this in #10276, but something in that change was broken,
and I am now trying to land pieces individually to figure out what the problem
was.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Should be a no-op. Existing tests, plus testing on Stripe's codebase.