### PR TITLE
Use `test!` not `*.test.rb` in GenPackages

### DIFF
--- a/packager/GenPackages.cc
+++ b/packager/GenPackages.cc
@@ -201,7 +201,10 @@ void GenPackages::run(core::GlobalState &gs) {
                             // referencedPackage's `visible_to`s
                             //
                             // In either case, we'll add a new `visible_to` to referencedPackage's __package.db
-                            if (gs.packageDB().allowRelaxingTestVisibility() && file.data(gs).isPackagedTest()) {
+                            auto pkg = gs.packageDB().findPackageByPath(gs, file);
+                            auto &pkgInfo = gs.packageDB().getPackageInfo(pkg);
+                            if (gs.packageDB().allowRelaxingTestVisibility() && pkgInfo.exists() &&
+                                pkgInfo.testPackage()) {
                                 // If --allow-relaxing-test-visibility, and this reference is in a test file, add
                                 // `visible_to 'tests'`
                                 neededVisibleToTests[referencedPackageName] = true;

--- a/test/cli/package-gen-packages/D/test/__package.rb
+++ b/test/cli/package-gen-packages/D/test/__package.rb
@@ -1,0 +1,9 @@
+# typed: strict
+
+class Test::D < PackageSpec
+  test!
+  layer 'test'
+  strict_dependencies 'dag'
+
+  import D, uses_internals: true
+end

--- a/test/cli/package-gen-packages/test.out
+++ b/test/cli/package-gen-packages/test.out
@@ -70,8 +70,8 @@ E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
      3 |class E < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    E/__package.rb:7: Inserted `visible_to 'tests'
-      visible_to C`
+    E/__package.rb:7: Inserted `visible_to C
+      visible_to D`
      7 |  export E::CONSTANT_FROM_E
                                    ^
 
@@ -190,8 +190,8 @@ class E < PackageSpec
   layer 'util'
 
   export E::CONSTANT_FROM_E
-  visible_to 'tests'
   visible_to C
+  visible_to D
 end
 
 ###### cat PackageWithIgnore/__package.rb ######
@@ -254,8 +254,8 @@ E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
      3 |class E < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    E/__package.rb:7: Inserted `visible_to 'tests'
-      visible_to C`
+    E/__package.rb:7: Inserted `visible_to C
+      visible_to D`
      7 |  export E::CONSTANT_FROM_E
                                    ^
 
@@ -387,8 +387,8 @@ class E < PackageSpec
   layer 'util'
 
   export E::CONSTANT_FROM_E
-  visible_to 'tests'
   visible_to C
+  visible_to D
 end
 
 ###### cat PackageWithIgnore/__package.rb ######

--- a/test/cli/package-gen-packages/test.out
+++ b/test/cli/package-gen-packages/test.out
@@ -70,18 +70,31 @@ E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
      3 |class E < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    E/__package.rb:7: Inserted `visible_to C
-      visible_to D`
+    E/__package.rb:7: Inserted `visible_to 'tests'
+      visible_to C`
      7 |  export E::CONSTANT_FROM_E
                                    ^
 
-D/__package.rb:3: `D` is missing imports and exports https://srb.help/3734
+D/test/__package.rb:3: `Test::D` is missing imports https://srb.help/3734
+     3 |class Test::D < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    D/test/__package.rb:8: Inserted `import E`
+     8 |  import D, uses_internals: true
+                                        ^
+
+D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://srb.help/3734
+     3 |class D::ANestedPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    D/ANestedPackage/__package.rb:5: Inserted `export D::ANestedPackage::Foo`
+     5 |  layer 'util'
+                      ^
+
+D/__package.rb:3: `D` is missing exports https://srb.help/3734
      3 |class D < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    D/__package.rb:7: Inserted `import E`
-     7 |  import B
-                  ^
     D/__package.rb:9: Deleted
      9 |  export D::ANestedPackage::Foo
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -93,21 +106,6 @@ D/__package.rb:3: `D` is missing imports and exports https://srb.help/3734
       export D::EnumFromD`
      9 |  export D::ANestedPackage::Foo
                                        ^
-
-D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://srb.help/3734
-     3 |class D::ANestedPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    D/ANestedPackage/__package.rb:5: Inserted `export D::ANestedPackage::Foo`
-     5 |  layer 'util'
-                      ^
-
-D/test/test_constants.rb:3: File belongs to package `D` but defines a constant that does not match this namespace https://srb.help/3713
-     3 |module Test::D
-               ^^^^^^^
-    D/__package.rb:3: Enclosing package declared here
-     3 |class D < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^
 
 C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
      8 |      puts F::CONSTANT_FROM_F
@@ -166,7 +164,6 @@ class D < PackageSpec
   layer 'util'
 
   import B
-  import E
   export D::AlreadyExportedClass
   export D::CONSTANT_FROM_D
   export D::ClassFromD
@@ -190,8 +187,8 @@ class E < PackageSpec
   layer 'util'
 
   export E::CONSTANT_FROM_E
+  visible_to 'tests'
   visible_to C
-  visible_to D
 end
 
 ###### cat PackageWithIgnore/__package.rb ######
@@ -254,18 +251,31 @@ E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
      3 |class E < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    E/__package.rb:7: Inserted `visible_to C
-      visible_to D`
+    E/__package.rb:7: Inserted `visible_to 'tests'
+      visible_to C`
      7 |  export E::CONSTANT_FROM_E
                                    ^
 
-D/__package.rb:3: `D` is missing imports and exports https://srb.help/3734
+D/test/__package.rb:3: `Test::D` is missing imports https://srb.help/3734
+     3 |class Test::D < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    D/test/__package.rb:8: Inserted `import E`
+     8 |  import D, uses_internals: true
+                                        ^
+
+D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://srb.help/3734
+     3 |class D::ANestedPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    D/ANestedPackage/__package.rb:5: Inserted `export D::ANestedPackage::Foo`
+     5 |  layer 'util'
+                      ^
+
+D/__package.rb:3: `D` is missing exports https://srb.help/3734
      3 |class D < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    D/__package.rb:7: Inserted `import E`
-     7 |  import B
-                  ^
     D/__package.rb:9: Deleted
      9 |  export D::ANestedPackage::Foo
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -277,14 +287,6 @@ D/__package.rb:3: `D` is missing imports and exports https://srb.help/3734
       export D::EnumFromD`
      9 |  export D::ANestedPackage::Foo
                                        ^
-
-D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://srb.help/3734
-     3 |class D::ANestedPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    D/ANestedPackage/__package.rb:5: Inserted `export D::ANestedPackage::Foo`
-     5 |  layer 'util'
-                      ^
 
 A/constants.rb:5: Unable to resolve constant `G` https://srb.help/5002
      5 |  puts G::ANOTHER_CONSTANT_FROM_G
@@ -298,13 +300,6 @@ A/constants.rb:5: Unable to resolve constant `G` https://srb.help/5002
     A/constants.rb:3: `A` defined here
      3 |module A
         ^^^^^^^^
-
-D/test/test_constants.rb:3: File belongs to package `D` but defines a constant that does not match this namespace https://srb.help/3713
-     3 |module Test::D
-               ^^^^^^^
-    D/__package.rb:3: Enclosing package declared here
-     3 |class D < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^
 
 C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
      8 |      puts F::CONSTANT_FROM_F
@@ -363,7 +358,6 @@ class D < PackageSpec
   layer 'util'
 
   import B
-  import E
   export D::AlreadyExportedClass
   export D::CONSTANT_FROM_D
   export D::ClassFromD
@@ -387,8 +381,8 @@ class E < PackageSpec
   layer 'util'
 
   export E::CONSTANT_FROM_E
+  visible_to 'tests'
   visible_to C
-  visible_to D
 end
 
 ###### cat PackageWithIgnore/__package.rb ######


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm trying to get rid of `isPackagedTest` as a helper, because I don't want Sorbet to know or care about `*.test.rb` as a file path. This helps ease adoption of Sorbet in a non-Stripe codebase.

This GenPackages change leads to a slight change in beahvior, and I'm not sure whether or how much that matters. e.g., do we need to change `deppy` too?


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.