### PR TITLE
Fix resolution of top-level constants accessed via Object

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -182,7 +182,7 @@ private:
         core::FileRef file;
         vector<T> items;
 
-        ResolveItems(core::FileRef file, vector<T> &&items) : file(file), items(move(items)){};
+        ResolveItems(core::FileRef file, vector<T> &&items) : file(file), items(move(items)) {};
     };
 
     struct AncestorResolutionItem {
@@ -386,6 +386,10 @@ private:
             core::SymbolRef result;
             if (resolved.isClassOrModule()) {
                 result = resolved.asClassOrModuleRef().data(ctx)->findMemberNoDealias(c.cnst);
+
+                if (!result.exists() && resolved == core::Symbols::Object()) {
+                    result = core::Symbols::root().data(ctx)->findMemberNoDealias(c.cnst);
+                }
             }
 
             // Private constants are allowed to be resolved, when there is no scope set (the scope is checked above),

--- a/test/testdata/resolver/object_string.rb
+++ b/test/testdata/resolver/object_string.rb
@@ -1,0 +1,2 @@
+# typed: true
+Object::String


### PR DESCRIPTION
### Motivation
In Ruby, the top-level namespace acts as if it is nested under `Object`. This means that constants like `String` can be validly referenced as `Object::String` or even `Object::Object::String`. 

However, Sorbet's internal static representation treats `String` as nested under a fictional `<root>` class, making it unaware of their existence under `Object`. This caused a resolution error (`Unable to resolve constant`) when users explicitly scoped top-level constants with `Object::`.

### Solution
This PR adds a fallback mechanism inside `resolveConstant` in `resolver/resolver.cc`. If the standard `findMemberNoDealias` lookup fails and the enclosing scope is exactly `core::Symbols::Object()`, the resolver will gracefully fallback to searching within `core::Symbols::root()`.

### Tests
- Added a new test `test/testdata/resolver/object_string.rb` to ensure `Object::String` resolves without errors.
- Verified that all existing tests in `//test:test_corpus` pass successfully.

Fixes #10322 