### PR TITLE
Sorbet optimizations (1/4): tests + benchmarks

### DIFF
--- a/gems/sorbet-runtime/bench/deep_clone.rb
+++ b/gems/sorbet-runtime/bench/deep_clone.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'benchmark'
+
+require_relative '../lib/sorbet-runtime'
+
+module SorbetBenchmarks
+  module DeepClone
+    extend T::Sig
+
+    def self.time_block(name, iterations_of_block: 100_000, &blk)
+      1_000.times(&blk) # warmup
+
+      GC.start
+      GC.disable
+
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      iterations_of_block.times(&blk)
+      duration_s = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
+
+      GC.enable
+
+      ns_per_iter = duration_s * 1_000_000_000 / iterations_of_block
+      duration_str = ns_per_iter >= 1000 ? "#{(ns_per_iter / 1000).round(3)} μs" : "#{ns_per_iter.round(3)} ns"
+      puts "#{name}: #{duration_str}"
+    end
+
+    def self.run
+      string_array = Array.new(20) { |i| "str#{i}" }.freeze
+      mixed_array = Array.new(20) { |i| i.even? ? "str#{i}" : i }.freeze
+      int_array = (1..20).to_a.freeze
+      nested_hash = {
+        'a' => {'b' => ['x', 'y', 1, 2], 'c' => 'z'},
+        'd' => [{'e' => 'f'}, {'g' => 1}],
+        'h' => 'i',
+      }.freeze
+
+      time_block("deep_clone_object(20-string array)") do
+        T::Props::Utils.deep_clone_object(string_array)
+      end
+
+      time_block("deep_clone_object(20-elem mixed array)") do
+        T::Props::Utils.deep_clone_object(mixed_array)
+      end
+
+      time_block("deep_clone_object(20-int array)") do
+        T::Props::Utils.deep_clone_object(int_array)
+      end
+
+      time_block("deep_clone_object(nested hash)") do
+        T::Props::Utils.deep_clone_object(nested_hash)
+      end
+
+      time_block("deep_clone_object(20-string array, freeze: true)") do
+        T::Props::Utils.deep_clone_object(string_array, freeze: true)
+      end
+    end
+  end
+end

--- a/gems/sorbet-runtime/bench/enum.rb
+++ b/gems/sorbet-runtime/bench/enum.rb
@@ -72,8 +72,37 @@ module SorbetBenchmarks
       end
     end
 
+    def self.accessors
+      time_block("T::Enum#serialize") do
+        MyEnum::X.serialize
+        MyEnum::Y.serialize
+      end
+
+      time_block("T::Enum#to_s") do
+        MyEnum::X.to_s
+        MyEnum::Y.to_s
+      end
+
+      time_block("T::Enum#inspect") do
+        MyEnum::X.inspect
+        MyEnum::Y.inspect
+      end
+
+      time_block("T::Enum.values") do
+        MyEnum.values
+        MyEnum.values
+      end
+
+      time_block("T::Enum.each_value {}", iterations_of_block: 500_000) do
+        MyEnum.each_value {}
+        MyEnum.each_value {}
+      end
+    end
+
     def self.run
-      puts("before T::Configuration.enable_legacy_t_enum_migration_mode")
+      accessors
+
+      puts("\nbefore T::Configuration.enable_legacy_t_enum_migration_mode")
 
       all_comparisons
 

--- a/gems/sorbet-runtime/bench/prop_definition.rb
+++ b/gems/sorbet-runtime/bench/prop_definition.rb
@@ -68,6 +68,34 @@ module SorbetBenchmarks
 
       puts "Subclassing T::Struct, with ten props (ms/iter):"
       puts result
+
+      parent = Class.new do
+        include T::Props::Serializable
+
+        prop :prop1, T.nilable(Integer)
+        prop :prop2, Integer, default: 0
+        prop :prop3, Integer
+        prop :prop4, T::Array[Integer]
+        prop :prop5, T::Array[Integer], default: []
+        prop :prop6, T::Hash[String, Integer]
+        prop :prop7, T::Hash[String, Integer], default: {}
+        prop :prop8, T.nilable(String)
+        prop :prop9, T::Array[String], default: []
+        prop :prop10, T::Hash[String, String], default: {}
+      end
+
+      100.times do
+        Class.new(parent)
+      end
+
+      result = Benchmark.measure do
+        1_000.times do
+          Class.new(parent)
+        end
+      end
+
+      puts "Subclassing a 10-prop T::Props::Serializable class (ms/iter):"
+      puts result
     end
   end
 end

--- a/gems/sorbet-runtime/bench/serialize_custom_type.rb
+++ b/gems/sorbet-runtime/bench/serialize_custom_type.rb
@@ -28,6 +28,44 @@ module SorbetBenchmarks
       end
     end
 
+    # A CustomType whose serialized form is an untyped container of scalars,
+    # exercising valid_serialization?'s recursive scalar_type? walk.
+    class ContainerCustomType
+      extend T::Props::CustomType
+
+      attr_accessor :value
+
+      def initialize(value=nil)
+        @value = value
+      end
+
+      def self.deserialize(value)
+        new(value.clone.freeze)
+      end
+
+      def self.serialize(instance)
+        instance.value
+      end
+    end
+
+    def self.time_block(name, iterations_of_block: 1_000_000, iterations_in_block: 2, &blk)
+      1_000.times(&blk) # warmup
+
+      GC.start
+      GC.disable
+      before_alloc = GC.stat(:total_allocated_objects)
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      iterations_of_block.times(&blk)
+      duration_s = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
+      after_alloc = GC.stat(:total_allocated_objects)
+      GC.enable
+
+      ns_per_iter = duration_s * 1_000_000_000 / (iterations_of_block * iterations_in_block)
+      duration_str = ns_per_iter >= 1000 ? "#{(ns_per_iter / 1000).round(3)} μs" : "#{ns_per_iter.round(3)} ns"
+      puts "#{name}: #{duration_str}"
+      puts "Allocations for #{name}: #{(after_alloc - before_alloc) / iterations_in_block}"
+    end
+
     def self.run
       input = MyCustomType.new(123)
 
@@ -43,6 +81,20 @@ module SorbetBenchmarks
 
       puts "T::Props::CustomType.checked_serialize (μs/iter):"
       puts result
+
+      time_block("T::Props::CustomType.scalar_type?('str')") do
+        T::Props::CustomType.scalar_type?("str")
+        T::Props::CustomType.scalar_type?("str")
+      end
+
+      # checked_serialize on a CustomType whose serialized form is an untyped
+      # array of scalars: valid_serialization? recurses through scalar_type? for
+      # every element.
+      container_input = ContainerCustomType.new([1, "two", 3.0, true, :sym, 6, "seven", 8, 9, 10])
+      time_block("checked_serialize(untyped container)") do
+        T::Props::CustomType.checked_serialize(container_input)
+        T::Props::CustomType.checked_serialize(container_input)
+      end
     end
   end
 end

--- a/gems/sorbet-runtime/bench/sigs.rb
+++ b/gems/sorbet-runtime/bench/sigs.rb
@@ -22,5 +22,110 @@ module SorbetBenchmarks
       str = duration_s >= 1000 ? "#{(duration_s / 1000).round(3)} μs" : "#{duration_s.round(3)} ns"
       puts "run_all_sigs: #{str} #{end_allocs - begin_allocs}"
     end
+
+    # Measures the per-declaration cost of `sig` + method definition (the
+    # _on_method_added hook and slow-wrapper install), without running the
+    # resulting sig blocks.
+    def self.run_declaration
+      cls = Class.new do
+        extend T::Sig
+      end
+
+      1_000.times do |i|
+        cls.class_eval do
+          sig { returns(Integer) }
+          define_method(:"warmup_m#{i}") { 1 }
+        end
+      end
+
+      GC.start
+      GC.disable
+
+      count = 20_000
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+      begin_allocs = GC.stat(:total_allocated_objects)
+      count.times do |i|
+        cls.class_eval do
+          sig { returns(Integer) }
+          define_method(:"m#{i}") { 1 }
+        end
+      end
+      duration_ns = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond) - t0
+      allocs = GC.stat(:total_allocated_objects) - begin_allocs - 1
+
+      GC.enable
+
+      puts "declare sig'd method: #{(duration_ns.to_f / count).round(1)} ns/decl, #{(allocs.to_f / count).round(4)} allocs/decl"
+    end
+
+    # Measures re-wrapping an already-sig'd method through the public
+    # T::Utils.wrap_method_with_call_validation_if_needed entry point (the
+    # path mocha-style stubbing takes for every stubbed sig'd method).
+    def self.run_wrap
+      cls = Class.new do
+        extend T::Sig
+
+        sig { params(x: Integer).returns(Integer) }
+        def compute(x)
+          x
+        end
+      end
+      cls.new.compute(1) # force the sig block to run
+      signature = T::Utils.signature_for_instance_method(cls, :compute)
+      original_method = cls.instance_method(:compute)
+
+      1_000.times do
+        T::Utils.wrap_method_with_call_validation_if_needed(cls, signature, original_method)
+      end
+
+      GC.start
+      GC.disable
+
+      count = 20_000
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+      begin_allocs = GC.stat(:total_allocated_objects)
+      count.times do
+        T::Utils.wrap_method_with_call_validation_if_needed(cls, signature, original_method)
+      end
+      duration_ns = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond) - t0
+      allocs = GC.stat(:total_allocated_objects) - begin_allocs - 1
+
+      GC.enable
+
+      puts "wrap_method_with_call_validation_if_needed: #{(duration_ns.to_f / count).round(1)} ns/wrap, #{(allocs.to_f / count).round(4)} allocs/wrap"
+    end
+
+    # Measures declaring a base + subclass that overrides ten sig'd methods and
+    # running all the sig blocks, exercising the override-validation path
+    # (subtype_of? checks between each override and its super sig).
+    def self.run_override
+      count = 2_000
+      GC.start
+      GC.disable
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+      begin_allocs = GC.stat(:total_allocated_objects)
+      count.times do
+        base = Class.new do
+          extend T::Sig
+          10.times do |i|
+            sig { overridable.params(x: Integer).returns(Integer) }
+            define_method(:"m#{i}") { |x| x }
+          end
+        end
+        Class.new(base) do
+          extend T::Sig
+          10.times do |i|
+            sig { override.params(x: Integer).returns(Integer) }
+            define_method(:"m#{i}") { |x| x }
+          end
+        end
+        T::Utils.run_all_sig_blocks
+      end
+      duration_ns = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond) - t0
+      allocs = GC.stat(:total_allocated_objects) - begin_allocs - 1
+      GC.enable
+
+      puts "declare+override 10 sigs + run_all: #{(duration_ns.to_f / count).round(1)} ns/iter, #{(allocs.to_f / count).round(1)} allocs/iter"
+    end
   end
 end

--- a/gems/sorbet-runtime/bench/tasks.rb
+++ b/gems/sorbet-runtime/bench/tasks.rb
@@ -10,6 +10,9 @@ require_relative 'prop_validation'
 require_relative 'serialize_custom_type'
 require_relative 'sigs'
 require_relative 'tutils'
+require_relative 'type_derivation'
+require_relative 'validation'
+require_relative 'deep_clone'
 require_relative 'typecheck'
 require_relative 'typecheck_kwargs_splat'
 require_relative 'enum'
@@ -47,6 +50,18 @@ namespace :bench do
     SorbetBenchmarks::Sigs.run
   end
 
+  task :sigs_declare do
+    SorbetBenchmarks::Sigs.run_declaration
+  end
+
+  task :sigs_wrap do
+    SorbetBenchmarks::Sigs.run_wrap
+  end
+
+  task :sigs_override do
+    SorbetBenchmarks::Sigs.run_override
+  end
+
   task :typecheck do
     SorbetBenchmarks::Typecheck.run
   end
@@ -57,6 +72,18 @@ namespace :bench do
 
   task :tutils do
     SorbetBenchmarks::TUtils.run
+  end
+
+  task :type_derivation do
+    SorbetBenchmarks::TypeDerivation.run
+  end
+
+  task :validation do
+    SorbetBenchmarks::Validation.run
+  end
+
+  task :deep_clone do
+    SorbetBenchmarks::DeepClone.run
   end
 
   task :enum do

--- a/gems/sorbet-runtime/bench/type_derivation.rb
+++ b/gems/sorbet-runtime/bench/type_derivation.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'benchmark'
+
+require_relative '../lib/sorbet-runtime'
+
+module SorbetBenchmarks
+  module TypeDerivation
+    extend T::Sig
+
+    class Example; end
+
+    def self.time_block(name, iterations_of_block: 1_000_000, iterations_in_block: 2, &blk)
+      1_000.times(&blk) # warmup
+
+      GC.start
+      GC.disable
+
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      iterations_of_block.times(&blk)
+      duration_s = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
+
+      GC.enable
+
+      ns_per_iter = duration_s * 1_000_000_000 / (iterations_of_block * iterations_in_block)
+      duration_str = ns_per_iter >= 1000 ? "#{(ns_per_iter / 1000).round(3)} μs" : "#{ns_per_iter.round(3)} ns"
+      puts "#{name}: #{duration_str}"
+    end
+
+    def self.run
+      time_block("T.nilable(Integer)") do
+        T.nilable(Integer)
+        T.nilable(Integer)
+      end
+
+      time_block("T.nilable(Example)") do
+        T.nilable(Example)
+        T.nilable(Example)
+      end
+
+      time_block("T.any(Integer, Float)") do
+        T.any(Integer, Float)
+        T.any(Integer, Float)
+      end
+
+      time_block("T.all(Comparable, Integer)") do
+        T.all(Comparable, Integer)
+        T.all(Comparable, Integer)
+      end
+
+      time_block("T::Array[Integer]") do
+        T::Array[Integer]
+        T::Array[Integer]
+      end
+
+      time_block("T::Hash[String, Integer]") do
+        T::Hash[String, Integer]
+        T::Hash[String, Integer]
+      end
+
+      time_block("T::Hash[T.untyped, T.untyped]") do
+        T::Hash[T.untyped, T.untyped]
+        T::Hash[T.untyped, T.untyped]
+      end
+
+      pooled = T::Utils.coerce(Integer)
+      same_name_a = T::Types::Simple.new(Integer)
+      same_name_b = T::Types::Simple.new(Integer)
+      # rubocop:disable Lint/BinaryOperatorWithIdenticalOperands
+      # rubocop:disable Lint/Void
+      time_block("Base#== identity hit") do
+        pooled == pooled
+        pooled == pooled
+      end
+
+      time_block("Base#== equal-name distinct instances") do
+        same_name_a == same_name_b
+        same_name_a == same_name_b
+      end
+      # rubocop:enable Lint/Void
+      # rubocop:enable Lint/BinaryOperatorWithIdenticalOperands
+
+      simple_int = T::Utils.coerce(Integer)
+      simple_num = T::Utils.coerce(Numeric)
+      union = T::Utils.coerce(T.any(Integer, Float))
+      time_block("subtype_of?(Simple, Simple)") do
+        simple_int.subtype_of?(simple_num)
+        simple_num.subtype_of?(simple_int)
+      end
+
+      time_block("subtype_of? Simple vs Union") do
+        union.subtype_of?(simple_num)
+        simple_int.subtype_of?(union)
+      end
+    end
+  end
+end

--- a/gems/sorbet-runtime/bench/typecheck.rb
+++ b/gems/sorbet-runtime/bench/typecheck.rb
@@ -115,9 +115,23 @@ module SorbetBenchmarks
         type.valid?('hi')
       end
 
+      type = T::Utils.coerce(T.any(Integer, Float, T::Array[String]))
+      time_block("T.any(Integer, Float, T::Array[String]).valid?", iterations_in_block: 5) do
+        type.valid?(0)
+        type.valid?(1)
+        type.valid?(2)
+        type.valid?(nil)
+        type.valid?('hi')
+      end
+
       time_block("T.let(..., Integer)") do
         T.let(0, Integer)
         T.let(1, Integer)
+      end
+
+      time_block("T.cast(..., Integer)") do
+        T.cast(0, Integer)
+        T.cast(1, Integer)
       end
 
       time_block("sig {params(x: Integer).void}") do
@@ -149,6 +163,17 @@ module SorbetBenchmarks
       time_block("T.let(..., T.nilable(Integer))") do
         T.let(nil, T.nilable(Integer))
         T.let(1, T.nilable(Integer))
+      end
+
+      nilable_integer = T.nilable(Integer)
+      time_block("T.let(..., predefined T.nilable(Integer))") do
+        T.let(nil, nilable_integer)
+        T.let(1, nilable_integer)
+      end
+
+      time_block("sig {params(x: T.nilable(T::Boolean)).void} (nil)") do
+        nilable_boolean_param(nil)
+        nilable_boolean_param(true)
       end
 
       time_block("sig {params(x: T.nilable(Integer)).void}") do
@@ -191,6 +216,11 @@ module SorbetBenchmarks
         arg_plus_kwargs(:bar, x: 1)
       end
 
+      time_block("sig {params(x: Integer, y: Integer).void} (optional positional)") do
+        optional_positional(0)
+        optional_positional(0, 1)
+      end
+
       time_block("direct call Object#class") do
         example.class
         example.class
@@ -219,6 +249,9 @@ module SorbetBenchmarks
     sig { params(x: T.nilable(Integer)).void }
     def self.nilable_integer_param(x); end
 
+    sig { params(x: T.nilable(T::Boolean)).void }
+    def self.nilable_boolean_param(x); end
+
     sig { params(x: Example).void }
     def self.application_class_param(x); end
 
@@ -233,5 +266,8 @@ module SorbetBenchmarks
 
     sig { params(s: Symbol, x: Integer, y: Integer).void }
     def self.arg_plus_kwargs(s, x:, y: 0); end
+
+    sig { params(x: Integer, y: Integer).void }
+    def self.optional_positional(x, y=0); end
   end
 end

--- a/gems/sorbet-runtime/bench/validation.rb
+++ b/gems/sorbet-runtime/bench/validation.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'benchmark'
+
+require_relative '../lib/sorbet-runtime'
+
+module SorbetBenchmarks
+  module Validation
+    extend T::Sig
+
+    def self.time_block(name, iterations_of_block: 1_000_000, iterations_in_block: 1, &blk)
+      1_000.times(&blk) # warmup
+
+      GC.start
+      GC.disable
+
+      t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      iterations_of_block.times(&blk)
+      duration_s = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
+
+      GC.enable
+
+      ns_per_iter = duration_s * 1_000_000_000 / (iterations_of_block * iterations_in_block)
+      duration_str = ns_per_iter >= 1000 ? "#{(ns_per_iter / 1000).round(3)} μs" : "#{ns_per_iter.round(3)} ns"
+      puts "#{name}: #{duration_str}"
+    end
+
+    def self.run
+      ints3 = [1, 2, 3].freeze
+      ints100 = (1..100).to_a.freeze
+      array_type = T::Utils.coerce(T::Array[Integer])
+
+      time_block("T::Array[Integer].recursively_valid?(3-int array)") do
+        array_type.recursively_valid?(ints3)
+      end
+
+      time_block("T::Array[Integer].recursively_valid?(100-int array)", iterations_of_block: 100_000) do
+        array_type.recursively_valid?(ints100)
+      end
+
+      hash_type = T::Utils.coerce(T::Hash[Symbol, String])
+      hash10 = (1..10).to_h { |i| [:"k#{i}", "v#{i}"] }.freeze
+
+      time_block("T::Hash[Symbol, String].recursively_valid?(10 entries)", iterations_of_block: 300_000) do
+        hash_type.recursively_valid?(hash10)
+      end
+
+      simple_type = T::Utils.coerce(Integer)
+      time_block("Simple(Integer).recursively_valid?(1)") do
+        simple_type.recursively_valid?(1)
+      end
+
+      tuple_type = T::Utils.coerce([Integer, String])
+      tuple = [1, 'a'].freeze
+      time_block("[Integer, String] tuple valid?") do
+        tuple_type.valid?(tuple)
+      end
+
+      time_block("[Integer, String] tuple recursively_valid?") do
+        tuple_type.recursively_valid?(tuple)
+      end
+
+      shape_type = T::Utils.coerce({a: Integer, b: String})
+      shape_ok = {a: 1, b: 'b'}.freeze
+      shape_extra = {a: 1, b: 'b', c: :c}.freeze
+      time_block("{a:, b:} shape valid? (ok)") do
+        shape_type.valid?(shape_ok)
+      end
+
+      time_block("{a:, b:} shape valid? (extra key)") do
+        shape_type.valid?(shape_extra)
+      end
+
+      time_block("{a:, b:} shape recursively_valid? (ok)") do
+        shape_type.recursively_valid?(shape_ok)
+      end
+
+      intersection_type = T::Utils.coerce(T.all(Comparable, Integer))
+      time_block("T.all(Comparable, Integer) valid?(1)") do
+        intersection_type.valid?(1)
+      end
+
+      time_block("T.all(Comparable, Integer) recursively_valid?(1)") do
+        intersection_type.recursively_valid?(1)
+      end
+
+      union_type = T::Utils.coerce(T.any(Integer, Float, Symbol))
+      time_block("T.any(Integer, Float, Symbol).recursively_valid?(:sym)") do
+        union_type.recursively_valid?(:sym)
+      end
+
+      require 'set'
+      set_type = T::Utils.coerce(T::Set[Integer])
+      int_set = Set[1, 2, 3].freeze
+      time_block("T::Set[Integer].valid?(3-int set)") do
+        set_type.valid?(int_set)
+      end
+
+      time_block("T::Set[Integer].recursively_valid?(3-int set)") do
+        set_type.recursively_valid?(int_set)
+      end
+    end
+  end
+end

--- a/gems/sorbet-runtime/test/types/props/private/setter_factory.rb
+++ b/gems/sorbet-runtime/test/types/props/private/setter_factory.rb
@@ -58,4 +58,45 @@ class Opus::Types::Test::Props::Private::SetterFactoryTest < Critic::Unit::UnitT
     end
   end
 
+  class TestSoftError
+    include T::Props
+    include T::Props::WeakConstructor
+
+    prop :i, Integer
+    prop :ni, T.nilable(Integer)
+  end
+
+  describe 'when call_validation_error_handler does not raise' do
+    # Pins the deliberate set-after-soft-error behavior across every setter
+    # entry point: the value must still be set when the handler returns.
+    before do
+      T::Configuration.call_validation_error_handler = ->(_signature, _opts) {}
+    end
+
+    after do
+      T::Configuration.call_validation_error_handler = nil
+    end
+
+    it 'still sets the value from the constructor' do
+      obj = TestSoftError.new(i: 'nope', ni: 'also nope')
+      assert_equal('nope', obj.i)
+      assert_equal('also nope', obj.ni)
+    end
+
+    it 'still sets the value via Decorator#prop_set' do
+      obj = TestSoftError.new
+      TestSoftError.decorator.prop_set(obj, :i, 'nope')
+      assert_equal('nope', obj.i)
+      TestSoftError.decorator.prop_set(obj, :ni, 'also nope')
+      assert_equal('also nope', obj.ni)
+    end
+
+    it 'still sets the value via the generated setter' do
+      obj = TestSoftError.new
+      obj.i = 'nope'
+      assert_equal('nope', obj.i)
+      obj.ni = 'also nope'
+      assert_equal('also nope', obj.ni)
+    end
+  end
 end

--- a/gems/sorbet-runtime/test/types/ruby2_keywords.rb
+++ b/gems/sorbet-runtime/test/types/ruby2_keywords.rb
@@ -77,4 +77,122 @@ class Opus::Types::Test::Ruby2KeywordsTest < Critic::Unit::UnitTest
     assert_equal 6, instance.sum(1, 2, 3)
     assert_equal 10, instance.double(a: 5)
   end
+
+  # Regression: optimized wrappers must hand arguments to the wrapped method with the same
+  # ruby2_keywords flagging the slow `|*args, &blk|` validator would. When an upstream ruby2_keywords
+  # splat forwards `key: val` into a sig'd method that binds it to a named positional parameter, Ruby
+  # strips the keyword flag as the value lands in the positional slot. A specialized wrapper binding
+  # through its own `*rest`/`**kwargs` instead preserved the flag, so a downstream re-forwarder
+  # re-splatted the hash as keywords and raised `missing keywords` / `wrong number of arguments`.
+  # `Hash.ruby2_keywords_hash?` asserts the flag state directly; the expected state is stripped (false),
+  # matching a plain `def` and the slow validator.
+
+  # Builds a ruby2_keywords-flagged forwarder that calls `create` on `target` directly. The single hop
+  # matters: an intermediate non-flagged call (e.g. `public_send`) would strip the flag before it reached
+  # the sig wrapper, masking the regression.
+  def create_forwarder(target)
+    mod = Module.new do
+      define_method(:fwd) { |*args| target.create(*args) }
+      ruby2_keywords(:fwd)
+    end
+    Object.new.extend(mod)
+  end
+
+  it "strips the ruby2_keywords flag when binding to an optional positional (Mutator.create shape)" do
+    klass = Class.new do
+      extend T::Sig
+      sig do
+        params(params: T::Hash[T.untyped, T.untyped], opts: T::Hash[T.untyped, T.untyped])
+          .returns(T.untyped)
+          .checked(:always)
+      end
+      # Mirrors Mutator.create(params = {}, opts = {}, &blk).
+      def create(params={}, opts={})
+        [Hash.ruby2_keywords_hash?(params), params]
+      end
+    end
+
+    instance = klass.new
+    fwd = create_forwarder(instance)
+    5.times { fwd.fwd(warm: 1) } # install the optimized wrapper
+
+    # The trailing keyword binds to the positional `params`, so the flag must be stripped (as a plain
+    # `def` would) -- a downstream re-forwarder must see a positional hash, not keywords.
+    flagged, params = fwd.fwd(task: "do_thing", event: "evt_123")
+    refute(flagged, "expected the ruby2_keywords flag to be stripped")
+    assert_equal({task: "do_thing", event: "evt_123"}, params)
+  end
+
+  it "preserves positional hash arguments for an optional-positional method" do
+    klass = Class.new do
+      extend T::Sig
+      sig do
+        params(params: T::Hash[T.untyped, T.untyped], opts: T::Hash[T.untyped, T.untyped])
+          .returns(T.untyped)
+          .checked(:always)
+      end
+      def create(params={}, opts={})
+        [params, opts]
+      end
+    end
+
+    instance = klass.new
+    3.times { instance.create({a: 1}) } # install optimized wrapper
+
+    assert_equal [{x: 1}, {}], instance.create({x: 1})
+    assert_equal [{x: 1}, {y: 2}], instance.create({x: 1}, {y: 2})
+  end
+
+  it "forwards keywords for an all-keyword method through a sig wrapper" do
+    klass = Class.new do
+      extend T::Sig
+      sig { params(livemode: T::Boolean, account: T.nilable(String)).returns(T::Array[T.untyped]).checked(:always) }
+      def create(livemode:, account: nil)
+        [livemode, account]
+      end
+    end
+
+    instance = klass.new
+    3.times { instance.create(livemode: true) } # install optimized wrapper
+
+    assert_equal [false, "acct_1"], instance.create(livemode: false, account: "acct_1")
+    opts = {livemode: true, account: "a"}
+    assert_equal [true, "a"], instance.create(**opts)
+  end
+
+  # Regression: the wrapper-shape decision must read the parameters of the method being wrapped, not
+  # `method_sig.parameters`. They diverge under the mocha pattern -- stub a method as
+  # `def m(*args, **kwargs, &blk)`, then re-wrap it against the original fixed-arity sig via
+  # `T::Utils.wrap_method_with_call_validation_if_needed`. Keying off the original sig's parameters picks
+  # a fixed-arity wrapper for an `*args, **kwargs` method, dropping the ruby2_keywords flag so a trailing
+  # `key: val` forwards positionally, breaking `.with { |t, **kw| }` matchers.
+  it "preserves keyword forwarding when re-wrapping a splat method with a fixed-arity sig (mocha stub shape)" do
+    klass = Class.new do
+      extend T::Sig
+      sig { params(name: String, opts: T::Hash[Symbol, T.untyped]).void.checked(:always) }
+      def mutate(name, opts); end
+    end
+    original = klass.instance_method(:mutate)
+    signature = T::Private::Methods.signature_for_method(original)
+
+    # Emulate mocha: redefine as an `(*args, **kwargs)` capture, then re-wrap against the original sig.
+    captured = nil
+    klass.send(:define_method, :mutate) do |*args, **kwargs, &_blk|
+      captured = {args: args, kwargs: kwargs}
+    end
+    stub = klass.instance_method(:mutate)
+    wrapped = T::Utils.wrap_method_with_call_validation_if_needed(klass, signature, stub)
+
+    # `wrap_method_with_call_validation_if_needed` is public API: it must return the
+    # (possibly re-wrapped) UnboundMethod, not nil/void.
+    assert_instance_of(UnboundMethod, wrapped)
+    assert_equal(:mutate, wrapped.name)
+
+    klass.new.mutate("rec_1", some_opt: :value)
+
+    assert_equal(["rec_1"], captured[:args],
+                 "the trailing keyword must not forward into the positional args")
+    assert_equal({some_opt: :value}, captured[:kwargs],
+                 "the trailing keyword must arrive as keywords (ruby2_keywords preserved)")
+  end
 end

--- a/gems/sorbet-runtime/test/types/validate_override_types.rb
+++ b/gems/sorbet-runtime/test/types/validate_override_types.rb
@@ -94,6 +94,28 @@ module Opus::Types::Test
       assert_includes(err.message, "Incompatible type for arg `kw` in signature for override of method `foo`")
     end
 
+    it "raises if an override declares a rest param but fewer named positionals than the base" do
+      # The override's *rest skips the arity shape check, and the positional
+      # type walk pads the missing positions with nil (name and type): the
+      # base's second arg type is checked against nil and must still raise.
+      base = Class.new do
+        extend T::Sig
+        sig { overridable.params(a: BaseFoo1, b: BaseFoo2).returns(BaseFoo3) }
+        def foo(a, b); end
+      end
+      klass = Class.new(base) do
+        extend T::Sig
+        sig { override.params(a: BaseFoo1, rest: BaseFoo2).returns(BaseFoo3) }
+        def foo(a, *rest); end
+      end
+
+      err = assert_raises(RuntimeError) do
+        klass.new.foo(BaseFoo1.new, BaseFoo2.new)
+      end
+
+      assert_includes(err.message, "Incompatible type for arg #2 (``) in signature for override of method `foo`")
+    end
+
     it "raises if the return type is contravariant" do
       klass = Class.new(FailureBase) do
         extend T::Sig


### PR DESCRIPTION
**Stack (bottom → top):**
1. **#10359 — tests + benchmarks** (this PR)
2. #10362 — non-prop, non-call_validation optimizations
3. #10363 — props optimizations
4. #10364 — call_validation optimizations

This is the bottom of a 4-PR stack splitting the original "Various Sorbet Optimizations" change so each layer can be reviewed in isolation. It lands the benchmarks and the regression tests first, so the behavior the later PRs optimize is pinned before anything changes.

- **Benchmarks** for every area touched by the stack (deep_clone, enum, prop definition, custom-type serialize, sigs, type derivation, typecheck, validation).
- **Behavior tests that already pass on master** — included here to lock in current behavior:
  - `setter_factory`: value is still set after a non-raising soft error, across all setter entry points.
  - `ruby2_keywords`: keyword/splat forwarding through sig wrappers.
  - `validate_override_types`: an override declaring a `*rest` param vs fewer named positionals than the base.

Tests that assert behavior *introduced* by a later PR (e.g. the `deep_clone` rename, the new specialized-wrapper paths) ride along with that PR instead.
