### PR TITLE
Update sigs for `allbits?` and `anybits?` in `Integer`

### DIFF
--- a/rbi/core/integer.rbi
+++ b/rbi/core/integer.rbi
@@ -507,14 +507,42 @@ class Integer < Numeric
   sig {returns(Integer)}
   def abs2(); end
 
-  # Returns `true` if all bits of `int & mask` are 1.
-  def allbits?(_); end
+  # Returns `true` if all bits that are set (=1) in `mask` are also set in
+  # `self`; returns `false` otherwise.
+  #
+  # ```ruby
+  # 0b1010101  self
+  # 0b1010100  mask
+  # 0b1010100  self & mask
+  #      true  self.allbits?(mask)
+  #
+  # 0b1010100  self
+  # 0b1010101  mask
+  # 0b1010100  self & mask
+  #     false  self.allbits?(mask)
+  # ```
+  sig {params(mask: Integer).returns(T::Boolean)}
+  def allbits?(mask); end
 
   sig {returns(Numeric)}
   def angle(); end
 
-  # Returns `true` if any bits of `int & mask` are 1.
-  def anybits?(_); end
+  # Returns `true` if any bit that is set (=1) in `mask` is also set in `self`;
+  # returns `false` otherwise.
+  #
+  # ```ruby
+  # 0b10000010  self
+  # 0b11111111  mask
+  # 0b10000010  self & mask
+  #       true  self.anybits?(mask)
+  #
+  # 0b00000000  self
+  # 0b11111111  mask
+  # 0b00000000  self & mask
+  #      false  self.anybits?(mask)
+  # ```
+  sig {params(mask: Integer).returns(T::Boolean)}
+  def anybits?(mask); end
 
   sig {returns(Numeric)}
   def arg(); end

--- a/test/testdata/rbi/integer.rb
+++ b/test/testdata/rbi/integer.rb
@@ -5,6 +5,14 @@
 255[1..]
 255[..4]
 
+# allbits? takes an Integer mask and return a Boolean
+T.reveal_type(0b1010.allbits?(0b1000)) # error: type: `T::Boolean`
+0b1010.allbits?(:nope) # error: Expected `Integer` but found `Symbol(:nope)` for argument `mask`
+
+# anybits? takes an Integer mask and return a Boolean
+T.reveal_type(0b1010.anybits?(0b1000)) # error: type: `T::Boolean`
+0b1010.anybits?(:nope) # error: Expected `Integer` but found `Symbol(:nope)` for argument `mask`
+
 # <=> returns Integer for comparable types, T.nilable(Integer) for incomparable types
 T.reveal_type(1 <=> 2) # error: type: `Integer`
 T.reveal_type(1 <=> 2.0) # error: type: `Integer`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Add sigs for [`allbits?`](https://docs.ruby-lang.org/en/3.4/Integer.html#method-i-allbits-3F) and [`anybits?`](https://docs.ruby-lang.org/en/3.4/Integer.html#method-i-anybits-3F) in [`Integer`](https://docs.ruby-lang.org/en/3.4/Integer.html) class.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sorbet already had definitions for the methods, but without sigs. With these sigs, Sorbet will have more information about the methods and will be able to check code more accurately. 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
