### PR TITLE
Copy shared refs, instead of referencing them

### DIFF
--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -902,7 +902,7 @@ public:
         // N.B.: `workers.size()` can be `0` when threads are disabled, which would result in undefined behavior for
         // `BlockingCounter`.
         absl::BlockingCounter barrier(std::max(workers.size(), 1));
-        workers.multiplexJob("VisibilityChecker", [&taskq, &filesSpan, &gs, &resultq, &barrier]() {
+        workers.multiplexJob("VisibilityChecker", [taskq, &filesSpan, &gs, resultq, &barrier]() {
             size_t idx;
             for (auto result = taskq->try_pop(idx); !result.done(); result = taskq->try_pop(idx)) {
                 if (!result.gotItem()) {


### PR DESCRIPTION
The `shared_ptr` values of `taskq` and `resultq` should be copied into the closure given to `multiplexJob` to ensure that the refcount gets incremented. Without this, if the `run` function were to exit before the jobs had finished, the queues would become invalid.

### Motivation
Memory lifetime correctness.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No changes expected, memory lifetime fix.
