### PR TITLE
Remove "Prism" from RBS API names

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -40,7 +40,7 @@
 #include "parser/prism/Parser.h"
 #include "payload/binary/binary.h"
 #include "pipeline.h"
-#include "rbs/prism/RBSRewriterPrism.h"
+#include "rbs/RBSRewriter.h"
 #include "resolver/resolver.h"
 #include "rewriter/rewriter.h"
 

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -261,16 +261,15 @@ parser::Prism::ParseResult runPrismParser(core::GlobalState &gs, core::FileRef f
     return parser::Prism::Parser::run(ctx);
 }
 
-void runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file, parser::Prism::ParseResult &parseResult,
-                        const options::Printers &print) {
+void runRBSRewrite(core::GlobalState &gs, core::FileRef file, parser::Prism::ParseResult &parseResult,
+                   const options::Printers &print) {
     if (gs.cacheSensitiveOptions.rbsEnabled) {
         Timer timeit(gs.tracer(), "runRBSRewrite", {{"file", string(file.data(gs).path())}});
         core::MutableContext ctx(gs, core::Symbols::root(), file);
         core::UnfreezeNameTable nameTableAccess(gs);
 
         auto &parser = parseResult.getParser();
-        rbs::runPrismRBSRewrite(gs, file, parseResult.getRawNodePointer(), parseResult.getCommentLocations(), ctx,
-                                parser);
+        rbs::runRBSRewrite(gs, file, parseResult.getRawNodePointer(), parseResult.getCommentLocations(), ctx, parser);
     }
 
     if (print.RBSRewriteTree.enabled) {
@@ -418,7 +417,7 @@ ast::ParsedFile indexOne(const options::Options &opts, core::GlobalState &lgs, c
                         return emptyParsedFile(file);
                     }
 
-                    runPrismRBSRewrite(lgs, file, parseResult, print);
+                    runRBSRewrite(lgs, file, parseResult, print);
                     if (opts.stopAfterPhase == options::Phase::RBS_REWRITER) {
                         return emptyParsedFile(file);
                     }

--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -25,18 +25,18 @@ const regex absurdPattern("^\\s*absurd\\s*(#.*)?$");
  *
  * Returns `nullopt` if the comment is not a valid RBS expression (an error is produced).
  */
-optional<pair<pm_node_t *, InlineCommentPrism::Kind>>
-parseComment(core::MutableContext ctx, parser::Prism::Parser &parser, InlineCommentPrism comment,
+optional<pair<pm_node_t *, InlineComment::Kind>>
+parseComment(core::MutableContext ctx, parser::Prism::Parser &parser, InlineComment comment,
              absl::Span<pair<core::LocOffsets, core::NameRef>> typeParams) {
     Factory prism{parser};
 
-    if (comment.kind == InlineCommentPrism::Kind::MUST || comment.kind == InlineCommentPrism::Kind::UNSAFE ||
-        comment.kind == InlineCommentPrism::Kind::ABSURD) {
+    if (comment.kind == InlineComment::Kind::MUST || comment.kind == InlineComment::Kind::UNSAFE ||
+        comment.kind == InlineComment::Kind::ABSURD) {
         // The type should never be used but we need to hold the location...
         return pair{prism.Nil(comment.comment.typeLoc), comment.kind};
     }
 
-    auto type = rbs::SignatureTranslatorPrism(ctx, parser)
+    auto type = rbs::SignatureTranslator(ctx, parser)
                     .translateAssertionType(absl::MakeSpan(typeParams), RBSDeclaration({comment.comment}));
 
     if (type == nullptr) {
@@ -59,8 +59,8 @@ parseComment(core::MutableContext ctx, parser::Prism::Parser &parser, InlineComm
  *
  * We need to be aware of the type parameter `X` so we can use it to resolve the type of `y`.
  */
-vector<pair<core::LocOffsets, core::NameRef>>
-extractTypeParamsPrism(core::MutableContext ctx, const parser::Prism::Parser &parser, pm_node_t *block) {
+vector<pair<core::LocOffsets, core::NameRef>> extractTypeParams(core::MutableContext ctx,
+                                                                const parser::Prism::Parser &parser, pm_node_t *block) {
     vector<pair<core::LocOffsets, core::NameRef>> typeParams;
 
     auto *blockNode = down_cast<pm_block_node_t>(block);
@@ -296,7 +296,7 @@ void maybeSupplyGenericTypeArguments(core::MutableContext ctx, parser::Prism::Pa
  *
  * Returns `true` if the node is a `sig` call (so caller can skip further processing), `false` otherwise.
  */
-bool AssertionsRewriterPrism::saveMethodTypeParams(pm_node_t *call) {
+bool AssertionsRewriter::saveMethodTypeParams(pm_node_t *call) {
     auto *callNode = down_cast<pm_call_node_t>(call);
     if (!callNode) {
         return false;
@@ -313,7 +313,7 @@ bool AssertionsRewriterPrism::saveMethodTypeParams(pm_node_t *call) {
         return false;
     }
 
-    this->typeParams = extractTypeParamsPrism(ctx, parser, callNode->block);
+    this->typeParams = extractTypeParams(ctx, parser, callNode->block);
 
     return true;
 }
@@ -321,21 +321,21 @@ bool AssertionsRewriterPrism::saveMethodTypeParams(pm_node_t *call) {
 /**
  * Mark the given comment location as "consumed" so it won't be picked up by subsequent calls to `commentForNode`.
  */
-void AssertionsRewriterPrism::consumeComment(core::LocOffsets loc) {
+void AssertionsRewriter::consumeComment(core::LocOffsets loc) {
     consumedComments.emplace(make_pair(loc.beginPos(), loc.endPos()));
 }
 
 /**
  * Check if the given comment location has been consumed.
  */
-bool AssertionsRewriterPrism::hasConsumedComment(core::LocOffsets loc) {
+bool AssertionsRewriter::hasConsumedComment(core::LocOffsets loc) {
     return consumedComments.count(make_pair(loc.beginPos(), loc.endPos()));
 }
 
 /**
  * Helper to convert Prism location to core::LocOffsets.
  */
-core::LocOffsets AssertionsRewriterPrism::translateLocation(pm_location_t location) {
+core::LocOffsets AssertionsRewriter::translateLocation(pm_location_t location) {
     const uint8_t *sourceStart = (const uint8_t *)ctx.file.data(ctx).source().data();
     uint32_t start = static_cast<uint32_t>(location.start - sourceStart);
     uint32_t end = static_cast<uint32_t>(location.end - sourceStart);
@@ -347,7 +347,7 @@ core::LocOffsets AssertionsRewriterPrism::translateLocation(pm_location_t locati
  *
  * Returns `nullopt` if no comment is found or if the comment was already consumed.
  */
-optional<rbs::InlineCommentPrism> AssertionsRewriterPrism::commentForNode(pm_node_t *node) {
+optional<rbs::InlineComment> AssertionsRewriter::commentForNode(pm_node_t *node) {
     if (node == nullptr) {
         return nullopt;
     }
@@ -358,7 +358,7 @@ optional<rbs::InlineCommentPrism> AssertionsRewriterPrism::commentForNode(pm_nod
     }
 
     for (const auto &commentNode : it->second) {
-        if (!absl::StartsWith(commentNode.string, CommentsAssociatorPrism::RBS_PREFIX)) {
+        if (!absl::StartsWith(commentNode.string, CommentsAssociator::RBS_PREFIX)) {
             continue;
         }
 
@@ -371,21 +371,21 @@ optional<rbs::InlineCommentPrism> AssertionsRewriterPrism::commentForNode(pm_nod
             content = content.substr(1);
         }
 
-        auto kind = InlineCommentPrism::Kind::LET;
+        auto kind = InlineComment::Kind::LET;
         if (absl::StartsWith(content, "as ")) {
-            kind = InlineCommentPrism::Kind::CAST;
+            kind = InlineComment::Kind::CAST;
             contentStart += 3;
             content = content.substr(3);
 
             if (regex_match(content.begin(), content.end(), notNilPattern)) {
-                kind = InlineCommentPrism::Kind::MUST;
+                kind = InlineComment::Kind::MUST;
             } else if (regex_match(content.begin(), content.end(), untypedPattern)) {
-                kind = InlineCommentPrism::Kind::UNSAFE;
+                kind = InlineComment::Kind::UNSAFE;
             }
         } else if (regex_match(content.begin(), content.end(), absurdPattern)) {
-            kind = InlineCommentPrism::Kind::ABSURD;
+            kind = InlineComment::Kind::ABSURD;
         } else if (absl::StartsWith(content, "self as ")) {
-            kind = InlineCommentPrism::Kind::BIND;
+            kind = InlineComment::Kind::BIND;
             contentStart += 8;
             content = content.substr(8);
         }
@@ -395,7 +395,7 @@ optional<rbs::InlineCommentPrism> AssertionsRewriterPrism::commentForNode(pm_nod
         }
         consumeComment(commentNode.loc);
 
-        return InlineCommentPrism{
+        return InlineComment{
             rbs::Comment{
                 commentNode.loc,
                 core::LocOffsets{contentStart, commentNode.loc.endPos()},
@@ -418,8 +418,7 @@ optional<rbs::InlineCommentPrism> AssertionsRewriterPrism::commentForNode(pm_nod
  * - `x #: as !nil`: `T.must(x)`
  * - `x #: as untyped`: `T.unsafe(x)`
  */
-pm_node_t *AssertionsRewriterPrism::insertCast(pm_node_t *node,
-                                               optional<pair<pm_node_t *, InlineCommentPrism::Kind>> pair) {
+pm_node_t *AssertionsRewriter::insertCast(pm_node_t *node, optional<pair<pm_node_t *, InlineComment::Kind>> pair) {
     if (!pair) {
         return node;
     }
@@ -435,17 +434,17 @@ pm_node_t *AssertionsRewriterPrism::insertCast(pm_node_t *node,
     auto typeLoc = translateLocation(type->location);
 
     switch (kind) {
-        case InlineCommentPrism::Kind::LET:
+        case InlineComment::Kind::LET:
             return prism.TLet(typeLoc, node, type);
-        case InlineCommentPrism::Kind::CAST:
+        case InlineComment::Kind::CAST:
             return prism.TCast(typeLoc, node, type);
-        case InlineCommentPrism::Kind::MUST:
+        case InlineComment::Kind::MUST:
             return prism.TMust(typeLoc, node);
-        case InlineCommentPrism::Kind::UNSAFE:
+        case InlineComment::Kind::UNSAFE:
             return prism.TUnsafe(typeLoc, node);
-        case InlineCommentPrism::Kind::ABSURD:
+        case InlineComment::Kind::ABSURD:
             return prism.TAbsurd(typeLoc, node);
-        case InlineCommentPrism::Kind::BIND:
+        case InlineComment::Kind::BIND:
             if (auto e = ctx.beginIndexerError(typeLoc, core::errors::Rewriter::RBSUnsupported)) {
                 e.setHeader("`{}` binding can't be used as a trailing comment", "self");
             }
@@ -457,7 +456,7 @@ pm_node_t *AssertionsRewriterPrism::insertCast(pm_node_t *node,
 /**
  * Replace the synthetic RBS placeholder node with a `T.bind(self, Type)` call.
  */
-pm_node_t *AssertionsRewriterPrism::replaceSyntheticBind(pm_node_t *node) {
+pm_node_t *AssertionsRewriter::replaceSyntheticBind(pm_node_t *node) {
     auto inlineComment = commentForNode(node);
     ENFORCE(inlineComment, "No inline comment found for synthetic bind");
 
@@ -470,7 +469,7 @@ pm_node_t *AssertionsRewriterPrism::replaceSyntheticBind(pm_node_t *node) {
     }
 
     auto [type, kind] = *pair;
-    ENFORCE(kind == InlineCommentPrism::Kind::BIND, "Invalid inline comment for synthetic bind");
+    ENFORCE(kind == InlineComment::Kind::BIND, "Invalid inline comment for synthetic bind");
 
     auto typeLoc = translateLocation(type->location);
 
@@ -480,7 +479,7 @@ pm_node_t *AssertionsRewriterPrism::replaceSyntheticBind(pm_node_t *node) {
 /**
  * Insert a cast into the given Prism node if there is an not yet consumed RBS assertion comment.
  */
-pm_node_t *AssertionsRewriterPrism::maybeInsertCast(pm_node_t *node) {
+pm_node_t *AssertionsRewriter::maybeInsertCast(pm_node_t *node) {
     if (node == nullptr) {
         return node;
     }
@@ -494,20 +493,20 @@ pm_node_t *AssertionsRewriterPrism::maybeInsertCast(pm_node_t *node) {
     return node;
 }
 
-void AssertionsRewriterPrism::rewriteStatements(pm_statements_node_t *stmts) {
+void AssertionsRewriter::rewriteStatements(pm_statements_node_t *stmts) {
     rewriteNodes(stmts->body);
 }
 
 /**
  * Rewrite a collection of Prism nodes in place.
  */
-void AssertionsRewriterPrism::rewriteNodes(pm_node_list_t &nodes) {
+void AssertionsRewriter::rewriteNodes(pm_node_list_t &nodes) {
     for (size_t i = 0; i < nodes.size; i++) {
         nodes.nodes[i] = rewriteNode(nodes.nodes[i]);
     }
 }
 
-void AssertionsRewriterPrism::rewriteArgumentsNode(pm_arguments_node_t *args) {
+void AssertionsRewriter::rewriteArgumentsNode(pm_arguments_node_t *args) {
     if (args) {
         rewriteNodes(args->arguments);
     }
@@ -516,7 +515,7 @@ void AssertionsRewriterPrism::rewriteArgumentsNode(pm_arguments_node_t *args) {
 /**
  * Rewrite a collection of nodes, wrap them in an array and cast the array.
  */
-void AssertionsRewriterPrism::rewriteNodesAsArray(pm_node_t *node, pm_node_list_t &nodes) {
+void AssertionsRewriter::rewriteNodesAsArray(pm_node_t *node, pm_node_list_t &nodes) {
     if (auto inlineComment = commentForNode(node)) {
         if (nodes.size > 1) {
             auto nodeSpan = absl::MakeSpan(nodes.nodes, nodes.size);
@@ -545,7 +544,7 @@ void AssertionsRewriterPrism::rewriteNodesAsArray(pm_node_t *node, pm_node_list_
 /**
  * Rewrite a node.
  */
-inline pm_node_t *AssertionsRewriterPrism::rewriteNullableNode(pm_node_t *node) {
+inline pm_node_t *AssertionsRewriter::rewriteNullableNode(pm_node_t *node) {
     if (node == nullptr) {
         return node;
     }
@@ -553,7 +552,7 @@ inline pm_node_t *AssertionsRewriterPrism::rewriteNullableNode(pm_node_t *node) 
     return rewriteNode(node);
 }
 
-pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
+pm_node_t *AssertionsRewriter::rewriteNode(pm_node_t *node) {
     // If all comments have been consumed, we can skip the rest of the tree.
     if (consumedComments.size() >= totalComments) {
         return node;
@@ -1064,7 +1063,7 @@ pm_node_t *AssertionsRewriterPrism::rewriteNode(pm_node_t *node) {
     }
 }
 
-void AssertionsRewriterPrism::run(pm_node_t *node) {
+void AssertionsRewriter::run(pm_node_t *node) {
     if (node == nullptr) {
         return;
     }

--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -1,8 +1,8 @@
-#include "rbs/prism/AssertionsRewriterPrism.h"
+#include "rbs/AssertionsRewriter.h"
 
 #include "absl/strings/match.h"
 #include "core/errors/rewriter.h"
-#include "rbs/prism/SignatureTranslatorPrism.h"
+#include "rbs/SignatureTranslator.h"
 #include <cctype>
 #include <regex>
 

--- a/rbs/AssertionsRewriter.h
+++ b/rbs/AssertionsRewriter.h
@@ -12,7 +12,7 @@ extern "C" {
 
 namespace sorbet::rbs {
 
-struct InlineCommentPrism {
+struct InlineComment {
     enum class Kind {
         ABSURD,
         BIND,
@@ -26,10 +26,10 @@ struct InlineCommentPrism {
     Kind kind;
 };
 
-class AssertionsRewriterPrism {
+class AssertionsRewriter {
 public:
-    AssertionsRewriterPrism(core::MutableContext ctx, parser::Prism::Parser &parser,
-                            UnorderedMap<pm_node_t *, std::vector<CommentNodePrism>> &commentsByNode)
+    AssertionsRewriter(core::MutableContext ctx, parser::Prism::Parser &parser,
+                       UnorderedMap<pm_node_t *, std::vector<CommentNode>> &commentsByNode)
         : ctx(ctx), parser(parser), prism(parser), commentsByNode(commentsByNode){};
     // Rewrite the RBS assertions in the Prism AST, in-place.
     void run(pm_node_t *node);
@@ -38,14 +38,14 @@ private:
     core::MutableContext ctx;
     parser::Prism::Parser &parser;
     parser::Prism::Factory prism;
-    UnorderedMap<pm_node_t *, std::vector<CommentNodePrism>> &commentsByNode;
+    UnorderedMap<pm_node_t *, std::vector<CommentNode>> &commentsByNode;
     std::vector<std::pair<core::LocOffsets, core::NameRef>> typeParams = {};
     std::set<std::pair<uint32_t, uint32_t>> consumedComments = {};
     size_t totalComments = 0;
 
     void consumeComment(core::LocOffsets loc);
     bool hasConsumedComment(core::LocOffsets loc);
-    std::optional<InlineCommentPrism> commentForNode(pm_node_t *node);
+    std::optional<InlineComment> commentForNode(pm_node_t *node);
 
     core::LocOffsets translateLocation(pm_location_t location);
 
@@ -58,7 +58,7 @@ private:
 
     bool saveMethodTypeParams(pm_node_t *call);
     pm_node_t *maybeInsertCast(pm_node_t *node);
-    pm_node_t *insertCast(pm_node_t *node, std::optional<std::pair<pm_node_t *, InlineCommentPrism::Kind>> pair);
+    pm_node_t *insertCast(pm_node_t *node, std::optional<std::pair<pm_node_t *, InlineComment::Kind>> pair);
     pm_node_t *replaceSyntheticBind(pm_node_t *node);
 };
 

--- a/rbs/AssertionsRewriter.h
+++ b/rbs/AssertionsRewriter.h
@@ -1,9 +1,9 @@
-#ifndef SORBET_RBS_ASSERTIONS_REWRITER_PRISM_H
-#define SORBET_RBS_ASSERTIONS_REWRITER_PRISM_H
+#ifndef SORBET_RBS_ASSERTIONS_REWRITER_H
+#define SORBET_RBS_ASSERTIONS_REWRITER_H
 
 #include "parser/prism/Helpers.h"
 #include "parser/prism/Parser.h"
-#include "rbs/prism/CommentsAssociatorPrism.h"
+#include "rbs/CommentsAssociator.h"
 #include "rbs/rbs_common.h"
 
 extern "C" {
@@ -64,4 +64,4 @@ private:
 
 } // namespace sorbet::rbs
 
-#endif // SORBET_RBS_ASSERTIONS_REWRITER_PRISM_H
+#endif // SORBET_RBS_ASSERTIONS_REWRITER_H

--- a/rbs/BUILD
+++ b/rbs/BUILD
@@ -3,8 +3,6 @@ cc_library(
     srcs = glob([
         "*.cc",
         "*.h",
-        "prism/*.cc",
-        "prism/*.h",
     ]),
     linkstatic = select({
         "//tools/config:linkshared": 0,

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -1,4 +1,4 @@
-#include "rbs/prism/CommentsAssociatorPrism.h"
+#include "rbs/CommentsAssociator.h"
 
 #include "absl/strings/match.h"
 #include "absl/strings/str_split.h"

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -12,10 +12,10 @@ using namespace sorbet::parser::Prism;
 
 namespace sorbet::rbs {
 
-const string_view CommentsAssociatorPrism::RBS_PREFIX = "#:";
-const string_view CommentsAssociatorPrism::ANNOTATION_PREFIX = "# @";
-const string_view CommentsAssociatorPrism::MULTILINE_RBS_PREFIX = "#|";
-const string_view CommentsAssociatorPrism::BIND_PREFIX = "#: self as ";
+const string_view CommentsAssociator::RBS_PREFIX = "#:";
+const string_view CommentsAssociator::ANNOTATION_PREFIX = "# @";
+const string_view CommentsAssociator::MULTILINE_RBS_PREFIX = "#|";
+const string_view CommentsAssociator::BIND_PREFIX = "#: self as ";
 
 namespace {
 
@@ -60,7 +60,7 @@ optional<uint32_t> hasHeredocMarker(const core::Context &ctx, uint32_t fromPos, 
 }
 } // namespace
 
-optional<uint32_t> CommentsAssociatorPrism::locateTargetLine(pm_node_t *node) {
+optional<uint32_t> CommentsAssociator::locateTargetLine(pm_node_t *node) {
     if (node == nullptr) {
         return nullopt;
     }
@@ -102,22 +102,22 @@ optional<uint32_t> CommentsAssociatorPrism::locateTargetLine(pm_node_t *node) {
     return nullopt;
 }
 
-core::LocOffsets CommentsAssociatorPrism::translateLocation(pm_location_t location) {
+core::LocOffsets CommentsAssociator::translateLocation(pm_location_t location) {
     return parser.translateLocation(location);
 }
 
-uint32_t CommentsAssociatorPrism::posToLine(uint32_t pos) {
+uint32_t CommentsAssociator::posToLine(uint32_t pos) {
     return core::Loc::pos2Detail(ctx.file.data(ctx), pos).line;
 }
 
-void CommentsAssociatorPrism::consumeCommentsInsideNode(pm_node_t *node, string_view kind) {
+void CommentsAssociator::consumeCommentsInsideNode(pm_node_t *node, string_view kind) {
     auto loc = translateLocation(node->location);
     auto beginLine = posToLine(loc.beginPos());
     auto endLine = posToLine(loc.endPos());
     consumeCommentsBetweenLines(beginLine, endLine, kind);
 }
 
-void CommentsAssociatorPrism::consumeCommentsBetweenLines(int startLine, int endLine, string_view kind) {
+void CommentsAssociator::consumeCommentsBetweenLines(int startLine, int endLine, string_view kind) {
     // Find the first comment on or after the startLine
     auto it = commentByLine.begin();
     while (it != commentByLine.end() && it->first < startLine) {
@@ -158,7 +158,7 @@ void CommentsAssociatorPrism::consumeCommentsBetweenLines(int startLine, int end
     commentByLine.erase(startIt, it);
 }
 
-void CommentsAssociatorPrism::consumeOrphanedSignatureComments(int startLine, int endLine) {
+void CommentsAssociator::consumeOrphanedSignatureComments(int startLine, int endLine) {
     auto source = ctx.file.data(ctx).source();
     for (auto it = commentByLine.begin(); it != commentByLine.end();) {
         if (it->first <= startLine) {
@@ -185,7 +185,7 @@ void CommentsAssociatorPrism::consumeOrphanedSignatureComments(int startLine, in
     }
 }
 
-void CommentsAssociatorPrism::consumeCommentsUntilLine(int line) {
+void CommentsAssociator::consumeCommentsUntilLine(int line) {
     auto it = commentByLine.begin();
     while (it != commentByLine.end()) {
         if (it->first < line) {
@@ -203,7 +203,7 @@ void CommentsAssociatorPrism::consumeCommentsUntilLine(int line) {
     commentByLine.erase(commentByLine.begin(), it);
 }
 
-void CommentsAssociatorPrism::associateAssertionCommentsToNode(pm_node_t *node, bool adjustLocForHeredoc) {
+void CommentsAssociator::associateAssertionCommentsToNode(pm_node_t *node, bool adjustLocForHeredoc) {
     auto loc = translateLocation(node->location);
     uint32_t targetLine = posToLine(loc.endPos());
     if (adjustLocForHeredoc) {
@@ -212,7 +212,7 @@ void CommentsAssociatorPrism::associateAssertionCommentsToNode(pm_node_t *node, 
         }
     }
 
-    vector<CommentNodePrism> comments;
+    vector<CommentNode> comments;
 
     auto it = commentByLine.find(targetLine);
     if (it != commentByLine.end() && absl::StartsWith(it->second.string, RBS_PREFIX)) {
@@ -223,11 +223,11 @@ void CommentsAssociatorPrism::associateAssertionCommentsToNode(pm_node_t *node, 
     }
 }
 
-void CommentsAssociatorPrism::associateSignatureCommentsToNode(pm_node_t *node) {
+void CommentsAssociator::associateSignatureCommentsToNode(pm_node_t *node) {
     auto loc = translateLocation(node->location);
     auto nodeStartLine = posToLine(loc.beginPos());
 
-    vector<CommentNodePrism> comments;
+    vector<CommentNode> comments;
 
     for (auto it = commentByLine.begin(); it != commentByLine.end();) {
         auto commentLine = it->first;
@@ -250,7 +250,7 @@ void CommentsAssociatorPrism::associateSignatureCommentsToNode(pm_node_t *node) 
     signaturesForNode[node] = move(comments);
 }
 
-bool CommentsAssociatorPrism::typeAliasAllowedInContext() const {
+bool CommentsAssociator::typeAliasAllowedInContext() const {
     return !contextAllowingTypeAlias.empty() && contextAllowingTypeAlias.back().first;
 }
 
@@ -259,8 +259,8 @@ bool CommentsAssociatorPrism::typeAliasAllowedInContext() const {
 // 1. Bind comments (#: self as Type): placeholders later replaced with T.bind(self, Type)
 // 2. Type alias comments (#: type foo = String): placeholders later replaced with T.type_alias { String }
 // Returns the number of placeholder nodes inserted.
-int CommentsAssociatorPrism::maybeInsertStandalonePlaceholders(pm_node_list_t &nodes, int index, int lastLine,
-                                                               int currentLine) {
+int CommentsAssociator::maybeInsertStandalonePlaceholders(pm_node_list_t &nodes, int index, int lastLine,
+                                                          int currentLine) {
     if (lastLine == currentLine) {
         return 0;
     }
@@ -294,7 +294,7 @@ int CommentsAssociatorPrism::maybeInsertStandalonePlaceholders(pm_node_list_t &n
             pm_node_t *placeholder = createSyntheticPlaceholder(it->second, RBS_SYNTHETIC_BIND_MARKER);
 
             // Register comment for later processing by AssertionsRewriter
-            assertionsForNode[placeholder] = vector<CommentNodePrism>{it->second};
+            assertionsForNode[placeholder] = vector<CommentNode>{it->second};
             it = commentByLine.erase(it);
 
             // Insert placeholder into statement list
@@ -336,7 +336,7 @@ int CommentsAssociatorPrism::maybeInsertStandalonePlaceholders(pm_node_list_t &n
             pm_node_t *placeholder = createSyntheticPlaceholder(it->second, RBS_SYNTHETIC_TYPE_ALIAS_MARKER);
 
             // Register comment for later processing by SigsRewriter
-            signaturesForNode[placeholder] = vector<CommentNodePrism>{it->second};
+            signaturesForNode[placeholder] = vector<CommentNode>{it->second};
 
             continuationFor = placeholder;
 
@@ -361,9 +361,8 @@ int CommentsAssociatorPrism::maybeInsertStandalonePlaceholders(pm_node_list_t &n
 
 // Walks a conditional node and associates RBS comments.
 // Handles if/unless/elsif/else conditionals (both block and modifier forms) and ternary operators.
-void CommentsAssociatorPrism::walkConditionalNode(pm_node_t *node, pm_node_t *predicate,
-                                                  pm_statements_node_t *&statements, pm_node_t *&elsePart,
-                                                  std::string_view kind) {
+void CommentsAssociator::walkConditionalNode(pm_node_t *node, pm_node_t *predicate, pm_statements_node_t *&statements,
+                                             pm_node_t *&elsePart, std::string_view kind) {
     auto nodeLoc = translateLocation(node->location);
     auto beginLine = posToLine(nodeLoc.beginPos());
     auto endLine = posToLine(nodeLoc.endPos());
@@ -396,7 +395,7 @@ void CommentsAssociatorPrism::walkConditionalNode(pm_node_t *node, pm_node_t *pr
     consumeCommentsInsideNode(node, kind);
 }
 
-void CommentsAssociatorPrism::processTrailingComments(pm_node_t *node, pm_node_list_t &nodes) {
+void CommentsAssociator::processTrailingComments(pm_node_t *node, pm_node_list_t &nodes) {
     if (node == nullptr || contextAllowingTypeAlias.empty()) {
         return;
     }
@@ -407,7 +406,7 @@ void CommentsAssociatorPrism::processTrailingComments(pm_node_t *node, pm_node_l
     lastLine = endLine;
 }
 
-pm_node_t *CommentsAssociatorPrism::walkBody(pm_node_t *node, pm_node_t *body) {
+pm_node_t *CommentsAssociator::walkBody(pm_node_t *node, pm_node_t *body) {
     // Empty class/module bodies can still contain RBS type alias comments.
     // Check for standalone placeholders before falling through to the general null-body path.
     if (typeAliasAllowedInContext() && body == nullptr) {
@@ -496,7 +495,7 @@ pm_node_t *CommentsAssociatorPrism::walkBody(pm_node_t *node, pm_node_t *body) {
     return body;
 }
 
-template <typename PrismNode> void CommentsAssociatorPrism::walkAssignmentNode(pm_node_t *untypedNode) {
+template <typename PrismNode> void CommentsAssociator::walkAssignmentNode(pm_node_t *untypedNode) {
     auto *assign = down_cast_nonnull<PrismNode>(untypedNode);
     associateAssertionCommentsToNode(assign->value, true);
     walkNode(assign->value);
@@ -504,7 +503,7 @@ template <typename PrismNode> void CommentsAssociatorPrism::walkAssignmentNode(p
 }
 
 template <typename PrismNode>
-void CommentsAssociatorPrism::walkCallAssignmentNode(pm_node_t *untypedNode, std::string_view label) {
+void CommentsAssociator::walkCallAssignmentNode(pm_node_t *untypedNode, std::string_view label) {
     auto *assign = down_cast_nonnull<PrismNode>(untypedNode);
     associateAssertionCommentsToNode(assign->value, true);
     walkNode(assign->value);
@@ -513,7 +512,7 @@ void CommentsAssociatorPrism::walkCallAssignmentNode(pm_node_t *untypedNode, std
 }
 
 template <typename PrismNode>
-void CommentsAssociatorPrism::walkIndexAssignmentNode(pm_node_t *untypedNode, std::string_view label) {
+void CommentsAssociator::walkIndexAssignmentNode(pm_node_t *untypedNode, std::string_view label) {
     auto *assign = down_cast_nonnull<PrismNode>(untypedNode);
     associateAssertionCommentsToNode(assign->value, true);
     walkNode(assign->receiver);
@@ -525,20 +524,20 @@ void CommentsAssociatorPrism::walkIndexAssignmentNode(pm_node_t *untypedNode, st
     consumeCommentsInsideNode(untypedNode, label);
 }
 
-void CommentsAssociatorPrism::walkNodes(pm_node_list_t &nodes) {
+void CommentsAssociator::walkNodes(pm_node_list_t &nodes) {
     for (size_t i = 0; i < nodes.size; i++) {
         auto node = nodes.nodes[i];
         walkNode(node);
     }
 }
 
-void CommentsAssociatorPrism::walkArgumentsNode(pm_arguments_node_t *args) {
+void CommentsAssociator::walkArgumentsNode(pm_arguments_node_t *args) {
     if (args) {
         walkNodes(args->arguments);
     }
 }
 
-void CommentsAssociatorPrism::walkStatements(pm_node_list_t &nodes) {
+void CommentsAssociator::walkStatements(pm_node_list_t &nodes) {
     for (size_t i = 0; i < nodes.size; i++) {
         auto *stmt = nodes.nodes[i];
 
@@ -564,7 +563,7 @@ void CommentsAssociatorPrism::walkStatements(pm_node_list_t &nodes) {
     }
 }
 
-void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
+void CommentsAssociator::walkNode(pm_node_t *node) {
     if (node == nullptr) {
         return;
     }
@@ -1165,7 +1164,7 @@ void CommentsAssociatorPrism::walkNode(pm_node_t *node) {
     }
 }
 
-CommentMapPrism CommentsAssociatorPrism::run(pm_node_t *node) {
+CommentMap CommentsAssociator::run(pm_node_t *node) {
     // Remove any comments that don't start with RBS prefixes
     for (auto it = commentByLine.begin(); it != commentByLine.end();) {
         if (!absl::StartsWith(it->second.string, RBS_PREFIX) &&
@@ -1189,23 +1188,22 @@ CommentMapPrism CommentsAssociatorPrism::run(pm_node_t *node) {
         }
     }
 
-    return CommentMapPrism{signaturesForNode, assertionsForNode};
+    return CommentMap{signaturesForNode, assertionsForNode};
 }
 
-pm_node_t *CommentsAssociatorPrism::createSyntheticPlaceholder(const CommentNodePrism &comment,
-                                                               pm_constant_id_t marker) {
+pm_node_t *CommentsAssociator::createSyntheticPlaceholder(const CommentNode &comment, pm_constant_id_t marker) {
     return prism.ConstantReadNode(marker, comment.loc);
 }
 
-CommentsAssociatorPrism::CommentsAssociatorPrism(core::MutableContext ctx, parser::Prism::Parser &parser,
-                                                 vector<core::LocOffsets> commentLocations)
+CommentsAssociator::CommentsAssociator(core::MutableContext ctx, parser::Prism::Parser &parser,
+                                       vector<core::LocOffsets> commentLocations)
     : ctx(ctx), parser(parser), prism(parser), commentLocations(commentLocations), commentByLine() {
     auto source = ctx.file.data(ctx).source();
     for (auto &loc : commentLocations) {
         auto commentString = source.substr(loc.beginPos(), loc.endPos() - loc.beginPos());
         auto start32 = static_cast<uint32_t>(loc.beginPos());
         auto end32 = static_cast<uint32_t>(loc.endPos());
-        auto comment = CommentNodePrism{core::LocOffsets{start32, end32}, commentString};
+        auto comment = CommentNode{core::LocOffsets{start32, end32}, commentString};
 
         auto line = posToLine(start32);
         commentByLine[line] = comment;

--- a/rbs/CommentsAssociator.h
+++ b/rbs/CommentsAssociator.h
@@ -1,5 +1,5 @@
-#ifndef SORBET_RBS_COMMENTS_ASSOCIATOR_PRISM_H
-#define SORBET_RBS_COMMENTS_ASSOCIATOR_PRISM_H
+#ifndef SORBET_RBS_COMMENTS_ASSOCIATOR_H
+#define SORBET_RBS_COMMENTS_ASSOCIATOR_H
 
 #include "common/common.h"
 #include "parser/parser.h"
@@ -81,4 +81,4 @@ private:
 };
 
 } // namespace sorbet::rbs
-#endif // SORBET_RBS_COMMENTS_ASSOCIATOR_PRISM_H
+#endif // SORBET_RBS_COMMENTS_ASSOCIATOR_H

--- a/rbs/CommentsAssociator.h
+++ b/rbs/CommentsAssociator.h
@@ -21,23 +21,23 @@ extern "C" {
 
 namespace sorbet::rbs {
 
-struct CommentNodePrism {
+struct CommentNode {
     core::LocOffsets loc;
     std::string_view string;
 };
 
-struct CommentMapPrism {
-    UnorderedMap<pm_node_t *, std::vector<CommentNodePrism>> signaturesForNode;
-    UnorderedMap<pm_node_t *, std::vector<CommentNodePrism>> assertionsForNode;
+struct CommentMap {
+    UnorderedMap<pm_node_t *, std::vector<CommentNode>> signaturesForNode;
+    UnorderedMap<pm_node_t *, std::vector<CommentNode>> assertionsForNode;
 };
 
-class CommentsAssociatorPrism {
+class CommentsAssociator {
 public:
     static const std::string_view RBS_PREFIX;
 
-    CommentsAssociatorPrism(core::MutableContext ctx, parser::Prism::Parser &parser,
-                            std::vector<core::LocOffsets> commentLocations);
-    CommentMapPrism run(pm_node_t *node);
+    CommentsAssociator(core::MutableContext ctx, parser::Prism::Parser &parser,
+                       std::vector<core::LocOffsets> commentLocations);
+    CommentMap run(pm_node_t *node);
 
 private:
     static const std::string_view ANNOTATION_PREFIX;
@@ -48,9 +48,9 @@ private:
     parser::Prism::Parser &parser;
     parser::Prism::Factory prism;
     std::vector<core::LocOffsets> commentLocations;
-    std::map<int, CommentNodePrism> commentByLine;
-    UnorderedMap<pm_node_t *, std::vector<CommentNodePrism>> signaturesForNode;
-    UnorderedMap<pm_node_t *, std::vector<CommentNodePrism>> assertionsForNode;
+    std::map<int, CommentNode> commentByLine;
+    UnorderedMap<pm_node_t *, std::vector<CommentNode>> signaturesForNode;
+    UnorderedMap<pm_node_t *, std::vector<CommentNode>> assertionsForNode;
     std::vector<std::pair<bool, core::LocOffsets>> contextAllowingTypeAlias;
     int lastLine;
 
@@ -77,7 +77,7 @@ private:
 
     bool typeAliasAllowedInContext() const;
     int maybeInsertStandalonePlaceholders(pm_node_list_t &nodes, int index, int lastLine, int currentLine);
-    pm_node_t *createSyntheticPlaceholder(const CommentNodePrism &comment, pm_constant_id_t marker);
+    pm_node_t *createSyntheticPlaceholder(const CommentNode &comment, pm_constant_id_t marker);
 };
 
 } // namespace sorbet::rbs

--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -455,9 +455,9 @@ vector<pm_node_t *> getMethodParams(pm_def_node_t *def) {
 
 } // namespace
 
-pm_node_t *MethodTypeToParserNodePrism::attrSignature(pm_call_node_t *call, const rbs_node_t *type,
-                                                      const RBSDeclaration &declaration,
-                                                      absl::Span<const Comment> annotations) {
+pm_node_t *MethodTypeToParserNode::attrSignature(pm_call_node_t *call, const rbs_node_t *type,
+                                                 const RBSDeclaration &declaration,
+                                                 absl::Span<const Comment> annotations) {
     auto typeParams = vector<pair<core::LocOffsets, core::NameRef>>{};
     auto fullTypeLoc = declaration.fullTypeLoc();
     auto firstLineTypeLoc = declaration.firstLineTypeLoc();
@@ -474,7 +474,7 @@ pm_node_t *MethodTypeToParserNodePrism::attrSignature(pm_call_node_t *call, cons
         return nullptr;
     }
 
-    auto typeTranslator = TypeToParserNodePrism(ctx, typeParams, parser, prismParser);
+    auto typeTranslator = TypeToParserNode(ctx, typeParams, parser, prismParser);
 
     auto methodName = prismParser.resolveConstant(call->name);
 
@@ -522,9 +522,9 @@ pm_node_t *MethodTypeToParserNodePrism::attrSignature(pm_call_node_t *call, cons
     return prism.Call(fullTypeLoc, sigReceiver, "sig"sv, absl::MakeSpan(sigArgs), block);
 }
 
-pm_node_t *MethodTypeToParserNodePrism::methodSignature(pm_node_t *methodDef, const rbs_method_type_t *methodType,
-                                                        const RBSDeclaration &declaration,
-                                                        absl::Span<const Comment> annotations) {
+pm_node_t *MethodTypeToParserNode::methodSignature(pm_node_t *methodDef, const rbs_method_type_t *methodType,
+                                                   const RBSDeclaration &declaration,
+                                                   absl::Span<const Comment> annotations) {
     const auto &node = *methodType;
 
     // Collect type parameters
@@ -602,7 +602,7 @@ pm_node_t *MethodTypeToParserNodePrism::methodSignature(pm_node_t *methodDef, co
         methodParams = getMethodParams(def);
     }
 
-    auto typeToPrismNode = TypeToParserNodePrism(ctx, typeParams, parser, prismParser);
+    auto typeToPrismNode = TypeToParserNode(ctx, typeParams, parser, prismParser);
 
     // Only error if RBS has more parameters than the method.
     // If RBS has fewer, generate a partial sig and let the resolver error on missing types.
@@ -708,7 +708,7 @@ pm_node_t *MethodTypeToParserNodePrism::methodSignature(pm_node_t *methodDef, co
     return prism.Call(fullTypeLoc, receiver, "sig"sv, absl::MakeSpan(sigArgs), block);
 }
 
-pm_node_t *MethodTypeToParserNodePrism::createSymbolNode(rbs_ast_symbol_t *name, core::LocOffsets nameLoc) {
+pm_node_t *MethodTypeToParserNode::createSymbolNode(rbs_ast_symbol_t *name, core::LocOffsets nameLoc) {
     if (!name) {
         return nullptr;
     }

--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -1,9 +1,9 @@
-#include "rbs/prism/MethodTypeToParserNodePrism.h"
+#include "rbs/MethodTypeToParserNode.h"
 
 #include "absl/algorithm/container.h"
 #include "core/errors/rewriter.h"
 #include "parser/prism/Helpers.h"
-#include "rbs/prism/TypeToParserNodePrism.h"
+#include "rbs/TypeToParserNode.h"
 #include "rbs/rbs_method_common.h"
 
 extern "C" {

--- a/rbs/MethodTypeToParserNode.h
+++ b/rbs/MethodTypeToParserNode.h
@@ -1,5 +1,5 @@
-#ifndef RBS_METHOD_TYPE_TO_PARSER_NODE_PRISM_H
-#define RBS_METHOD_TYPE_TO_PARSER_NODE_PRISM_H
+#ifndef RBS_METHOD_TYPE_TO_PARSER_NODE_H
+#define RBS_METHOD_TYPE_TO_PARSER_NODE_H
 
 #include "parser/prism/Factory.h"
 #include "parser/prism/Parser.h"
@@ -46,4 +46,4 @@ private:
 
 } // namespace sorbet::rbs
 
-#endif // RBS_METHOD_TYPE_TO_PARSER_NODE_PRISM_H
+#endif // RBS_METHOD_TYPE_TO_PARSER_NODE_H

--- a/rbs/MethodTypeToParserNode.h
+++ b/rbs/MethodTypeToParserNode.h
@@ -11,14 +11,14 @@ extern "C" {
 
 namespace sorbet::rbs {
 
-class MethodTypeToParserNodePrism {
+class MethodTypeToParserNode {
     core::MutableContext ctx;
     Parser parser;
     parser::Prism::Parser &prismParser; // For Prism node creation
     const parser::Prism::Factory prism;
 
 public:
-    MethodTypeToParserNodePrism(core::MutableContext ctx, Parser parser, parser::Prism::Parser &prismParser)
+    MethodTypeToParserNode(core::MutableContext ctx, Parser parser, parser::Prism::Parser &prismParser)
         : ctx(ctx), parser(parser), prismParser(prismParser), prism(prismParser) {}
 
     /**

--- a/rbs/RBSRewriter.cc
+++ b/rbs/RBSRewriter.cc
@@ -9,18 +9,18 @@ using namespace std;
 
 namespace sorbet::rbs {
 
-void runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file, pm_node_t *node,
-                        const vector<core::LocOffsets> &commentLocations, core::MutableContext &ctx,
-                        parser::Prism::Parser &parser) {
-    Timer timeit(gs.tracer(), "runPrismRBSRewrite", {{"file", string(file.data(gs).path())}});
+void runRBSRewrite(core::GlobalState &gs, core::FileRef file, pm_node_t *node,
+                   const vector<core::LocOffsets> &commentLocations, core::MutableContext &ctx,
+                   parser::Prism::Parser &parser) {
+    Timer timeit(gs.tracer(), "runRBSRewrite", {{"file", string(file.data(gs).path())}});
 
-    auto associator = CommentsAssociatorPrism(ctx, parser, commentLocations);
+    auto associator = CommentsAssociator(ctx, parser, commentLocations);
     auto commentMap = associator.run(node);
 
-    auto sigsRewriter = SigsRewriterPrism(ctx, parser, commentMap.signaturesForNode);
+    auto sigsRewriter = SigsRewriter(ctx, parser, commentMap.signaturesForNode);
     sigsRewriter.run(node);
 
-    auto assertionsRewriter = AssertionsRewriterPrism(ctx, parser, commentMap.assertionsForNode);
+    auto assertionsRewriter = AssertionsRewriter(ctx, parser, commentMap.assertionsForNode);
     assertionsRewriter.run(node);
 }
 

--- a/rbs/RBSRewriter.cc
+++ b/rbs/RBSRewriter.cc
@@ -1,9 +1,9 @@
-#include "rbs/prism/RBSRewriterPrism.h"
+#include "rbs/RBSRewriter.h"
 
 #include "common/timers/Timer.h"
-#include "rbs/prism/AssertionsRewriterPrism.h"
-#include "rbs/prism/CommentsAssociatorPrism.h"
-#include "rbs/prism/SigsRewriterPrism.h"
+#include "rbs/AssertionsRewriter.h"
+#include "rbs/CommentsAssociator.h"
+#include "rbs/SigsRewriter.h"
 
 using namespace std;
 

--- a/rbs/RBSRewriter.h
+++ b/rbs/RBSRewriter.h
@@ -1,5 +1,5 @@
-#ifndef SORBET_RBS_RBS_REWRITER_PRISM_H
-#define SORBET_RBS_RBS_REWRITER_PRISM_H
+#ifndef SORBET_RBS_RBS_REWRITER_H
+#define SORBET_RBS_RBS_REWRITER_H
 
 #include "core/Context.h"
 #include "core/LocOffsets.h"
@@ -18,4 +18,4 @@ void runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file, pm_node_t *no
 
 } // namespace sorbet::rbs
 
-#endif // SORBET_RBS_RBS_REWRITER_PRISM_H
+#endif // SORBET_RBS_RBS_REWRITER_H

--- a/rbs/RBSRewriter.h
+++ b/rbs/RBSRewriter.h
@@ -12,9 +12,9 @@ extern "C" {
 
 namespace sorbet::rbs {
 
-void runPrismRBSRewrite(core::GlobalState &gs, core::FileRef file, pm_node_t *node,
-                        const std::vector<core::LocOffsets> &commentLocations, core::MutableContext &ctx,
-                        parser::Prism::Parser &parser);
+void runRBSRewrite(core::GlobalState &gs, core::FileRef file, pm_node_t *node,
+                   const std::vector<core::LocOffsets> &commentLocations, core::MutableContext &ctx,
+                   parser::Prism::Parser &parser);
 
 } // namespace sorbet::rbs
 

--- a/rbs/SignatureTranslator.cc
+++ b/rbs/SignatureTranslator.cc
@@ -1,8 +1,8 @@
-#include "rbs/prism/SignatureTranslatorPrism.h"
+#include "rbs/SignatureTranslator.h"
 #include "core/errors/rewriter.h"
-#include "rbs/prism/MethodTypeToParserNodePrism.h"
-#include "rbs/prism/TypeParamsToParserNodesPrism.h"
-#include "rbs/prism/TypeToParserNodePrism.h"
+#include "rbs/MethodTypeToParserNode.h"
+#include "rbs/TypeParamsToParserNodes.h"
+#include "rbs/TypeToParserNode.h"
 #include "rbs/rbs_common.h"
 
 using namespace std;

--- a/rbs/SignatureTranslator.cc
+++ b/rbs/SignatureTranslator.cc
@@ -16,9 +16,8 @@ Parser makeParser(string_view str) {
 }
 } // namespace
 
-pm_node_t *
-SignatureTranslatorPrism::translateAssertionType(absl::Span<pair<core::LocOffsets, core::NameRef>> typeParams,
-                                                 const rbs::RBSDeclaration &assertion) {
+pm_node_t *SignatureTranslator::translateAssertionType(absl::Span<pair<core::LocOffsets, core::NameRef>> typeParams,
+                                                       const rbs::RBSDeclaration &assertion) {
     Parser rbsParser = makeParser(assertion.string);
     rbs_node_t *rbsType = rbsParser.parseType();
 
@@ -30,11 +29,11 @@ SignatureTranslatorPrism::translateAssertionType(absl::Span<pair<core::LocOffset
         return nullptr;
     }
 
-    auto typeToParserNodePrism = TypeToParserNodePrism{ctx, typeParams, move(rbsParser), *prismParser};
-    return typeToParserNodePrism.toPrismNode(rbsType, assertion);
+    auto typeToParserNode = TypeToParserNode{ctx, typeParams, move(rbsParser), *prismParser};
+    return typeToParserNode.toPrismNode(rbsType, assertion);
 }
 
-pm_node_t *SignatureTranslatorPrism::translateType(const RBSDeclaration &declaration) {
+pm_node_t *SignatureTranslator::translateType(const RBSDeclaration &declaration) {
     Parser rbsParser = makeParser(declaration.string);
     rbs_node_t *rbsType = rbsParser.parseType();
 
@@ -46,12 +45,12 @@ pm_node_t *SignatureTranslatorPrism::translateType(const RBSDeclaration &declara
         return nullptr;
     }
 
-    auto typeTranslator = TypeToParserNodePrism{ctx, {}, move(rbsParser), *prismParser};
+    auto typeTranslator = TypeToParserNode{ctx, {}, move(rbsParser), *prismParser};
     return typeTranslator.toPrismNode(rbsType, declaration);
 }
 
-pm_node_t *SignatureTranslatorPrism::translateAttrSignature(pm_call_node_t *call, const RBSDeclaration &declaration,
-                                                            absl::Span<const Comment> annotations) {
+pm_node_t *SignatureTranslator::translateAttrSignature(pm_call_node_t *call, const RBSDeclaration &declaration,
+                                                       absl::Span<const Comment> annotations) {
     Parser rbsParser = makeParser(declaration.string);
     rbs_node_t *rbsType = rbsParser.parseType();
 
@@ -74,12 +73,12 @@ pm_node_t *SignatureTranslatorPrism::translateAttrSignature(pm_call_node_t *call
         return nullptr;
     }
 
-    auto methodTypeToParserNode = MethodTypeToParserNodePrism{ctx, move(rbsParser), *prismParser};
+    auto methodTypeToParserNode = MethodTypeToParserNode{ctx, move(rbsParser), *prismParser};
     return methodTypeToParserNode.attrSignature(call, rbsType, declaration, annotations);
 }
 
-pm_node_t *SignatureTranslatorPrism::translateMethodSignature(pm_node_t *methodDef, const RBSDeclaration &declaration,
-                                                              absl::Span<const Comment> annotations) {
+pm_node_t *SignatureTranslator::translateMethodSignature(pm_node_t *methodDef, const RBSDeclaration &declaration,
+                                                         absl::Span<const Comment> annotations) {
     Parser rbsParser = makeParser(declaration.string);
     rbs_method_type_t *rbsMethodType = rbsParser.parseMethodType();
 
@@ -91,11 +90,11 @@ pm_node_t *SignatureTranslatorPrism::translateMethodSignature(pm_node_t *methodD
         return nullptr;
     }
 
-    auto methodTypeToParserNodePrism = MethodTypeToParserNodePrism{ctx, move(rbsParser), *prismParser};
-    return methodTypeToParserNodePrism.methodSignature(methodDef, rbsMethodType, declaration, annotations);
+    auto methodTypeToParserNode = MethodTypeToParserNode{ctx, move(rbsParser), *prismParser};
+    return methodTypeToParserNode.methodSignature(methodDef, rbsMethodType, declaration, annotations);
 }
 
-vector<pm_node_t *> SignatureTranslatorPrism::translateTypeParams(const RBSDeclaration &declaration) {
+vector<pm_node_t *> SignatureTranslator::translateTypeParams(const RBSDeclaration &declaration) {
     Parser rbsParser = makeParser(declaration.string);
     rbs_node_list_t *rbsTypeParams = rbsParser.parseTypeParams();
 
@@ -107,7 +106,7 @@ vector<pm_node_t *> SignatureTranslatorPrism::translateTypeParams(const RBSDecla
         return {};
     }
 
-    TypeParamsToParserNodesPrism typeParamsTranslator{ctx, rbsParser, *prismParser};
+    TypeParamsToParserNodes typeParamsTranslator{ctx, rbsParser, *prismParser};
     return typeParamsTranslator.typeParams(rbsTypeParams, declaration);
 }
 

--- a/rbs/SignatureTranslator.h
+++ b/rbs/SignatureTranslator.h
@@ -14,10 +14,10 @@ extern "C" {
 
 namespace sorbet::rbs {
 
-class SignatureTranslatorPrism final {
+class SignatureTranslator final {
 public:
-    SignatureTranslatorPrism(core::MutableContext ctx) : ctx(ctx), prismParser{nullptr} {}
-    SignatureTranslatorPrism(core::MutableContext ctx, parser::Prism::Parser &prismParser)
+    SignatureTranslator(core::MutableContext ctx) : ctx(ctx), prismParser{nullptr} {}
+    SignatureTranslator(core::MutableContext ctx, parser::Prism::Parser &prismParser)
         : ctx(ctx), prismParser{&prismParser} {}
 
     pm_node_t *translateMethodSignature(pm_node_t *methodDef, const RBSDeclaration &declaration,

--- a/rbs/SignatureTranslator.h
+++ b/rbs/SignatureTranslator.h
@@ -1,5 +1,5 @@
-#ifndef SORBET_RBS_SIGNATURE_TRANSLATOR_PRISM_H
-#define SORBET_RBS_SIGNATURE_TRANSLATOR_PRISM_H
+#ifndef SORBET_RBS_SIGNATURE_TRANSLATOR_H
+#define SORBET_RBS_SIGNATURE_TRANSLATOR_H
 
 #include "parser/parser.h"
 #include "parser/prism/Parser.h"
@@ -40,4 +40,4 @@ private:
 
 } // namespace sorbet::rbs
 
-#endif // SORBET_RBS_SIGNATURE_TRANSLATOR_PRISM_H
+#endif // SORBET_RBS_SIGNATURE_TRANSLATOR_H

--- a/rbs/SigsRewriter.cc
+++ b/rbs/SigsRewriter.cc
@@ -1,4 +1,4 @@
-#include "rbs/prism/SigsRewriterPrism.h"
+#include "rbs/SigsRewriter.h"
 
 #include "absl/algorithm/container.h"
 #include "absl/strings/match.h"
@@ -10,7 +10,7 @@
 extern "C" {
 #include "prism.h"
 }
-#include "rbs/prism/SignatureTranslatorPrism.h"
+#include "rbs/SignatureTranslator.h"
 
 using namespace std;
 using namespace sorbet::parser::Prism;

--- a/rbs/SigsRewriter.cc
+++ b/rbs/SigsRewriter.cc
@@ -57,7 +57,7 @@ pm_node_t *extractHelperArgument(core::MutableContext ctx, parser::Prism::Parser
         annotation.string.substr(offset),
     };
 
-    return rbs::SignatureTranslatorPrism(ctx, parser).translateType(RBSDeclaration{{comment}});
+    return rbs::SignatureTranslator(ctx, parser).translateType(RBSDeclaration{{comment}});
 }
 
 /**
@@ -211,7 +211,7 @@ void insertHelpers(pm_node_t *body, absl::Span<pm_node_t *const> helpers) {
 
 } // namespace
 
-void SigsRewriterPrism::insertTypeParams(pm_node_t *node, pm_node_t *body) {
+void SigsRewriter::insertTypeParams(pm_node_t *node, pm_node_t *body) {
     ENFORCE(isa_node<pm_class_node_t>(node) || isa_node<pm_module_node_t>(node) ||
                 isa_node<pm_singleton_class_node_t>(node),
             "Type parameters can only exist on classes, singleton classes, and modules");
@@ -230,7 +230,7 @@ void SigsRewriterPrism::insertTypeParams(pm_node_t *node, pm_node_t *body) {
     }
 
     auto signature = comments.signatures[0];
-    auto typeParamsTranslator = SignatureTranslatorPrism{ctx, parser};
+    auto typeParamsTranslator = SignatureTranslator{ctx, parser};
     auto typeParams = typeParamsTranslator.translateTypeParams(signature);
 
     if (typeParams.empty()) {
@@ -244,8 +244,8 @@ void SigsRewriterPrism::insertTypeParams(pm_node_t *node, pm_node_t *body) {
     }
 }
 
-CommentsPrism SigsRewriterPrism::commentsForNode(pm_node_t *node) {
-    auto comments = CommentsPrism{};
+Comments SigsRewriter::commentsForNode(pm_node_t *node) {
+    auto comments = Comments{};
 
     if (node == nullptr) {
         return comments;
@@ -323,7 +323,7 @@ CommentsPrism SigsRewriterPrism::commentsForNode(pm_node_t *node) {
     return comments;
 }
 
-unique_ptr<vector<pm_node_t *>> SigsRewriterPrism::signaturesForNode(pm_node_t *node) {
+unique_ptr<vector<pm_node_t *>> SigsRewriter::signaturesForNode(pm_node_t *node) {
     auto comments = commentsForNode(node);
 
     if (comments.signatures.empty()) {
@@ -331,7 +331,7 @@ unique_ptr<vector<pm_node_t *>> SigsRewriterPrism::signaturesForNode(pm_node_t *
     }
 
     auto signatures = make_unique<vector<pm_node_t *>>();
-    auto signatureTranslator = rbs::SignatureTranslatorPrism{ctx, parser};
+    auto signatureTranslator = rbs::SignatureTranslator{ctx, parser};
 
     for (auto &declaration : comments.signatures) {
         if (isa_node<pm_def_node_t>(node)) {
@@ -366,7 +366,7 @@ unique_ptr<vector<pm_node_t *>> SigsRewriterPrism::signaturesForNode(pm_node_t *
 /**
  * Replace the synthetic type alias node with a `T.type_alias` call.
  */
-pm_node_t *SigsRewriterPrism::replaceSyntheticTypeAlias(pm_node_t *node) {
+pm_node_t *SigsRewriter::replaceSyntheticTypeAlias(pm_node_t *node) {
     auto comments = commentsForNode(node);
     ENFORCE(!comments.signatures.empty(), "No inline comment found for synthetic type alias");
     ENFORCE(comments.signatures.size() <= 1, "Multiple signatures found for synthetic type alias");
@@ -388,7 +388,7 @@ pm_node_t *SigsRewriterPrism::replaceSyntheticTypeAlias(pm_node_t *node) {
         .string = fullString.substr(typeBeginLoc + 1),
     }}};
 
-    auto signatureTranslator = rbs::SignatureTranslatorPrism{ctx, parser};
+    auto signatureTranslator = rbs::SignatureTranslator{ctx, parser};
     absl::Span<pair<core::LocOffsets, core::NameRef>> typeParams; // Empty for type aliases
     auto type = signatureTranslator.translateAssertionType(typeParams, typeDeclaration);
 
@@ -401,19 +401,19 @@ pm_node_t *SigsRewriterPrism::replaceSyntheticTypeAlias(pm_node_t *node) {
     return prism.TTypeAlias(loc, type);
 }
 
-void SigsRewriterPrism::rewriteNodes(pm_node_list_t &nodes) {
+void SigsRewriter::rewriteNodes(pm_node_list_t &nodes) {
     for (size_t i = 0; i < nodes.size; i++) {
         nodes.nodes[i] = rewriteBody(nodes.nodes[i]);
     }
 }
 
-void SigsRewriterPrism::rewriteArgumentsNode(pm_arguments_node_t *args) {
+void SigsRewriter::rewriteArgumentsNode(pm_arguments_node_t *args) {
     if (args) {
         rewriteNodes(args->arguments);
     }
 }
 
-pm_node_t *SigsRewriterPrism::rewriteBody(pm_node_t *node) {
+pm_node_t *SigsRewriter::rewriteBody(pm_node_t *node) {
     if (node == nullptr) {
         return node;
     }
@@ -464,11 +464,11 @@ pm_node_t *SigsRewriterPrism::rewriteBody(pm_node_t *node) {
     return node;
 }
 
-void SigsRewriterPrism::rewriteBody(pm_statements_node_t *stmts) {
+void SigsRewriter::rewriteBody(pm_statements_node_t *stmts) {
     rewriteBody(up_cast(stmts));
 }
 
-void SigsRewriterPrism::processClassBody(pm_node_t *node, pm_node_t *&body, absl::Span<pm_node_t *const> helpers) {
+void SigsRewriter::processClassBody(pm_node_t *node, pm_node_t *&body, absl::Span<pm_node_t *const> helpers) {
     auto loc = body ? parser.translateLocation(body->location) : parser.translateLocation(node->location);
 
     body = maybeWrapBody(body, loc, parser);
@@ -480,7 +480,7 @@ void SigsRewriterPrism::processClassBody(pm_node_t *node, pm_node_t *&body, absl
     insertTypeParams(node, body);
 }
 
-void SigsRewriterPrism::rewriteClass(pm_node_t *node) {
+void SigsRewriter::rewriteClass(pm_node_t *node) {
     if (node == nullptr) {
         return;
     }
@@ -507,13 +507,13 @@ void SigsRewriterPrism::rewriteClass(pm_node_t *node) {
     }
 }
 
-inline void SigsRewriterPrism::rewriteNullableNode(pm_node_t *node) {
+inline void SigsRewriter::rewriteNullableNode(pm_node_t *node) {
     if (node != nullptr) {
         rewriteNode(node);
     }
 }
 
-void SigsRewriterPrism::rewriteNode(pm_node_t *node) {
+void SigsRewriter::rewriteNode(pm_node_t *node) {
     switch (PM_NODE_TYPE(node)) {
         case PM_BEGIN_NODE: {
             auto *begin = down_cast_nonnull<pm_begin_node_t>(node);
@@ -728,7 +728,7 @@ void SigsRewriterPrism::rewriteNode(pm_node_t *node) {
     }
 }
 
-void SigsRewriterPrism::run(pm_node_t *node) {
+void SigsRewriter::run(pm_node_t *node) {
     // If there are no signature comments to process, we can skip the entire tree walk.
     if (commentsByNode.empty()) {
         return;
@@ -738,8 +738,8 @@ void SigsRewriterPrism::run(pm_node_t *node) {
 }
 
 // Helper method to create statements nodes with signatures
-pm_node_t *SigsRewriterPrism::createStatementsWithSignatures(pm_node_t *originalNode,
-                                                             unique_ptr<vector<pm_node_t *>> signatures) {
+pm_node_t *SigsRewriter::createStatementsWithSignatures(pm_node_t *originalNode,
+                                                        unique_ptr<vector<pm_node_t *>> signatures) {
     if (!signatures || signatures->empty()) {
         return originalNode;
     }

--- a/rbs/SigsRewriter.h
+++ b/rbs/SigsRewriter.h
@@ -18,7 +18,7 @@ namespace sorbet::rbs {
 /**
  * A collection of annotations and signatures comments found on a method definition.
  */
-struct CommentsPrism {
+struct Comments {
     /**
      * RBS annotation comments found on a method definition.
      *
@@ -34,10 +34,10 @@ struct CommentsPrism {
     std::vector<RBSDeclaration> signatures;
 };
 
-class SigsRewriterPrism {
+class SigsRewriter {
 public:
-    SigsRewriterPrism(core::MutableContext ctx, parser::Prism::Parser &parser,
-                      UnorderedMap<pm_node_t *, std::vector<rbs::CommentNodePrism>> &commentsByNode)
+    SigsRewriter(core::MutableContext ctx, parser::Prism::Parser &parser,
+                 UnorderedMap<pm_node_t *, std::vector<rbs::CommentNode>> &commentsByNode)
         : ctx{ctx}, parser{parser}, prism{parser}, commentsByNode{commentsByNode} {}
 
     // Rewrite the RBS signatures in the Prism AST, in-place.
@@ -47,7 +47,7 @@ private:
     core::MutableContext ctx;
     parser::Prism::Parser &parser;
     parser::Prism::Factory prism;
-    UnorderedMap<pm_node_t *, std::vector<rbs::CommentNodePrism>> &commentsByNode;
+    UnorderedMap<pm_node_t *, std::vector<rbs::CommentNode>> &commentsByNode;
 
     pm_node_t *rewriteBody(pm_node_t *node);
     void rewriteBody(pm_statements_node_t *stmts);
@@ -57,7 +57,7 @@ private:
     void rewriteArgumentsNode(pm_arguments_node_t *args);
     void rewriteClass(pm_node_t *node);
     std::unique_ptr<std::vector<pm_node_t *>> signaturesForNode(pm_node_t *node);
-    CommentsPrism commentsForNode(pm_node_t *node);
+    Comments commentsForNode(pm_node_t *node);
     void insertTypeParams(pm_node_t *node, pm_node_t *body);
     void processClassBody(pm_node_t *node, pm_node_t *&body, absl::Span<pm_node_t *const> helpers);
     pm_node_t *replaceSyntheticTypeAlias(pm_node_t *node);

--- a/rbs/SigsRewriter.h
+++ b/rbs/SigsRewriter.h
@@ -1,12 +1,12 @@
-#ifndef SORBET_RBS_SIGS_REWRITER_PRISM_H
-#define SORBET_RBS_SIGS_REWRITER_PRISM_H
+#ifndef SORBET_RBS_SIGS_REWRITER_H
+#define SORBET_RBS_SIGS_REWRITER_H
 
 #include <memory>
 
 #include "parser/prism/Factory.h"
 #include "parser/prism/Helpers.h"
 #include "parser/prism/Parser.h"
-#include "rbs/prism/CommentsAssociatorPrism.h"
+#include "rbs/CommentsAssociator.h"
 #include "rbs/rbs_common.h"
 
 extern "C" {
@@ -67,4 +67,4 @@ private:
 
 } // namespace sorbet::rbs
 
-#endif // SORBET_RBS_SIGS_REWRITER_PRISM_H
+#endif // SORBET_RBS_SIGS_REWRITER_H

--- a/rbs/TypeParamsToParserNodes.cc
+++ b/rbs/TypeParamsToParserNodes.cc
@@ -1,7 +1,7 @@
-#include "rbs/prism/TypeParamsToParserNodesPrism.h"
+#include "rbs/TypeParamsToParserNodes.h"
 
 #include "core/errors/rewriter.h"
-#include "rbs/prism/TypeToParserNodePrism.h"
+#include "rbs/TypeToParserNode.h"
 
 using namespace std;
 

--- a/rbs/TypeParamsToParserNodes.cc
+++ b/rbs/TypeParamsToParserNodes.cc
@@ -7,8 +7,8 @@ using namespace std;
 
 namespace sorbet::rbs {
 
-vector<pm_node_t *> TypeParamsToParserNodesPrism::typeParams(const rbs_node_list_t *rbsTypeParams,
-                                                             const RBSDeclaration &declaration) {
+vector<pm_node_t *> TypeParamsToParserNodes::typeParams(const rbs_node_list_t *rbsTypeParams,
+                                                        const RBSDeclaration &declaration) {
     vector<pm_node_t *> result{};
     result.reserve(rbsTypeParams->length);
 
@@ -40,7 +40,7 @@ vector<pm_node_t *> TypeParamsToParserNodesPrism::typeParams(const rbs_node_list
 
         pm_node_t *block = nullptr;
         if (defaultType || upperBound || lowerBound) {
-            auto typeTranslator = TypeToParserNodePrism{ctx, {}, parser, prismParser};
+            auto typeTranslator = TypeToParserNode{ctx, {}, parser, prismParser};
             absl::InlinedVector<pm_node_t *, 3> pairs{};
 
             if (defaultType) {

--- a/rbs/TypeParamsToParserNodes.h
+++ b/rbs/TypeParamsToParserNodes.h
@@ -12,14 +12,14 @@ extern "C" {
 
 namespace sorbet::rbs {
 
-class TypeParamsToParserNodesPrism {
+class TypeParamsToParserNodes {
     core::MutableContext ctx;
     const Parser &parser;
     parser::Prism::Parser &prismParser;
     const parser::Prism::Factory prism;
 
 public:
-    TypeParamsToParserNodesPrism(core::MutableContext ctx, const Parser &parser, parser::Prism::Parser &prismParser)
+    TypeParamsToParserNodes(core::MutableContext ctx, const Parser &parser, parser::Prism::Parser &prismParser)
         : ctx(ctx), parser(parser), prismParser(prismParser), prism{prismParser} {}
 
     std::vector<pm_node_t *> typeParams(const rbs_node_list_t *rbsTypeParams, const RBSDeclaration &declaration);

--- a/rbs/TypeParamsToParserNodes.h
+++ b/rbs/TypeParamsToParserNodes.h
@@ -1,5 +1,5 @@
-#ifndef SORBET_RBS_TYPE_PARAMS_TO_PARSER_NODES_PRISM_H
-#define SORBET_RBS_TYPE_PARAMS_TO_PARSER_NODES_PRISM_H
+#ifndef SORBET_RBS_TYPE_PARAMS_TO_PARSER_NODES_H
+#define SORBET_RBS_TYPE_PARAMS_TO_PARSER_NODES_H
 
 #include "parser/prism/Factory.h"
 #include "parser/prism/Parser.h"
@@ -27,4 +27,4 @@ public:
 
 } // namespace sorbet::rbs
 
-#endif // SORBET_RBS_TYPE_PARAMS_TO_PARSER_NODES_PRISM_H
+#endif // SORBET_RBS_TYPE_PARAMS_TO_PARSER_NODES_H

--- a/rbs/TypeToParserNode.cc
+++ b/rbs/TypeToParserNode.cc
@@ -1,4 +1,4 @@
-#include "rbs/prism/TypeToParserNodePrism.h"
+#include "rbs/TypeToParserNode.h"
 
 #include "common/typecase.h"
 #include "core/GlobalState.h"

--- a/rbs/TypeToParserNode.cc
+++ b/rbs/TypeToParserNode.cc
@@ -35,8 +35,8 @@ bool isEnumerator(pm_node_t *node, parser::Prism::Parser &prismParser, core::Glo
 // Converts an RBS namespace to a Prism constant path node.
 //   Foo::Bar -> ConstantPathNode(ConstantReadNode(Foo), Bar)
 //   ::Foo    -> ConstantPathNode(nullptr, Foo)
-pm_node_t *TypeToParserNodePrism::namespaceConst(const rbs_namespace_t *rbsNamespace, const RBSDeclaration &declaration,
-                                                 core::LocOffsets loc) {
+pm_node_t *TypeToParserNode::namespaceConst(const rbs_namespace_t *rbsNamespace, const RBSDeclaration &declaration,
+                                            core::LocOffsets loc) {
     rbs_node_list *typePath = rbsNamespace->path;
 
     pm_node_t *parent = nullptr;
@@ -65,8 +65,8 @@ pm_node_t *TypeToParserNodePrism::namespaceConst(const rbs_namespace_t *rbsNames
     return parent;
 }
 
-pm_node_t *TypeToParserNodePrism::typeNameType(const rbs_type_name_t *typeName, bool isGeneric,
-                                               const RBSDeclaration &declaration) {
+pm_node_t *TypeToParserNode::typeNameType(const rbs_type_name_t *typeName, bool isGeneric,
+                                          const RBSDeclaration &declaration) {
     auto loc = declaration.typeLocFromRange(typeName->base.location);
 
     pm_node_t *parent = namespaceConst(typeName->rbs_namespace, declaration, loc);
@@ -114,8 +114,8 @@ pm_node_t *TypeToParserNodePrism::typeNameType(const rbs_type_name_t *typeName, 
     }
 }
 
-pm_node_t *TypeToParserNodePrism::aliasType(const rbs_types_alias_t *node, core::LocOffsets loc,
-                                            const RBSDeclaration &declaration) {
+pm_node_t *TypeToParserNode::aliasType(const rbs_types_alias_t *node, core::LocOffsets loc,
+                                       const RBSDeclaration &declaration) {
     pm_node_t *parent = namespaceConst(node->name->rbs_namespace, declaration, loc);
     auto nameView = parser.resolveConstant(node->name->name);
     auto nameStr = "type " + string(nameView);
@@ -127,8 +127,8 @@ pm_node_t *TypeToParserNodePrism::aliasType(const rbs_types_alias_t *node, core:
     }
 }
 
-pm_node_t *TypeToParserNodePrism::classInstanceType(const rbs_types_class_instance_t *node, core::LocOffsets loc,
-                                                    const RBSDeclaration &declaration) {
+pm_node_t *TypeToParserNode::classInstanceType(const rbs_types_class_instance_t *node, core::LocOffsets loc,
+                                               const RBSDeclaration &declaration) {
     auto argsValue = node->args;
     auto isGeneric = argsValue != nullptr && argsValue->length > 0;
     auto typeConstant = typeNameType(node->name, isGeneric, declaration);
@@ -142,8 +142,8 @@ pm_node_t *TypeToParserNodePrism::classInstanceType(const rbs_types_class_instan
     return typeConstant;
 }
 
-pm_node_t *TypeToParserNodePrism::classSingletonType(const rbs_types_class_singleton_t *node, core::LocOffsets loc,
-                                                     const RBSDeclaration &declaration) {
+pm_node_t *TypeToParserNode::classSingletonType(const rbs_types_class_singleton_t *node, core::LocOffsets loc,
+                                                const RBSDeclaration &declaration) {
     auto argsValue = node->args;
     auto isGeneric = argsValue != nullptr && argsValue->length > 0;
     auto innerType = typeNameType(node->name, false, declaration);
@@ -158,20 +158,20 @@ pm_node_t *TypeToParserNodePrism::classSingletonType(const rbs_types_class_singl
     return classOfNode;
 }
 
-pm_node_t *TypeToParserNodePrism::unionType(const rbs_types_union_t *node, core::LocOffsets loc,
-                                            const RBSDeclaration &declaration) {
+pm_node_t *TypeToParserNode::unionType(const rbs_types_union_t *node, core::LocOffsets loc,
+                                       const RBSDeclaration &declaration) {
     auto args = translateNodeList(node->types, declaration);
     return prism.TAny(loc, absl::MakeSpan(args));
 }
 
-pm_node_t *TypeToParserNodePrism::intersectionType(const rbs_types_intersection_t *node, core::LocOffsets loc,
-                                                   const RBSDeclaration &declaration) {
+pm_node_t *TypeToParserNode::intersectionType(const rbs_types_intersection_t *node, core::LocOffsets loc,
+                                              const RBSDeclaration &declaration) {
     auto args = translateNodeList(node->types, declaration);
     return prism.TAll(loc, absl::MakeSpan(args));
 }
 
-pm_node_t *TypeToParserNodePrism::optionalType(const rbs_types_optional_t *node, core::LocOffsets loc,
-                                               const RBSDeclaration &declaration) {
+pm_node_t *TypeToParserNode::optionalType(const rbs_types_optional_t *node, core::LocOffsets loc,
+                                          const RBSDeclaration &declaration) {
     auto innerType = toPrismNode(node->type, declaration);
     if (prismParser.isTUntyped(innerType)) {
         return innerType;
@@ -179,8 +179,8 @@ pm_node_t *TypeToParserNodePrism::optionalType(const rbs_types_optional_t *node,
     return prism.TNilable(loc, innerType);
 }
 
-pm_node_t *TypeToParserNodePrism::functionType(const rbs_types_function_t *node, core::LocOffsets loc,
-                                               const RBSDeclaration &declaration) {
+pm_node_t *TypeToParserNode::functionType(const rbs_types_function_t *node, core::LocOffsets loc,
+                                          const RBSDeclaration &declaration) {
     vector<pm_node_t *> pairs;
     pairs.reserve(node->required_positionals->length);
 
@@ -218,8 +218,8 @@ pm_node_t *TypeToParserNodePrism::functionType(const rbs_types_function_t *node,
     return prism.TProc(loc, argsHash, returnType);
 }
 
-pm_node_t *TypeToParserNodePrism::procType(const rbs_types_proc_t *node, core::LocOffsets loc,
-                                           const RBSDeclaration &declaration) {
+pm_node_t *TypeToParserNode::procType(const rbs_types_proc_t *node, core::LocOffsets loc,
+                                      const RBSDeclaration &declaration) {
     rbs_node_t *functionTypeNode = node->type;
     pm_node_t *function;
 
@@ -249,8 +249,8 @@ pm_node_t *TypeToParserNodePrism::procType(const rbs_types_proc_t *node, core::L
     return function;
 }
 
-pm_node_t *TypeToParserNodePrism::blockType(const rbs_types_block_t *node, core::LocOffsets loc,
-                                            const RBSDeclaration &declaration) {
+pm_node_t *TypeToParserNode::blockType(const rbs_types_block_t *node, core::LocOffsets loc,
+                                       const RBSDeclaration &declaration) {
     rbs_node_t *functionTypeNode = node->type;
     pm_node_t *function;
 
@@ -285,14 +285,14 @@ pm_node_t *TypeToParserNodePrism::blockType(const rbs_types_block_t *node, core:
     return function;
 }
 
-pm_node_t *TypeToParserNodePrism::tupleType(const rbs_types_tuple_t *node, core::LocOffsets loc,
-                                            const RBSDeclaration &declaration) {
+pm_node_t *TypeToParserNode::tupleType(const rbs_types_tuple_t *node, core::LocOffsets loc,
+                                       const RBSDeclaration &declaration) {
     auto types = translateNodeList(node->types, declaration);
     return prism.Array(loc, absl::MakeSpan(types));
 }
 
-pm_node_t *TypeToParserNodePrism::recordType(const rbs_types_record_t *node, core::LocOffsets loc,
-                                             const RBSDeclaration &declaration) {
+pm_node_t *TypeToParserNode::recordType(const rbs_types_record_t *node, core::LocOffsets loc,
+                                        const RBSDeclaration &declaration) {
     vector<pm_node_t *> pairs;
     pairs.reserve(node->all_fields->length);
 
@@ -335,11 +335,11 @@ pm_node_t *TypeToParserNodePrism::recordType(const rbs_types_record_t *node, cor
     return prism.Hash(loc, absl::MakeSpan(pairs));
 }
 
-pm_node_t *TypeToParserNodePrism::variableType(const rbs_types_variable_t *node, core::LocOffsets loc) {
+pm_node_t *TypeToParserNode::variableType(const rbs_types_variable_t *node, core::LocOffsets loc) {
     return prism.TTypeParameter(loc, prism.Symbol(loc, parser.resolveConstant(node->name)));
 }
 
-vector<pm_node_t *> TypeToParserNodePrism::translateNodeList(rbs_node_list *list, const RBSDeclaration &declaration) {
+vector<pm_node_t *> TypeToParserNode::translateNodeList(rbs_node_list *list, const RBSDeclaration &declaration) {
     vector<pm_node_t *> result;
     result.reserve(list->length);
     for (rbs_node_list_node *node = list->head; node != nullptr; node = node->next) {
@@ -348,7 +348,7 @@ vector<pm_node_t *> TypeToParserNodePrism::translateNodeList(rbs_node_list *list
     return result;
 }
 
-pm_node_t *TypeToParserNodePrism::toPrismNode(const rbs_node_t *node, const RBSDeclaration &declaration) {
+pm_node_t *TypeToParserNode::toPrismNode(const rbs_node_t *node, const RBSDeclaration &declaration) {
     auto nodeLoc = declaration.typeLocFromRange(node->location);
 
     switch (node->type) {

--- a/rbs/TypeToParserNode.h
+++ b/rbs/TypeToParserNode.h
@@ -1,5 +1,5 @@
-#ifndef RBS_PRISM_TYPE_TO_PARSER_NODE_PRISM_H
-#define RBS_PRISM_TYPE_TO_PARSER_NODE_PRISM_H
+#ifndef RBS_TYPE_TO_PARSER_NODE_H
+#define RBS_TYPE_TO_PARSER_NODE_H
 
 #include "parser/prism/Factory.h"
 #include "parser/prism/Helpers.h"
@@ -56,4 +56,4 @@ private:
 
 } // namespace sorbet::rbs
 
-#endif // RBS_PRISM_TYPE_TO_PARSER_NODE_PRISM_H
+#endif // RBS_TYPE_TO_PARSER_NODE_H

--- a/rbs/TypeToParserNode.h
+++ b/rbs/TypeToParserNode.h
@@ -9,7 +9,7 @@
 
 namespace sorbet::rbs {
 
-class TypeToParserNodePrism {
+class TypeToParserNode {
     core::MutableContext ctx;
     absl::Span<const std::pair<core::LocOffsets, core::NameRef>> typeParams;
     rbs::Parser parser;
@@ -17,9 +17,8 @@ class TypeToParserNodePrism {
     parser::Prism::Factory prism;
 
 public:
-    TypeToParserNodePrism(core::MutableContext ctx,
-                          absl::Span<const std::pair<core::LocOffsets, core::NameRef>> typeParams, Parser parser,
-                          parser::Prism::Parser &prismParser)
+    TypeToParserNode(core::MutableContext ctx, absl::Span<const std::pair<core::LocOffsets, core::NameRef>> typeParams,
+                     Parser parser, parser::Prism::Parser &prismParser)
         : ctx(ctx), typeParams(typeParams), parser(parser), prismParser(prismParser), prism(prismParser) {}
 
     /**

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -270,8 +270,8 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> f
 
                     if (gs.cacheSensitiveOptions.rbsEnabled) {
                         auto &prismParser = prismParseResult->getParser();
-                        rbs::runPrismRBSRewrite(gs, file, prismParseResult->getRawNodePointer(),
-                                                prismParseResult->getCommentLocations(), ctx, prismParser);
+                        rbs::runRBSRewrite(gs, file, prismParseResult->getRawNodePointer(),
+                                           prismParseResult->getCommentLocations(), ctx, prismParser);
                         disableParserComparison = true;
 
                         handler.addObserved(gs, "rbs-rewrite-tree", [&]() { return prismParseResult->prettyPrint(); });
@@ -803,11 +803,11 @@ TEST_CASE("PerPhaseTest") {
             case realmain::options::Parser::PRISM: {
                 auto prismResult = parser::Prism::Parser::run(ctx);
 
-                // Run the Prism-level RBS rewriter
+                // Run the RBS rewriter
                 if (gs->cacheSensitiveOptions.rbsEnabled) {
                     auto &prismParser = prismResult.getParser();
-                    rbs::runPrismRBSRewrite(*gs, f, prismResult.getRawNodePointer(), prismResult.getCommentLocations(),
-                                            ctx, prismParser);
+                    rbs::runRBSRewrite(*gs, f, prismResult.getRawNodePointer(), prismResult.getCommentLocations(), ctx,
+                                       prismParser);
 
                     handler.addObserved(*gs, "rbs-rewrite-tree", [&]() { return prismResult.prettyPrint(); });
                 }

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -37,7 +37,7 @@
 #include "parser/prism/Parser.h"
 #include "payload/binary/binary.h"
 #include "payload/payload.h"
-#include "rbs/prism/RBSRewriterPrism.h"
+#include "rbs/RBSRewriter.h"
 #include "resolver/resolver.h"
 #include "rewriter/rewriter.h"
 #include "spdlog/sinks/stdout_color_sinks.h"


### PR DESCRIPTION
### Motivation

Since the legacy RBS rewriter [was deleted](#10285), there's no longer a Prism vs non-Prism distinction to be made. This PR renames files and APIs to remove the "Prism" suffixes

### Merge notes

Please merge via merge commit or rebase.

Squash-merging these two commits together will cause `rbs/RBSRewriter.cc` to lose its git history.

### Test plan

Pure refactor.
