### PR TITLE
Add a ConcurrentIdex type

### DIFF
--- a/common/concurrency/BUILD
+++ b/common/concurrency/BUILD
@@ -10,7 +10,9 @@ cc_library(
         exclude = ["flycheck_*"],
     ),
     hdrs = [
+        "ConcurrentIndex.h",
         "ConcurrentQueue.h",
+        "Parallel.h",
         "WorkerPool.h",
     ],
     linkopts = select({

--- a/common/concurrency/ConcurrentIndex.h
+++ b/common/concurrency/ConcurrentIndex.h
@@ -1,0 +1,33 @@
+#ifndef SORBET_CONCURRENCY_CONCURRENT_INDEX_H
+#define SORBET_CONCURRENCY_CONCURRENT_INDEX_H
+
+#include <atomic>
+#include <optional>
+
+namespace sorbet {
+
+// An atomic counter, up to a given limit. Aligned on a 64-byte boundary to ensure that it's in its own cache line, to
+// minimize any unintended synchronization between other threads.
+class alignas(64) ConcurrentIndex {
+    std::atomic<size_t> _next = 0;
+    const size_t _size;
+
+public:
+    ConcurrentIndex(size_t size) : _size{size} {}
+
+    // Fetch the next available index, returning `std::nullopt` if there are no more available.
+    std::optional<size_t> next() {
+        auto val = this->_next.fetch_add(1);
+        return val < this->_size ? std::make_optional(val) : std::nullopt;
+    }
+
+    // Returns how many indices have been consumed.
+    size_t doneEstimate() {
+        auto consumed = this->_next.load(std::memory_order_relaxed);
+        return consumed < this->_size ? consumed : this->_size;
+    }
+};
+
+} // namespace sorbet
+
+#endif

--- a/common/concurrency/Parallel.h
+++ b/common/concurrency/Parallel.h
@@ -1,7 +1,8 @@
 #ifndef SORBET_CONCURRENCY_PARALLEL_H
 #define SORBET_CONCURRENCY_PARALLEL_H
 
-#include "common/concurrency/ConcurrentQueue.h"
+#include "absl/types/span.h"
+#include "common/concurrency/ConcurrentIndex.h"
 #include "common/concurrency/WorkerPool.h"
 
 namespace sorbet {
@@ -20,18 +21,14 @@ public:
                 std::invoke(body, arg);
             }
         } else {
-            auto taskq = std::make_shared<ConcurrentBoundedQueue<size_t>>(args.size());
-            for (size_t i = 0; i < args.size(); ++i) {
-                taskq->push(i, 1);
-            }
+            // We can avoid the use of a `shared_ptr` here because we're using `multiplexJobWait` below. That ensures
+            // that this function won't return before the workers have all completed.
+            ConcurrentIndex index(args.size());
 
-            workers.multiplexJobWait(taskName, [taskq, &args, body]() mutable {
-                size_t idx;
-                for (auto result = taskq->try_pop(idx); !result.done(); result = taskq->try_pop(idx)) {
-                    if (result.gotItem()) {
-                        T &arg = args[idx];
-                        std::invoke(body, arg);
-                    }
+            workers.multiplexJobWait(taskName, [&index, &args, body]() mutable {
+                while (auto ix = index.next()) {
+                    T &arg = args[*ix];
+                    std::invoke(body, arg);
                 }
             });
         }

--- a/hashing/hashing.cc
+++ b/hashing/hashing.cc
@@ -1,6 +1,7 @@
 #include "hashing/hashing.h"
 #include "ast/substitute/substitute.h"
 #include "ast/treemap/treemap.h"
+#include "common/concurrency/ConcurrentIndex.h"
 #include "common/concurrency/ConcurrentQueue.h"
 #include "core/ErrorQueue.h"
 #include "core/FileHash.h"
@@ -121,10 +122,7 @@ unique_ptr<core::FileHash> computeFileHashForFile(shared_ptr<core::File> forWhat
 void Hashing::computeFileHashes(absl::Span<const shared_ptr<core::File>> files, spdlog::logger &logger,
                                 WorkerPool &workers, const realmain::options::Options &opts) {
     Timer timeit(logger, "computeFileHashes");
-    auto fileq = make_shared<ConcurrentBoundedQueue<size_t>>(files.size());
-    for (size_t i = 0; i < files.size(); i++) {
-        fileq->push(i, 1);
-    }
+    auto fileq = make_shared<ConcurrentIndex>(files.size());
 
     logger.trace("Computing state hashes for {} files", files.size());
 
@@ -133,18 +131,16 @@ void Hashing::computeFileHashes(absl::Span<const shared_ptr<core::File>> files, 
     workers.multiplexJob("lspStateHash", [fileq, resultq, &files, &logger, &opts]() {
         vector<pair<size_t, unique_ptr<const core::FileHash>>> threadResult;
         int processedByThread = 0;
-        size_t job;
         {
-            for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
-                if (result.gotItem()) {
-                    processedByThread++;
+            while (auto idx = fileq->next()) {
+                processedByThread++;
 
-                    if (!files[job] || files[job]->getFileHash() != nullptr) {
-                        continue;
-                    }
-
-                    threadResult.emplace_back(job, computeFileHashForFile(files[job], logger, opts));
+                auto &file = files[*idx];
+                if (!file || file->getFileHash() != nullptr) {
+                    continue;
                 }
+
+                threadResult.emplace_back(*idx, computeFileHashForFile(file, logger, opts));
             }
         }
 
@@ -179,10 +175,7 @@ Hashing::indexAndComputeFileHashes(core::GlobalState &gs, const realmain::option
     ENFORCE_NO_TIMER(asts.size() == files.size());
 
     // Below, we rewrite ASTs to an empty GlobalState and use them for hashing.
-    auto fileq = make_shared<ConcurrentBoundedQueue<size_t>>(asts.size());
-    for (size_t i = 0; i < asts.size(); i++) {
-        fileq->push(i, 1);
-    }
+    auto fileq = make_shared<ConcurrentIndex>(asts.size());
 
     logger.trace("Computing state hashes for {} files", asts.size());
 
@@ -193,29 +186,25 @@ Hashing::indexAndComputeFileHashes(core::GlobalState &gs, const realmain::option
         unique_ptr<Timer> timeit;
         vector<pair<core::FileRef, unique_ptr<const core::FileHash>>> threadResult;
         int processedByThread = 0;
-        size_t job;
-        {
-            for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
-                if (result.gotItem()) {
-                    if (timeit == nullptr) {
-                        timeit = make_unique<Timer>(logger, "computeFileHashesWorker");
-                    }
-                    processedByThread++;
 
-                    const auto &ast = asts[job];
-
-                    if (!ast.file.exists() || ast.file.data(sharedGs).getFileHash() != nullptr) {
-                        continue;
-                    }
-
-                    unique_ptr<core::GlobalState> lgs;
-                    auto newFref = makeEmptyGlobalStateForFile(logger, sharedGs.getFiles()[ast.file.id()], lgs, opts);
-                    auto [rewrittenAST, usageHash] = rewriteAST(sharedGs, *lgs, newFref, ast);
-
-                    threadResult.emplace_back(ast.file,
-                                              computeFileHashForAST(logger, *lgs, move(usageHash), move(rewrittenAST)));
-                }
+        while (auto idx = fileq->next()) {
+            if (timeit == nullptr) {
+                timeit = make_unique<Timer>(logger, "computeFileHashesWorker");
             }
+            processedByThread++;
+
+            const auto &ast = asts[*idx];
+
+            if (!ast.file.exists() || ast.file.data(sharedGs).getFileHash() != nullptr) {
+                continue;
+            }
+
+            unique_ptr<core::GlobalState> lgs;
+            auto newFref = makeEmptyGlobalStateForFile(logger, sharedGs.getFiles()[ast.file.id()], lgs, opts);
+            auto [rewrittenAST, usageHash] = rewriteAST(sharedGs, *lgs, newFref, ast);
+
+            threadResult.emplace_back(ast.file,
+                                      computeFileHashForAST(logger, *lgs, move(usageHash), move(rewrittenAST)));
         }
 
         if (processedByThread > 0) {

--- a/main/cache/cache.cc
+++ b/main/cache/cache.cc
@@ -1,6 +1,7 @@
 #include "main/cache/cache.h"
 #include "common/FileOps.h"
 #include "common/Random.h"
+#include "common/concurrency/ConcurrentIndex.h"
 #include "common/concurrency/ConcurrentQueue.h"
 #include "common/exception/Exception.h"
 #include "common/kvstore/KeyValueStore.h"
@@ -118,38 +119,33 @@ bool cacheTreesAndFiles(const core::GlobalState &gs, WorkerPool &workers, absl::
     Timer timeit(gs.tracer(), "pipeline::cacheTreesAndFiles");
 
     // Compress files in parallel.
-    auto fileq = make_shared<ConcurrentBoundedQueue<const ast::ParsedFile *>>(parsedFiles.size());
-    for (auto &parsedFile : parsedFiles) {
-        fileq->push(&parsedFile, 1);
-    }
+    auto fileq = make_shared<ConcurrentIndex>(parsedFiles.size());
 
     auto resultq = make_shared<BlockingBoundedQueue<vector<pair<string, vector<uint8_t>>>>>(parsedFiles.size());
-    workers.multiplexJob("compressTreesAndFiles", [fileq, resultq, &gs]() {
+    workers.multiplexJob("compressTreesAndFiles", [fileq, resultq, &gs, &parsedFiles]() {
         vector<pair<string, vector<uint8_t>>> threadResult;
         int processedByThread = 0;
-        const ast::ParsedFile *job = nullptr;
         unique_ptr<Timer> timeit;
         {
-            for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
-                if (result.gotItem()) {
-                    processedByThread++;
-                    if (timeit == nullptr) {
-                        timeit = make_unique<Timer>(gs.tracer(), "cacheTreesAndFilesWorker");
-                    }
+            while (auto idx = fileq->next()) {
+                processedByThread++;
+                if (timeit == nullptr) {
+                    timeit = make_unique<Timer>(gs.tracer(), "cacheTreesAndFilesWorker");
+                }
 
-                    if (!job->file.exists()) {
-                        continue;
-                    }
+                auto &job = parsedFiles[*idx];
+                if (!job.file.exists()) {
+                    continue;
+                }
 
-                    auto &file = job->file.data(gs);
-                    if (!job->cached() && !file.hasIndexErrors()) {
-                        threadResult.emplace_back(core::serialize::Serializer::fileKey(file),
-                                                  core::serialize::Serializer::storeTree(file, *job));
-                        // Stream out compressed files so that writes happen in parallel with processing.
-                        if (processedByThread > 100) {
-                            resultq->push(move(threadResult), processedByThread);
-                            processedByThread = 0;
-                        }
+                auto &file = job.file.data(gs);
+                if (!job.cached() && !file.hasIndexErrors()) {
+                    threadResult.emplace_back(core::serialize::Serializer::fileKey(file),
+                                              core::serialize::Serializer::storeTree(file, job));
+                    // Stream out compressed files so that writes happen in parallel with processing.
+                    if (processedByThread > 100) {
+                        resultq->push(move(threadResult), processedByThread);
+                        processedByThread = 0;
                     }
                 }
             }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -16,6 +16,7 @@
 #include "cfg/CFG.h"
 #include "cfg/builder/builder.h"
 #include "common/FileOps.h"
+#include "common/concurrency/ConcurrentIndex.h"
 #include "common/concurrency/ConcurrentQueue.h"
 #include "common/sort/sort.h"
 #include "common/strings/formatting.h"
@@ -708,10 +709,7 @@ ast::ParsedFilesOrCancelled indexSuppliedFiles(core::GlobalState &baseGs, absl::
                                                const options::Options &opts, WorkerPool &workers,
                                                const unique_ptr<const OwnedKeyValueStore> &kvstore, bool cancelable) {
     auto resultq = make_shared<BlockingBoundedQueue<IndexThreadResultPack>>(files.size());
-    auto fileq = make_shared<ConcurrentBoundedQueue<core::FileRef>>(files.size());
-    for (auto file : files) {
-        fileq->push(move(file), 1);
-    }
+    auto fileq = make_shared<ConcurrentIndex>(files.size());
 
     shared_ptr<const core::GlobalState> emptyGs = baseGs.copyForIndexThread(
         opts.cacheSensitiveOptions.sorbetPackages, opts.extraPackageFilesDirectoryUnderscorePrefixes,
@@ -720,7 +718,7 @@ ast::ParsedFilesOrCancelled indexSuppliedFiles(core::GlobalState &baseGs, absl::
         opts.packagerLayers, opts.sorbetPackagesHint, opts.genPackagesMode, opts.allowRelaxingTestVisibility,
         opts.packageAttributedErrors, opts.testPackages);
 
-    workers.multiplexJob("indexSuppliedFiles", [emptyGs, &opts, fileq, resultq, &kvstore, cancelable]() {
+    workers.multiplexJob("indexSuppliedFiles", [emptyGs, &opts, fileq, files, resultq, &kvstore, cancelable]() {
         Timer timeit(emptyGs->tracer(), "indexSuppliedFilesWorker");
 
         // clone the empty global state to avoid manually re-entering everything, and copy the base filetable so that
@@ -736,22 +734,21 @@ ast::ParsedFilesOrCancelled indexSuppliedFiles(core::GlobalState &baseGs, absl::
         IndexThreadResultPack threadResult;
 
         {
-            core::FileRef job;
-            for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
-                if (result.gotItem()) {
-                    // Increment the count even if we're cancelled to ensure that we indicate downstream that all inputs
-                    // have been processed.
-                    threadResult.res.numTreesProcessed++;
+            while (auto idx = fileq->next()) {
+                auto file = files[*idx];
 
-                    // Drain the queue if the slow path gets canceled.
-                    if (cancelable && epochManager.wasTypecheckingCanceled()) {
-                        continue;
-                    }
-                    core::FileRef file = job;
-                    auto cachedTree = readFileWithStrictnessOverrides(*localGs, file, opts, kvstore);
-                    auto parsedFile = indexOne(opts, *localGs, file, move(cachedTree));
-                    threadResult.res.trees.emplace_back(move(parsedFile));
+                // Increment the count even if we're cancelled to ensure that we indicate downstream that all inputs
+                // have been processed.
+                threadResult.res.numTreesProcessed++;
+
+                // Drain the queue if the slow path gets canceled.
+                if (cancelable && epochManager.wasTypecheckingCanceled()) {
+                    continue;
                 }
+
+                auto cachedTree = readFileWithStrictnessOverrides(*localGs, file, opts, kvstore);
+                auto parsedFile = indexOne(opts, *localGs, file, move(cachedTree));
+                threadResult.res.trees.emplace_back(move(parsedFile));
             }
         }
 
@@ -1481,55 +1478,48 @@ void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> &&what, cons
             preemptionManager->tryRunScheduledPreemptionTask(gs, currentStratum, /* allowReschedule */ true);
         }
 
-        auto fileq = make_shared<ConcurrentBoundedQueue<ast::ParsedFile>>(what.size());
+        auto fileq = make_shared<ConcurrentIndex>(what.size());
         auto outputq = make_shared<BlockingBoundedQueue<core::FileRef>>(what.size());
-
-        for (auto &resolved : what) {
-            fileq->push(move(resolved), 1);
-        }
 
         {
             ProgressIndicator cfgInferProgress(opts.showProgress, "CFG+Inference", what.size());
-            workers.multiplexJob("typecheck", [&gs, &opts, epoch, &epochManager, &preemptionManager, fileq, outputq,
-                                               cancelable, intentionallyLeakASTs]() {
-                ast::ParsedFile job;
+            workers.multiplexJob("typecheck", [&gs, &opts, epoch, &epochManager, &preemptionManager, fileq, &what,
+                                               outputq, cancelable, intentionallyLeakASTs]() {
                 int processedByThread = 0;
 
-                {
-                    for (auto result = fileq->try_pop(job); !result.done(); result = fileq->try_pop(job)) {
-                        if (result.gotItem()) {
-                            unique_ptr<absl::ReaderMutexLock> lock;
-                            if (preemptionManager) {
-                                // [IDE] While held, no preemption tasks can run. Auto-released after each turn of
-                                // the loop. Does not starve writers (tryRunScheduledPreemptionTask)
-                                // because this call can block once tryRunScheduledPreemptionTask tries to acquire
-                                // a (writer) lock.
-                                lock = preemptionManager->lockPreemption();
-                            }
-                            processedByThread++;
-                            // [IDE] Only do the work if typechecking hasn't been canceled.
-                            const bool isCanceled = cancelable && epochManager.wasTypecheckingCanceled();
-                            // [IDE] Also, don't do work if the file has changed under us since we began
-                            // typechecking!
-                            // TODO(jvilk): epoch is unlikely to overflow, but it is theoretically possible.
-                            const bool fileWasChanged = preemptionManager && job.file.data(gs).epoch > epoch;
-                            if (!isCanceled && !fileWasChanged && gs.errorQueue->wouldFlushErrorsForFile(job.file)) {
-                                core::FileRef file = job.file;
-                                try {
-                                    core::Context ctx(gs, core::Symbols::root(), file);
-                                    typecheckOne(ctx, move(job), opts, intentionallyLeakASTs);
-                                } catch (SorbetException &) {
-                                    Exception::failInFuzzer();
-                                    gs.tracer().error("Exception typing file: {} (backtrace is above)",
-                                                      file.data(gs).path());
-                                }
-                                // Stream out errors
-                                outputq->push(file, processedByThread);
-                                processedByThread = 0;
-                            }
+                while (auto idx = fileq->next()) {
+                    auto job = move(what[*idx]);
+
+                    unique_ptr<absl::ReaderMutexLock> lock;
+                    if (preemptionManager) {
+                        // [IDE] While held, no preemption tasks can run. Auto-released after each turn of
+                        // the loop. Does not starve writers (tryRunScheduledPreemptionTask)
+                        // because this call can block once tryRunScheduledPreemptionTask tries to acquire
+                        // a (writer) lock.
+                        lock = preemptionManager->lockPreemption();
+                    }
+                    processedByThread++;
+                    // [IDE] Only do the work if typechecking hasn't been canceled.
+                    const bool isCanceled = cancelable && epochManager.wasTypecheckingCanceled();
+                    // [IDE] Also, don't do work if the file has changed under us since we began
+                    // typechecking!
+                    // TODO(jvilk): epoch is unlikely to overflow, but it is theoretically possible.
+                    const bool fileWasChanged = preemptionManager && job.file.data(gs).epoch > epoch;
+                    if (!isCanceled && !fileWasChanged && gs.errorQueue->wouldFlushErrorsForFile(job.file)) {
+                        core::FileRef file = job.file;
+                        try {
+                            core::Context ctx(gs, core::Symbols::root(), file);
+                            typecheckOne(ctx, move(job), opts, intentionallyLeakASTs);
+                        } catch (SorbetException &) {
+                            Exception::failInFuzzer();
+                            gs.tracer().error("Exception typing file: {} (backtrace is above)", file.data(gs).path());
                         }
+                        // Stream out errors
+                        outputq->push(file, processedByThread);
+                        processedByThread = 0;
                     }
                 }
+
                 if (processedByThread > 0) {
                     outputq->push(core::FileRef(), processedByThread);
                 }

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -20,6 +20,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
 #include "common/FileOps.h"
+#include "common/concurrency/ConcurrentIndex.h"
 #include "common/concurrency/Parallel.h"
 #include "common/timers/Timer.h"
 #include "core/Error.h"
@@ -264,11 +265,8 @@ void runAutogen(core::GlobalState &gs, options::Options &opts, WorkerPool &worke
     Timer timeit(logger, "autogen");
 
     auto resultq = make_shared<BlockingBoundedQueue<AutogenResult>>(indexed.size());
-    auto fileq = make_shared<ConcurrentBoundedQueue<int>>(indexed.size());
+    auto fileq = make_shared<ConcurrentIndex>(indexed.size());
     vector<AutogenResult::Serialized> merged(indexed.size());
-    for (int i = 0; i < indexed.size(); ++i) {
-        fileq->push(i, 1);
-    }
     auto crcBuilder = autogen::CRCBuilder::create();
     int autogenVersion = opts.autogenVersion == 0 ? autogen::AutogenVersion::MAX_VERSION : opts.autogenVersion;
 
@@ -278,11 +276,9 @@ void runAutogen(core::GlobalState &gs, options::Options &opts, WorkerPool &worke
             int n = 0;
             {
                 Timer timeit(logger, "autogenWorker");
-                int idx = 0;
-
-                for (auto result = fileq->try_pop(idx); !result.done(); result = fileq->try_pop(idx)) {
+                while (auto idx = fileq->next()) {
                     ++n;
-                    auto &tree = indexed[idx];
+                    auto &tree = indexed[*idx];
                     // This does package-specific behavior without checking `--sorbet-packages`!
                     if (tree.file.data(gs).hasPackageRbPath()) {
                         continue;
@@ -318,7 +314,7 @@ void runAutogen(core::GlobalState &gs, options::Options &opts, WorkerPool &worke
                         }
                     }
 
-                    out.prints.emplace_back(idx, move(serialized));
+                    out.prints.emplace_back(*idx, move(serialized));
                 }
             }
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -7,6 +7,7 @@
 #include "ast/ParamParsing.h"
 #include "ast/packager/packager.h"
 #include "ast/treemap/treemap.h"
+#include "common/concurrency/ConcurrentIndex.h"
 #include "common/concurrency/ConcurrentQueue.h"
 #include "common/concurrency/Parallel.h"
 #include "common/concurrency/WorkerPool.h"
@@ -2372,25 +2373,18 @@ public:
 
 AllFoundDefinitions findSymbols(const core::GlobalState &gs, absl::Span<ast::ParsedFile> trees, WorkerPool &workers) {
     Timer timeit(gs.tracer(), "naming.findSymbols");
-    auto taskq = make_shared<ConcurrentBoundedQueue<size_t>>(trees.size());
+    auto taskq = make_shared<ConcurrentIndex>(trees.size());
     AllFoundDefinitions allFoundDefinitions(trees.size());
-
-    for (size_t i = 0, size = trees.size(); i < size; ++i) {
-        taskq->push(i, 1);
-    }
 
     workers.multiplexJobWait("findSymbols", [&gs, &allFoundDefinitions, trees, taskq]() {
         Timer timeit(gs.tracer(), "naming.findSymbolsWorker");
         SymbolFinder finder;
-        size_t idx;
-        for (auto result = taskq->try_pop(idx); !result.done(); result = taskq->try_pop(idx)) {
-            if (result.gotItem()) {
-                auto &parsedFile = trees[idx];
-                Timer timeit(gs.tracer(), "naming.findSymbolsOne", {{"file", string(parsedFile.file.data(gs).path())}});
-                core::Context ctx(gs, core::Symbols::root(), parsedFile.file);
-                ast::TreeWalk::apply(ctx, finder, parsedFile.tree);
-                allFoundDefinitions[idx] = make_pair(parsedFile.file, finder.getAndClearFoundDefinitions());
-            }
+        while (auto idx = taskq->next()) {
+            auto &parsedFile = trees[*idx];
+            Timer timeit(gs.tracer(), "naming.findSymbolsOne", {{"file", string(parsedFile.file.data(gs).path())}});
+            core::Context ctx(gs, core::Symbols::root(), parsedFile.file);
+            ast::TreeWalk::apply(ctx, finder, parsedFile.tree);
+            allFoundDefinitions[*idx] = make_pair(parsedFile.file, finder.getAndClearFoundDefinitions());
         }
     });
 

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -3,7 +3,8 @@
 #include "absl/strings/match.h"
 #include "absl/synchronization/blocking_counter.h"
 #include "ast/treemap/treemap.h"
-#include "common/concurrency/Parallel.h"
+#include "common/concurrency/ConcurrentIndex.h"
+#include "common/concurrency/ConcurrentQueue.h"
 #include "common/sort/sort.h"
 #include "common/strings/formatting.h"
 #include "core/Context.h"
@@ -894,21 +895,14 @@ public:
         };
         auto resultq = std::make_shared<BlockingBoundedQueue<std::optional<ThreadResult>>>(filesSpan.size());
         Timer timeit(gs.tracer(), "visibility_checker.check_visibility");
-        auto taskq = std::make_shared<ConcurrentBoundedQueue<size_t>>(filesSpan.size());
-        for (size_t i = 0; i < filesSpan.size(); ++i) {
-            taskq->push(i, 1);
-        }
+        auto taskq = std::make_shared<ConcurrentIndex>(filesSpan.size());
 
         // N.B.: `workers.size()` can be `0` when threads are disabled, which would result in undefined behavior for
         // `BlockingCounter`.
         absl::BlockingCounter barrier(std::max(workers.size(), 1));
         workers.multiplexJob("VisibilityChecker", [taskq, &filesSpan, &gs, resultq, &barrier]() {
-            size_t idx;
-            for (auto result = taskq->try_pop(idx); !result.done(); result = taskq->try_pop(idx)) {
-                if (!result.gotItem()) {
-                    continue;
-                }
-                auto &f = filesSpan[idx];
+            while (auto idx = taskq->next()) {
+                auto &f = filesSpan[*idx];
                 if (f.file.data(gs).isPackage(gs)) {
                     resultq->push(std::nullopt, 1);
                     continue;


### PR DESCRIPTION
We often populate queues with incrementing index values, and then use those values to index into a separate vector. This is a little bit wasteful, as we're allocating memory for an incrementing index, and then using all the additional overhead of a queue to farm those values out to the worker pool.

This PR simplifies things a bit by introducing a `ConcurrentIndex` type, which is just a wrapper over a `std::atomic<size_t>` and a maximum value.

I'm not super attached to the name `ConcurrentIndex`, and would be happy to hear better alternatives.


### Motivation
Simplifying some of our worker pool usage, and potentially seeing some performance improvements by avoiding queue allocation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No changes expected, refactoring only.
