### PR TITLE
`reset!` eagerly, after fetching the `active_declaration`

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -105,12 +105,17 @@ module T::Private::Methods
   #
   # we assume that source_method_names has already been filtered to only include method
   # names that were declared final at one point.
+  #
+  # Returns a boolean indicating whether it's okay to define any of `source_method_names` in `target`
+  # (e.g. true if no final method violations)
   def self._check_final_ancestors(target, source_method_names, source)
     source_ancestors = nil
     if T::Private::IS_TYPECHECKING
       # Need to avoid a pinning error, but don't want to use runtime types in _methods.rb
       source_ancestors = T.let(nil, T.nilable(T::Array[T::Module[T.anything]]))
+      found_error = T.let(false, T::Boolean)
     end
+    found_error = false
     # use reverse_each to check farther-up ancestors first, for better error messages.
     target.ancestors.reverse_each do |ancestor|
       final_methods = @modules_with_final.fetch(ancestor, nil)
@@ -142,6 +147,8 @@ module T::Private::Methods
           next if defining_ancestor_idx && source_ancestors[defining_ancestor_idx] == ancestor
         end
 
+        found_error = true
+
         final_sig = T::Private::Methods.signature_for_method(ancestor.instance_method(method_name))
         definition_file, definition_line = final_sig&.method&.source_location
         is_redefined = target == ancestor
@@ -158,19 +165,14 @@ module T::Private::Methods
                          "#{extra_info}"
 
         begin
+          # raise + rescue to populate the backtrace
           raise pretty_message
         rescue => e
-          # sig_validation_error_handler raises by default; on the off chance that
-          # it doesn't raise, we need to ensure that the rest of signature building
-          # sees a consistent state.  This sig failed to validate, so we should get
-          # rid of it.  If we don't do this, errors of the form "You called sig
-          # twice without declaring a method in between" will non-deterministically
-          # crop up in tests.
-          T::Private::DeclState.current.reset!
           T::Configuration.sig_validation_error_handler(e, {})
         end
       end
     end
+    !found_error
   end
 
   def self.add_module_with_final_method(mod, method_name)
@@ -193,22 +195,22 @@ module T::Private::Methods
     end
 
     current_declaration = T::Private::DeclState.current.active_declaration
+    T::Private::DeclState.current.reset!
 
     if T::Private::Final.final_module?(mod) && (current_declaration.nil? || !current_declaration.final)
       raise "#{mod} was declared as final but its method `#{method_name}` was not declared as final"
     end
     # Don't compute mod.ancestors if we don't need to bother checking final-ness.
-    if @was_ever_final_names.include?(method_name) && @modules_with_final.include?(mod)
-      _check_final_ancestors(mod, [method_name], nil)
-      # We need to fetch the active declaration again, as _check_final_ancestors
-      # may have reset it (see the comment in that method for details).
-      current_declaration = T::Private::DeclState.current.active_declaration
+    if @was_ever_final_names.include?(method_name) && @modules_with_final.include?(mod) &&
+       !_check_final_ancestors(mod, [method_name], nil)
+      # We want to pretend like the method did not have a sig, so return.
+      # (This code is not dead, because some `sig_validation_error_handler`'s do not raise.)
+      return
     end
 
     if current_declaration.nil?
       return
     end
-    T::Private::DeclState.current.reset!
 
     if method_name == :method_added || method_name == :singleton_method_added
       raise(
@@ -507,6 +509,7 @@ module T::Private::Methods
     end
 
     _check_final_ancestors(target, methods, source)
+    nil
   end
 
   def self.set_final_checks_on_hooks(enable)

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
@@ -53,7 +53,7 @@ module T::Private::Methods
 
   IS_TYPECHECKING = T.let(false, T::Boolean)
 
-  sig {params(target: Module, source_method_names: T::Array[Symbol], source: T.nilable(Module)).void}
+  sig {params(target: Module, source_method_names: T::Array[Symbol], source: T.nilable(Module)).returns(T::Boolean)}
   def self._check_final_ancestors(target, source_method_names, source); end
 
   sig {params(mod: Module, method_name: Symbol).returns(NilClass)}

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -505,4 +505,78 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
     end
     assert_includes(err.message, "The syntax for declaring a method final is `sig(:final) {...}`, not `sig {final. ...}`")
   end
+
+  it 'does not drop signatures when _check_final_ancestors is triggered but finds no violation' do
+    Class.new do
+      extend T::Sig
+      sig(:final) { returns(String) }
+      def foo = "unrelated"
+    end
+
+    parent = Class.new do
+      extend T::Sig
+      sig(:final) { returns(String) }
+      def some_other_final_method = "hello"
+    end
+
+    child = Class.new(parent) do
+      sig { returns(String) }
+      def foo = "world"
+    end
+
+    sig = T::Utils.signature_for_method(child.instance_method(:foo))
+    refute_nil(sig)
+    assert_equal(:foo, sig.method_name)
+  end
+
+  it 'does not store sig when a swallowed final violation occurs' do
+    parent = Class.new do
+      extend T::Sig
+      sig(:final) { returns(String) }
+      def foo = "parent"
+    end
+
+    T::Configuration.sig_validation_error_handler = lambda do |error, opts|
+      # no-op to swallow the final error
+    end
+
+    begin
+      child = Class.new(parent) do
+        extend T::Sig
+        sig { returns(String) }
+        def foo = "child"
+      end
+    ensure
+      T::Configuration.sig_validation_error_handler = nil
+    end
+
+    sig = T::Utils.signature_for_method(child.instance_method(:foo))
+    assert_nil(sig)
+  end
+
+  it 'reports all final violations to the handler when including a module with multiple overrides' do
+    mod = Module.new do
+      def foo = "m2"
+      def bar = "m2"
+    end
+
+    violations = []
+    T::Configuration.sig_validation_error_handler = lambda do |error, _opts|
+      violations << error
+    end
+
+    Class.new do
+      extend T::Sig
+      sig(:final) { returns(String) }
+      def foo = "m1"
+      sig(:final) { returns(String) }
+      def bar = "m1"
+
+      include mod
+    end
+
+    assert_equal(2, violations.length)
+  ensure
+    T::Configuration.sig_validation_error_handler = nil
+  end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm working on a change to introduce a `consume!` method, which (among
other things), makes it look like the `active_declaration` is "dropped"
after you read it.

My first stab at this (in #10276) failed because I forgot to address how
this would affect the logic after `_check_final_ancestors`:

<https://github.com/sorbet/sorbet/pull/10276/changes/bb9f01242125b31788741501e6921d8f7db715b0>

Looking at this change, what's not obvious from the (collapsed) diff is
that re-reading `current_declaration = (...).active_declaration` on line
205 will always be `nil`, because `consume!` dropped
`active_declaration`.

Looking back at why that assignment exists at all (see #3964), we can
maintain the original motivation by simply not having
`_check_final_ancestors` need to worry about this. As of that first PR, we
needed the reassignment because maybe `_check_final_ancestors` would have
called `reset!` as a way to signal to the caller that the sig should
**not** be stored into the `@sig_wrappers` Hash. But the easiest way to
signal that would just be to return something from
`_check_final_ancestors` that indicates that something failed, and that we
should early return directly. In particular, it was never the case that
`current_declaration = (...).active_declaration` would ever produce a
_new_, _unrelated_ declaration. So it was really just a roundabout way to
request that `current_declaration` be `nil`'d out, meaning we should
return.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Added a few handful of tests that would have failed if we had tried to land
#10276 and they existed.