### PR TITLE
TypedSet: drop the Set autoload probes, assume Set is always defined

### DIFF
--- a/gems/sorbet-runtime/lib/types/types/typed_set.rb
+++ b/gems/sorbet-runtime/lib/types/types/typed_set.rb
@@ -3,6 +3,11 @@
 
 module T::Types
   class TypedSet < TypedEnumerable
+    # We can reference `Set` directly without a load guard: as of Ruby 3.2 it
+    # ships as a default-autoloaded constant (Ruby registers `autoload :Set,
+    # "set"`), so the first reference here transparently loads it. Ruby 3.3 --
+    # the most recently supported release -- keeps this behavior, and Ruby 3.1
+    # and earlier (which required an explicit `require "set"`) are past EOL.
     def underlying_class
       Set
     end
@@ -14,22 +19,15 @@ module T::Types
 
     # overrides Base
     def recursively_valid?(obj)
-      return false if Object.autoload?(:Set) # Set is meant to be autoloaded but not yet loaded, this value can't be a Set
-      return false unless Object.const_defined?(:Set) # Set is not loaded yet
       obj.is_a?(Set) && super
     end
 
     # overrides Base
     def valid?(obj)
-      return false if Object.autoload?(:Set) # Set is meant to be autoloaded but not yet loaded, this value can't be a Set
-      return false unless Object.const_defined?(:Set) # Set is not loaded yet
       obj.is_a?(Set)
     end
 
     def new(...)
-      # Fine for this to blow up, because hopefully if they're trying to make a
-      # Set, they don't mind putting (or already have put) a `require 'set'` in
-      # their program directly.
       Set.new(...)
     end
 
@@ -39,8 +37,6 @@ module T::Types
       end
 
       def valid?(obj)
-        return false if Object.autoload?(:Set) # Set is meant to be autoloaded but not yet loaded, this value can't be a Set
-        return false unless Object.const_defined?(:Set) # Set is not loaded yet
         obj.is_a?(Set)
       end
     end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

The `Set` class became a built-in class in Ruby 3.2, which reached EOL ~3 months ago. Ruby 3.3 is the most recently supported Ruby version.

Users who want to continue to use `sorbet-runtime` with old versions of Ruby can explicitly `require 'set'` in their codebase (or register an `autoload` to require `"set"` after `:Set` is accessed):

```ruby
# lazy solution, approximates Ruby 3.2's solution
autoload :Set, "set"
```

```ruby
# eager solution
require "set"
```

This affects codebases that load runtime `T::Set` types that haven't created any values of those set objects—the `Set` constant only gets used when trying to actually use those runtime signatures (i.e., `::Set` does not need to be defined when the `sig` evaluates, just when it's used).

Since it's possible to monkey patch around the problem in old versions, we have explicitly chosen to **NOT** update the minimum required version in the `*.gemspec`, as that would preclude people being able to work around this in their own applications or libraries.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This improves performance of runtime type checking for `T::Set` types, because we don't have to do reflection on loaded constants.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

We test in 3.1 and 3.3 in CI, but `T::Enum` also requires "set" under the hood if a user actually creates a `T::Enum` subclass, so our tests already `require "set"` in practice meaning that this doesn't affect the tests.