### PR TITLE
Sorbet optimizations (3/4): T::Props

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/constructor.rb
+++ b/gems/sorbet-runtime/lib/types/props/constructor.rb
@@ -20,10 +20,10 @@ module T::Props::Constructor::DecoratorMethods
     # Use `each_pair` rather than `count` because, as of Ruby 2.6, the latter delegates to Enumerator
     # and therefore allocates for each entry.
     result = 0
-    props_without_defaults&.each_pair do |p, setter_proc|
+    props_without_defaults&.each_pair do |p, bound_setter|
       begin
         val = hash[p]
-        instance.instance_exec(val, &setter_proc)
+        bound_setter.call(instance, val)
         if val || hash.key?(p)
           result += 1
         end

--- a/gems/sorbet-runtime/lib/types/props/custom_type.rb
+++ b/gems/sorbet-runtime/lib/types/props/custom_type.rb
@@ -62,9 +62,15 @@ module T::Props
       # We don't need to check for val's included modules in
       # T::Configuration.scalar_types, because T::Configuration.scalar_types
       # are all classes.
+      #
+      # `name` rather than `to_s`: identical for real classes, but returns the
+      # cached frozen string (Ruby 3.2+) where to_s allocates per call.
+      # Anonymous classes yield nil, and `include?(nil)` is false (an
+      # anonymous class can never be a registered scalar type).
+      scalar_types = T::Configuration.scalar_types
       klass = val.class
       until klass.nil?
-        return true if T::Configuration.scalar_types.include?(klass.to_s)
+        return true if scalar_types.include?(klass.name)
         klass = klass.superclass
       end
       false

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -71,7 +71,12 @@ class T::Props::Decorator
       raise ArgumentError.new("Attempted to redefine prop #{name.inspect} on class #{@class} that's already defined without specifying :override => true: #{prop_rules(name)}")
     end
 
-    @props = @props.merge(name => rules.freeze).freeze
+    # dup/store/freeze rather than @props.merge(name => rules.freeze).freeze:
+    # merge would allocate a temporary single-entry Hash and re-insert every
+    # existing entry. The published hash stays frozen between adds.
+    new_props = @props.dup
+    new_props[name] = rules.freeze
+    @props = new_props.freeze
   end
 
   # Heads up!
@@ -644,12 +649,25 @@ class T::Props::Decorator
       T::Props::Plugin::Private.apply_class_methods(mod, child)
     end
 
-    props.each do |name, rules|
+    parent_props = props
+    # Return before child.decorator below: forcing decorator creation for a
+    # prop-less parent would defeat any decorator_class override (see the NB).
+    return if parent_props.empty?
+
+    # NB: Calling `child.decorator` here is a time bomb that's going to give someone a really bad
+    # time. Any class that defines props and also overrides the `decorator_class` method is going
+    # to reach this line before its override take effect, turning it into a no-op.
+    child_decorator = child.decorator
+
+    # Computed once for all props: the owner comparison cannot change inside
+    # the loop below (it only defines prop accessors on child), and each
+    # Object#method call allocates a fresh Method.
+    clobber_getters = child_decorator.method(:prop_get).owner != method(:prop_get).owner
+    clobber_setters = child_decorator.method(:prop_set).owner != method(:prop_set).owner
+
+    parent_props.each do |name, rules|
       copied_rules = rules.dup
-      # NB: Calling `child.decorator` here is a time bomb that's going to give someone a really bad
-      # time. Any class that defines props and also overrides the `decorator_class` method is going
-      # to reach this line before its override take effect, turning it into a no-op.
-      child.decorator.add_prop_definition(name, copied_rules)
+      child_decorator.add_prop_definition(name, copied_rules)
 
       # It's a bit tricky to support `prop_get` hooks added by plugins without
       # sacrificing the `attr_reader` fast path or clobbering customized getters
@@ -660,13 +678,13 @@ class T::Props::Decorator
       # (b) it's safe because the getter was defined by this file.
       #
       unless rules[:without_accessors]
-        if clobber_getter?(child, name)
+        if clobber_getters && child.instance_method(name).source_location&.first == __FILE__
           child.send(:define_method, name) do
             T.unsafe(self.class).decorator.prop_get(self, name, rules)
           end
         end
 
-        if !rules[:immutable] && clobber_setter?(child, name)
+        if !rules[:immutable] && clobber_setters && child.instance_method("#{name}=").source_location&.first == __FILE__
           child.send(:define_method, "#{name}=") do |val|
             T.unsafe(self.class).decorator.prop_set(self, name, val, rules)
           end
@@ -719,18 +737,6 @@ class T::Props::Decorator
     elaborate_override_entry(:reader, d, result)
     elaborate_override_entry(:writer, d, result)
     result
-  end
-
-  sig { params(child: DecoratedClassType, prop: Symbol).returns(T::Boolean).checked(:never) }
-  private def clobber_getter?(child, prop)
-    !!(child.decorator.method(:prop_get).owner != method(:prop_get).owner &&
-       child.instance_method(prop).source_location&.first == __FILE__)
-  end
-
-  sig { params(child: DecoratedClassType, prop: Symbol).returns(T::Boolean).checked(:never) }
-  private def clobber_setter?(child, prop)
-    !!(child.decorator.method(:prop_set).owner != method(:prop_set).owner &&
-       child.instance_method("#{prop}=").source_location&.first == __FILE__)
   end
 
   sig { params(mod: T::Module[T.anything]).void.checked(:never) }

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -131,7 +131,7 @@ class T::Props::Decorator
   # preexisting behavior).
   #
   # Note this path is NOT used by generated setters on instances,
-  # which are defined using `setter_proc` directly.
+  # which are defined using the 1-arity `:setter_proc` directly.
   #
   # checked(:never) - O(prop accesses)
   sig do
@@ -145,7 +145,9 @@ class T::Props::Decorator
     .checked(:never)
   end
   def prop_set(instance, prop, val, rules=prop_rules(prop))
-    instance.instance_exec(val, &rules.fetch(:setter_proc))
+    # The 2-arity bound proc does the same validation/assignment as the
+    # 1-arity setter proc without instance_exec's per-call self-rebinding.
+    rules.fetch(:_bound_setter_proc).call(instance, val)
   end
   alias_method :set, :prop_set
 
@@ -426,11 +428,20 @@ class T::Props::Decorator
       end
     end
 
-    setter_proc, value_validate_proc = T::Props::Private::SetterFactory.build_setter_proc(@class, name, rules)
+    setter_proc, value_validate_proc, bound_setter_proc = T::Props::Private::SetterFactory.build_setter_proc(@class, name, rules)
     setter_proc.freeze
     value_validate_proc.freeze
-    rules[:setter_proc] = setter_proc
+    bound_setter_proc.freeze
     rules[:value_validate_proc] = value_validate_proc
+    # :setter_proc is a pre-existing rules key and is preserved as-is: the
+    # 1-arity, self-bound proc used only to define the generated `name=`
+    # instance setter via `define_method(&proc)` (its fast path). The net-new
+    # :_bound_setter_proc is the 2-arity (instance, val) equivalent that every
+    # other write goes through without instance_exec's per-call self-rebinding;
+    # it is underscore-prefixed (like :_tnilable) so external code that replays
+    # rules hashes back into prop() filters it out as internal.
+    rules[:setter_proc] = setter_proc
+    rules[:_bound_setter_proc] = bound_setter_proc
 
     validate_overrides(name, rules)
     add_prop_definition(name, rules)

--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -182,7 +182,7 @@ class T::Props::Decorator
     if !val.nil?
       val
     elsif (d = rules[:ifunset])
-      T::Props::Utils.deep_clone_object(d)
+      T::Props::Utils.deep_clone(d)
     else
       nil
     end

--- a/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
+++ b/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
@@ -268,7 +268,7 @@ module T::Props
       @whitelisted_methods_for_serialize ||= {
         lvar: %i{dup map transform_values transform_keys each_with_object nil? []= serialize},
         ivar: %i[dup map transform_values transform_keys each_with_object serialize],
-        const: %i[checked_serialize deep_clone_object],
+        const: %i[checked_serialize deep_clone deep_clone_object],
       }
     end
 
@@ -276,7 +276,7 @@ module T::Props
     private_class_method def self.whitelisted_methods_for_deserialize
       @whitelisted_methods_for_deserialize ||= {
         lvar: %i{dup map transform_values transform_keys each_with_object nil? []= to_f},
-        const: %i[deserialize from_hash deep_clone_object],
+        const: %i[deserialize from_hash deep_clone deep_clone_object],
       }
     end
   end

--- a/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
+++ b/gems/sorbet-runtime/lib/types/props/generated_code_validation.rb
@@ -119,7 +119,7 @@ module T::Props
 
     private_class_method def self.validate_deserialize_ivar_set(clause)
       # %<accessor_key>s = if val.nil?
-      #   found -= 1 unless hash.key?(%<serialized_form>s)
+      #   found -= 1 unless hash.key?(%<serialized_form>s.freeze)
       #   %<nil_handler>s
       # else
       #   %<serialized_val>s
@@ -143,7 +143,13 @@ module T::Props
       receiver, method, arg = found_condition.children
       assert_equal(s(:lvar, :hash), receiver)
       assert_equal(:key?, method)
-      assert_equal(:str, arg.type)
+      # hash.key?(%<serialized_form>s.freeze), where `.freeze` on a string
+      # literal is side-effect-free (and avoids a per-call allocation)
+      assert_equal(:send, arg.type)
+      arg_receiver, arg_method, *arg_rest = arg.children
+      assert_equal(:str, arg_receiver.type)
+      assert_equal(:freeze, arg_method)
+      assert_equal([], arg_rest)
       assert_equal(nil, found_if_body)
       assert_equal(s(:op_asgn, s(:lvasgn, :found), :-, s(:int, 1)), found_else_body)
 

--- a/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
+++ b/gems/sorbet-runtime/lib/types/props/has_lazily_specialized_methods.rb
@@ -59,13 +59,23 @@ module T::Props
           raise SourceEvaluationDisabled.new
         end
 
-        source = lazily_defined_methods.fetch(name).call
+        blk = lazily_defined_methods[name]
+        # A concurrent first call can have already evaluated and removed
+        # this entry; the specialized method is installed, so the
+        # placeholder's retry dispatch will reach it directly.
+        return if blk.nil?
+
+        source = blk.call
 
         cls = decorated_class
         T::Configuration.without_ruby_warnings do
           cls.class_eval(source.to_s)
         end
         cls.send(:private, name)
+        # Removing the entry records that no placeholder is installed, so a
+        # later prop addition (possible, if unusual: props added after first
+        # use) re-enqueues a fresh placeholder instead of being skipped.
+        lazily_defined_methods.delete(name)
       end
 
       sig { params(name: Symbol).void }
@@ -74,15 +84,31 @@ module T::Props
           raise SourceEvaluationDisabled.new
         end
 
-        lazily_defined_vm_methods.fetch(name).call
+        blk = lazily_defined_vm_methods[name]
+        # See eval_lazily_defined_method!.
+        return if blk.nil?
+
+        blk.call
 
         cls = decorated_class
         cls.send(:private, name)
+        lazily_defined_vm_methods.delete(name)
       end
 
       sig { params(name: Symbol, blk: T.proc.returns(String)).void }
       private def enqueue_lazy_method_definition!(name, &blk)
-        lazily_defined_methods[name] = blk
+        methods = lazily_defined_methods
+        if methods.key?(name)
+          # The placeholder installed below is already in place (every prop
+          # addition lands here, so this is hit from the second prop of a
+          # class onward, and again for every prop re-added to a subclass).
+          # It reads the generator from the hash at call time, so updating
+          # the entry suffices; skipping the re-install avoids 2-4 method
+          # table writes (and their cache invalidations) per addition.
+          methods[name] = blk
+          return
+        end
+        methods[name] = blk
 
         cls = decorated_class
         if cls.method_defined?(name) || cls.private_method_defined?(name)
@@ -102,7 +128,13 @@ module T::Props
 
       sig { params(name: Symbol, blk: T.untyped).void }
       private def enqueue_lazy_vm_method_definition!(name, &blk)
-        lazily_defined_vm_methods[name] = blk
+        methods = lazily_defined_vm_methods
+        if methods.key?(name)
+          # See enqueue_lazy_method_definition!.
+          methods[name] = blk
+          return
+        end
+        methods[name] = blk
 
         cls = decorated_class
         cls.send(:define_method, name) do |*args|

--- a/gems/sorbet-runtime/lib/types/props/optional.rb
+++ b/gems/sorbet-runtime/lib/types/props/optional.rb
@@ -47,7 +47,7 @@ module T::Props::Optional::DecoratorMethods
   attr_reader :props_with_defaults
 
   # checked(:never) - O(runtime object construction)
-  sig { returns(T::Hash[Symbol, T::Props::Private::SetterFactory::SetterProc]).checked(:never) }
+  sig { returns(T::Hash[Symbol, T::Props::Private::SetterFactory::BoundSetterProc]).checked(:never) }
   attr_reader :props_without_defaults
 
   def add_prop_definition(prop, rules)
@@ -62,7 +62,7 @@ module T::Props::Optional::DecoratorMethods
       rules[DEFAULT_SETTER_RULE_KEY] = default_setter
     else
       @props_without_defaults ||= {}
-      @props_without_defaults[prop] = rules.fetch(:setter_proc)
+      @props_without_defaults[prop] = rules.fetch(:_bound_setter_proc)
       props_with_defaults&.delete(prop) # Handle potential override
     end
 

--- a/gems/sorbet-runtime/lib/types/props/private/apply_default.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/apply_default.rb
@@ -9,14 +9,14 @@ module T::Props
       abstract!
 
       # checked(:never) - O(object construction x prop count)
-      sig { returns(SetterFactory::SetterProc).checked(:never) }
-      attr_reader :setter_proc
+      sig { returns(SetterFactory::BoundSetterProc).checked(:never) }
+      attr_reader :bound_setter_proc
 
       # checked(:never) - We do this with `T.let` instead
-      sig { params(accessor_key: Symbol, setter_proc: SetterFactory::SetterProc).void.checked(:never) }
-      def initialize(accessor_key, setter_proc)
+      sig { params(accessor_key: Symbol, bound_setter_proc: SetterFactory::BoundSetterProc).void.checked(:never) }
+      def initialize(accessor_key, bound_setter_proc)
         @accessor_key = T.let(accessor_key, Symbol)
-        @setter_proc = T.let(setter_proc, SetterFactory::SetterProc)
+        @bound_setter_proc = T.let(bound_setter_proc, SetterFactory::BoundSetterProc)
       end
 
       # checked(:never) - O(object construction x prop count)
@@ -33,30 +33,30 @@ module T::Props
       sig { params(cls: T::Module[T.anything], rules: T::Hash[Symbol, T.untyped]).returns(T.nilable(ApplyDefault)).checked(:never) }
       def self.for(cls, rules)
         accessor_key = rules.fetch(:accessor_key)
-        setter = rules.fetch(:setter_proc)
+        bound_setter = rules.fetch(:_bound_setter_proc)
 
         if rules.key?(:factory)
-          ApplyDefaultFactory.new(cls, rules.fetch(:factory), accessor_key, setter)
+          ApplyDefaultFactory.new(cls, rules.fetch(:factory), accessor_key, bound_setter)
         elsif rules.key?(:default)
           default = rules.fetch(:default)
           case default
           when *NO_CLONE_TYPES
-            return ApplyPrimitiveDefault.new(default, accessor_key, setter)
+            return ApplyPrimitiveDefault.new(default, accessor_key, bound_setter)
           when String
             if default.frozen?
-              return ApplyPrimitiveDefault.new(default, accessor_key, setter)
+              return ApplyPrimitiveDefault.new(default, accessor_key, bound_setter)
             end
           when Array
             if default.empty? && default.class == Array
-              return ApplyEmptyArrayDefault.new(accessor_key, setter)
+              return ApplyEmptyArrayDefault.new(accessor_key, bound_setter)
             end
           when Hash
             if default.empty? && default.default.nil? && T.unsafe(default).default_proc.nil? && default.class == Hash
-              return ApplyEmptyHashDefault.new(accessor_key, setter)
+              return ApplyEmptyHashDefault.new(accessor_key, bound_setter)
             end
           end
 
-          ApplyComplexDefault.new(default, accessor_key, setter)
+          ApplyComplexDefault.new(default, accessor_key, bound_setter)
         else
           nil
         end
@@ -67,16 +67,16 @@ module T::Props
       abstract!
 
       # checked(:never) - We do this with `T.let` instead
-      sig { params(default: BasicObject, accessor_key: Symbol, setter_proc: SetterFactory::SetterProc).void.checked(:never) }
-      def initialize(default, accessor_key, setter_proc)
+      sig { params(default: BasicObject, accessor_key: Symbol, bound_setter_proc: SetterFactory::BoundSetterProc).void.checked(:never) }
+      def initialize(default, accessor_key, bound_setter_proc)
         # FIXME: Ideally we'd check here that the default is actually a valid
         # value for this field, but existing code relies on the fact that we don't.
         #
         # :(
         #
-        # setter_proc.call(default)
+        # bound_setter_proc.call(instance, default)
         @default = T.let(default, BasicObject)
-        super(accessor_key, setter_proc)
+        super(accessor_key, bound_setter_proc)
       end
 
       # checked(:never) - O(object construction x prop count)
@@ -141,15 +141,15 @@ module T::Props
           cls: T::Module[T.anything],
           factory: T.any(Proc, Method),
           accessor_key: Symbol,
-          setter_proc: SetterFactory::SetterProc,
+          bound_setter_proc: SetterFactory::BoundSetterProc,
         )
         .void
         .checked(:never)
       end
-      def initialize(cls, factory, accessor_key, setter_proc)
+      def initialize(cls, factory, accessor_key, bound_setter_proc)
         @class = T.let(cls, T::Module[T.anything])
         @factory = T.let(factory, T.any(Proc, Method))
-        super(accessor_key, setter_proc)
+        super(accessor_key, bound_setter_proc)
       end
 
       # checked(:never) - O(object construction x prop count)
@@ -157,7 +157,7 @@ module T::Props
       def set_default(instance)
         # Use the actual setter to validate the factory returns a legitimate
         # value every time
-        instance.instance_exec(default, &@setter_proc)
+        @bound_setter_proc.call(instance, default)
       end
 
       # checked(:never) - O(object construction x prop count)

--- a/gems/sorbet-runtime/lib/types/props/private/apply_default.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/apply_default.rb
@@ -96,7 +96,7 @@ module T::Props
       # checked(:never) - O(object construction x prop count)
       sig { override.returns(T.untyped).checked(:never) }
       def default
-        T::Props::Utils.deep_clone_object(@default)
+        T::Props::Utils.deep_clone(@default)
       end
     end
 

--- a/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
@@ -81,10 +81,16 @@ module T::Props
             raise_on_nil_write: !!rules[:raise_on_nil_write],
           )
 
+          # The `.freeze` on the `hash.key?` argument matters: when this source
+          # is eval'd lazily (without a frozen-string-literal prefix, unlike
+          # `eagerly_define_lazy_methods!`), a bare literal here would allocate
+          # a new String on every call for each nil/missing prop. `"str".freeze`
+          # compiles to a no-allocation VM instruction (opt_str_freeze). The
+          # `hash[...]` read doesn't need it because of opt_aref_with.
           <<~RUBY
             val = hash[#{hash_key.inspect}]
             #{ivar_name} = if val.nil?
-              found -= 1 unless hash.key?(#{hash_key.inspect})
+              found -= 1 unless hash.key?(#{hash_key.inspect}.freeze)
               #{nil_handler}
             else
               #{transformed_val}

--- a/gems/sorbet-runtime/lib/types/props/private/serde_transform.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/serde_transform.rb
@@ -88,7 +88,7 @@ module T::Props
             # string comparisons.
             nil
           else
-            "T::Props::Utils.deep_clone_object(#{varname})"
+            "T::Props::Utils.deep_clone(#{varname})"
           end
         when T::Types::Union
           non_nil_type = T::Utils.unwrap_nilable(type)
@@ -110,10 +110,10 @@ module T::Props
             # this union to have no specific serde transform (the only reason
             # why Float has a special case is because round tripping through
             # JSON might normalize Floats to Integers)
-            "T::Props::Utils.deep_clone_object(#{varname})"
+            "T::Props::Utils.deep_clone(#{varname})"
           end
         when T::Types::Intersection
-          dynamic_fallback = "T::Props::Utils.deep_clone_object(#{varname})"
+          dynamic_fallback = "T::Props::Utils.deep_clone(#{varname})"
 
           # Transformations for any members of the intersection type where we
           # know what we need to do and did not have to fall back to the
@@ -147,7 +147,7 @@ module T::Props
         when T::Types::Enum
           generate(T::Utils.lift_enum(type), mode, varname)
         else
-          "T::Props::Utils.deep_clone_object(#{varname})"
+          "T::Props::Utils.deep_clone(#{varname})"
         end
       end
 

--- a/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/setter_factory.rb
@@ -8,6 +8,10 @@ module T::Props
 
       SetterProc = T.type_alias { T.proc.params(val: T.untyped).void }
       ValueValidationProc = T.type_alias { T.proc.params(val: T.untyped).void }
+      # Same validation/assignment as SetterProc, but takes the instance
+      # explicitly so per-prop construction/prop_set paths skip the
+      # self-rebinding instance_exec dispatch.
+      BoundSetterProc = T.type_alias { T.proc.params(instance: T.untyped, val: T.untyped).void }
       ValidateProc = T.type_alias { T.proc.params(prop: Symbol, value: T.untyped).void }
 
       sig do
@@ -16,7 +20,7 @@ module T::Props
           prop: Symbol,
           rules: T::Hash[Symbol, T.untyped]
         )
-        .returns([SetterProc, ValueValidationProc])
+        .returns([SetterProc, ValueValidationProc, BoundSetterProc])
         .checked(:never)
       end
       def self.build_setter_proc(klass, prop, rules)
@@ -56,7 +60,7 @@ module T::Props
           non_nil_type: T::Module[T.anything],
           klass: T.all(T::Module[T.anything], T::Props::ClassMethods),
         )
-        .returns([SetterProc, ValueValidationProc])
+        .returns([SetterProc, ValueValidationProc, BoundSetterProc])
       end
       private_class_method def self.simple_non_nil_proc(prop, accessor_key, non_nil_type, klass)
         [
@@ -81,6 +85,19 @@ module T::Props
               )
             end
           end,
+          # The ivar set is unconditional, exactly as above: the value must
+          # still be set when call_validation_error_handler does not raise.
+          proc do |instance, val|
+            unless val.is_a?(non_nil_type)
+              T::Props::Private::SetterFactory.raise_pretty_error(
+                klass,
+                prop,
+                T::Utils.coerce(non_nil_type),
+                val,
+              )
+            end
+            instance.instance_variable_set(accessor_key, val)
+          end,
         ]
       end
 
@@ -92,7 +109,7 @@ module T::Props
           klass: T.all(T::Module[T.anything], T::Props::ClassMethods),
           validate: T.nilable(ValidateProc)
         )
-        .returns([SetterProc, ValueValidationProc])
+        .returns([SetterProc, ValueValidationProc, BoundSetterProc])
       end
       private_class_method def self.non_nil_proc(prop, accessor_key, non_nil_type, klass, validate)
         [
@@ -131,6 +148,21 @@ module T::Props
               )
             end
           end,
+          # The ivar set is unconditional, exactly as above: the value must
+          # still be set when call_validation_error_handler does not raise.
+          proc do |instance, val|
+            if non_nil_type.recursively_valid?(val)
+              validate&.call(prop, val)
+            else
+              T::Props::Private::SetterFactory.raise_pretty_error(
+                klass,
+                prop,
+                non_nil_type,
+                val,
+              )
+            end
+            instance.instance_variable_set(accessor_key, val)
+          end,
         ]
       end
 
@@ -141,7 +173,7 @@ module T::Props
           non_nil_type: T::Module[T.anything],
           klass: T.all(T::Module[T.anything], T::Props::ClassMethods),
         )
-        .returns([SetterProc, ValueValidationProc])
+        .returns([SetterProc, ValueValidationProc, BoundSetterProc])
       end
       private_class_method def self.simple_nilable_proc(prop, accessor_key, non_nil_type, klass)
         [
@@ -166,6 +198,19 @@ module T::Props
               )
             end
           end,
+          # The ivar set is unconditional, exactly as above: the value must
+          # still be set when call_validation_error_handler does not raise.
+          proc do |instance, val|
+            unless val.nil? || val.is_a?(non_nil_type)
+              T::Props::Private::SetterFactory.raise_pretty_error(
+                klass,
+                prop,
+                T::Utils.coerce(non_nil_type),
+                val,
+              )
+            end
+            instance.instance_variable_set(accessor_key, val)
+          end,
         ]
       end
 
@@ -177,7 +222,7 @@ module T::Props
           klass: T.all(T::Module[T.anything], T::Props::ClassMethods),
           validate: T.nilable(ValidateProc),
         )
-        .returns([SetterProc, ValueValidationProc])
+        .returns([SetterProc, ValueValidationProc, BoundSetterProc])
       end
       private_class_method def self.nilable_proc(prop, accessor_key, non_nil_type, klass, validate)
         [
@@ -218,6 +263,24 @@ module T::Props
                 non_nil_type,
                 val,
               )
+            end
+          end,
+          # Branch structure (including the set-after-soft-error in the
+          # invalid arm) replicated exactly from the first proc above.
+          proc do |instance, val|
+            if val.nil?
+              instance.instance_variable_set(accessor_key, nil)
+            elsif non_nil_type.recursively_valid?(val)
+              validate&.call(prop, val)
+              instance.instance_variable_set(accessor_key, val)
+            else
+              T::Props::Private::SetterFactory.raise_pretty_error(
+                klass,
+                prop,
+                non_nil_type,
+                val,
+              )
+              instance.instance_variable_set(accessor_key, val)
             end
           end,
         ]

--- a/gems/sorbet-runtime/lib/types/props/utils.rb
+++ b/gems/sorbet-runtime/lib/types/props/utils.rb
@@ -5,20 +5,25 @@ module T::Props::Utils
   # Deep copy an object. The object must consist of Ruby primitive
   # types and Hashes and Arrays.
   def self.deep_clone_object(what, freeze: false)
-    result = case what
-    when true
-      true
-    when false
-      false
-    when Symbol, NilClass, Numeric
+    freeze ? deep_clone_freeze(what) : deep_clone(what)
+  end
+
+  # deep_clone_object with freeze: false. Kept kwarg-free, with String (the
+  # most common serialized scalar) tested first: this is what generated
+  # serializers/deserializers emit for dynamic fallbacks, so it runs per
+  # element of every untyped container prop.
+  def self.deep_clone(what)
+    case what
+    when String
+      what.clone
+    when true, false, Symbol, NilClass, Numeric
       what
     when Array
-      what.map { |v| deep_clone_object(v, freeze: freeze) }
+      what.map { |v| deep_clone(v) }
     when Hash
       h = what.class.new
-      what.each do |k, v|
-        k.freeze if freeze
-        h[k] = deep_clone_object(v, freeze: freeze)
+      what.each_pair do |k, v|
+        h[k] = deep_clone(v)
       end
       h
     when Regexp
@@ -28,7 +33,30 @@ module T::Props::Utils
     else
       what.clone
     end
-    freeze ? result.freeze : result
+  end
+
+  # deep_clone_object with freeze: true.
+  def self.deep_clone_freeze(what)
+    result = case what
+    when true, false, Symbol, NilClass, Numeric
+      what
+    when Array
+      what.map { |v| deep_clone_freeze(v) }
+    when Hash
+      h = what.class.new
+      what.each_pair do |k, v|
+        k.freeze
+        h[k] = deep_clone_freeze(v)
+      end
+      h
+    when Regexp
+      what.dup
+    when T::Enum
+      what
+    else
+      what.clone
+    end
+    result.freeze
   end
 
   # The prop_rules indicate whether we should check for reading a nil value for the prop/field.

--- a/gems/sorbet-runtime/lib/types/props/weak_constructor.rb
+++ b/gems/sorbet-runtime/lib/types/props/weak_constructor.rb
@@ -5,9 +5,14 @@ module T::Props::WeakConstructor
   include T::Props::Optional
   extend T::Sig
 
+  # Shared default so zero-arg construction doesn't allocate a fresh Hash;
+  # the construct_props_* methods only ever read from `hash`.
+  EMPTY_HASH = T.let({}.freeze, T::Hash[Symbol, T.untyped])
+  private_constant :EMPTY_HASH
+
   # checked(:never) - O(runtime object construction)
   sig { params(hash: T::Hash[Symbol, T.untyped]).void.checked(:never) }
-  def initialize(hash={})
+  def initialize(hash=EMPTY_HASH)
     decorator = self.class.decorator
 
     hash_keys_matching_props = decorator.construct_props_with_defaults(self, hash) +

--- a/gems/sorbet-runtime/lib/types/props/weak_constructor.rb
+++ b/gems/sorbet-runtime/lib/types/props/weak_constructor.rb
@@ -38,9 +38,9 @@ module T::Props::WeakConstructor::DecoratorMethods
     # Use `each_pair` rather than `count` because, as of Ruby 2.6, the latter delegates to Enumerator
     # and therefore allocates for each entry.
     result = 0
-    props_without_defaults&.each_pair do |p, setter_proc|
+    props_without_defaults&.each_pair do |p, bound_setter|
       if hash.key?(p)
-        instance.instance_exec(hash[p], &setter_proc)
+        bound_setter.call(instance, hash[p])
         result += 1
       end
     end
@@ -61,7 +61,7 @@ module T::Props::WeakConstructor::DecoratorMethods
     result = 0
     props_with_defaults&.each_pair do |p, default_struct|
       if hash.key?(p)
-        instance.instance_exec(hash[p], &default_struct.setter_proc)
+        default_struct.bound_setter_proc.call(instance, hash[p])
         result += 1
       else
         default_struct.set_default(instance)

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -263,7 +263,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
 
       assert_includes(e.message.tr("`", "'"), "undefined method 'transform_values'")
       assert_includes(e.message, "foo")
-      assert_includes(e.message, "val.transform_values {|v| T::Props::Utils.deep_clone_object(v)}")
+      assert_includes(e.message, "val.transform_values {|v| T::Props::Utils.deep_clone(v)}")
     end
 
     it 'includes relevant generated code on serialize' do
@@ -274,7 +274,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       end
 
       assert_includes(e.message.tr("`", "'"), "undefined method 'transform_values'")
-      assert_includes(e.message, 'h["foo"] = @foo.transform_values {|v| T::Props::Utils.deep_clone_object(v)}')
+      assert_includes(e.message, 'h["foo"] = @foo.transform_values {|v| T::Props::Utils.deep_clone(v)}')
     end
 
     it 'handles exceptions without a #backtrace_locations' do
@@ -290,7 +290,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       end
 
       assert_includes(e.message.tr("`", "'"), "undefined method 'transform_values'")
-      assert_includes(e.message, 'h["foo"] = @foo.transform_values {|v| T::Props::Utils.deep_clone_object(v)}')
+      assert_includes(e.message, 'h["foo"] = @foo.transform_values {|v| T::Props::Utils.deep_clone(v)}')
     end
   end
 
@@ -587,7 +587,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
 
   describe 'boolean props' do
     it 'are not cloned on serde' do
-      T::Props::Utils.expects(:deep_clone_object).never
+      T::Props::Utils.expects(:deep_clone).never
 
       s = BooleanStruct.new(prop: true)
       assert_equal(true, BooleanStruct.from_hash(s.serialize).prop)
@@ -600,7 +600,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
 
   describe 'heterogenous union props' do
     it 'are cloned on serde' do
-      T::Props::Utils.expects(:deep_clone_object).with('foo').at_least_once.returns('foo')
+      T::Props::Utils.expects(:deep_clone).with('foo').at_least_once.returns('foo')
 
       s = HeterogenousUnionStruct.new(prop: 'foo')
       assert_equal('foo', HeterogenousUnionStruct.from_hash(s.serialize).prop)
@@ -614,7 +614,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
   describe 'unions of two different serializables' do
     it 'are just cloned on serde' do
       obj = MyNilableSerializable.new
-      T::Props::Utils.expects(:deep_clone_object).with(obj).at_least_once.returns(obj)
+      T::Props::Utils.expects(:deep_clone).with(obj).at_least_once.returns(obj)
 
       s = MultipleStructUnionStruct.new(prop: obj)
       assert_equal(obj, MultipleStructUnionStruct.from_hash(s.serialize).prop)
@@ -1182,7 +1182,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
 
     it 'is cloned on serde by default' do
       val = ModulePropStruct::ConcreteNonScalar.new
-      T::Props::Utils.expects(:deep_clone_object).with(val).returns(val).at_least_once
+      T::Props::Utils.expects(:deep_clone).with(val).returns(val).at_least_once
 
       s = ModulePropStruct.new(nonscalar: val)
       assert_equal(val, ModulePropStruct.from_hash(s.serialize).nonscalar)
@@ -1190,7 +1190,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
 
     it 'is not cloned on serde if set as scalar' do
       val = ModulePropStruct::ConcreteScalar.new
-      T::Props::Utils.expects(:deep_clone_object).never
+      T::Props::Utils.expects(:deep_clone).never
 
       s = ModulePropStruct.new(scalar: val)
       assert_equal(val, ModulePropStruct.from_hash(s.serialize).scalar)

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -1242,6 +1242,17 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       obj2 = DefaultStringProp.from_hash(h)
       refute_equal(obj1.stringprop.object_id, obj2.stringprop.object_id)
     end
+
+    it 'returns mutable string defaults from the lazily-eval\'d deserializer' do
+      # The generated deserializer inlines the default as a bare string
+      # literal, and the lazily-eval'd source must not carry a
+      # frozen_string_literal prefix: that would freeze (and dedupe) the
+      # literal, so instances would share one frozen default.
+      obj1 = DefaultStringProp.from_hash({})
+      refute_predicate(obj1.stringprop, :frozen?)
+      obj1.stringprop << ' mutated'
+      assert_equal('default', DefaultStringProp.from_hash({}).stringprop)
+    end
   end
 
   class ComplexStruct < T::Struct


### PR DESCRIPTION
**Stack (bottom → top):** #10359 → #10362 → **#10363 (this)** → #10364

`T::Props` optimizations. One commit per optimization, as requested in review:

- Stop allocating hash-key strings in lazily-eval'd generated deserializers.
- Runtime trims: split `deep_clone` from `deep_clone_object`, `scalar_type?` alloc reduction, shared empty-hash default.
- Boot/decl-time: `model_inherited` hoists, lazy-method enqueue dedup, props-hash dup-store-freeze instead of merge.
- 2-arity bound setter procs for `prop_set` and all construction paths (no more per-call `instance_exec` self-rebinding).
- Drop the load-bearing `:setter_proc` rules-hash key (now an internal underscore-prefixed `:_setter_proc` used only for the generated `name=` setter's fast path) and the never-read `ApplyDefault#setter_proc` reader.

Includes the `serializable` test updates for the `deep_clone` rename (these fail on master, so they live here rather than in the tests PR).
