### PR TITLE
`--print=symbol-table`: "type-argument" → "type-parameter"

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -1210,7 +1210,7 @@ string_view TypeMemberRef::showKind(const GlobalState &gs) const {
 }
 
 string_view TypeParameterRef::showKind(const GlobalState &gs) const {
-    return "type-argument"sv;
+    return "type-parameter"sv;
 }
 
 string ClassOrModuleRef::toStringWithOptions(const GlobalState &gs, int tabs, bool showFull, bool showRaw) const {

--- a/test/testdata/resolver/type_arguments.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/type_arguments.rb.symbol-table-raw.exp
@@ -8,7 +8,7 @@ class <C <U <root>>> < <C <U Object>> ()
     method <S <C <U Func>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/type_arguments.rb start=3:1 end=13:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/type_arguments.rb start=??? end=???}
     method <S <C <U Func>> $1>#<U id>[<T <U U> $1>] (x, <blk>) -> TypeVar(<T <U U> $1>) @ Loc {file=test/testdata/resolver/type_arguments.rb start=10:3 end=10:17}
-      type-argument(+) <S <C <U Func>> $1>#<U id>#<T <U U> $1> -> TypeVar(<T <U U> $1>) @ Loc {file=test/testdata/resolver/type_arguments.rb start=6:21 end=6:23}
+      type-parameter(+) <S <C <U Func>> $1>#<U id>#<T <U U> $1> -> TypeVar(<T <U U> $1>) @ Loc {file=test/testdata/resolver/type_arguments.rb start=6:21 end=6:23}
       argument x<> -> T.type_parameter(:U) @ Loc {file=test/testdata/resolver/type_arguments.rb start=7:15 end=7:16}
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/resolver/type_arguments.rb start=??? end=???}
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This represents `type_parameter` types, may as well change the printing


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.