### PR TITLE
Keep relative constants in missing type arg autocorrect

### DIFF
--- a/core/TypeErrorDiagnostics.cc
+++ b/core/TypeErrorDiagnostics.cc
@@ -48,15 +48,16 @@ void TypeErrorDiagnostics::insertTypeArguments(const GlobalState &gs, ErrorBuild
     // if we're already looking at `T::Array` instead.
     klass = klass.maybeUnwrapBuiltinGenericForwarder();
     auto typePrefixSym = klass.forwarderForBuiltinGeneric();
-    if (!typePrefixSym.exists()) {
-        typePrefixSym = klass;
-    }
 
     auto loc = replaceLoc;
     if (loc.exists()) {
         if (klass == core::Symbols::Hash() || klass == core::Symbols::T_Hash()) {
             // Hash is special because it has arity 3 but you're only supposed to write the first 2
-            e.replaceWith("Add type arguments", loc, "{}[T.untyped, T.untyped]", typePrefixSym.show(gs));
+            if (typePrefixSym.exists()) {
+                e.replaceWith("Add type arguments", loc, "{}[T.untyped, T.untyped]", typePrefixSym.show(gs));
+            } else {
+                e.replaceWith("Add type arguments", loc.copyEndWithZeroLength(), "[T.untyped, T.untyped]");
+            }
         } else {
             auto numTypeArgs = klass.data(gs)->typeArity(gs);
             auto arg = ((klass == Symbols::Class() || klass == Symbols::T_Class()) ||
@@ -67,7 +68,12 @@ void TypeErrorDiagnostics::insertTypeArguments(const GlobalState &gs, ErrorBuild
             for (int i = 0; i < numTypeArgs; i++) {
                 untypeds.emplace_back(arg);
             }
-            e.replaceWith("Add type arguments", loc, "{}[{}]", typePrefixSym.show(gs), absl::StrJoin(untypeds, ", "));
+            if (typePrefixSym.exists()) {
+                e.replaceWith("Add type arguments", loc, "{}[{}]", typePrefixSym.show(gs),
+                              absl::StrJoin(untypeds, ", "));
+            } else {
+                e.replaceWith("Add type arguments", loc.copyEndWithZeroLength(), "[{}]", absl::StrJoin(untypeds, ", "));
+            }
         }
     }
 }

--- a/test/testdata/resolver/missing_type_args.rb
+++ b/test/testdata/resolver/missing_type_args.rb
@@ -35,3 +35,12 @@ def example(a, b, c, d)
   T.reveal_type(b.elem) # error: `Integer`
   T.reveal_type(c.another) # error: `String`
 end
+
+class A::B
+  class C::D
+    extend T::Generic
+    Elem = type_member
+  end
+
+  X = T.let(C::D.new, C::D) # error: Malformed type declaration. Generic class without type arguments `A::B::C::D`
+end

--- a/test/testdata/resolver/missing_type_args.rb.autocorrects.exp
+++ b/test/testdata/resolver/missing_type_args.rb.autocorrects.exp
@@ -43,6 +43,6 @@ class A::B
     Elem = type_member
   end
 
-  X = T.let(C::D.new, A::B::C::D[T.untyped]) # error: Malformed type declaration. Generic class without type arguments `A::B::C::D`
+  X = T.let(C::D.new, C::D[T.untyped]) # error: Malformed type declaration. Generic class without type arguments `A::B::C::D`
 end
 # ------------------------------

--- a/test/testdata/resolver/missing_type_args.rb.autocorrects.exp
+++ b/test/testdata/resolver/missing_type_args.rb.autocorrects.exp
@@ -36,4 +36,13 @@ def example(a, b, c, d)
   T.reveal_type(b.elem) # error: `Integer`
   T.reveal_type(c.another) # error: `String`
 end
+
+class A::B
+  class C::D
+    extend T::Generic
+    Elem = type_member
+  end
+
+  X = T.let(C::D.new, A::B::C::D[T.untyped]) # error: Malformed type declaration. Generic class without type arguments `A::B::C::D`
+end
 # ------------------------------


### PR DESCRIPTION
Fixes  #9663

Prevents the fully qualified name from being autocorrect

### Motivation
The autocorrect should make the minimum code change to fix the user's input code. Before, the autocorrect returned the full reference.

### Test plan
See included automated tests.
