### PR TITLE
Add RBIs for type alias

### DIFF
--- a/gems/sorbet-runtime/lib/types/utils.rbi
+++ b/gems/sorbet-runtime/lib/types/utils.rbi
@@ -6,11 +6,6 @@ module T::Utils
   def self.methods_excluding_object(mod)
   end
 
-  # Should be in rbi/sorbet/t.rbi, but should this accept arbitrary type
-  # syntax? Unclear, leaving the type private for now.
-  sig { params(type: T.any(Module, T::Types::Base)).returns(T::Types::Base) }
-  def self.resolve_alias(type); end
-
   # Should be in rbi/sorbet/t.rbi, but that would require exposing
   # T::Private::Methods::Signature, which is bigger than I want to tackle rn
   sig { params(method: UnboundMethod).returns(T.nilable(T::Private::Methods::Signature)) }

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -445,6 +445,18 @@ module T::Utils
   sig {params(val: T.untyped).returns(T::Types::Base)}
   def self.coerce(val); end
 
+  # Unwraps a TypeAlias object to its aliased type, or else returns the input
+  #
+  # ```ruby
+  # resolve_alias(Integer)         # => Integer
+  # resolve_alias(AliasToInteger)  # => Integer
+  # resolve_alias(T.any(A, B))     # => T.any(A, B)
+  # ```
+  sig {
+    type_parameters(:Type)
+      .params(type: T.any(T.type_parameter(:Type), T::Private::Types::TypeAlias))
+      .returns(T.any(T.type_parameter(:Type), T::Types::Base))
+  }
   def self.resolve_alias(type); end
 
   sig { params(force_type_init: T::Boolean).void }

--- a/rbi/sorbet/tprivate.rbi
+++ b/rbi/sorbet/tprivate.rbi
@@ -11,6 +11,26 @@ end
 class T::Private::Types::Void < T::Types::Base
 end
 
+class T::Private::Types::TypeAlias < T::Types::Base
+  sig { params(callable: T.proc.returns(T.anything)).void }
+  def initialize(callable); end
+
+  sig { override.void }
+  def build_type; end
+
+  sig {returns(T::Types::Base)}
+  def aliased_type; end
+
+  sig { override.returns(String) }
+  def name; end
+
+  sig { override.params(obj: Kernel).returns(T::Boolean) }
+  def recursively_valid?(obj); end
+
+  sig { override.params(obj: Kernel).returns(T::Boolean) }
+  def valid?(obj); end
+end
+
 module T::Private::Methods
   def self.signature_for_method(method); end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I noticed that some people in Stripe's codebase were doing

```ruby
type.class.to_s == "T::Types::Private::TypeAlias"
```

because this class isn't defined. Comparing class names as strings is worse
than depending on a private API, so let's just write types for it.

It's not even clear to me whether this should permanently remain a private
API--it's on the same conceptual level as other, non-private APIs like
`T::Types::Base`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.