### PR TITLE
Add sigs for `#hash` and `#pack` in `Array` class

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -1421,6 +1421,7 @@ class Array < Object
   #
   # See also
   # [`Object#hash`](https://docs.ruby-lang.org/en/2.7.0/Object.html#method-i-hash).
+  sig { returns(Integer) }
   def hash; end
 
   # Returns `true` if the given `object` is present in `self` (that is, if any
@@ -1857,7 +1858,8 @@ class Array < Object
   # X            | ---     | back up a byte
   # x            | ---     | null byte
   # ```
-  def pack(*_); end
+  sig { params(template: String, buffer: T.nilable(String)).returns(String) }
+  def pack(template, buffer: nil); end
 
   # When invoked with a block, yield all permutations of length `n` of the
   # elements of the array, then return the array itself.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Add sigs for `#hash` and `#pack`  methods in `Array` class.

`Array#hash` docs: [2.7](https://docs.ruby-lang.org/en/2.7.0/Array.html#method-i-hash), [3.4](https://docs.ruby-lang.org/en/3.4/Array.html#method-i-hash), [master](https://docs.ruby-lang.org/en/master/Array.html#method-i-hash)


`Array#pack` docs: [2.7](https://docs.ruby-lang.org/en/2.7.0/Array.html#method-i-pack), [3.4](https://docs.ruby-lang.org/en/3.4/Array.html#method-i-pack), [master](https://docs.ruby-lang.org/en/master/Array.html#method-i-pack)

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Improve Sorbet's RBIs

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
