### PR TITLE
`# typed: ignore` in `gems/sorbet-runtime/test`

### DIFF
--- a/gems/sorbet-runtime/test/test_helper.rb
+++ b/gems/sorbet-runtime/test/test_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 
 # Ideally we might run tests with warnings enabled, but currently this triggers
 # a number of uninitialized instance variable warnings.

--- a/gems/sorbet-runtime/test/types/abstract_validation.rb
+++ b/gems/sorbet-runtime/test/types/abstract_validation.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/absurd.rb
+++ b/gems/sorbet-runtime/test/types/absurd.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 module Opus::Types::Test

--- a/gems/sorbet-runtime/test/types/attached_class.rb
+++ b/gems/sorbet-runtime/test/types/attached_class.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 module Opus::Types::Test

--- a/gems/sorbet-runtime/test/types/builder_syntax.rb
+++ b/gems/sorbet-runtime/test/types/builder_syntax.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 module Opus::Types::Test

--- a/gems/sorbet-runtime/test/types/casts.rb
+++ b/gems/sorbet-runtime/test/types/casts.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 module Opus::Types::Test

--- a/gems/sorbet-runtime/test/types/circular_load.rb
+++ b/gems/sorbet-runtime/test/types/circular_load.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 module Opus::Types::Test

--- a/gems/sorbet-runtime/test/types/configuration.rb
+++ b/gems/sorbet-runtime/test/types/configuration.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 module Opus::Types::Test

--- a/gems/sorbet-runtime/test/types/dsl_methods.rb
+++ b/gems/sorbet-runtime/test/types/dsl_methods.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 class Opus::Types::Test::DSLMethodsTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 require 'concurrent/atomic/cyclic_barrier'
 

--- a/gems/sorbet-runtime/test/types/enum.rb
+++ b/gems/sorbet-runtime/test/types/enum.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 # typed: false
 require_relative '../test_helper'
 

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/final_module.rb
+++ b/gems/sorbet-runtime/test/types/final_module.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 class Opus::Types::Test::FinalModuleTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/interface_validation.rb
+++ b/gems/sorbet-runtime/test/types/interface_validation.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 class Opus::Types::Test::InterfacesTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/method_modes.rb
+++ b/gems/sorbet-runtime/test/types/method_modes.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 class Opus::Types::Test::MethodModesTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/method_patches.rb
+++ b/gems/sorbet-runtime/test/types/method_patches.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 module Opus::Types::Test

--- a/gems/sorbet-runtime/test/types/method_validation.rb
+++ b/gems/sorbet-runtime/test/types/method_validation.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 module Opus::Types::Test

--- a/gems/sorbet-runtime/test/types/mixins.rb
+++ b/gems/sorbet-runtime/test/types/mixins.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 module Opus::Types::Test

--- a/gems/sorbet-runtime/test/types/module_include_t_sig.rb
+++ b/gems/sorbet-runtime/test/types/module_include_t_sig.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 class Opus::Types::Test::ModuleIncludeTSig < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/must.rb
+++ b/gems/sorbet-runtime/test/types/must.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 module Opus::Types::Test

--- a/gems/sorbet-runtime/test/types/must_because.rb
+++ b/gems/sorbet-runtime/test/types/must_because.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 module Opus::Types::Test

--- a/gems/sorbet-runtime/test/types/props/_props.rb
+++ b/gems/sorbet-runtime/test/types/props/_props.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../../test_helper'
 
 class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/props/constructor.rb
+++ b/gems/sorbet-runtime/test/types/props/constructor.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../../test_helper'
 
 class Opus::Types::Test::Props::ConstructorTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/props/decorator.rb
+++ b/gems/sorbet-runtime/test/types/props/decorator.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../../test_helper'
 
 class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/props/optional.rb
+++ b/gems/sorbet-runtime/test/types/props/optional.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../../test_helper'
 
 class Opus::Types::Test::Props::OptionalTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/props/private/setter_factory.rb
+++ b/gems/sorbet-runtime/test/types/props/private/setter_factory.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../../../test_helper'
 
 class Opus::Types::Test::Props::Private::SetterFactoryTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../../test_helper'
 
 class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/props/struct.rb
+++ b/gems/sorbet-runtime/test/types/props/struct.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../../test_helper'
 
 class Opus::Types::Test::Props::StructTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/returns.rb
+++ b/gems/sorbet-runtime/test/types/returns.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 module Opus::Types::Test

--- a/gems/sorbet-runtime/test/types/ruby2_keywords.rb
+++ b/gems/sorbet-runtime/test/types/ruby2_keywords.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 class Opus::Types::Test::Ruby2KeywordsTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/runtime_levels.rb
+++ b/gems/sorbet-runtime/test/types/runtime_levels.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 module Opus::Types::Test

--- a/gems/sorbet-runtime/test/types/sealed_module.rb
+++ b/gems/sorbet-runtime/test/types/sealed_module.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 class Opus::Types::Test::SealedModuleTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/sig.rb
+++ b/gems/sorbet-runtime/test/types/sig.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 class Opus::Types::Test::SigTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/struct.rb
+++ b/gems/sorbet-runtime/test/types/struct.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 class Opus::Types::Test::StructValidationTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/syntax.rb
+++ b/gems/sorbet-runtime/test/types/syntax.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 class Opus::Types::Test::SyntaxTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/top_level.rb
+++ b/gems/sorbet-runtime/test/types/top_level.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 class Opus::Types::Test::TopLevel < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/types.rb
+++ b/gems/sorbet-runtime/test/types/types.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 module Opus::Types::Test

--- a/gems/sorbet-runtime/test/types/types_to_ruby.rb
+++ b/gems/sorbet-runtime/test/types/types_to_ruby.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 class Opus::Types::Test::TypesToRubyTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/types/utils.rb
+++ b/gems/sorbet-runtime/test/types/utils.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 module Opus::Types::Test

--- a/gems/sorbet-runtime/test/types/validate_override_shape.rb
+++ b/gems/sorbet-runtime/test/types/validate_override_shape.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 module Opus::Types::Test

--- a/gems/sorbet-runtime/test/types/validate_override_types.rb
+++ b/gems/sorbet-runtime/test/types/validate_override_types.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 module Opus::Types::Test

--- a/gems/sorbet-runtime/test/types/visibility.rb
+++ b/gems/sorbet-runtime/test/types/visibility.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 require_relative '../test_helper'
 
 class Opus::Types::Test::VisibilityTest < Critic::Unit::UnitTest

--- a/gems/sorbet-runtime/test/wholesome/Rakefile
+++ b/gems/sorbet-runtime/test/wholesome/Rakefile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 
 task default: %i[test]
 

--- a/gems/sorbet-runtime/test/wholesome/tenum_oj.rb
+++ b/gems/sorbet-runtime/test/wholesome/tenum_oj.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: ignore
 
 require 'minitest/autorun'
 require 'minitest/spec'


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Sometimes I open these files from outside of `gems/sorbet-runtime` and
then I get a ton of squiggles. I figure we can just write `# typed:
ignore` explicitly so that if I happen to open it on the wrong path or
with the wrong config that I don't get the squiggles.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested in the editor