### PR TITLE
Sorbet optimizations (4/4): call_validation

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -523,8 +523,8 @@ module T::Private::Methods
   end
 
   private_class_method def self.unwrap_method(mod, signature, original_method)
-    CallValidation.wrap_method_if_needed(mod, signature, original_method)
-    @signatures_by_method[method_to_key(mod.instance_method(signature.method_name))] = signature
+    maybe_wrapped_method = CallValidation.wrap_method_if_needed(mod, signature, original_method)
+    @signatures_by_method[method_to_key(maybe_wrapped_method)] = signature
   end
 
   def self.has_sig_block_for_method(method)

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -523,8 +523,8 @@ module T::Private::Methods
   end
 
   private_class_method def self.unwrap_method(mod, signature, original_method)
-    maybe_wrapped_method = CallValidation.wrap_method_if_needed(mod, signature, original_method)
-    @signatures_by_method[method_to_key(maybe_wrapped_method)] = signature
+    CallValidation.wrap_method_if_needed(mod, signature, original_method)
+    @signatures_by_method[method_to_key(mod.instance_method(signature.method_name))] = signature
   end
 
   def self.has_sig_block_for_method(method)

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -72,8 +72,16 @@ module T::Private::Methods::CallValidation
   end
 
   def self.create_validator_method(mod, original_method, method_sig, original_visibility)
+    # Wrapper-shape decisions must read the parameters of the method actually being wrapped, not
+    # `method_sig.parameters` (captured at sig-build time). The two diverge when a sig'd method is
+    # re-wrapped over a different implementation: a stub redefined as `def m(*args, **kwargs, &blk)`
+    # then re-validated against the original fixed-arity sig would otherwise pick a fixed-arity wrapper,
+    # which binds args to named positionals and forwards them without the `ruby2_keywords` flag, turning
+    # a trailing `key: val` into a positional hash. Reading from `original_method` costs one array per
+    # wrap, off the hot path.
+    parameters = original_method.parameters
     has_fixed_arity = method_sig.kwarg_types.empty? && method_sig.rest_type.nil? && method_sig.keyrest_type.nil? &&
-      original_method.parameters.all? { |(kind, _name)| kind == :req || kind == :block }
+      parameters.all? { |(kind, _name)| kind == :req || kind == :block }
 
     # nil implies block_type.nil?
     # true implies !block_type.nil? and block_type.valid?(nil)
@@ -82,6 +90,29 @@ module T::Private::Methods::CallValidation
     can_skip_block_type = method_sig.block_type&.valid?(nil) != false
 
     ok_for_fast_path = has_fixed_arity && can_skip_block_type && !method_sig.bind && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path
+
+    # Like `ok_for_fast_path`, but for the specialized wrappers below, each of
+    # which supports exactly one extra call shape (kwargs, a required block, or
+    # optional positional args) on top of what the fast/medium wrappers support.
+    ok_for_specialized_path = !ok_for_fast_path && !method_sig.bind && method_sig.rest_type.nil? &&
+      method_sig.keyrest_type.nil? && method_sig.arg_types.length < 5 && is_allowed_to_have_fast_path
+
+    # Restricted to methods with no positional args. The kwargs wrapper's `|**kwargs, &blk|` declares a
+    # keyword-rest, which would capture a bare `key: val` hash that a method with a positional parameter
+    # expects to receive positionally, starving that parameter. All-kwargs methods have no such parameter,
+    # so the wrapper matches a direct call. (Most kwargs-shaped sigs take only kwargs.)
+    kwargs_path = ok_for_specialized_path && can_skip_block_type && !method_sig.kwarg_types.empty? &&
+      method_sig.arg_types.empty? &&
+      parameters.all? { |(kind, _name)| kind == :key || kind == :keyreq || kind == :block }
+
+    required_block_path = ok_for_specialized_path && !can_skip_block_type && has_fixed_arity
+
+    # At least one param is `:opt` here (otherwise `ok_for_fast_path` would hold). The wrapper forwards
+    # through a `ruby2_keywords`-flagged `|*args, &blk|` splat (see below), not named optional parameters:
+    # named params have no `*rest` for `def_with_visibility` to flag, so a trailing `key: val` that Ruby
+    # packs into an optional positional would lose the keyword flag the slow path preserves.
+    optional_args_path = ok_for_specialized_path && can_skip_block_type && method_sig.kwarg_types.empty? &&
+      parameters.all? { |(kind, _name)| kind == :req || kind == :opt || kind == :block }
 
     all_args_are_simple = ok_for_fast_path && method_sig.arg_types.all? { |_name, type| type.is_a?(T::Types::Simple) }
 
@@ -115,6 +146,12 @@ module T::Private::Methods::CallValidation
           create_validator_method_skip_return_medium(mod, original_method, method_sig, original_visibility)
         elsif ok_for_fast_path
           create_validator_method_medium(mod, original_method, method_sig, original_visibility)
+        elsif kwargs_path
+          create_validator_method_kwargs(mod, original_method, method_sig, original_visibility)
+        elsif required_block_path
+          create_validator_method_with_block(mod, original_method, method_sig, original_visibility)
+        elsif optional_args_path
+          create_validator_method_optional_args(mod, original_method, method_sig, original_visibility)
         elsif can_skip_block_type
           # The Ruby VM already validates that any block passed to a method
           # must be either `nil` or a `Proc` object, so there's no need to also
@@ -126,6 +163,67 @@ module T::Private::Methods::CallValidation
       end
       mod.send(original_visibility, method_sig.method_name)
     end
+  end
+
+  def self.create_validator_method_kwargs(mod, original_method, method_sig, original_visibility)
+    # `kwargs_path` requires `arg_types.empty?`, so the wrapper only ever covers the all-kwargs shape.
+    # `nil` for `return_type` means the method is `.void` (the wrapper returns Void::VOID without
+    # validating the return).
+    return_type = method_sig.effective_return_type
+    return_type = nil if return_type.is_a?(T::Private::Types::Void)
+    create_validator_method_kwargs0(mod, original_method, method_sig, original_visibility, return_type, method_sig.kwarg_types)
+  end
+
+  def self.create_validator_method_with_block(mod, original_method, method_sig, original_visibility)
+    # `nil` for `return_type` means the method is `.void` (the wrapper then
+    # returns `T::Private::Types::Void::VOID` without validating the return).
+    return_type = method_sig.effective_return_type
+    return_type = nil if return_type.is_a?(T::Private::Types::Void)
+    block_type = method_sig.block_type
+    # trampoline to reduce stack frame size
+    arg_types = method_sig.arg_types
+    case arg_types.length
+    when 0
+      create_validator_method_with_block0(mod, original_method, method_sig, original_visibility, return_type, block_type)
+    when 1
+      create_validator_method_with_block1(mod, original_method, method_sig, original_visibility, return_type, block_type,
+                                          arg_types[0][1])
+    when 2
+      create_validator_method_with_block2(mod, original_method, method_sig, original_visibility, return_type, block_type,
+                                          arg_types[0][1],
+                                          arg_types[1][1])
+    when 3
+      create_validator_method_with_block3(mod, original_method, method_sig, original_visibility, return_type, block_type,
+                                          arg_types[0][1],
+                                          arg_types[1][1],
+                                          arg_types[2][1])
+    when 4
+      create_validator_method_with_block4(mod, original_method, method_sig, original_visibility, return_type, block_type,
+                                          arg_types[0][1],
+                                          arg_types[1][1],
+                                          arg_types[2][1],
+                                          arg_types[3][1])
+    else
+      raise 'should not happen'
+    end
+  end
+
+  def self.create_validator_method_optional_args(mod, original_method, method_sig, original_visibility)
+    # `nil` for `return_type` means the method is `.void` (the wrapper then
+    # returns `T::Private::Types::Void::VOID` without validating the return).
+    return_type = method_sig.effective_return_type
+    return_type = nil if return_type.is_a?(T::Private::Types::Void)
+    # trampoline to reduce stack frame size
+    arg_types = method_sig.arg_types
+    arg_count = arg_types.length
+    if arg_count > 4 || method_sig.req_arg_count >= arg_count
+      raise 'should not happen'
+    end
+    send(
+      :"create_validator_method_optional_args#{method_sig.req_arg_count}_#{arg_count}",
+      mod, original_method, method_sig, original_visibility, return_type,
+      *arg_types.map { |_name, type| type }
+    )
   end
 
   def self.create_validator_slow_skip_block_type(mod, original_method, method_sig, original_visibility)

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -165,67 +165,6 @@ module T::Private::Methods::CallValidation
     end
   end
 
-  def self.create_validator_method_kwargs(mod, original_method, method_sig, original_visibility)
-    # `kwargs_path` requires `arg_types.empty?`, so the wrapper only ever covers the all-kwargs shape.
-    # `nil` for `return_type` means the method is `.void` (the wrapper returns Void::VOID without
-    # validating the return).
-    return_type = method_sig.effective_return_type
-    return_type = nil if return_type.is_a?(T::Private::Types::Void)
-    create_validator_method_kwargs0(mod, original_method, method_sig, original_visibility, return_type, method_sig.kwarg_types)
-  end
-
-  def self.create_validator_method_with_block(mod, original_method, method_sig, original_visibility)
-    # `nil` for `return_type` means the method is `.void` (the wrapper then
-    # returns `T::Private::Types::Void::VOID` without validating the return).
-    return_type = method_sig.effective_return_type
-    return_type = nil if return_type.is_a?(T::Private::Types::Void)
-    block_type = method_sig.block_type
-    # trampoline to reduce stack frame size
-    arg_types = method_sig.arg_types
-    case arg_types.length
-    when 0
-      create_validator_method_with_block0(mod, original_method, method_sig, original_visibility, return_type, block_type)
-    when 1
-      create_validator_method_with_block1(mod, original_method, method_sig, original_visibility, return_type, block_type,
-                                          arg_types[0][1])
-    when 2
-      create_validator_method_with_block2(mod, original_method, method_sig, original_visibility, return_type, block_type,
-                                          arg_types[0][1],
-                                          arg_types[1][1])
-    when 3
-      create_validator_method_with_block3(mod, original_method, method_sig, original_visibility, return_type, block_type,
-                                          arg_types[0][1],
-                                          arg_types[1][1],
-                                          arg_types[2][1])
-    when 4
-      create_validator_method_with_block4(mod, original_method, method_sig, original_visibility, return_type, block_type,
-                                          arg_types[0][1],
-                                          arg_types[1][1],
-                                          arg_types[2][1],
-                                          arg_types[3][1])
-    else
-      raise 'should not happen'
-    end
-  end
-
-  def self.create_validator_method_optional_args(mod, original_method, method_sig, original_visibility)
-    # `nil` for `return_type` means the method is `.void` (the wrapper then
-    # returns `T::Private::Types::Void::VOID` without validating the return).
-    return_type = method_sig.effective_return_type
-    return_type = nil if return_type.is_a?(T::Private::Types::Void)
-    # trampoline to reduce stack frame size
-    arg_types = method_sig.arg_types
-    arg_count = arg_types.length
-    if arg_count > 4 || method_sig.req_arg_count >= arg_count
-      raise 'should not happen'
-    end
-    send(
-      :"create_validator_method_optional_args#{method_sig.req_arg_count}_#{arg_count}",
-      mod, original_method, method_sig, original_visibility, return_type,
-      *arg_types.map { |_name, type| type }
-    )
-  end
-
   def self.create_validator_slow_skip_block_type(mod, original_method, method_sig, original_visibility)
     T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |*args, &blk|
       CallValidation.validate_call_skip_block_type(self, original_method, method_sig, args, blk)

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation_2_7.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation_2_7.rb
@@ -1726,6 +1726,12 @@ module T::Private::Methods::CallValidation
     end
   end
 
+  def self.create_validator_method_kwargs(mod, original_method, method_sig, original_visibility)
+    return_type = method_sig.effective_return_type
+    return_type = nil if return_type.is_a?(T::Private::Types::Void)
+    create_validator_method_kwargs0(mod, original_method, method_sig, original_visibility, return_type, method_sig.kwarg_types)
+  end
+
   def self.create_validator_method_kwargs0(mod, original_method, method_sig, original_visibility, return_type, kwarg_types)
     T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |**kwargs, &blk|
       # This method is a manually sped-up version of more general code in `validate_call`
@@ -1765,6 +1771,38 @@ module T::Private::Methods::CallValidation
         end
         return_value
       end
+    end
+  end
+
+  def self.create_validator_method_with_block(mod, original_method, method_sig, original_visibility)
+    return_type = method_sig.effective_return_type
+    return_type = nil if return_type.is_a?(T::Private::Types::Void)
+    block_type = method_sig.block_type
+    # trampoline to reduce stack frame size
+    arg_types = method_sig.arg_types
+    case arg_types.length
+    when 0
+      create_validator_method_with_block0(mod, original_method, method_sig, original_visibility, return_type, block_type)
+    when 1
+      create_validator_method_with_block1(mod, original_method, method_sig, original_visibility, return_type, block_type,
+                                          arg_types[0][1])
+    when 2
+      create_validator_method_with_block2(mod, original_method, method_sig, original_visibility, return_type, block_type,
+                                          arg_types[0][1],
+                                          arg_types[1][1])
+    when 3
+      create_validator_method_with_block3(mod, original_method, method_sig, original_visibility, return_type, block_type,
+                                          arg_types[0][1],
+                                          arg_types[1][1],
+                                          arg_types[2][1])
+    when 4
+      create_validator_method_with_block4(mod, original_method, method_sig, original_visibility, return_type, block_type,
+                                          arg_types[0][1],
+                                          arg_types[1][1],
+                                          arg_types[2][1],
+                                          arg_types[3][1])
+    else
+      raise 'should not happen'
     end
   end
 
@@ -2060,6 +2098,67 @@ module T::Private::Methods::CallValidation
         end
         return_value
       end
+    end
+  end
+
+  def self.create_validator_method_optional_args(mod, original_method, method_sig, original_visibility)
+    return_type = method_sig.effective_return_type
+    return_type = nil if return_type.is_a?(T::Private::Types::Void)
+    # trampoline to reduce stack frame size
+    arg_types = method_sig.arg_types
+    case [method_sig.req_arg_count, arg_types.length]
+    when [0, 1]
+      create_validator_method_optional_args0_1(mod, original_method, method_sig, original_visibility, return_type,
+                                                arg_types[0][1])
+    when [0, 2]
+      create_validator_method_optional_args0_2(mod, original_method, method_sig, original_visibility, return_type,
+                                                arg_types[0][1],
+                                                arg_types[1][1])
+    when [1, 2]
+      create_validator_method_optional_args1_2(mod, original_method, method_sig, original_visibility, return_type,
+                                                arg_types[0][1],
+                                                arg_types[1][1])
+    when [0, 3]
+      create_validator_method_optional_args0_3(mod, original_method, method_sig, original_visibility, return_type,
+                                                arg_types[0][1],
+                                                arg_types[1][1],
+                                                arg_types[2][1])
+    when [1, 3]
+      create_validator_method_optional_args1_3(mod, original_method, method_sig, original_visibility, return_type,
+                                                arg_types[0][1],
+                                                arg_types[1][1],
+                                                arg_types[2][1])
+    when [2, 3]
+      create_validator_method_optional_args2_3(mod, original_method, method_sig, original_visibility, return_type,
+                                                arg_types[0][1],
+                                                arg_types[1][1],
+                                                arg_types[2][1])
+    when [0, 4]
+      create_validator_method_optional_args0_4(mod, original_method, method_sig, original_visibility, return_type,
+                                                arg_types[0][1],
+                                                arg_types[1][1],
+                                                arg_types[2][1],
+                                                arg_types[3][1])
+    when [1, 4]
+      create_validator_method_optional_args1_4(mod, original_method, method_sig, original_visibility, return_type,
+                                                arg_types[0][1],
+                                                arg_types[1][1],
+                                                arg_types[2][1],
+                                                arg_types[3][1])
+    when [2, 4]
+      create_validator_method_optional_args2_4(mod, original_method, method_sig, original_visibility, return_type,
+                                                arg_types[0][1],
+                                                arg_types[1][1],
+                                                arg_types[2][1],
+                                                arg_types[3][1])
+    when [3, 4]
+      create_validator_method_optional_args3_4(mod, original_method, method_sig, original_visibility, return_type,
+                                                arg_types[0][1],
+                                                arg_types[1][1],
+                                                arg_types[2][1],
+                                                arg_types[3][1])
+    else
+      raise 'should not happen'
     end
   end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation_2_7.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation_2_7.rb
@@ -1726,4 +1726,931 @@ module T::Private::Methods::CallValidation
     end
   end
 
+  def self.create_validator_method_kwargs0(mod, original_method, method_sig, original_visibility, return_type, kwarg_types)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |**kwargs, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      # NOTE: like `validate_call`, we don't validate for missing or extra
+      # kwargs; the `bind_call` below takes care of that.
+      kwargs.each do |name, val|
+        type = kwarg_types[name]
+        next unless type
+        next if type.valid?(val)
+        CallValidation.report_error(
+          method_sig,
+          type.error_message_for_obj(val),
+          'Parameter',
+          name,
+          type,
+          val,
+          caller_offset: 1
+        )
+      end
+      return_value = original_method.bind_call(self, **kwargs, &blk)
+      if return_type.nil?
+        T::Private::Types::Void::VOID
+      else
+        unless return_type.valid?(return_value)
+          message = method_sig.effective_return_type.error_message_for_obj(return_value)
+          if message
+            CallValidation.report_error(
+              method_sig,
+              message,
+              'Return value',
+              nil,
+              method_sig.effective_return_type,
+              return_value,
+              caller_offset: -1
+            )
+          end
+        end
+        return_value
+      end
+    end
+  end
+
+  def self.create_validator_method_with_block0(mod, original_method, method_sig, original_visibility, return_type, block_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |&blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      if blk.nil?
+        CallValidation.report_error(
+          method_sig,
+          block_type.error_message_for_obj(blk),
+          'Block parameter',
+          method_sig.block_name,
+          block_type,
+          blk,
+          caller_offset: -1
+        )
+      end
+      return_value = original_method.bind_call(self, &blk)
+      if return_type.nil?
+        T::Private::Types::Void::VOID
+      else
+        unless return_type.valid?(return_value)
+          message = method_sig.effective_return_type.error_message_for_obj(return_value)
+          if message
+            CallValidation.report_error(
+              method_sig,
+              message,
+              'Return value',
+              nil,
+              method_sig.effective_return_type,
+              return_value,
+              caller_offset: -1
+            )
+          end
+        end
+        return_value
+      end
+    end
+  end
+
+  def self.create_validator_method_with_block1(mod, original_method, method_sig, original_visibility, return_type, block_type, arg0_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0_type.valid?(arg0)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+      if blk.nil?
+        CallValidation.report_error(
+          method_sig,
+          block_type.error_message_for_obj(blk),
+          'Block parameter',
+          method_sig.block_name,
+          block_type,
+          blk,
+          caller_offset: -1
+        )
+      end
+      return_value = original_method.bind_call(self, arg0, &blk)
+      if return_type.nil?
+        T::Private::Types::Void::VOID
+      else
+        unless return_type.valid?(return_value)
+          message = method_sig.effective_return_type.error_message_for_obj(return_value)
+          if message
+            CallValidation.report_error(
+              method_sig,
+              message,
+              'Return value',
+              nil,
+              method_sig.effective_return_type,
+              return_value,
+              caller_offset: -1
+            )
+          end
+        end
+        return_value
+      end
+    end
+  end
+
+  def self.create_validator_method_with_block2(mod, original_method, method_sig, original_visibility, return_type, block_type, arg0_type, arg1_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, arg1, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0_type.valid?(arg0)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+      unless arg1_type.valid?(arg1)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(arg1),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          arg1,
+          caller_offset: -1
+        )
+      end
+      if blk.nil?
+        CallValidation.report_error(
+          method_sig,
+          block_type.error_message_for_obj(blk),
+          'Block parameter',
+          method_sig.block_name,
+          block_type,
+          blk,
+          caller_offset: -1
+        )
+      end
+      return_value = original_method.bind_call(self, arg0, arg1, &blk)
+      if return_type.nil?
+        T::Private::Types::Void::VOID
+      else
+        unless return_type.valid?(return_value)
+          message = method_sig.effective_return_type.error_message_for_obj(return_value)
+          if message
+            CallValidation.report_error(
+              method_sig,
+              message,
+              'Return value',
+              nil,
+              method_sig.effective_return_type,
+              return_value,
+              caller_offset: -1
+            )
+          end
+        end
+        return_value
+      end
+    end
+  end
+
+  def self.create_validator_method_with_block3(mod, original_method, method_sig, original_visibility, return_type, block_type, arg0_type, arg1_type, arg2_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, arg1, arg2, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0_type.valid?(arg0)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+      unless arg1_type.valid?(arg1)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(arg1),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          arg1,
+          caller_offset: -1
+        )
+      end
+      unless arg2_type.valid?(arg2)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[2][1].error_message_for_obj(arg2),
+          'Parameter',
+          method_sig.arg_types[2][0],
+          arg2_type,
+          arg2,
+          caller_offset: -1
+        )
+      end
+      if blk.nil?
+        CallValidation.report_error(
+          method_sig,
+          block_type.error_message_for_obj(blk),
+          'Block parameter',
+          method_sig.block_name,
+          block_type,
+          blk,
+          caller_offset: -1
+        )
+      end
+      return_value = original_method.bind_call(self, arg0, arg1, arg2, &blk)
+      if return_type.nil?
+        T::Private::Types::Void::VOID
+      else
+        unless return_type.valid?(return_value)
+          message = method_sig.effective_return_type.error_message_for_obj(return_value)
+          if message
+            CallValidation.report_error(
+              method_sig,
+              message,
+              'Return value',
+              nil,
+              method_sig.effective_return_type,
+              return_value,
+              caller_offset: -1
+            )
+          end
+        end
+        return_value
+      end
+    end
+  end
+
+  def self.create_validator_method_with_block4(mod, original_method, method_sig, original_visibility, return_type, block_type, arg0_type, arg1_type, arg2_type, arg3_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |arg0, arg1, arg2, arg3, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0_type.valid?(arg0)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(arg0),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          arg0,
+          caller_offset: -1
+        )
+      end
+      unless arg1_type.valid?(arg1)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(arg1),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          arg1,
+          caller_offset: -1
+        )
+      end
+      unless arg2_type.valid?(arg2)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[2][1].error_message_for_obj(arg2),
+          'Parameter',
+          method_sig.arg_types[2][0],
+          arg2_type,
+          arg2,
+          caller_offset: -1
+        )
+      end
+      unless arg3_type.valid?(arg3)
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[3][1].error_message_for_obj(arg3),
+          'Parameter',
+          method_sig.arg_types[3][0],
+          arg3_type,
+          arg3,
+          caller_offset: -1
+        )
+      end
+      if blk.nil?
+        CallValidation.report_error(
+          method_sig,
+          block_type.error_message_for_obj(blk),
+          'Block parameter',
+          method_sig.block_name,
+          block_type,
+          blk,
+          caller_offset: -1
+        )
+      end
+      return_value = original_method.bind_call(self, arg0, arg1, arg2, arg3, &blk)
+      if return_type.nil?
+        T::Private::Types::Void::VOID
+      else
+        unless return_type.valid?(return_value)
+          message = method_sig.effective_return_type.error_message_for_obj(return_value)
+          if message
+            CallValidation.report_error(
+              method_sig,
+              message,
+              'Return value',
+              nil,
+              method_sig.effective_return_type,
+              return_value,
+              caller_offset: -1
+            )
+          end
+        end
+        return_value
+      end
+    end
+  end
+
+  def self.create_validator_method_optional_args0_1(mod, original_method, method_sig, original_visibility, return_type, arg0_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |*args, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless args.empty? || arg0_type.valid?(args[0])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(args[0]),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          args[0],
+          caller_offset: -1
+        )
+      end
+      return_value = original_method.bind_call(self, *args, &blk)
+      if return_type.nil?
+        T::Private::Types::Void::VOID
+      else
+        unless return_type.valid?(return_value)
+          message = method_sig.effective_return_type.error_message_for_obj(return_value)
+          if message
+            CallValidation.report_error(
+              method_sig,
+              message,
+              'Return value',
+              nil,
+              method_sig.effective_return_type,
+              return_value,
+              caller_offset: -1
+            )
+          end
+        end
+        return_value
+      end
+    end
+  end
+
+  def self.create_validator_method_optional_args0_2(mod, original_method, method_sig, original_visibility, return_type, arg0_type, arg1_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |*args, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless args.empty? || arg0_type.valid?(args[0])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(args[0]),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          args[0],
+          caller_offset: -1
+        )
+      end
+      unless args.length <= 1 || arg1_type.valid?(args[1])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(args[1]),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          args[1],
+          caller_offset: -1
+        )
+      end
+      return_value = original_method.bind_call(self, *args, &blk)
+      if return_type.nil?
+        T::Private::Types::Void::VOID
+      else
+        unless return_type.valid?(return_value)
+          message = method_sig.effective_return_type.error_message_for_obj(return_value)
+          if message
+            CallValidation.report_error(
+              method_sig,
+              message,
+              'Return value',
+              nil,
+              method_sig.effective_return_type,
+              return_value,
+              caller_offset: -1
+            )
+          end
+        end
+        return_value
+      end
+    end
+  end
+
+  def self.create_validator_method_optional_args1_2(mod, original_method, method_sig, original_visibility, return_type, arg0_type, arg1_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |*args, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0_type.valid?(args[0])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(args[0]),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          args[0],
+          caller_offset: -1
+        )
+      end
+      unless args.length <= 1 || arg1_type.valid?(args[1])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(args[1]),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          args[1],
+          caller_offset: -1
+        )
+      end
+      return_value = original_method.bind_call(self, *args, &blk)
+      if return_type.nil?
+        T::Private::Types::Void::VOID
+      else
+        unless return_type.valid?(return_value)
+          message = method_sig.effective_return_type.error_message_for_obj(return_value)
+          if message
+            CallValidation.report_error(
+              method_sig,
+              message,
+              'Return value',
+              nil,
+              method_sig.effective_return_type,
+              return_value,
+              caller_offset: -1
+            )
+          end
+        end
+        return_value
+      end
+    end
+  end
+
+  def self.create_validator_method_optional_args0_3(mod, original_method, method_sig, original_visibility, return_type, arg0_type, arg1_type, arg2_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |*args, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless args.empty? || arg0_type.valid?(args[0])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(args[0]),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          args[0],
+          caller_offset: -1
+        )
+      end
+      unless args.length <= 1 || arg1_type.valid?(args[1])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(args[1]),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          args[1],
+          caller_offset: -1
+        )
+      end
+      unless args.length <= 2 || arg2_type.valid?(args[2])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[2][1].error_message_for_obj(args[2]),
+          'Parameter',
+          method_sig.arg_types[2][0],
+          arg2_type,
+          args[2],
+          caller_offset: -1
+        )
+      end
+      return_value = original_method.bind_call(self, *args, &blk)
+      if return_type.nil?
+        T::Private::Types::Void::VOID
+      else
+        unless return_type.valid?(return_value)
+          message = method_sig.effective_return_type.error_message_for_obj(return_value)
+          if message
+            CallValidation.report_error(
+              method_sig,
+              message,
+              'Return value',
+              nil,
+              method_sig.effective_return_type,
+              return_value,
+              caller_offset: -1
+            )
+          end
+        end
+        return_value
+      end
+    end
+  end
+
+  def self.create_validator_method_optional_args1_3(mod, original_method, method_sig, original_visibility, return_type, arg0_type, arg1_type, arg2_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |*args, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0_type.valid?(args[0])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(args[0]),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          args[0],
+          caller_offset: -1
+        )
+      end
+      unless args.length <= 1 || arg1_type.valid?(args[1])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(args[1]),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          args[1],
+          caller_offset: -1
+        )
+      end
+      unless args.length <= 2 || arg2_type.valid?(args[2])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[2][1].error_message_for_obj(args[2]),
+          'Parameter',
+          method_sig.arg_types[2][0],
+          arg2_type,
+          args[2],
+          caller_offset: -1
+        )
+      end
+      return_value = original_method.bind_call(self, *args, &blk)
+      if return_type.nil?
+        T::Private::Types::Void::VOID
+      else
+        unless return_type.valid?(return_value)
+          message = method_sig.effective_return_type.error_message_for_obj(return_value)
+          if message
+            CallValidation.report_error(
+              method_sig,
+              message,
+              'Return value',
+              nil,
+              method_sig.effective_return_type,
+              return_value,
+              caller_offset: -1
+            )
+          end
+        end
+        return_value
+      end
+    end
+  end
+
+  def self.create_validator_method_optional_args2_3(mod, original_method, method_sig, original_visibility, return_type, arg0_type, arg1_type, arg2_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |*args, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0_type.valid?(args[0])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(args[0]),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          args[0],
+          caller_offset: -1
+        )
+      end
+      unless arg1_type.valid?(args[1])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(args[1]),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          args[1],
+          caller_offset: -1
+        )
+      end
+      unless args.length <= 2 || arg2_type.valid?(args[2])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[2][1].error_message_for_obj(args[2]),
+          'Parameter',
+          method_sig.arg_types[2][0],
+          arg2_type,
+          args[2],
+          caller_offset: -1
+        )
+      end
+      return_value = original_method.bind_call(self, *args, &blk)
+      if return_type.nil?
+        T::Private::Types::Void::VOID
+      else
+        unless return_type.valid?(return_value)
+          message = method_sig.effective_return_type.error_message_for_obj(return_value)
+          if message
+            CallValidation.report_error(
+              method_sig,
+              message,
+              'Return value',
+              nil,
+              method_sig.effective_return_type,
+              return_value,
+              caller_offset: -1
+            )
+          end
+        end
+        return_value
+      end
+    end
+  end
+
+  def self.create_validator_method_optional_args0_4(mod, original_method, method_sig, original_visibility, return_type, arg0_type, arg1_type, arg2_type, arg3_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |*args, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless args.empty? || arg0_type.valid?(args[0])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(args[0]),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          args[0],
+          caller_offset: -1
+        )
+      end
+      unless args.length <= 1 || arg1_type.valid?(args[1])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(args[1]),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          args[1],
+          caller_offset: -1
+        )
+      end
+      unless args.length <= 2 || arg2_type.valid?(args[2])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[2][1].error_message_for_obj(args[2]),
+          'Parameter',
+          method_sig.arg_types[2][0],
+          arg2_type,
+          args[2],
+          caller_offset: -1
+        )
+      end
+      unless args.length <= 3 || arg3_type.valid?(args[3])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[3][1].error_message_for_obj(args[3]),
+          'Parameter',
+          method_sig.arg_types[3][0],
+          arg3_type,
+          args[3],
+          caller_offset: -1
+        )
+      end
+      return_value = original_method.bind_call(self, *args, &blk)
+      if return_type.nil?
+        T::Private::Types::Void::VOID
+      else
+        unless return_type.valid?(return_value)
+          message = method_sig.effective_return_type.error_message_for_obj(return_value)
+          if message
+            CallValidation.report_error(
+              method_sig,
+              message,
+              'Return value',
+              nil,
+              method_sig.effective_return_type,
+              return_value,
+              caller_offset: -1
+            )
+          end
+        end
+        return_value
+      end
+    end
+  end
+
+  def self.create_validator_method_optional_args1_4(mod, original_method, method_sig, original_visibility, return_type, arg0_type, arg1_type, arg2_type, arg3_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |*args, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0_type.valid?(args[0])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(args[0]),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          args[0],
+          caller_offset: -1
+        )
+      end
+      unless args.length <= 1 || arg1_type.valid?(args[1])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(args[1]),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          args[1],
+          caller_offset: -1
+        )
+      end
+      unless args.length <= 2 || arg2_type.valid?(args[2])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[2][1].error_message_for_obj(args[2]),
+          'Parameter',
+          method_sig.arg_types[2][0],
+          arg2_type,
+          args[2],
+          caller_offset: -1
+        )
+      end
+      unless args.length <= 3 || arg3_type.valid?(args[3])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[3][1].error_message_for_obj(args[3]),
+          'Parameter',
+          method_sig.arg_types[3][0],
+          arg3_type,
+          args[3],
+          caller_offset: -1
+        )
+      end
+      return_value = original_method.bind_call(self, *args, &blk)
+      if return_type.nil?
+        T::Private::Types::Void::VOID
+      else
+        unless return_type.valid?(return_value)
+          message = method_sig.effective_return_type.error_message_for_obj(return_value)
+          if message
+            CallValidation.report_error(
+              method_sig,
+              message,
+              'Return value',
+              nil,
+              method_sig.effective_return_type,
+              return_value,
+              caller_offset: -1
+            )
+          end
+        end
+        return_value
+      end
+    end
+  end
+
+  def self.create_validator_method_optional_args2_4(mod, original_method, method_sig, original_visibility, return_type, arg0_type, arg1_type, arg2_type, arg3_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |*args, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0_type.valid?(args[0])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(args[0]),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          args[0],
+          caller_offset: -1
+        )
+      end
+      unless arg1_type.valid?(args[1])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(args[1]),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          args[1],
+          caller_offset: -1
+        )
+      end
+      unless args.length <= 2 || arg2_type.valid?(args[2])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[2][1].error_message_for_obj(args[2]),
+          'Parameter',
+          method_sig.arg_types[2][0],
+          arg2_type,
+          args[2],
+          caller_offset: -1
+        )
+      end
+      unless args.length <= 3 || arg3_type.valid?(args[3])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[3][1].error_message_for_obj(args[3]),
+          'Parameter',
+          method_sig.arg_types[3][0],
+          arg3_type,
+          args[3],
+          caller_offset: -1
+        )
+      end
+      return_value = original_method.bind_call(self, *args, &blk)
+      if return_type.nil?
+        T::Private::Types::Void::VOID
+      else
+        unless return_type.valid?(return_value)
+          message = method_sig.effective_return_type.error_message_for_obj(return_value)
+          if message
+            CallValidation.report_error(
+              method_sig,
+              message,
+              'Return value',
+              nil,
+              method_sig.effective_return_type,
+              return_value,
+              caller_offset: -1
+            )
+          end
+        end
+        return_value
+      end
+    end
+  end
+
+  def self.create_validator_method_optional_args3_4(mod, original_method, method_sig, original_visibility, return_type, arg0_type, arg1_type, arg2_type, arg3_type)
+    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |*args, &blk|
+      # This method is a manually sped-up version of more general code in `validate_call`
+      unless arg0_type.valid?(args[0])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[0][1].error_message_for_obj(args[0]),
+          'Parameter',
+          method_sig.arg_types[0][0],
+          arg0_type,
+          args[0],
+          caller_offset: -1
+        )
+      end
+      unless arg1_type.valid?(args[1])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[1][1].error_message_for_obj(args[1]),
+          'Parameter',
+          method_sig.arg_types[1][0],
+          arg1_type,
+          args[1],
+          caller_offset: -1
+        )
+      end
+      unless arg2_type.valid?(args[2])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[2][1].error_message_for_obj(args[2]),
+          'Parameter',
+          method_sig.arg_types[2][0],
+          arg2_type,
+          args[2],
+          caller_offset: -1
+        )
+      end
+      unless args.length <= 3 || arg3_type.valid?(args[3])
+        CallValidation.report_error(
+          method_sig,
+          method_sig.arg_types[3][1].error_message_for_obj(args[3]),
+          'Parameter',
+          method_sig.arg_types[3][0],
+          arg3_type,
+          args[3],
+          caller_offset: -1
+        )
+      end
+      return_value = original_method.bind_call(self, *args, &blk)
+      if return_type.nil?
+        T::Private::Types::Void::VOID
+      else
+        unless return_type.valid?(return_value)
+          message = method_sig.effective_return_type.error_message_for_obj(return_value)
+          if message
+            CallValidation.report_error(
+              method_sig,
+              message,
+              'Return value',
+              nil,
+              method_sig.effective_return_type,
+              return_value,
+              caller_offset: -1
+            )
+          end
+        end
+        return_value
+      end
+    end
+  end
+
 end

--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
@@ -67,7 +67,9 @@ module T::Private::Methods::SignatureValidation
     super_method = signature.method.super_method
 
     if super_method && super_method.owner != signature.method.owner
-      Methods.maybe_run_sig_block_for_method(super_method)
+      # No need to run the sig block for super_method explicitly:
+      # signature_for_method forces it internally (via signature_for_key ->
+      # maybe_run_sig_block_for_key on the identical registry key).
       super_signature = Methods.signature_for_method(super_method)
 
       # If the super_method has any kwargs we can't build a
@@ -200,7 +202,10 @@ module T::Private::Methods::SignatureValidation
             "#{base_override_loc_str(signature, super_signature)}"
     end
 
-    if signature.keyrest_type.nil?
+    # The kwarg_types.empty? guard is an exact implication (an empty super
+    # kwarg set can never yield missing kwargs) that skips two fresh
+    # `.keys` arrays plus the Array#- for the common kwarg-free method.
+    if signature.keyrest_type.nil? && !super_signature.kwarg_types.empty?
       # O(nm), but n and m are tiny here
       missing_kwargs = super_signature.kwarg_names - signature.kwarg_names
       if !missing_kwargs.empty?
@@ -216,12 +221,15 @@ module T::Private::Methods::SignatureValidation
             "#{base_override_loc_str(signature, super_signature)}"
     end
 
-    # O(nm), but n and m are tiny here
-    extra_req_kwargs = signature.req_kwarg_names - super_signature.req_kwarg_names
-    if !extra_req_kwargs.empty?
-      raise "Your definition of `#{method_name}` has extra required keyword arg(s) " \
-            "#{extra_req_kwargs} relative to the method it #{mode_verb}, making it incompatible: " \
-            "#{base_override_loc_str(signature, super_signature)}"
+    # Guard on the minuend: an empty req_kwarg_names can never yield extras.
+    if !signature.req_kwarg_names.empty?
+      # O(nm), but n and m are tiny here
+      extra_req_kwargs = signature.req_kwarg_names - super_signature.req_kwarg_names
+      if !extra_req_kwargs.empty?
+        raise "Your definition of `#{method_name}` has extra required keyword arg(s) " \
+              "#{extra_req_kwargs} relative to the method it #{mode_verb}, making it incompatible: " \
+              "#{base_override_loc_str(signature, super_signature)}"
+      end
     end
 
     if super_signature.block_name && !signature.block_name
@@ -231,16 +239,33 @@ module T::Private::Methods::SignatureValidation
     end
   end
 
+  # Evaluation order matters: check_tests? must only run for a :tests-checked
+  # sig (it side-effectfully arms the @wrapped_tests_with_validation trapdoor
+  # in RuntimeLevels).
+  private_class_method def self.check_level_active?(sig)
+    sig.check_level == :always || (sig.check_level == :tests && T::Private::RuntimeLevels.check_tests?)
+  end
+
   def self.validate_override_types(signature, super_signature)
     return if signature.override_allow_incompatible == true
     return if super_signature.mode == Modes.untyped
-    return unless [signature, super_signature].all? do |sig|
-      sig.check_level == :always || (sig.check_level == :tests && T::Private::RuntimeLevels.check_tests?)
-    end
+    return unless check_level_active?(signature) && check_level_active?(super_signature)
     mode_noun = super_signature.mode == Modes.abstract ? 'implementation' : 'override'
 
     # arg types must be contravariant
-    super_signature.arg_types.zip(signature.arg_types).each_with_index do |((_super_name, super_type), (name, type)), index|
+    #
+    # An index loop avoids allocating a pair array per positional arg.
+    # Iterating to super's length is deliberate: extra override positionals
+    # go unchecked, and when the override has a rest param and fewer named
+    # args than the base, the missing positions are checked as nil name/type.
+    super_arg_types = super_signature.arg_types
+    arg_types = signature.arg_types
+    index = 0
+    while index < super_arg_types.length
+      super_type = super_arg_types.fetch(index)[1]
+      pair = arg_types[index]
+      name = pair && pair[0]
+      type = pair && pair[1]
       if !super_type.subtype_of?(type)
         raise "Incompatible type for arg ##{index + 1} (`#{name}`) in signature for #{mode_noun} of method " \
               "`#{signature.method_name}`:\n" \
@@ -248,6 +273,7 @@ module T::Private::Methods::SignatureValidation
               "* #{mode_noun.capitalize}: `#{type}` (in #{signature.method_desc})\n" \
               "(The types must be contravariant.)"
       end
+      index += 1
     end
 
     # kwarg types must be contravariant

--- a/gems/sorbet-runtime/lib/types/types/base.rb
+++ b/gems/sorbet-runtime/lib/types/types/base.rb
@@ -52,6 +52,16 @@ module T::Types
     def subtype_of?(t2)
       t1 = self
 
+      # Fast path over the isSubType mirror below: the dominant pair during
+      # override validation is two plain Simples, which match none of the
+      # branches in the walk. instance_of? (never
+      # is_a?) so that any hypothetical Simple subclass takes the full walk,
+      # and the raw subtype_of_single? result is returned unmodified
+      # (Module#<= yields nil for unrelated modules, which callers observe).
+      if t1.instance_of?(T::Types::Simple) && t2.instance_of?(T::Types::Simple)
+        return subtype_of_single?(t2)
+      end
+
       if t2.is_a?(T::Private::Types::TypeAlias)
         t2 = t2.aliased_type
       end

--- a/gems/sorbet-runtime/lib/types/types/typed_set.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_set.rb
@@ -3,6 +3,11 @@
 
 module T::Types
   class TypedSet < TypedEnumerable
+    # We can reference `Set` directly without a load guard: as of Ruby 3.2 it
+    # ships as a default-autoloaded constant (Ruby registers `autoload :Set,
+    # "set"`), so the first reference here transparently loads it. Ruby 3.3 --
+    # the most recently supported release -- keeps this behavior, and Ruby 3.1
+    # and earlier (which required an explicit `require "set"`) are past EOL.
     def underlying_class
       Set
     end
@@ -14,22 +19,15 @@ module T::Types
 
     # overrides Base
     def recursively_valid?(obj)
-      return false if Object.autoload?(:Set) # Set is meant to be autoloaded but not yet loaded, this value can't be a Set
-      return false unless Object.const_defined?(:Set) # Set is not loaded yet
       obj.is_a?(Set) && super
     end
 
     # overrides Base
     def valid?(obj)
-      return false if Object.autoload?(:Set) # Set is meant to be autoloaded but not yet loaded, this value can't be a Set
-      return false unless Object.const_defined?(:Set) # Set is not loaded yet
       obj.is_a?(Set)
     end
 
     def new(...)
-      # Fine for this to blow up, because hopefully if they're trying to make a
-      # Set, they don't mind putting (or already have put) a `require 'set'` in
-      # their program directly.
       Set.new(...)
     end
 
@@ -39,8 +37,6 @@ module T::Types
       end
 
       def valid?(obj)
-        return false if Object.autoload?(:Set) # Set is meant to be autoloaded but not yet loaded, this value can't be a Set
-        return false unless Object.const_defined?(:Set) # Set is not loaded yet
         obj.is_a?(Set)
       end
     end

--- a/gems/sorbet-runtime/tools/generate_call_validation.cc
+++ b/gems/sorbet-runtime/tools/generate_call_validation.cc
@@ -248,6 +248,179 @@ void generateCreateValidatorFast(const Options &options, ValidatorKind kind, Typ
                "\n");
 }
 
+// Emits one positional-arg check, matching the `unless argN_type.valid?(argN)`
+// checks in the medium wrappers. `accessor` is how argN is read: "arg{i}" for a
+// named block param, "args[{i}]" for the *args splat. `guard`, when non-empty, is
+// a presence predicate OR-ed into the `unless` so the check is skipped when the
+// arg was not passed (e.g. "args.length <= 2"); merging it into the `unless`
+// rather than wrapping in an outer `if` keeps the output rubocop-clean.
+void generateArgCheck(size_t i, const string &accessor, const string &guard = "") {
+    fmt::print("      unless {2}arg{0}_type.valid?({1})\n"
+               "        CallValidation.report_error(\n"
+               "          method_sig,\n"
+               "          method_sig.arg_types[{0}][1].error_message_for_obj({1}),\n"
+               "          'Parameter',\n"
+               "          method_sig.arg_types[{0}][0],\n"
+               "          arg{0}_type,\n"
+               "          {1},\n"
+               "          caller_offset: -1\n"
+               "        )\n"
+               "      end\n",
+               i, accessor, guard.empty() ? ""s : guard + " || ");
+}
+
+// Emits the shared return-value tail for the kwargs/block/optional-args wrappers.
+// Unlike the fast/medium wrappers, these use one method for both `.void` and
+// non-void sigs: a `nil` `return_type` means `.void` (return VOID, skip the check).
+void generateReturnTail() {
+    fmt::print("      if return_type.nil?\n"
+               "        T::Private::Types::Void::VOID\n"
+               "      else\n"
+               "        unless return_type.valid?(return_value)\n"
+               "          message = method_sig.effective_return_type.error_message_for_obj(return_value)\n"
+               "          if message\n"
+               "            CallValidation.report_error(\n"
+               "              method_sig,\n"
+               "              message,\n"
+               "              'Return value',\n"
+               "              nil,\n"
+               "              method_sig.effective_return_type,\n"
+               "              return_value,\n"
+               "              caller_offset: -1\n"
+               "            )\n"
+               "          end\n"
+               "        end\n"
+               "        return_value\n"
+               "      end\n");
+}
+
+// The kwargs path only covers the all-kwargs shape (`kwargs_path` requires
+// `arg_types.empty?`), so only the zero-positional `kwargs0` wrapper exists.
+void generateCreateValidatorKwargs(const Options &options) {
+    fmt::print("  def self.create_validator_method_kwargs0(mod, original_method, method_sig, original_visibility, "
+               "return_type, kwarg_types)\n");
+    fmt::print("    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do "
+               "|**kwargs, &blk|\n");
+    fmt::print("      # This method is a manually sped-up version of more general code in `validate_call`\n");
+    fmt::print("      # NOTE: like `validate_call`, we don't validate for missing or extra\n"
+               "      # kwargs; the `bind_call` below takes care of that.\n");
+    fmt::print("      kwargs.each do |name, val|\n"
+               "        type = kwarg_types[name]\n"
+               "        next unless type\n"
+               "        next if type.valid?(val)\n"
+               "        CallValidation.report_error(\n"
+               "          method_sig,\n"
+               "          type.error_message_for_obj(val),\n"
+               "          'Parameter',\n"
+               "          name,\n"
+               "          type,\n"
+               "          val,\n"
+               "          caller_offset: 1\n"
+               "        )\n"
+               "      end\n");
+    if (options.bindCall) {
+        fmt::print("      return_value = original_method.bind_call(self, **kwargs, &blk)\n");
+    } else {
+        fmt::print("      return_value = original_method.bind(self).call(**kwargs, &blk)\n");
+    }
+    generateReturnTail();
+    fmt::print("    end\n"
+               "  end\n"
+               "\n");
+}
+
+// Wrapper for a method with a required (non-nilable) block, unrolled per arity.
+void generateCreateValidatorWithBlock(const Options &options, size_t arity) {
+    fmt::print("  def self.create_validator_method_with_block{}(mod, original_method, method_sig, "
+               "original_visibility, return_type, block_type",
+               arity);
+    for (size_t i = 0; i < arity; i++) {
+        fmt::print(", arg{}_type", i);
+    }
+    fmt::print(")\n");
+
+    fmt::print("    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do |");
+    for (size_t i = 0; i < arity; i++) {
+        fmt::print("arg{}, ", i);
+    }
+    fmt::print("&blk|\n");
+    fmt::print("      # This method is a manually sped-up version of more general code in `validate_call`\n");
+
+    for (size_t i = 0; i < arity; i++) {
+        generateArgCheck(i, fmt::format("arg{}", i));
+    }
+
+    fmt::print("      if blk.nil?\n"
+               "        CallValidation.report_error(\n"
+               "          method_sig,\n"
+               "          block_type.error_message_for_obj(blk),\n"
+               "          'Block parameter',\n"
+               "          method_sig.block_name,\n"
+               "          block_type,\n"
+               "          blk,\n"
+               "          caller_offset: -1\n"
+               "        )\n"
+               "      end\n");
+
+    fmt::print("      return_value = original_method");
+    if (options.bindCall) {
+        fmt::print(".bind_call(self, ");
+    } else {
+        fmt::print(".bind(self).call(");
+    }
+    for (size_t i = 0; i < arity; i++) {
+        fmt::print("arg{}, ", i);
+    }
+    fmt::print("&blk)\n");
+
+    generateReturnTail();
+    fmt::print("    end\n"
+               "  end\n"
+               "\n");
+}
+
+// Wrapper for a method with optional positional args: `req` required positionals
+// followed by `total - req` optional ones. Forwards through a ruby2_keywords-flagged
+// `|*args, &blk|` splat so argument-collection semantics match the slow path.
+void generateCreateValidatorOptionalArgs(const Options &options, size_t req, size_t total) {
+    fmt::print("  def self.create_validator_method_optional_args{}_{}(mod, original_method, method_sig, "
+               "original_visibility, return_type",
+               req, total);
+    for (size_t i = 0; i < total; i++) {
+        fmt::print(", arg{}_type", i);
+    }
+    fmt::print(")\n");
+
+    fmt::print("    T::Private::ClassUtils.def_with_visibility(mod, method_sig.method_name, original_visibility) do "
+               "|*args, &blk|\n");
+    fmt::print("      # This method is a manually sped-up version of more general code in `validate_call`\n");
+
+    // Required args are always present; optional args are checked only when the
+    // caller actually passed them. Defaults are never validated (matches the slow
+    // path); `bind_call` enforces the arity bounds.
+    for (size_t i = 0; i < req; i++) {
+        generateArgCheck(i, fmt::format("args[{}]", i));
+    }
+    for (size_t i = req; i < total; i++) {
+        // Skip the check when the optional arg was not passed. `i == 0` uses
+        // `args.empty?` (rubocop prefers it over `args.length <= 0`).
+        auto guard = i == 0 ? "args.empty?"s : fmt::format("args.length <= {}", i);
+        generateArgCheck(i, fmt::format("args[{}]", i), guard);
+    }
+
+    fmt::print("      return_value = original_method");
+    if (options.bindCall) {
+        fmt::print(".bind_call(self, *args, &blk)\n");
+    } else {
+        fmt::print(".bind(self).call(*args, &blk)\n");
+    }
+
+    generateReturnTail();
+    fmt::print("    end\n"
+               "  end\n"
+               "\n");
+}
+
 int generateCallValidation(const Options &options) {
     fmt::print("# frozen_string_literal: true\n"
                "# typed: false\n"
@@ -286,6 +459,21 @@ int generateCallValidation(const Options &options) {
     generateCreateValidatorFastDispatcher(ValidatorKind::Procedure, TypeKind::Complex);
     for (size_t i = 0; i <= MAX_ARITY; i++) {
         generateCreateValidatorFast(options, ValidatorKind::Procedure, TypeKind::Complex, i);
+    }
+
+    // Specialized wrappers that cover three call shapes the fast/medium families
+    // do not: keyword args, required (non-nilable) blocks, and optional positional
+    // args. Dispatched from the matching trampolines in call_validation.rb.
+    generateCreateValidatorKwargs(options);
+
+    for (size_t i = 0; i <= MAX_ARITY; i++) {
+        generateCreateValidatorWithBlock(options, i);
+    }
+
+    for (size_t total = 1; total <= MAX_ARITY; total++) {
+        for (size_t req = 0; req < total; req++) {
+            generateCreateValidatorOptionalArgs(options, req, total);
+        }
     }
 
     fmt::print("end\n");

--- a/gems/sorbet-runtime/tools/generate_call_validation.cc
+++ b/gems/sorbet-runtime/tools/generate_call_validation.cc
@@ -294,6 +294,81 @@ void generateReturnTail() {
                "      end\n");
 }
 
+// Trampoline for the kwargs family. The kwargs path only covers the all-kwargs
+// shape, so it always dispatches to the single zero-positional `kwargs0` leaf.
+// `nil` for `return_type` means the method is `.void` (the leaf returns
+// Void::VOID without validating the return).
+void generateCreateValidatorKwargsDispatcher() {
+    fmt::print("  def self.create_validator_method_kwargs(mod, original_method, method_sig, original_visibility)\n");
+    fmt::print("    return_type = method_sig.effective_return_type\n"
+               "    return_type = nil if return_type.is_a?(T::Private::Types::Void)\n");
+    fmt::print("    create_validator_method_kwargs0(mod, original_method, method_sig, original_visibility, "
+               "return_type, method_sig.kwarg_types)\n");
+    fmt::print("  end\n"
+               "\n");
+}
+
+// Trampoline for the required-block family: dispatches on the positional arity to
+// the matching `with_blockN` leaf, forwarding each arg type. `nil` for
+// `return_type` means the method is `.void`.
+void generateCreateValidatorWithBlockDispatcher() {
+    fmt::print(
+        "  def self.create_validator_method_with_block(mod, original_method, method_sig, original_visibility)\n");
+    fmt::print("    return_type = method_sig.effective_return_type\n"
+               "    return_type = nil if return_type.is_a?(T::Private::Types::Void)\n"
+               "    block_type = method_sig.block_type\n");
+    fmt::print("    # trampoline to reduce stack frame size\n"
+               "    arg_types = method_sig.arg_types\n"
+               "    case arg_types.length\n");
+    for (size_t arity = 0; arity <= MAX_ARITY; arity++) {
+        fmt::print("    when {}\n", arity);
+        fmt::print("      create_validator_method_with_block{}(mod, original_method, method_sig, "
+                   "original_visibility, return_type, block_type",
+                   arity);
+        for (size_t i = 0; i < arity; i++) {
+            fmt::print(",\n");
+            fmt::print("                                          arg_types[{}][1]", i);
+        }
+        fmt::print(")\n");
+    }
+    fmt::print("    else\n"
+               "      raise 'should not happen'\n"
+               "    end\n"
+               "  end\n"
+               "\n");
+}
+
+// Trampoline for the optional-positional-args family: dispatches on the
+// (required-count, total-count) pair to the matching `optional_argsR_T` leaf,
+// forwarding each arg type. `nil` for `return_type` means the method is `.void`.
+void generateCreateValidatorOptionalArgsDispatcher() {
+    fmt::print(
+        "  def self.create_validator_method_optional_args(mod, original_method, method_sig, original_visibility)\n");
+    fmt::print("    return_type = method_sig.effective_return_type\n"
+               "    return_type = nil if return_type.is_a?(T::Private::Types::Void)\n");
+    fmt::print("    # trampoline to reduce stack frame size\n"
+               "    arg_types = method_sig.arg_types\n"
+               "    case [method_sig.req_arg_count, arg_types.length]\n");
+    for (size_t total = 1; total <= MAX_ARITY; total++) {
+        for (size_t req = 0; req < total; req++) {
+            fmt::print("    when [{}, {}]\n", req, total);
+            fmt::print("      create_validator_method_optional_args{}_{}(mod, original_method, method_sig, "
+                       "original_visibility, return_type",
+                       req, total);
+            for (size_t i = 0; i < total; i++) {
+                fmt::print(",\n");
+                fmt::print("                                                arg_types[{}][1]", i);
+            }
+            fmt::print(")\n");
+        }
+    }
+    fmt::print("    else\n"
+               "      raise 'should not happen'\n"
+               "    end\n"
+               "  end\n"
+               "\n");
+}
+
 // The kwargs path only covers the all-kwargs shape (`kwargs_path` requires
 // `arg_types.empty?`), so only the zero-positional `kwargs0` wrapper exists.
 void generateCreateValidatorKwargs(const Options &options) {
@@ -463,13 +538,17 @@ int generateCallValidation(const Options &options) {
 
     // Specialized wrappers that cover three call shapes the fast/medium families
     // do not: keyword args, required (non-nilable) blocks, and optional positional
-    // args. Dispatched from the matching trampolines in call_validation.rb.
+    // args. Each family is emitted as a trampoline (which unpacks method_sig and
+    // dispatches on arity) followed by its per-arity leaf wrappers.
+    generateCreateValidatorKwargsDispatcher();
     generateCreateValidatorKwargs(options);
 
+    generateCreateValidatorWithBlockDispatcher();
     for (size_t i = 0; i <= MAX_ARITY; i++) {
         generateCreateValidatorWithBlock(options, i);
     }
 
+    generateCreateValidatorOptionalArgsDispatcher();
     for (size_t total = 1; total <= MAX_ARITY; total++) {
         for (size_t req = 0; req < total; req++) {
             generateCreateValidatorOptionalArgs(options, req, total);


### PR DESCRIPTION
**Stack (bottom → top):** #10359 → #10362 → #10363 → **#10364 (this)**

Call-validation and method/override-validation optimizations (top of the stack).

- Specialized validator families in `create_validator_method` for three call shapes the fast/medium wrappers don't cover: keyword args, required (non-nilable) blocks, and optional positional args (plus `method_sig.parameters` reuse).
- Override-validation decl-time trims: `subtype_of?` Simple-Simple fast path, duplicate sig-block force removal, alloc guards, zip removal.
- Fix the specialized wrappers mangling `ruby2_keywords` / argument collection (keys off the wrapped method's parameters, not the sig's).
- Restore the `UnboundMethod` return from `wrap_method_if_needed` / `T::Utils.wrap_method_with_call_validation_if_needed` (public API).
- Generate the specialized wrappers via the C++ pipeline (`tools/generate_call_validation.cc` → `call_validation_2_7.rb`) instead of hand-written `module_eval`.

Fully applied, this stack reproduces the exact tree of the originally-reviewed change.
