### PR TITLE
Some .lldbinit settings

### DIFF
--- a/.lldbinit
+++ b/.lldbinit
@@ -1,1 +1,8 @@
 command script import lldbinit.py
+
+# Print std::string with the newlines
+#
+# If you're debugging the cache, where non-printables might be binary data,
+# maybe you want to change this
+settings set escape-non-printables false
+settings set target.max-string-summary-length 100000


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I often print the symbol-table in lldb, and I want to avoid having to jump
through hoops to have it formatted nicely with newlines (instead of seeing all
the `\n` escaped newline characters).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Worked in lldb