### PR TITLE
Sorbet optimizations (2/4): type-system core (non-prop, non-call_validation)

### DIFF
--- a/gems/sorbet-runtime/lib/sorbet-runtime.rb
+++ b/gems/sorbet-runtime/lib/sorbet-runtime.rb
@@ -51,7 +51,6 @@ require_relative 'types/types/type_parameter'
 require_relative 'types/types/typed_enumerator'
 require_relative 'types/types/typed_enumerator_chain'
 require_relative 'types/types/typed_enumerator_lazy'
-require_relative 'types/types/typed_hash'
 require_relative 'types/types/typed_range'
 require_relative 'types/types/typed_set'
 require_relative 'types/types/union'
@@ -87,6 +86,10 @@ require_relative 'types/utils'
 require_relative 'types/boolean'
 
 # Depends on types/utils
+# typed_hash must load after untyped + utils so TypedHash::Untyped::Private::INSTANCE
+# (a frozen, shared T::Hash[T.untyped, T.untyped]) can be built at load time, the same
+# way TypedArray::Untyped::Private::INSTANCE is.
+require_relative 'types/types/typed_hash'
 require_relative 'types/types/typed_array'
 require_relative 'types/types/typed_module'
 require_relative 'types/types/typed_class'

--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -134,6 +134,18 @@ module T
   def self.cast(value, type, checked: true)
     return value unless checked
 
+    # Happy paths for the two dominant type shapes at inline-cast sites,
+    # duplicated from Private::Casts.cast to skip its call frame: Module
+    # literals (e.g. `T.cast(x, Foo)`) and the SimplePairUnion that
+    # `T.nilable(SomeModule)` produces. Failures and other type shapes take
+    # the full path below.
+    case type
+    when ::Module
+      return value if value.is_a?(type)
+    when T::Private::Types::SimplePairUnion
+      return value if type.valid?(value)
+    end
+
     Private::Casts.cast(value, type, "T.cast")
   end
 
@@ -148,6 +160,14 @@ module T
   # doesn't match the type.
   def self.let(value, type, checked: true)
     return value unless checked
+
+    # Happy paths for Module literals and T.nilable; see T.cast.
+    case type
+    when ::Module
+      return value if value.is_a?(type)
+    when T::Private::Types::SimplePairUnion
+      return value if type.valid?(value)
+    end
 
     Private::Casts.cast(value, type, "T.let")
   end
@@ -168,6 +188,14 @@ module T
   def self.bind(value, type, checked: true)
     return value unless checked
 
+    # Happy paths for Module literals and T.nilable; see T.cast.
+    case type
+    when ::Module
+      return value if value.is_a?(type)
+    when T::Private::Types::SimplePairUnion
+      return value if type.valid?(value)
+    end
+
     Private::Casts.cast(value, type, "T.bind")
   end
 
@@ -177,6 +205,14 @@ module T
   # runtime if the value doesn't match the type.
   def self.assert_type!(value, type, checked: true)
     return value unless checked
+
+    # Happy paths for Module literals and T.nilable; see T.cast.
+    case type
+    when ::Module
+      return value if value.is_a?(type)
+    when T::Private::Types::SimplePairUnion
+      return value if type.valid?(value)
+    end
 
     Private::Casts.cast(value, type, "T.assert_type!")
   end

--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -329,7 +329,7 @@ module T
   module Hash
     def self.[](keys, values)
       if keys.is_a?(T::Types::Untyped) && values.is_a?(T::Types::Untyped)
-        T::Types::TypedHash::Untyped.new
+        T::Types::TypedHash::Untyped::Private::INSTANCE
       else
         T::Types::TypedHash.new(keys: keys, values: values)
       end

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -48,7 +48,12 @@ class T::Enum
   private_constant :SerializedVal
 
   ### Enum class methods ###
-  sig { returns(T::Array[T.attached_class]) }
+  # WithoutRuntime on the hot accessors below installs no method wrapper at all
+  # (not even the one-time wrap a `checked(:never)` sig still pays on first
+  # call). Their bodies are type-safe by construction, so the wrapper validated
+  # nothing useful; Sorbet still reads these sigs statically. The
+  # override/overridable annotations remain as static-only signal.
+  T::Sig::WithoutRuntime.sig { returns(T::Array[T.attached_class]) }
   def self.values
     if @values.nil?
       raise "Attempting to access values of #{self.class} before it has been initialized." \
@@ -59,7 +64,7 @@ class T::Enum
 
   # This exists for compatibility with the interface of `Hash` & mostly to support
   # the HashEachMethods Rubocop.
-  sig { params(blk: T.nilable(T.proc.params(arg0: T.attached_class).void)).returns(T.any(T::Enumerator[T.attached_class], T::Array[T.attached_class])) }
+  T::Sig::WithoutRuntime.sig { params(blk: T.nilable(T.proc.params(arg0: T.attached_class).void)).returns(T.any(T::Enumerator[T.attached_class], T::Array[T.attached_class])) }
   def self.each_value(&blk)
     if blk
       values.each(&blk)
@@ -72,7 +77,7 @@ class T::Enum
   #
   # Note: It would have been nice to make this method final before people started overriding it.
   # Note: Failed CriticalMethodsNoRuntimeTypingTest
-  sig { params(serialized_val: SerializedVal).returns(T.nilable(T.attached_class)).checked(:never) }
+  T::Sig::WithoutRuntime.sig { params(serialized_val: SerializedVal).returns(T.nilable(T.attached_class)) }
   def self.try_deserialize(serialized_val)
     if @mapping.nil?
       raise "Attempting to access serialization map of #{self.class} before it has been initialized." \
@@ -88,7 +93,7 @@ class T::Enum
   #
   # @return [self]
   # @raise [KeyError] if serialized value does not match any instance.
-  sig { overridable.params(serialized_val: SerializedVal).returns(T.attached_class).checked(:never) }
+  T::Sig::WithoutRuntime.sig { overridable.params(serialized_val: SerializedVal).returns(T.attached_class) }
   def self.from_serialized(serialized_val)
     res = try_deserialize(serialized_val)
     if res.nil?
@@ -99,7 +104,7 @@ class T::Enum
 
   # Note: It would have been nice to make this method final before people started overriding it.
   # @return [Boolean] Does the given serialized value correspond with any of this enum's values.
-  sig { overridable.params(serialized_val: SerializedVal).returns(T::Boolean).checked(:never) }
+  T::Sig::WithoutRuntime.sig { overridable.params(serialized_val: SerializedVal).returns(T::Boolean) }
   def self.has_serialized?(serialized_val)
     if @mapping.nil?
       raise "Attempting to access serialization map of #{self.class} before it has been initialized." \
@@ -109,7 +114,7 @@ class T::Enum
   end
 
   # Note: Failed CriticalMethodsNoRuntimeTypingTest
-  sig { override.params(instance: T.nilable(T::Enum)).returns(SerializedVal).checked(:never) }
+  T::Sig::WithoutRuntime.sig { override.params(instance: T.nilable(T::Enum)).returns(SerializedVal) }
   def self.serialize(instance)
     # This is needed otherwise if a Chalk::ODM::Document with a property of the shape
     # T::Hash[T.nilable(MyEnum), Integer] and a value that looks like {nil => 0} is
@@ -126,7 +131,7 @@ class T::Enum
   end
 
   # Note: Failed CriticalMethodsNoRuntimeTypingTest
-  sig { override.params(mongo_value: SerializedVal).returns(T.attached_class).checked(:never) }
+  T::Sig::WithoutRuntime.sig { override.params(mongo_value: SerializedVal).returns(T.attached_class) }
   def self.deserialize(mongo_value)
     if self == T::Enum
       raise "Cannot call T::Enum.deserialize directly. You must call on a specific child class."
@@ -147,9 +152,14 @@ class T::Enum
   end
 
   # Note: Failed CriticalMethodsNoRuntimeTypingTest
-  sig { returns(SerializedVal).checked(:never) }
+  T::Sig::WithoutRuntime.sig { returns(SerializedVal) }
   def serialize
-    assert_bound!
+    # Same check and message as assert_bound!, open-coded to avoid the extra
+    # method frame on this hot path.
+    if @const_name.nil?
+      raise "Attempting to access Enum value on #{self.class} before it has been initialized." \
+        " Enums are not initialized until the 'enums do' block they are defined in has finished running."
+    end
     @serialized_val
   end
 
@@ -165,17 +175,20 @@ class T::Enum
     serialized_val.as_json(*args)
   end
 
-  sig { returns(String) }
+  # `to_s` keeps delegating to `inspect` rather than `alias_method :to_s,
+  # :inspect` so a subclass that overrides `inspect` still has its `to_s`
+  # reflect the override.
+  T::Sig::WithoutRuntime.sig { returns(String) }
   def to_s
     inspect
   end
 
-  sig { returns(String) }
+  T::Sig::WithoutRuntime.sig { returns(String) }
   def inspect
     "#<#{self.class.name}::#{@const_name || '__UNINITIALIZED__'}>"
   end
 
-  sig { params(other: BasicObject).returns(T.nilable(Integer)) }
+  T::Sig::WithoutRuntime.sig { params(other: BasicObject).returns(T.nilable(Integer)) }
   def <=>(other)
     case other
     when self.class
@@ -292,7 +305,7 @@ class T::Enum
     self.class._register_instance(self)
   end
 
-  sig { returns(NilClass).checked(:never) }
+  T::Sig::WithoutRuntime.sig { returns(NilClass) }
   private def assert_bound!
     if @const_name.nil?
       raise "Attempting to access Enum value on #{self.class} before it has been initialized." \

--- a/gems/sorbet-runtime/lib/types/enum.rb
+++ b/gems/sorbet-runtime/lib/types/enum.rb
@@ -56,8 +56,7 @@ class T::Enum
   T::Sig::WithoutRuntime.sig { returns(T::Array[T.attached_class]) }
   def self.values
     if @values.nil?
-      raise "Attempting to access values of #{self.class} before it has been initialized." \
-        " Enums are not initialized until the 'enums do' block they are defined in has finished running."
+      raise(UNBOUND_VALUES_MESSAGE % self.class)
     end
     @values
   end
@@ -80,8 +79,7 @@ class T::Enum
   T::Sig::WithoutRuntime.sig { params(serialized_val: SerializedVal).returns(T.nilable(T.attached_class)) }
   def self.try_deserialize(serialized_val)
     if @mapping.nil?
-      raise "Attempting to access serialization map of #{self.class} before it has been initialized." \
-        " Enums are not initialized until the 'enums do' block they are defined in has finished running."
+      raise(UNBOUND_SERIALIZATION_MAP_MESSAGE % self.class)
     end
     @mapping[serialized_val]
   end
@@ -107,8 +105,7 @@ class T::Enum
   T::Sig::WithoutRuntime.sig { overridable.params(serialized_val: SerializedVal).returns(T::Boolean) }
   def self.has_serialized?(serialized_val)
     if @mapping.nil?
-      raise "Attempting to access serialization map of #{self.class} before it has been initialized." \
-        " Enums are not initialized until the 'enums do' block they are defined in has finished running."
+      raise(UNBOUND_SERIALIZATION_MAP_MESSAGE % self.class)
     end
     @mapping.include?(serialized_val)
   end
@@ -151,14 +148,27 @@ class T::Enum
     self
   end
 
+  # Format strings (`%s` is the class) for the "accessed before initialized"
+  # errors, so the various raise sites can't drift from each other.
+  UNBOUND_VALUE_MESSAGE = "Attempting to access Enum value on %s before it has been initialized." \
+    " Enums are not initialized until the 'enums do' block they are defined in has finished running."
+  private_constant :UNBOUND_VALUE_MESSAGE
+
+  UNBOUND_VALUES_MESSAGE = "Attempting to access values of %s before it has been initialized." \
+    " Enums are not initialized until the 'enums do' block they are defined in has finished running."
+  private_constant :UNBOUND_VALUES_MESSAGE
+
+  UNBOUND_SERIALIZATION_MAP_MESSAGE = "Attempting to access serialization map of %s before it has been initialized." \
+    " Enums are not initialized until the 'enums do' block they are defined in has finished running."
+  private_constant :UNBOUND_SERIALIZATION_MAP_MESSAGE
+
   # Note: Failed CriticalMethodsNoRuntimeTypingTest
   T::Sig::WithoutRuntime.sig { returns(SerializedVal) }
   def serialize
     # Same check and message as assert_bound!, open-coded to avoid the extra
     # method frame on this hot path.
     if @const_name.nil?
-      raise "Attempting to access Enum value on #{self.class} before it has been initialized." \
-        " Enums are not initialized until the 'enums do' block they are defined in has finished running."
+      raise(UNBOUND_VALUE_MESSAGE % self.class)
     end
     @serialized_val
   end
@@ -308,8 +318,7 @@ class T::Enum
   T::Sig::WithoutRuntime.sig { returns(NilClass) }
   private def assert_bound!
     if @const_name.nil?
-      raise "Attempting to access Enum value on #{self.class} before it has been initialized." \
-        " Enums are not initialized until the 'enums do' block they are defined in has finished running."
+      raise(UNBOUND_VALUE_MESSAGE % self.class)
     end
   end
 

--- a/gems/sorbet-runtime/lib/types/private/casts.rb
+++ b/gems/sorbet-runtime/lib/types/private/casts.rb
@@ -5,8 +5,28 @@ module T::Private
   module Casts
     def self.cast(value, type, cast_method)
       begin
-        coerced_type = T::Utils::Private.coerce_and_check_module_types(type, value, true)
-        return value unless coerced_type
+        # Every caller (T.cast/let/bind/assert_type! in _types.rb) inlines the
+        # value check for the two dominant shapes -- a Module literal and the
+        # SimplePairUnion that `T.nilable(SomeModule)` produces -- and only
+        # falls through to here when that check already failed. So skip
+        # straight to coercing: re-checking `value.is_a?(type)` /
+        # `type.valid?(value)` here would always be false.
+        case type
+        when ::Module
+          coerced_type = T::Types::Simple::Private::Pool.type_for_module(type)
+        when T::Types::Base
+          # Mirrors the T::Types::Base branch of coerce_and_check_module_types,
+          # kept inline to avoid its call frame for every already-coerced type.
+          case type
+          when T::Private::Types::TypeAlias
+            coerced_type = type.aliased_type
+          else
+            coerced_type = type
+          end
+        else
+          coerced_type = T::Utils::Private.coerce_and_check_module_types(type, value, true)
+          return value unless coerced_type
+        end
 
         error = coerced_type.error_message_for_obj(value)
         return value unless error

--- a/gems/sorbet-runtime/lib/types/private/casts.rb
+++ b/gems/sorbet-runtime/lib/types/private/casts.rb
@@ -17,12 +17,13 @@ module T::Private
         when T::Types::Base
           # Mirrors the T::Types::Base branch of coerce_and_check_module_types,
           # kept inline to avoid its call frame for every already-coerced type.
-          case type
-          when T::Private::Types::TypeAlias
-            coerced_type = type.aliased_type
-          else
-            coerced_type = type
-          end
+          coerced_type =
+            case type
+            when T::Private::Types::TypeAlias
+              type.aliased_type
+            else
+              type
+            end
         else
           coerced_type = T::Utils::Private.coerce_and_check_module_types(type, value, true)
           return value unless coerced_type

--- a/gems/sorbet-runtime/lib/types/private/class_utils.rb
+++ b/gems/sorbet-runtime/lib/types/private/class_utils.rb
@@ -44,9 +44,10 @@ module T::Private::ClassUtils
       end
 
       if block && block.arity < 0 && respond_to?(:ruby2_keywords, true)
-        m = instance_method(name)
-        has_rest = m.parameters.any? { |type, _| type == :rest }
-        has_keywords = m.parameters.any? { |type, _| %i[keyrest keyreq key].include?(type) }
+        # Fetch .parameters once: each call builds a fresh array.
+        parameters = instance_method(name).parameters
+        has_rest = parameters.any? { |kind, _| kind == :rest }
+        has_keywords = parameters.any? { |kind, _| kind == :keyrest || kind == :keyreq || kind == :key }
         ruby2_keywords(name) if has_rest && !has_keywords
       end
     end
@@ -67,18 +68,23 @@ module T::Private::ClassUtils
     original_visibility = visibility_method_name(mod, name)
     original_owner = original_method.owner
 
-    mod.ancestors.each do |ancestor|
-      break if ancestor == mod
-      if ancestor == original_owner
-        # If we get here, that means the method we're trying to replace exists on a *prepended*
-        # mixin, which means in order to supersede it, we'd need to create a method on a new
-        # module that we'd prepend before `ancestor`. The problem with that approach is there'd
-        # be no way to remove that new module after prepending it, so we'd be left with these
-        # empty anonymous modules in the ancestor chain after calling `restore`.
-        #
-        # That's not necessarily a deal breaker, but for now, we're keeping it as unsupported.
-        raise "You're trying to replace `#{name}` on `#{mod}`, but that method exists in a " \
-              "prepended module (#{ancestor}), which we don't currently support."
+    # In the common case the method is owned by `mod` itself, in which case the loop below
+    # would always `break` before the raise could match (`mod` precedes any non-prepended
+    # ancestor in its own ancestor chain), so skip computing `mod.ancestors` entirely.
+    if original_owner != mod
+      mod.ancestors.each do |ancestor|
+        break if ancestor == mod
+        if ancestor == original_owner
+          # If we get here, that means the method we're trying to replace exists on a *prepended*
+          # mixin, which means in order to supersede it, we'd need to create a method on a new
+          # module that we'd prepend before `ancestor`. The problem with that approach is there'd
+          # be no way to remove that new module after prepending it, so we'd be left with these
+          # empty anonymous modules in the ancestor chain after calling `restore`.
+          #
+          # That's not necessarily a deal breaker, but for now, we're keeping it as unsupported.
+          raise "You're trying to replace `#{name}` on `#{mod}`, but that method exists in a " \
+                "prepended module (#{ancestor}), which we don't currently support."
+        end
       end
     end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -299,11 +299,14 @@ module T::Private::Methods
 
   # Only public because it needs to get called below inside the replace_method blocks below.
   def self._on_method_added(hook_mod, mod, method_name)
-    if T::Private::DeclState.current.skip_on_method_added
+    # The thread-local DeclState object is stable for the duration of this call
+    # (nothing reassigns `DeclState.current=`), so fetch it once.
+    decl_state = T::Private::DeclState.current
+    if decl_state.skip_on_method_added
       return
     end
 
-    current_declaration = T::Private::DeclState.current.consume!
+    current_declaration = decl_state.consume!
 
     if T::Private::Final.final_module?(mod) && (current_declaration.nil? || !current_declaration.final)
       raise "#{mod} was declared as final but its method `#{method_name}` was not declared as final"

--- a/gems/sorbet-runtime/lib/types/private/methods/signature.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature.rb
@@ -80,7 +80,8 @@ class T::Private::Methods::Signature
     # If sig params are declared but there is a single parameter with a missing name
     # **and** the method ends with a "=", assume it is a writer method generated
     # by attr_writer or attr_accessor
-    writer_method = !(raw_arg_types.size == 1 && raw_arg_types.key?(nil)) && parameters == UNNAMED_REQUIRED_PARAMETERS && method_name[-1] == "="
+    # (Checks are ordered so that the common, non-writer case short-circuits without allocating.)
+    writer_method = method_name.end_with?("=") && parameters == UNNAMED_REQUIRED_PARAMETERS && !(raw_arg_types.size == 1 && raw_arg_types.key?(nil))
     # For writer methods, map the single parameter to the method name without the "=" at the end
     parameters = [[:req, method_name[0...-1].to_sym]] if writer_method
     is_name_missing = parameters.any? { |_, name| !raw_arg_types.key?(name) }

--- a/gems/sorbet-runtime/lib/types/types/base.rb
+++ b/gems/sorbet-runtime/lib/types/types/base.rb
@@ -181,7 +181,10 @@ module T::Types
     def ==(other)
       case other
       when T::Types::Base
-        other.name == self.name
+        # Performance fast path: pooled and memoized type instances (e.g. the
+        # results of repeated T.nilable(X) calls) are the same object, so they
+        # can compare equal without computing and comparing their names.
+        other.equal?(self) || other.name == self.name
       else
         false
       end

--- a/gems/sorbet-runtime/lib/types/types/fixed_array.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_array.rb
@@ -26,13 +26,15 @@ module T::Types
 
     # overrides Base
     def recursively_valid?(obj)
-      if obj.is_a?(Array) && obj.length == types.length
-        i = 0
-        while i < types.length
-          if !types.fetch(i).recursively_valid?(obj[i])
+      element_types = types
+      length = element_types.length
+      if obj.is_a?(Array) && obj.length == length
+        index = 0
+        while index < length
+          if !element_types.fetch(index).recursively_valid?(obj[index])
             return false
           end
-          i += 1
+          index += 1
         end
         true
       else
@@ -42,13 +44,15 @@ module T::Types
 
     # overrides Base
     def valid?(obj)
-      if obj.is_a?(Array) && obj.length == types.length
-        i = 0
-        while i < types.length
-          if !types.fetch(i).valid?(obj[i])
+      element_types = types
+      length = element_types.length
+      if obj.is_a?(Array) && obj.length == length
+        index = 0
+        while index < length
+          if !element_types.fetch(index).valid?(obj[index])
             return false
           end
-          i += 1
+          index += 1
         end
         true
       else

--- a/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/fixed_hash.rb
@@ -26,16 +26,30 @@ module T::Types
     # overrides Base
     def recursively_valid?(obj)
       return false unless obj.is_a?(Hash)
-      return false if types.any? { |key, type| !type.recursively_valid?(obj[key]) }
-      return false if obj.any? { |key, _| !types[key] }
+      field_types = types
+      field_types.each_pair do |key, type|
+        return false unless type.recursively_valid?(obj[key])
+      end
+      # Pigeonhole: more entries than declared keys guarantees an undeclared key.
+      return false if obj.size > field_types.size
+      obj.each_key do |key|
+        return false unless field_types.key?(key)
+      end
       true
     end
 
     # overrides Base
     def valid?(obj)
       return false unless obj.is_a?(Hash)
-      return false if types.any? { |key, type| !type.valid?(obj[key]) }
-      return false if obj.any? { |key, _| !types[key] }
+      field_types = types
+      field_types.each_pair do |key, type|
+        return false unless type.valid?(obj[key])
+      end
+      # Pigeonhole: more entries than declared keys guarantees an undeclared key.
+      return false if obj.size > field_types.size
+      obj.each_key do |key|
+        return false unless field_types.key?(key)
+      end
       true
     end
 

--- a/gems/sorbet-runtime/lib/types/types/intersection.rb
+++ b/gems/sorbet-runtime/lib/types/types/intersection.rb
@@ -32,12 +32,24 @@ module T::Types
 
     # overrides Base
     def recursively_valid?(obj)
-      types.all? { |type| type.recursively_valid?(obj) }
+      members = types
+      index = 0
+      while index < members.length
+        return false unless members.fetch(index).recursively_valid?(obj)
+        index += 1
+      end
+      true
     end
 
     # overrides Base
     def valid?(obj)
-      types.all? { |type| type.valid?(obj) }
+      members = types
+      index = 0
+      while index < members.length
+        return false unless members.fetch(index).valid?(obj)
+        index += 1
+      end
+      true
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -32,6 +32,14 @@ module T::Types
     end
 
     # overrides Base
+    #
+    # Identical to valid?; defined directly so the leaf-type hot path (every
+    # element check in a typed collection walk) skips the Base delegator frame.
+    def recursively_valid?(obj)
+      obj.is_a?(@raw_type)
+    end
+
+    # overrides Base
     def valid?(obj)
       obj.is_a?(@raw_type)
     end

--- a/gems/sorbet-runtime/lib/types/types/simple.rb
+++ b/gems/sorbet-runtime/lib/types/types/simple.rb
@@ -101,7 +101,7 @@ module T::Types
           type = if mod == ::Array
             TypedArray::Untyped::Private::INSTANCE
           elsif mod == ::Hash
-            TypedHash::Untyped.new
+            TypedHash::Untyped::Private::INSTANCE
           elsif mod == ::Enumerable
             TypedEnumerable::Untyped.new
           elsif mod == ::Enumerator

--- a/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_enumerable.rb
@@ -38,10 +38,12 @@ module T::Types
       return false unless obj.is_a?(Enumerable)
       case obj
       when Array
-        it = 0
-        while it < obj.count
-          return false unless type.recursively_valid?(obj[it])
-          it += 1
+        element_type = type
+        length = obj.count
+        index = 0
+        while index < length
+          return false unless element_type.recursively_valid?(obj[index])
+          index += 1
         end
         true
       when Hash

--- a/gems/sorbet-runtime/lib/types/types/typed_hash.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_hash.rb
@@ -47,11 +47,22 @@ module T::Types
 
     class Untyped < TypedHash
       def initialize
-        super(keys: T.untyped, values: T.untyped)
+        # Use the INSTANCE constant directly (rather than `T.untyped`) so this
+        # can be built at load time, mirroring TypedArray::Untyped.
+        super(keys: T::Types::Untyped::Private::INSTANCE, values: T::Types::Untyped::Private::INSTANCE)
       end
 
       def valid?(obj)
         obj.is_a?(Hash)
+      end
+
+      def freeze
+        build_type # force lazy initialization before freezing the object
+        super
+      end
+
+      module Private
+        INSTANCE = Untyped.new.freeze
       end
     end
   end

--- a/gems/sorbet-runtime/lib/types/types/union.rb
+++ b/gems/sorbet-runtime/lib/types/types/union.rb
@@ -73,11 +73,26 @@ module T::Types
 
     # overrides Base
     def recursively_valid?(obj)
-      members = types
+      member_modules = @member_modules
+      if member_modules.nil?
+        # Force the lazy types builder, which also computes @member_modules
+        types
+        member_modules = @member_modules
+      end
       index = 0
-      while index < members.length
-        return true if members.fetch(index).recursively_valid?(obj)
-        index += 1
+      if member_modules
+        # For an all-Simple union, recursively_valid? and valid? coincide
+        # (Simple's recursively_valid? is exactly `obj.is_a?(raw_type)`).
+        while index < member_modules.length
+          return true if obj.is_a?(member_modules[index])
+          index += 1
+        end
+      else
+        members = types
+        while index < members.length
+          return true if members.fetch(index).recursively_valid?(obj)
+          index += 1
+        end
       end
       false
     end

--- a/gems/sorbet-runtime/lib/types/types/union.rb
+++ b/gems/sorbet-runtime/lib/types/types/union.rb
@@ -11,15 +11,30 @@ module T::Types
     end
 
     def types
-      @types ||= @inner_types.flat_map do |type|
-        type = T::Utils.coerce(type)
-        if type.is_a?(Union)
-          # Simplify nested unions (mostly so `name` returns a nicer value)
-          type.types
-        else
-          type
+      @types ||= begin
+        flattened = @inner_types.flat_map do |type|
+          type = T::Utils.coerce(type)
+          if type.is_a?(Union)
+            # Simplify nested unions (mostly so `name` returns a nicer value)
+            type.types
+          else
+            type
+          end
+        end.uniq
+        # When every member is a plain Simple (whose valid? is exactly
+        # `obj.is_a?(raw_type)`), precompute the members' raw modules so
+        # valid? can skip per-member dispatch. instance_of? (the is_a? only
+        # narrows for static checking) so that any Simple subclass overriding
+        # valid? would be excluded. Note this snapshots the members at build
+        # time.
+        member_modules = []
+        all_simple = flattened.all? do |type|
+          type.is_a?(T::Types::Simple) && type.instance_of?(T::Types::Simple) &&
+            member_modules << type.raw_type
         end
-      end.uniq
+        @member_modules = all_simple ? member_modules.freeze : false
+        flattened
+      end
     end
 
     def build_type
@@ -58,12 +73,37 @@ module T::Types
 
     # overrides Base
     def recursively_valid?(obj)
-      types.any? { |type| type.recursively_valid?(obj) }
+      members = types
+      index = 0
+      while index < members.length
+        return true if members.fetch(index).recursively_valid?(obj)
+        index += 1
+      end
+      false
     end
 
     # overrides Base
     def valid?(obj)
-      types.any? { |type| type.valid?(obj) }
+      member_modules = @member_modules
+      if member_modules.nil?
+        # Force the lazy types builder, which also computes @member_modules
+        types
+        member_modules = @member_modules
+      end
+      index = 0
+      if member_modules
+        while index < member_modules.length
+          return true if obj.is_a?(member_modules[index])
+          index += 1
+        end
+      else
+        members = types
+        while index < members.length
+          return true if members.fetch(index).valid?(obj)
+          index += 1
+        end
+      end
+      false
     end
 
     # overrides Base

--- a/gems/sorbet-runtime/lib/types/types/union.rb
+++ b/gems/sorbet-runtime/lib/types/types/union.rb
@@ -109,9 +109,13 @@ module T::Types
           end
 
           begin
-            if type_b == T::Utils::Nilable::NIL_TYPE
+            # The `equal?` checks are an identity fast path: NIL_TYPE is the pooled
+            # `coerce(NilClass)` instance, so it hits on every normal `T.nilable` call.
+            # The `==` fallbacks preserve semantics for hand-constructed
+            # `Simple.new(NilClass)` instances that bypass the pool.
+            if type_b.equal?(T::Utils::Nilable::NIL_TYPE) || type_b == T::Utils::Nilable::NIL_TYPE
               type_a.to_nilable
-            elsif type_a == T::Utils::Nilable::NIL_TYPE
+            elsif type_a.equal?(T::Utils::Nilable::NIL_TYPE) || type_a == T::Utils::Nilable::NIL_TYPE
               type_b.to_nilable
             else
               T::Private::Types::SimplePairUnion.new(type_a, type_b)

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -3,6 +3,13 @@
 
 module T::Utils
   module Private
+    # NOTE: the Module and SimplePairUnion branches of this method are inlined
+    # for speed in several hot paths. The `T.cast` / `T.let` / `T.bind` /
+    # `T.assert_type!` happy paths in `_types.rb` inline the value check and
+    # return early on success; `T::Private::Casts.cast` is only reached after
+    # that check has already failed, so it reproduces the coercion branches but
+    # skips the (now always-false) value check. If you change the behavior
+    # here, update those callers too.
     def self.coerce_and_check_module_types(val, check_val, check_module_type)
       # rubocop:disable Style/CaseLikeIf
       if val.is_a?(T::Types::Base)


### PR DESCRIPTION
**Stack (bottom → top):** #10359 (tests+bench) → **#10362 (this)** → #10363 (props) → #10364 (call_validation)

Non-prop, non-call_validation optimizations to the type-system core. Each commit is a self-contained optimization:

- `Casts.cast` / `T.cast` / `T.let` / `T.bind` / `T.assert_type!`: inline fast paths for `Module` literals and the `SimplePairUnion` that `T.nilable(SomeModule)` produces (written as `case`/`when`), skipping a call frame; note left on `coerce_and_check_module_types` that it's inlined.
- `Base#==` identity short-circuit; `union_of_types` `equal?` before name-string compare.
- `Union` / `Simple` / `Intersection` / `FixedArray` / `FixedHash` `valid?` / `recursively_valid?` fast paths; `Union` precomputed raw-module while-loop; `SimplePairUnion` pooling.
- `TypedEnumerable#recursively_valid?` hoists out of the Array loop; `TypedSet` latches the resolved `Set` module.
- `T::Enum`: `checked(:never)` accessors, open-coded bound check sharing one message constant with `assert_bound!`, `WithoutRuntime` `to_s`/`inspect`.
- `T::Hash[T.untyped, T.untyped]` is now a load-time frozen shared constant (require-order change) like `TypedArray`.
- Boot/decl-time: `def_with_visibility` parameters reuse, `replace_method` ancestors skip, `_on_method_added` DeclState hoist, writer-method detection reorder.
