### PR TITLE
Infer `X = A.new.freeze` the same as `X = A.new`

### DIFF
--- a/rewriter/ConstantAssumeType.cc
+++ b/rewriter/ConstantAssumeType.cc
@@ -28,6 +28,14 @@ void ConstantAssumeType::run(core::MutableContext ctx, ast::Assign *asgn) {
         return;
     }
 
+    // Allow `A.new.freeze` to be treated the same as `A.new`
+    if (send->fun == core::Names::freeze() && !send->hasNonBlockArgs() && !send->hasBlock()) {
+        send = ast::cast_tree<ast::Send>(send->recv);
+        if (send == nullptr) {
+            return;
+        }
+    }
+
     if (send->fun != core::Names::new_()) {
         return;
     }

--- a/test/testdata/rewriter/constant_assume_type.rb
+++ b/test/testdata/rewriter/constant_assume_type.rb
@@ -94,10 +94,10 @@ L = ModuleWithCustomNew.new
 T.reveal_type(L) # error: `T.untyped`
 
 M = NormalClass.new.freeze
-T.reveal_type(M) # error: `T.untyped`
+T.reveal_type(M) # error: `NormalClass`
 
-N = NewIsNilable.new.freeze
-T.reveal_type(N) # error: `T.untyped`
+N = NewIsNilable.new.freeze # error: Assumed expression had type `NewIsNilable` but found `T.nilable(NewIsNilable)`
+T.reveal_type(N) # error: `NewIsNilable`
 
 class ClassWithCustomFreeze
   extend T::Sig
@@ -108,5 +108,5 @@ class ClassWithCustomFreeze
   end
 end
 
-O = ClassWithCustomFreeze.new.freeze
-T.reveal_type(O) # error: `T.untyped`
+O = ClassWithCustomFreeze.new.freeze # error: Assumed expression had type `ClassWithCustomFreeze` but found `Integer`
+T.reveal_type(O) # error: `ClassWithCustomFreeze`

--- a/test/testdata/rewriter/constant_assume_type.rb
+++ b/test/testdata/rewriter/constant_assume_type.rb
@@ -92,3 +92,21 @@ T.reveal_type(K) # error: `GenericClassWithFixed`
 
 L = ModuleWithCustomNew.new
 T.reveal_type(L) # error: `T.untyped`
+
+M = NormalClass.new.freeze
+T.reveal_type(M) # error: `T.untyped`
+
+N = NewIsNilable.new.freeze
+T.reveal_type(N) # error: `T.untyped`
+
+class ClassWithCustomFreeze
+  extend T::Sig
+
+  sig {returns(Integer)}
+  def freeze
+    0
+  end
+end
+
+O = ClassWithCustomFreeze.new.freeze
+T.reveal_type(O) # error: `T.untyped`

--- a/test/testdata/rewriter/constant_assume_type.rb.autocorrects.exp
+++ b/test/testdata/rewriter/constant_assume_type.rb.autocorrects.exp
@@ -93,4 +93,22 @@ T.reveal_type(K) # error: `GenericClassWithFixed`
 
 L = ModuleWithCustomNew.new
 T.reveal_type(L) # error: `T.untyped`
+
+M = NormalClass.new.freeze
+T.reveal_type(M) # error: `T.untyped`
+
+N = NewIsNilable.new.freeze
+T.reveal_type(N) # error: `T.untyped`
+
+class ClassWithCustomFreeze
+  extend T::Sig
+
+  sig {returns(Integer)}
+  def freeze
+    0
+  end
+end
+
+O = ClassWithCustomFreeze.new.freeze
+T.reveal_type(O) # error: `T.untyped`
 # ------------------------------

--- a/test/testdata/rewriter/constant_assume_type.rb.autocorrects.exp
+++ b/test/testdata/rewriter/constant_assume_type.rb.autocorrects.exp
@@ -95,10 +95,10 @@ L = ModuleWithCustomNew.new
 T.reveal_type(L) # error: `T.untyped`
 
 M = NormalClass.new.freeze
-T.reveal_type(M) # error: `T.untyped`
+T.reveal_type(M) # error: `NormalClass`
 
-N = NewIsNilable.new.freeze
-T.reveal_type(N) # error: `T.untyped`
+N = T.let(NewIsNilable.new.freeze, T.nilable(NewIsNilable)) # error: Assumed expression had type `NewIsNilable` but found `T.nilable(NewIsNilable)`
+T.reveal_type(N) # error: `NewIsNilable`
 
 class ClassWithCustomFreeze
   extend T::Sig
@@ -109,6 +109,6 @@ class ClassWithCustomFreeze
   end
 end
 
-O = ClassWithCustomFreeze.new.freeze
-T.reveal_type(O) # error: `T.untyped`
+O = T.let(ClassWithCustomFreeze.new.freeze, Integer) # error: Assumed expression had type `ClassWithCustomFreeze` but found `Integer`
+T.reveal_type(O) # error: `ClassWithCustomFreeze`
 # ------------------------------

--- a/website/docs/type-annotations.md
+++ b/website/docs/type-annotations.md
@@ -44,7 +44,7 @@ Sorbet does _very_ minimal inference for types of constants. These are the cases
 
 - Array literals are inferred to have type `T::Array[...]` where `...` is a [union type](union-types.md) of all the types of elements in the array. If the array literal is also frozen with the `.freeze` method, the inferred type will be a [tuple type](tuples.md) instead. This array vs tuple decision is not recursive, because `.freeze` is not recursive. To have Sorbet infer array of tuples types, call `.freeze` on each array nested inside the top-level array.
 
-- Constants initialized with a call to `SomeClass.new` will have their type inferred to `SomeClass`. Importantly, this assumption happens **regardless** of whether the `new` method actually returns an instance of `SomeClass`, which might not be the case if the `new` method has been overridden.
+- Constants initialized with a call to `SomeClass.new` (or `SomeClass.new.freeze`) will have their type inferred to `SomeClass`. Importantly, this assumption happens **regardless** of whether the `new` or `freeze` methods actually return an instance of `SomeClass`, which might not be the case if either method has been overridden.
 
   In these cases, Sorbet reports an error stating that it requires an explicit type annotation to correct the faulty assumption. This only applies at the top-level (e.g., not inside arrays).
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We already assume that `X = A.new` was effectively written like
`X = T.let(A.new, A)`.

This extends that to also recognize `A.new.freeze` (with no args/block),
since freeze returns T.self_type and chaining it on a constructor is
idiomatic Ruby for creating frozen constants.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tests show behavior before+after