### PR TITLE
Fix `private_class_method :new` visibility in sorbet (#7012)

### DIFF
--- a/core/FileHash.cc
+++ b/core/FileHash.cc
@@ -149,6 +149,22 @@ string FoundMethodHash::toString() const {
                        ownerIdx, ownerIsSymbol, useSingletonClass, nameHash._hashValue, arityHash._hashValue);
 }
 
+FoundDefinitionRef FoundNewVisibilityModifierHash::owner() const {
+    if (this->ownerIsSymbol) {
+        return {FoundDefinitionRef::Kind::Symbol, this->ownerIdx};
+    } else {
+        return {FoundDefinitionRef::Kind::Class, this->ownerIdx};
+    }
+}
+
+void FoundNewVisibilityModifierHash::sanityCheck() const {}
+
+string FoundNewVisibilityModifierHash::toString() const {
+    return fmt::format("FoundNewVisibilityModifierHash {{ ownerIdx = {}, ownerIsSymbol = {}, useSingletonClass = {}, "
+                       "isPrivate = {} }}",
+                       ownerIdx, ownerIsSymbol, useSingletonClass, isPrivate);
+}
+
 FoundDefinitionRef FoundFieldHash::owner() const {
     if (this->ownerIsSymbol) {
         return {FoundDefinitionRef::Kind::Symbol, this->ownerIdx};

--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -193,6 +193,30 @@ CheckSize(FoundMethodHash, 12, 4);
 
 using FoundMethodHashes = std::vector<FoundMethodHash>;
 
+struct FoundNewVisibilityModifierHash {
+    // The owner of this constructor visibility modifier.
+    FOUND_HASH_OWNER_INFO();
+
+    // Whether the modifier applies to the singleton class of the owner.
+    bool useSingletonClass : 1;
+
+    // Whether the modifier makes `new` private. False means public.
+    bool isPrivate : 1;
+
+    FoundNewVisibilityModifierHash(uint32_t ownerIdx, bool ownerIsSymbol, bool useSingletonClass, bool isPrivate)
+        : ownerIdx(ownerIdx), ownerIsSymbol(ownerIsSymbol), useSingletonClass(useSingletonClass), isPrivate(isPrivate) {
+        sanityCheck();
+    };
+
+    void sanityCheck() const;
+
+    // Debug string
+    std::string toString() const;
+};
+CheckSize(FoundNewVisibilityModifierHash, 4, 4);
+
+using FoundNewVisibilityModifierHashes = std::vector<FoundNewVisibilityModifierHash>;
+
 struct FoundFieldHash {
     // The owner of this field.
     FOUND_HASH_OWNER_INFO();
@@ -228,6 +252,7 @@ struct FoundDefHashes {
     FoundStaticFieldHashes staticFieldHashes;
     FoundTypeMemberHashes typeMemberHashes;
     FoundMethodHashes methodHashes;
+    FoundNewVisibilityModifierHashes newVisibilityModifierHashes;
     FoundFieldHashes fieldHashes;
 };
 

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -715,6 +715,91 @@ MethodRef ClassOrModule::findConcreteMethodTransitive(const GlobalState &gs, Nam
     return findConcreteMethodTransitiveInternal(gs, this->ref(gs), name, 100);
 }
 
+namespace {
+enum class NewVisibilityOverrideLookupResultKind {
+    Found,
+    NotFound,
+    ReachedMethodOwner,
+};
+
+struct NewVisibilityOverrideLookupResult {
+    NewVisibilityOverrideLookupResultKind kind;
+    Visibility visibility;
+
+    static NewVisibilityOverrideLookupResult found(Visibility visibility) {
+        return {NewVisibilityOverrideLookupResultKind::Found, visibility};
+    }
+
+    static NewVisibilityOverrideLookupResult notFound() {
+        return {NewVisibilityOverrideLookupResultKind::NotFound, Visibility::Public};
+    }
+
+    static NewVisibilityOverrideLookupResult reachedMethodOwner() {
+        return {NewVisibilityOverrideLookupResultKind::ReachedMethodOwner, Visibility::Public};
+    }
+};
+
+NewVisibilityOverrideLookupResult findNewVisibilityOverrideTransitiveInternal(const GlobalState &gs,
+                                                                              ClassOrModuleRef owner,
+                                                                              ClassOrModuleRef methodOwner,
+                                                                              int maxDepth) {
+    if (maxDepth == 0) {
+        if (auto e = gs.beginError(Loc::none(), errors::Internal::InternalError)) {
+            e.setHeader("findNewVisibilityOverrideTransitive hit a loop while resolving in `{}`",
+                        owner.showFullName(gs));
+        }
+        Exception::raise("findNewVisibilityOverrideTransitive hit a loop while resolving");
+    }
+
+    auto ownerData = owner.data(gs);
+    if (owner == methodOwner) {
+        return NewVisibilityOverrideLookupResult::reachedMethodOwner();
+    }
+
+    if (auto visibility = ownerData->newVisibilityOverride()) {
+        return NewVisibilityOverrideLookupResult::found(*visibility);
+    }
+
+    if (ownerData->flags.isLinearizationComputed) {
+        for (auto it = ownerData->mixins().begin(), end = ownerData->mixins().end(); it != end; ++it) {
+            ENFORCE(it->exists());
+            if (*it == methodOwner) {
+                return NewVisibilityOverrideLookupResult::reachedMethodOwner();
+            }
+
+            auto mixinData = it->data(gs);
+            if (auto visibility = mixinData->newVisibilityOverride()) {
+                return NewVisibilityOverrideLookupResult::found(*visibility);
+            }
+        }
+    } else {
+        for (auto it = ownerData->mixins().rbegin(), end = ownerData->mixins().rend(); it != end; ++it) {
+            ENFORCE(it->exists());
+            auto result = findNewVisibilityOverrideTransitiveInternal(gs, *it, methodOwner, maxDepth - 1);
+            if (result.kind != NewVisibilityOverrideLookupResultKind::NotFound) {
+                return result;
+            }
+        }
+    }
+
+    if (ownerData->superClass().exists()) {
+        return findNewVisibilityOverrideTransitiveInternal(gs, ownerData->superClass(), methodOwner, maxDepth - 1);
+    }
+
+    return NewVisibilityOverrideLookupResult::notFound();
+}
+} // namespace
+
+optional<Visibility> ClassOrModule::findNewVisibilityOverrideTransitive(const GlobalState &gs,
+                                                                        ClassOrModuleRef methodOwner) const {
+    auto result = findNewVisibilityOverrideTransitiveInternal(gs, this->ref(gs), methodOwner, 100);
+    if (result.kind == NewVisibilityOverrideLookupResultKind::Found) {
+        return result.visibility;
+    }
+
+    return nullopt;
+}
+
 SymbolRef ClassOrModule::findParentMemberTransitiveInternal(const GlobalState &gs, NameRef name, int maxDepth,
                                                             bool dealias) const {
     SymbolRef result;

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -400,14 +400,17 @@ public:
         bool isDeclaredInPackage : 1;
         bool isExported : 1;
         bool isBehaviorDefining : 1;
+        bool hasNewVisibilityOverride : 1;
+        bool isNewVisibilityOverridePrivate : 1;
 
-        constexpr static uint16_t NUMBER_OF_FLAGS = 12;
+        constexpr static uint16_t NUMBER_OF_FLAGS = 14;
         constexpr static uint16_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
 
         Flags() noexcept
             : isClass(false), isModule(false), isAbstract(false), isInterface(false), isLinearizationComputed(false),
               isFinal(false), isSealed(false), isPrivate(false), isDeclared(false), isDeclaredInPackage(false),
-              isExported(false), isBehaviorDefining(false) {}
+              isExported(false), isBehaviorDefining(false), hasNewVisibilityOverride(false),
+              isNewVisibilityOverridePrivate(false) {}
 
         uint16_t serialize() const {
             static_assert(sizeof(Flags) == sizeof(uint16_t));
@@ -560,6 +563,27 @@ public:
     // instead looking only in the members of any parent.
     MethodRef findParentMethodTransitive(const GlobalState &gs, NameRef name) const;
     MethodRef findConcreteMethodTransitive(const GlobalState &gs, NameRef name) const;
+    std::optional<Visibility> findNewVisibilityOverrideTransitive(const GlobalState &gs,
+                                                                  ClassOrModuleRef methodOwner) const;
+
+    void setNewVisibilityOverride(Visibility visibility) {
+        ENFORCE(visibility == Visibility::Private || visibility == Visibility::Public);
+        flags.hasNewVisibilityOverride = true;
+        flags.isNewVisibilityOverridePrivate = visibility == Visibility::Private;
+    }
+
+    void clearNewVisibilityOverride() {
+        flags.hasNewVisibilityOverride = false;
+        flags.isNewVisibilityOverridePrivate = false;
+    }
+
+    std::optional<Visibility> newVisibilityOverride() const {
+        if (!flags.hasNewVisibilityOverride) {
+            return std::nullopt;
+        }
+
+        return flags.isNewVisibilityOverridePrivate ? Visibility::Private : Visibility::Public;
+    }
 
     /* transitively finds a member with the most similar name */
 

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -312,6 +312,13 @@ void SerializerImpl::pickle(Pickler &p, shared_ptr<const FileHash> fh) {
         p.putU4(fdh.nameHash._hashValue);
         p.putU4(fdh.arityHash._hashValue);
     }
+    p.putU4(fh->foundHashes.newVisibilityModifierHashes.size());
+    for (const auto &fvh : fh->foundHashes.newVisibilityModifierHashes) {
+        p.putU4(fvh.ownerIdx);
+        p.putU1(fvh.ownerIsSymbol);
+        p.putU1(fvh.useSingletonClass);
+        p.putU1(fvh.isPrivate);
+    }
     p.putU4(fh->foundHashes.fieldHashes.size());
     for (const auto &ffh : fh->foundHashes.fieldHashes) {
         p.putU4(ffh.ownerIdx);
@@ -381,6 +388,16 @@ unique_ptr<const FileHash> SerializerImpl::unpickleFileHash(UnPickler &p) {
         ArityHash arityHash;
         arityHash._hashValue = p.getU4();
         ret.foundHashes.methodHashes.emplace_back(ownerIdx, ownerIsSymbol, useSingletonClass, fullNameHash, arityHash);
+    }
+    auto foundNewVisibilityModifierHashesSize = p.getU4();
+    ret.foundHashes.newVisibilityModifierHashes.reserve(foundNewVisibilityModifierHashesSize);
+    for (int it = 0; it < foundNewVisibilityModifierHashesSize; it++) {
+        auto ownerIdx = p.getU4();
+        auto ownerIsSymbol = p.getU1();
+        auto useSingletonClass = p.getU1();
+        auto isPrivate = p.getU1();
+        ret.foundHashes.newVisibilityModifierHashes.emplace_back(ownerIdx, ownerIsSymbol, useSingletonClass,
+                                                                 isPrivate);
     }
     auto foundFieldHashesSize = p.getU4();
     ret.foundHashes.fieldHashes.reserve(foundFieldHashesSize);

--- a/core/serialize/serialize.h
+++ b/core/serialize/serialize.h
@@ -6,7 +6,7 @@
 namespace sorbet::core::serialize {
 class Serializer {
 public:
-    static const uint32_t VERSION = 6;
+    static const uint32_t VERSION = 7;
 
     static constexpr std::string_view NAME_TABLE_UUID_KEY = "NameTableUUID";
     static constexpr std::string_view NAME_TABLE_DIFF_COUNT_AND_HASH_SIZE_KEY = "NameTableDiffCountAndHashSize";

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1026,7 +1026,14 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
         return DispatchResult(Types::untypedUntracked(), std::move(args.selfType), Symbols::noMethod());
     }
 
-    if (methodData->flags.isPrivate && !args.isPrivateOk) {
+    auto effectiveVisibility = methodData->methodVisibility();
+    if (args.name == core::Names::new_()) {
+        if (auto newVisibilityOverride = symbol.data(gs)->findNewVisibilityOverrideTransitive(gs, methodData->owner)) {
+            effectiveVisibility = *newVisibilityOverride;
+        }
+    }
+
+    if (effectiveVisibility == core::Visibility::Private && !args.isPrivateOk) {
         if (auto e = gs.beginError(args.errLoc(), core::errors::Infer::PrivateMethod)) {
             if (args.fullType.type != args.thisType) {
                 e.setHeader("Non-private call to private method `{}` on `{}` component of `{}`",

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1134,6 +1134,60 @@ private:
         return symbol;
     }
 
+    bool isPrivateVisibilityModifier(core::NameRef name) {
+        return name == core::Names::privateClassMethod() || name == core::Names::private_();
+    }
+
+    bool isConstructorVisibilityModifier(core::Context ctx, core::ClassOrModuleRef owner,
+                                         const core::FoundModifier &mod) {
+        if (mod.target != core::Names::new_()) {
+            return false;
+        }
+
+        if (mod.name == core::Names::privateClassMethod() || mod.name == core::Names::publicClassMethod()) {
+            return true;
+        }
+
+        if (mod.name != core::Names::private_() && mod.name != core::Names::public_()) {
+            return false;
+        }
+
+        return owner.data(ctx)->isSingletonClass(ctx);
+    }
+
+    void applyMethodVisibility(core::MutableContext ctx, core::ClassOrModuleRef owner, core::MethodRef method,
+                               const core::FoundModifier &mod) {
+        switch (mod.name.rawId()) {
+            case core::Names::private_().rawId():
+            case core::Names::privateClassMethod().rawId():
+                method.data(ctx)->flags.isPrivate = true;
+                break;
+            case core::Names::packagePrivate().rawId():
+            case core::Names::packagePrivateClassMethod().rawId():
+                if (!owner.data(ctx)->package.exists()) {
+                    if (auto e = ctx.beginError(mod.loc, core::errors::Namer::PackagePrivateOutsidePackage)) {
+                        e.setHeader("Method `{}` is not in a package and so cannot be made `{}`", method.show(ctx),
+                                    mod.name.show(ctx));
+                        e.addErrorLine(owner.data(ctx)->loc(), "This class has no package");
+                        e.addErrorLine(method.data(ctx)->loc(), "Method defined here");
+                    }
+                    break;
+                }
+
+                method.data(ctx)->flags.isPackagePrivate = true;
+                break;
+            case core::Names::protected_().rawId():
+                method.data(ctx)->flags.isProtected = true;
+                break;
+            case core::Names::public_().rawId():
+            case core::Names::publicClassMethod().rawId():
+                method.data(ctx)->setMethodPublic();
+                break;
+            default:
+                break;
+        }
+    }
+
     void modifyMethod(core::MutableContext ctx, const core::FoundModifier &mod) {
         ENFORCE(mod.kind == core::FoundModifier::Kind::Method);
 
@@ -1147,35 +1201,10 @@ private:
 
         auto method = ctx.state.lookupMethodSymbol(owner, mod.target);
         if (method.exists()) {
-            switch (mod.name.rawId()) {
-                case core::Names::private_().rawId():
-                case core::Names::privateClassMethod().rawId():
-                    method.data(ctx)->flags.isPrivate = true;
-                    break;
-                case core::Names::packagePrivate().rawId():
-                case core::Names::packagePrivateClassMethod().rawId():
-                    if (!owner.data(ctx)->package.exists()) {
-                        if (auto e = ctx.beginError(mod.loc, core::errors::Namer::PackagePrivateOutsidePackage)) {
-                            e.setHeader("Method `{}` is not in a package and so cannot be made `{}`", method.show(ctx),
-                                        mod.name.show(ctx));
-                            e.addErrorLine(owner.data(ctx)->loc(), "This class has no package");
-                            e.addErrorLine(method.data(ctx)->loc(), "Method defined here");
-                        }
-                        break;
-                    }
-
-                    method.data(ctx)->flags.isPackagePrivate = true;
-                    break;
-                case core::Names::protected_().rawId():
-                    method.data(ctx)->flags.isProtected = true;
-                    break;
-                case core::Names::public_().rawId():
-                case core::Names::publicClassMethod().rawId():
-                    method.data(ctx)->setMethodPublic();
-                    break;
-                default:
-                    break;
-            }
+            applyMethodVisibility(ctx, owner, method, mod);
+        } else if (isConstructorVisibilityModifier(ctx, owner, mod)) {
+            owner.data(ctx)->setNewVisibilityOverride(isPrivateVisibilityModifier(mod.name) ? core::Visibility::Private
+                                                                                           : core::Visibility::Public);
         }
     }
 
@@ -1720,6 +1749,14 @@ private:
         deleteSymbolViaFullNameHash(ctx, owner, oldDefHash.nameHash);
     }
 
+    void deleteNewVisibilityModifierHash(core::MutableContext ctx, const SymbolDefiner::State &state,
+                                         const core::FoundNewVisibilityModifierHash &oldDefHash) {
+        auto ownerSymbol = getOwnerSymbol(state, oldDefHash.owner());
+        auto owner = oldDefHash.useSingletonClass ? ownerSymbol.data(ctx)->singletonClass(ctx) : ownerSymbol;
+
+        owner.data(ctx)->clearNewVisibilityOverride();
+    }
+
 public:
     void deleteOldDefinitions(core::MutableContext ctx, const SymbolDefiner::State &state,
                               const core::FoundDefHashes &oldFoundHashes) {
@@ -1772,6 +1809,10 @@ public:
             // guarantee that deleteViaFullNameHash can use getOwnerSymbol to lookup an old owner
             // ref in the new definedClasses vector.
             deleteMethodViaFullNameHash(ctx, state, oldMethodHash);
+        }
+
+        for (const auto &oldNewVisibilityModifierHash : oldFoundHashes.newVisibilityModifierHashes) {
+            deleteNewVisibilityModifierHash(ctx, state, oldNewVisibilityModifierHash);
         }
     }
 
@@ -1898,6 +1939,39 @@ public:
             auto fullNameHash = core::FullNameHash(ctx, method.name);
             foundHashesOut.methodHashes.emplace_back(owner.idx(), ownerIsSymbol, method.flags.isSelfMethod,
                                                      fullNameHash, method.arityHash);
+        }
+
+        ENFORCE(foundHashesOut.newVisibilityModifierHashes.empty());
+        for (const auto &modifier : foundDefs.modifiers()) {
+            if (modifier.target != core::Names::new_()) {
+                continue;
+            }
+
+            auto owner = modifier.owner;
+            ENFORCE(owner.kind() == core::FoundDefinitionRef::Kind::Class ||
+                        owner.kind() == core::FoundDefinitionRef::Kind::Symbol,
+                    "kind={}", core::FoundDefinitionRef::kindToString(owner.kind()));
+
+            auto ownerIsSymbol = owner.kind() == core::FoundDefinitionRef::Kind::Symbol;
+            bool useSingletonClass;
+            bool isPrivate;
+            if (modifier.name == core::Names::privateClassMethod() ||
+                modifier.name == core::Names::publicClassMethod()) {
+                useSingletonClass = true;
+                isPrivate = modifier.name == core::Names::privateClassMethod();
+            } else if (modifier.name == core::Names::private_() || modifier.name == core::Names::public_()) {
+                auto ownerSymbol = getOwnerSymbol(state, owner);
+                if (!ownerSymbol.data(ctx)->isSingletonClass(ctx)) {
+                    continue;
+                }
+                useSingletonClass = false;
+                isPrivate = modifier.name == core::Names::private_();
+            } else {
+                continue;
+            }
+
+            foundHashesOut.newVisibilityModifierHashes.emplace_back(owner.idx(), ownerIsSymbol, useSingletonClass,
+                                                                    isPrivate);
         }
 
         ENFORCE(foundHashesOut.fieldHashes.empty());

--- a/test/testdata/infer/private_class_method_new.rb
+++ b/test/testdata/infer/private_class_method_new.rb
@@ -1,0 +1,109 @@
+# typed: true
+
+class Parent
+  private_class_method :new
+
+  def self.make
+    new
+  end
+
+  def self.make_explicit
+    self.new
+  end
+end
+
+class Child < Parent; end
+
+class PublicChild < Parent
+  public_class_method :new
+end
+
+class OwnNew < Parent
+  def self.new
+    :own
+  end
+end
+
+Parent.new # error: Non-private call to private method `new`
+Child.new # error: Non-private call to private method `new`
+PublicChild.new
+OwnNew.new
+
+Parent.make
+Child.make
+PublicChild.make
+OwnNew.make
+
+module MixinNew
+  def new
+    :from_mixin
+  end
+end
+
+class MixinParent
+  private_class_method :new
+end
+
+class MixinChild < MixinParent
+  extend MixinNew
+end
+
+class MixinPrivateChild < MixinParent
+  extend MixinNew
+  private_class_method :new
+end
+
+MixinChild.new
+MixinPrivateChild.new # error: Non-private call to private method `new`
+
+class RealParent
+  def self.new
+    :parent
+  end
+  private_class_method :new
+end
+
+class RealChild < RealParent; end
+
+class RealPublicChild < RealParent
+  public_class_method :new
+end
+
+RealParent.new # error: Non-private call to private method `new`
+RealChild.new # error: Non-private call to private method `new`
+RealPublicChild.new
+
+class WithInitialize
+  def initialize(x); end
+  private_class_method :new
+end
+
+class WithInitializeChild < WithInitialize; end
+
+WithInitialize.new(0) # error: Non-private call to private method `new`
+WithInitializeChild.new(0) # error: Non-private call to private method `new`
+
+class PublicInitializeChild < WithInitialize
+  public_class_method :new
+end
+
+PublicInitializeChild.new # error: Not enough arguments provided for method `WithInitialize#initialize`
+PublicInitializeChild.new(0)
+
+class EigenParent
+  class << self
+    private :new
+  end
+end
+
+class EigenChild < EigenParent; end
+
+class EigenPublicChild < EigenParent
+  class << self
+    public :new
+  end
+end
+
+EigenParent.new # error: Non-private call to private method `new`
+EigenChild.new # error: Non-private call to private method `new`
+EigenPublicChild.new

--- a/test/testdata/infer/private_initialize.rb
+++ b/test/testdata/infer/private_initialize.rb
@@ -20,12 +20,10 @@ b = B.new # error: Non-private call to private method `new`
 b.initialize
 
 class C
-  # At time of writing, Sorbet doesn't support changing visibility of an
-  # inherited method.
   private_class_method :new
 end
 
-c = C.new
+c = C.new # error: Non-private call to private method `new`
 c.initialize # error: Non-private call to private method `initialize` on `C`
 
 class D

--- a/test/testdata/lsp/fast_path/private_constructor_visibility.1.rbupdate
+++ b/test/testdata/lsp/fast_path/private_constructor_visibility.1.rbupdate
@@ -1,0 +1,12 @@
+# typed: true
+# assert-slow-path: true
+
+class FastPathPrivateCtorParent
+  private_class_method :new
+end
+
+class FastPathPrivateCtorChild < FastPathPrivateCtorParent
+  public_class_method :new
+end
+
+FastPathPrivateCtorChild.new

--- a/test/testdata/lsp/fast_path/private_constructor_visibility.2.rbupdate
+++ b/test/testdata/lsp/fast_path/private_constructor_visibility.2.rbupdate
@@ -1,0 +1,12 @@
+# typed: true
+# assert-slow-path: true
+
+class FastPathPrivateCtorParent
+  private_class_method :new
+end
+
+class FastPathPrivateCtorChild < FastPathPrivateCtorParent
+  private_class_method :new
+end
+
+FastPathPrivateCtorChild.new # error: Non-private call to private method `new`

--- a/test/testdata/lsp/fast_path/private_constructor_visibility.rb
+++ b/test/testdata/lsp/fast_path/private_constructor_visibility.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+class FastPathPrivateCtorParent
+  private_class_method :new
+end
+
+class FastPathPrivateCtorChild < FastPathPrivateCtorParent; end
+
+FastPathPrivateCtorChild.new # error: Non-private call to private method `new`


### PR DESCRIPTION
Sorbet now models `private_class_method :new` and `public_class_method :new` on inherited constructors.

This keeps callable method lookup unchanged, so `Class#new`, inherited singleton `new` methods, constructor arity, and `initialize` typing continue to work normally. During access checking, Sorbet now applies the nearest class-local `new` visibility override from the receiver singleton class ancestry.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

The problem arises when you specify `private_class_method :new`:

 ```ruby
  class Parent
    private_class_method :new
  end

  class Child < Parent; end

  Child.new
```

Ruby rejects Child.new, but Sorbet previously allowed it.

Ruby also lets subclasses restore public constructor visibility with public_class_method :new, and that needs to work without inventing a fake local new method or changing method ownership.

This bug was documented in issue #7012 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
