### PR TITLE
Build `.checked` support for `T.type_alias`

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/runtime_levels.rb
+++ b/gems/sorbet-runtime/lib/types/private/runtime_levels.rb
@@ -33,9 +33,12 @@ module T::Private::RuntimeLevels
     if !@check_tests && @wrapped_tests_with_validation
       all_checked_tests_sigs = T::Private::Methods.all_checked_tests_sigs
       locations = all_checked_tests_sigs.map { |sig| sig.method.source_location&.join(':') }.join("\n- ")
-      raise "Toggle `:tests`-level runtime type checking earlier. " \
-        "There are already some methods wrapped with `sig.checked(:tests)`:\n" \
-        "- #{locations}"
+      msg = "Toggle `:tests`-level runtime type checking earlier. " \
+        "There are already some methods or type aliases wrapped with `.checked(:tests)`"
+      if !locations.empty?
+        msg += ":\n- #{locations}"
+      end
+      raise msg
     end
 
     _toggle_checking_tests(true)

--- a/gems/sorbet-runtime/lib/types/private/types/type_alias.rb
+++ b/gems/sorbet-runtime/lib/types/private/types/type_alias.rb
@@ -7,6 +7,18 @@ module T::Private::Types
 
     def initialize(callable)
       @callable = callable
+      @checked_level = nil
+    end
+
+    def checked(level)
+      if !@checked_level.nil?
+        raise "You can't call .checked multiple times on a type alias."
+      end
+      if !T::Private::RuntimeLevels::LEVELS.include?(level)
+        raise ArgumentError, "Invalid `checked` level '#{level}'. Use one of: #{T::Private::RuntimeLevels::LEVELS}."
+      end
+      @checked_level = level
+      self
     end
 
     def build_type
@@ -17,6 +29,18 @@ module T::Private::Types
       @aliased_type ||= T::Utils.coerce(@callable.call)
     end
 
+    def effective_aliased_type
+      @effective_aliased_type ||= begin
+        real_type = aliased_type
+        level = @checked_level.nil? ? T::Private::RuntimeLevels.default_checked_level : @checked_level
+        if level == :always || (level == :tests && T::Private::RuntimeLevels.check_tests?)
+          real_type
+        else
+          T::Types::Anything::Private::INSTANCE
+        end
+      end
+    end
+
     # overrides Base
     def name
       aliased_type.name
@@ -24,12 +48,12 @@ module T::Private::Types
 
     # overrides Base
     def recursively_valid?(obj)
-      aliased_type.recursively_valid?(obj)
+      effective_aliased_type.recursively_valid?(obj)
     end
 
     # overrides Base
     def valid?(obj)
-      aliased_type.valid?(obj)
+      effective_aliased_type.valid?(obj)
     end
   end
 end

--- a/gems/sorbet-runtime/lib/types/private/types/type_alias.rb
+++ b/gems/sorbet-runtime/lib/types/private/types/type_alias.rb
@@ -15,7 +15,7 @@ module T::Private::Types
         raise "You can't call .checked multiple times on a type alias."
       end
       if !T::Private::RuntimeLevels::LEVELS.include?(level)
-        raise ArgumentError, "Invalid `checked` level '#{level}'. Use one of: #{T::Private::RuntimeLevels::LEVELS}."
+        raise ArgumentError.new("Invalid `checked` level '#{level}'. Use one of: #{T::Private::RuntimeLevels::LEVELS}.")
       end
       @checked_level = level
       self

--- a/gems/sorbet-runtime/lib/types/private/types/type_alias.rbi
+++ b/gems/sorbet-runtime/lib/types/private/types/type_alias.rbi
@@ -1,0 +1,12 @@
+# typed: true
+
+module T::Private::Types
+  class TypeAlias < T::Types::Base
+    def initialize(callable)
+      @callable = T.let(callable, T.proc.void)
+      @checked_level = T.let(nil, T.nilable(Symbol))
+      @aliased_type = T.let(nil, T.nilable(T::Types::Base))
+      @effective_aliased_type = T.let(nil, T.nilable(T::Types::Base))
+    end
+  end
+end

--- a/gems/sorbet-runtime/test/types/fixtures/type_alias_checked_tests.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/type_alias_checked_tests.rb
@@ -21,6 +21,6 @@ check("checked(:tests) name preserved") { checked_alias.name == "Integer" }
 # a rejected proposal made it so that once one `.checked(:tests)` type alias
 # was evaluated, no new ones could be defined.
 another_one = T.type_alias { Integer }.checked(:tests)
-check("another type alias defined after the initial load") {
+check("another type alias defined after the initial load") do
   another_one.valid?(1) && !another_one.valid?("not an int")
-}
+end

--- a/gems/sorbet-runtime/test/types/fixtures/type_alias_checked_tests.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/type_alias_checked_tests.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require_relative '../../../lib/sorbet-runtime'
+
+# This fixture runs in a subprocess so that T::Configuration state changes
+# are isolated from the main test process.
+
+T::Configuration.enable_checking_for_sigs_marked_checked_tests
+
+def check(description, loc: caller_locations(1, 1).first)
+  unless yield
+    puts "FAIL: #{loc.path}:#{loc.lineno}: #{description}"
+  end
+end
+
+checked_alias = T.type_alias { Integer }.checked(:tests)
+
+check("checked(:tests) validates Integer") { checked_alias.valid?(1) }
+check("checked(:tests) rejects String") { !checked_alias.valid?("hello") }
+check("checked(:tests) name preserved") { checked_alias.name == "Integer" }
+
+# a rejected proposal made it so that once one `.checked(:tests)` type alias
+# was evaluated, no new ones could be defined.
+another_one = T.type_alias { Integer }.checked(:tests)
+check("another type alias defined after the initial load") {
+  another_one.valid?(1) && !another_one.valid?("not an int")
+}

--- a/gems/sorbet-runtime/test/types/fixtures/type_alias_checked_tests_trapdoor.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/type_alias_checked_tests_trapdoor.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require_relative '../../../lib/sorbet-runtime'
+
+# This fixture runs in a subprocess so that T::Configuration state changes
+# are isolated from the main test process.
+
+alias_t = T.type_alias { Integer }.checked(:tests)
+alias_t.valid?(1)
+
+begin
+  T::Configuration.enable_checking_for_sigs_marked_checked_tests
+  puts "FAIL: expected RuntimeError about toggling too late"
+rescue RuntimeError => e
+  unless e.message.include?("Toggle `:tests`-level runtime type checking earlier")
+    puts "FAIL: wrong error: #{e.message}"
+  end
+end

--- a/gems/sorbet-runtime/test/types/type_alias_checked.rb
+++ b/gems/sorbet-runtime/test/types/type_alias_checked.rb
@@ -31,12 +31,12 @@ module Opus::Types::Test
     end
 
     it '.checked(:tests) behavior, load order, and override checking' do
-      result, status = Open3.capture2e("ruby", "test/types/fixtures/type_alias_checked_tests.rb")
+      result, _status = Open3.capture2e("ruby", "test/types/fixtures/type_alias_checked_tests.rb")
       flunk(result) unless result.empty?
     end
 
     it 'enable_checking_for_sigs_marked_checked_tests raises if called too late' do
-      result, status = Open3.capture2e("ruby", "test/types/fixtures/type_alias_checked_tests_trapdoor.rb")
+      result, _status = Open3.capture2e("ruby", "test/types/fixtures/type_alias_checked_tests_trapdoor.rb")
       flunk(result) unless result.empty?
     end
 
@@ -116,7 +116,6 @@ module Opus::Types::Test
           sig { overridable.params(x: Integer).void }
           def foo(x); end
         end
-
 
         child = Class.new(parent) do
           string_alias = T.type_alias { String }.checked(:never)

--- a/gems/sorbet-runtime/test/types/type_alias_checked.rb
+++ b/gems/sorbet-runtime/test/types/type_alias_checked.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+# typed: ignore
+require_relative '../test_helper'
+
+module Opus::Types::Test
+  class TypeAliasCheckedTest < Critic::Unit::UnitTest
+    Expected = T.type_alias { Integer }
+    T1 = T.type_alias { Integer }.checked(:always)
+    T2 = T.type_alias { Integer }.checked(:never)
+
+    it 'name is not affected by `.checked`' do
+      assert_equal(Expected.name, T1.name)
+      assert_equal(Expected.name, T2.name)
+    end
+
+    describe '.checked(:always)' do
+      it 'validates types' do
+        type_alias = T.type_alias { Integer }.checked(:always)
+        assert_nil(type_alias.error_message_for_obj(1))
+        assert_match(/Expected type Integer, got type String/, type_alias.error_message_for_obj("hello"))
+      end
+    end
+
+    describe '.checked(:never)' do
+      it 'valid? returns true for any object' do
+        type_alias = T.type_alias { Integer }.checked(:never)
+        assert(type_alias.valid?(1))
+        assert(type_alias.valid?("hello"))
+        assert(type_alias.valid?(nil))
+      end
+    end
+
+    it '.checked(:tests) behavior, load order, and override checking' do
+      result, status = Open3.capture2e("ruby", "test/types/fixtures/type_alias_checked_tests.rb")
+      flunk(result) unless result.empty?
+    end
+
+    it 'enable_checking_for_sigs_marked_checked_tests raises if called too late' do
+      result, status = Open3.capture2e("ruby", "test/types/fixtures/type_alias_checked_tests_trapdoor.rb")
+      flunk(result) unless result.empty?
+    end
+
+    it '.checked called twice raises' do
+      type_alias = T.type_alias { Integer }.checked(:always)
+      err = assert_raises(RuntimeError) do
+        type_alias.checked(:never)
+      end
+      assert_includes(err.message, "can't call .checked multiple times")
+    end
+
+    it 'invalid level raises ArgumentError' do
+      type_alias = T.type_alias { Integer }
+      assert_raises(ArgumentError) { type_alias.checked(:foo) }
+      assert_raises(ArgumentError) { type_alias.checked(true) }
+      assert_raises(ArgumentError) { type_alias.checked(false) }
+    end
+
+    describe 'default_checked_level integration' do
+      before do
+        @orig_default_checked_level = T::Private::RuntimeLevels.instance_variable_get(:@default_checked_level)
+        @orig_has_read_default_checked_level = T::Private::RuntimeLevels.instance_variable_get(:@has_read_default_checked_level)
+      end
+
+      after do
+        T::Private::RuntimeLevels.instance_variable_set(:@default_checked_level, @orig_default_checked_level)
+        T::Private::RuntimeLevels.instance_variable_set(:@has_read_default_checked_level, @orig_has_read_default_checked_level)
+      end
+
+      it 'no .checked + default :never — skips validation' do
+        T::Private::RuntimeLevels.instance_variable_set(:@default_checked_level, :never)
+        T::Private::RuntimeLevels.instance_variable_set(:@has_read_default_checked_level, false)
+        type_alias = T.type_alias { Integer }
+        assert(type_alias.valid?("hello"))
+      end
+
+      it 'explicit .checked(:always) overrides default :never' do
+        T::Private::RuntimeLevels.instance_variable_set(:@default_checked_level, :never)
+        T::Private::RuntimeLevels.instance_variable_set(:@has_read_default_checked_level, false)
+        type_alias = T.type_alias { Integer }.checked(:always)
+        refute(type_alias.valid?("hello"))
+      end
+    end
+
+    describe 'override checking uses the real type (aliased_type)' do
+      it 'subtype_of? uses aliased_type even when checked(:never)' do
+        int_alias = T.type_alias { Integer }.checked(:never)
+        numeric_alias = T.type_alias { Numeric }.checked(:never)
+
+        assert(int_alias.subtype_of?(numeric_alias))
+        refute(numeric_alias.subtype_of?(int_alias))
+      end
+
+      it 'override checking passes for compatible types with checked(:never)' do
+        parent = Class.new do
+          extend T::Sig
+
+          sig { overridable.params(x: Numeric).returns(Integer) }
+          def foo(x); 0; end
+        end
+
+        int_alias = T.type_alias { Integer }.checked(:never)
+        numeric_alias = T.type_alias { Numeric }.checked(:never)
+
+        child = Class.new(parent) do
+          sig { override.params(x: numeric_alias).returns(int_alias) }
+          def foo(x); 0; end
+        end
+
+        assert_equal(0, child.new.foo(1))
+      end
+
+      it 'override checking rejects incompatible types even with checked(:never)' do
+        parent = Class.new do
+          extend T::Sig
+
+          sig { overridable.params(x: Integer).void }
+          def foo(x); end
+        end
+
+
+        child = Class.new(parent) do
+          string_alias = T.type_alias { String }.checked(:never)
+          sig { override.params(x: string_alias).void }
+          def foo(x); end
+        end
+
+        err = assert_raises(RuntimeError) do
+          child.new.foo("hello")
+        end
+        assert_match(/Incompatible type for arg/, err.message)
+      end
+    end
+  end
+end

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -604,11 +604,18 @@ public:
     }
 
     core::FoundDefinitionRef handleAssignment(core::Context ctx, const ast::Assign &asgn) {
-        auto &send = ast::cast_tree_nonnull<ast::Send>(asgn.rhs);
+        auto send = ast::cast_tree<ast::Send>(asgn.rhs);
+        ENFORCE(send != nullptr);
         auto foundRef = fillAssign(ctx, asgn);
         ENFORCE(foundRef.kind() == core::FoundDefinitionRef::Kind::StaticField);
         auto &staticField = foundRef.staticField(*foundDefs);
-        staticField.isTypeAlias = sendRecvIsT(send) && send.fun == core::Names::typeAlias();
+        if (send->fun == core::Names::checked() && send->numPosArgs() == 1 &&
+            ast::isa_tree<ast::Literal>(send->getPosArg(0))) {
+            if (auto inner = ast::cast_tree<ast::Send>(send->recv)) {
+                send = inner;
+            }
+        }
+        staticField.isTypeAlias = send->fun == core::Names::typeAlias() && sendRecvIsT(*send);
         return foundRef;
     }
 

--- a/rbi/sorbet/tprivate.rbi
+++ b/rbi/sorbet/tprivate.rbi
@@ -15,11 +15,17 @@ class T::Private::Types::TypeAlias < T::Types::Base
   sig { params(callable: T.proc.returns(T.anything)).void }
   def initialize(callable); end
 
+  sig {params(arg: Symbol).returns(T::Private::Types::TypeAlias)}
+  def checked(arg); end
+
   sig { override.void }
   def build_type; end
 
   sig {returns(T::Types::Base)}
   def aliased_type; end
+
+  sig {returns(T::Types::Base)}
+  def effective_aliased_type; end
 
   sig { override.returns(String) }
   def name; end

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1417,29 +1417,38 @@ public:
         }
 
         auto send = ast::cast_tree<ast::Send>(asgn.rhs);
-        if (send != nullptr && send->fun == core::Names::typeAlias()) {
-            if (!send->hasBlock()) {
-                // if we have an invalid (i.e. nullary) call to TypeAlias, then we'll treat it as a type alias for
-                // Untyped and report an error here: otherwise, we end up in a state at the end of constant resolution
-                // that won't match our expected invariants (and in fact will fail our sanity checks)
-                // auto temporaryUntyped = ast::MK::Untyped(asgn->lhs.get()->loc);
-                auto temporaryUntyped = ast::MK::Block0(asgn.lhs.loc(), ast::MK::Untyped(asgn.lhs.loc()));
-                send->setBlock(std::move(temporaryUntyped));
-
-                // because we're synthesizing a fake "untyped" here and actually adding it to the AST, we won't report
-                // an arity mismatch for `T.untyped` in the future, so report the arity mismatch now
-                if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidTypeAlias)) {
-                    e.setHeader("No block given to `{}`", "T.type_alias");
-                    CorrectTypeAlias::eagerToLazy(ctx, e, send);
+        if (send != nullptr) {
+            // Unwrap .checked(:sym) to find T.type_alias { ... }.checked(:sym)
+            if (send->fun == core::Names::checked() && send->numPosArgs() == 1 &&
+                ast::isa_tree<ast::Literal>(send->getPosArg(0))) {
+                if (auto inner = ast::cast_tree<ast::Send>(send->recv)) {
+                    send = inner;
                 }
             }
-            auto *block = send->block();
-            this->todoTypeAliases_.emplace_back(id->symbol(), ctx.file, &block->body);
+            if (send->fun == core::Names::typeAlias()) {
+                if (!send->hasBlock()) {
+                    // if we have an invalid (i.e. nullary) call to TypeAlias, then we'll treat it as a type alias for
+                    // Untyped and report an error here: otherwise, we end up in a state at the end of constant
+                    // resolution that won't match our expected invariants (and in fact will fail our sanity checks)
+                    // auto temporaryUntyped = ast::MK::Untyped(asgn->lhs.get()->loc);
+                    auto temporaryUntyped = ast::MK::Block0(asgn.lhs.loc(), ast::MK::Untyped(asgn.lhs.loc()));
+                    send->setBlock(std::move(temporaryUntyped));
 
-            // We also enter a ResolutionItem for the lhs of a type alias so even if the type alias isn't used,
-            // we'll still emit a warning when the rhs of a type alias doesn't resolve.
-            this->todo_.emplace_back(nesting_, id);
-            return;
+                    // because we're synthesizing a fake "untyped" here and actually adding it to the AST, we won't
+                    // report an arity mismatch for `T.untyped` in the future, so report the arity mismatch now
+                    if (auto e = ctx.beginError(send->loc, core::errors::Resolver::InvalidTypeAlias)) {
+                        e.setHeader("No block given to `{}`", "T.type_alias");
+                        CorrectTypeAlias::eagerToLazy(ctx, e, send);
+                    }
+                }
+                auto *block = send->block();
+                this->todoTypeAliases_.emplace_back(id->symbol(), ctx.file, &block->body);
+
+                // We also enter a ResolutionItem for the lhs of a type alias so even if the type alias isn't used,
+                // we'll still emit a warning when the rhs of a type alias doesn't resolve.
+                this->todo_.emplace_back(nesting_, id);
+                return;
+            }
         }
 
         // Check for ambiguous definitions.
@@ -2997,7 +3006,17 @@ public:
             ENFORCE(!sym.isTypeMember() ||
                     (send->recv.isSelfReference() || ast::MK::isSorbetPrivateStatic(send->recv)));
 
-            if ((sym.isTypeAlias(ctx) && send->fun != core::Names::typeAlias()) ||
+            auto innerSend = send;
+            if (innerSend->fun == core::Names::checked() && innerSend->numPosArgs() == 1 &&
+                ast::isa_tree<ast::Literal>(innerSend->getPosArg(0))) {
+                if (auto inner = ast::cast_tree<ast::Send>(innerSend->recv)) {
+                    // We store the innerSend (if any) in the ResolveAssignItem because the
+                    // type_alias case expects to be able to unwrap the `Block`.
+                    innerSend = inner;
+                }
+            }
+
+            if ((sym.isTypeAlias(ctx) && innerSend->fun != core::Names::typeAlias()) ||
                 (sym.isTypeMember() && send->fun != core::Names::typeMember() &&
                  send->fun != core::Names::typeTemplate())) {
                 // This is a reassignment of a constant that was declared as a type member or a type alias.
@@ -3013,7 +3032,7 @@ public:
                 dependencies_.emplace_back(mixin);
             }
 
-            todoAssigns_.emplace_back(ResolveAssignItem{ctx.owner, sym, send, std::move(dependencies_), ctx.file});
+            todoAssigns_.emplace_back(ResolveAssignItem{ctx.owner, sym, innerSend, std::move(dependencies_), ctx.file});
         } else if (sym.isStaticField(ctx)) {
             ResolveStaticFieldItem job{ctx.file, sym.asFieldRef(), &asgn};
             auto resultType = tryResolveStaticField(ctx, job);

--- a/test/testdata/resolver/type_alias_checked.rb
+++ b/test/testdata/resolver/type_alias_checked.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # disable-parser-comparison: true
 # See <https://github.com/sorbet/sorbet/issues/10383>.
 # (This test happens to use syntax that Prism parses differently from Sorbet.)
@@ -36,3 +36,6 @@ sig { returns(MyAlias) }
 def wrong_return
   0 # error: Expected `String` but found `Integer(0)` for method result type
 end
+
+ForgotAliasBlock = T.type_alias.checked(:tests)
+#                  ^^^^^^^^^^^^ error: No block given

--- a/test/testdata/resolver/type_alias_checked.rb
+++ b/test/testdata/resolver/type_alias_checked.rb
@@ -1,0 +1,35 @@
+# typed: true
+extend T::Sig
+
+MyAlias = T.type_alias { String }.checked(:never)
+TestsAlias = T.type_alias { Integer }.checked(:tests)
+AlwaysAlias = T.type_alias { Symbol }.checked(:always)
+
+sig { params(x: MyAlias).returns(MyAlias) }
+def foo(x)
+  x
+end
+
+sig { params(x: TestsAlias).returns(TestsAlias) }
+def bar(x)
+  x
+end
+
+sig { params(x: AlwaysAlias).returns(AlwaysAlias) }
+def baz(x)
+  x
+end
+
+BadAlias = T.type_alias { DoesNotExist }.checked(:never) # error: Unable to resolve right hand side of type alias `BadAlias`
+#                         ^^^^^^^^^^^^ error: Unable to resolve constant `DoesNotExist`
+
+class HasGeneric
+  extend T::Generic
+  Elem = type_member
+  MyElem = T.type_alias { Elem }.checked(:tests) # error: Defining a `type_alias` to a generic `type_member` is not allowed
+end
+
+sig { returns(MyAlias) }
+def wrong_return
+  0 # error: Expected `String` but found `Integer(0)` for method result type
+end

--- a/test/testdata/resolver/type_alias_checked.rb
+++ b/test/testdata/resolver/type_alias_checked.rb
@@ -1,4 +1,7 @@
 # typed: true
+# disable-parser-comparison: true
+# See <https://github.com/sorbet/sorbet/issues/10383>.
+# (This test happens to use syntax that Prism parses differently from Sorbet.)
 extend T::Sig
 
 MyAlias = T.type_alias { String }.checked(:never)

--- a/website/docs/runtime.md
+++ b/website/docs/runtime.md
@@ -142,7 +142,7 @@ class Main
   extend T::Sig
 
   # (2) Use .on_failure in the sig for a method
-  #                                       ┌───────────────┐
+  #                                        ┌───────────────┐
   sig { params(argv: T::Array[String]).void.on_failure(:log) }
   def self.main(argv)
     puts argv
@@ -177,7 +177,7 @@ end
 
 # ...
 
-#                                       ┌─────────────────┐
+#                                        ┌─────────────────┐
 sig { params(argv: T::Array[String]).void.on_failure(:raise) }
 ```
 

--- a/website/docs/type-aliases.md
+++ b/website/docs/type-aliases.md
@@ -156,7 +156,7 @@ Note that types for lambdas and procs can be written in type aliases using [proc
 Some languages have recursive type aliases. For example, TypeScript allows writing type aliases like this one which vaguely describes the type of all JSON documents (example uses TypeScript syntax):
 
 ```typescript
-type JSON = null | number | string | JSON[] | { [arg: string]: JSON };
+type JSON = null | number | string | JSON[] | {[arg: string]: JSON};
 ```
 
 Sorbet does not support recursive type aliases. To have types that reference themselves, use [class types].

--- a/website/docs/type-aliases.md
+++ b/website/docs/type-aliases.md
@@ -130,11 +130,13 @@ MyType = T.type_alias { T.any(Integer, String) }.checked(:tests)
 MyType = T.type_alias { T.any(Integer, String) }.checked(:never)
 ```
 
+> **Note**: The `.checked` goes outside of the `{ ... }` block, unlike with `sig`, where it goes inside the block.
+
 When a type alias is not checked (either `.checked(:never)`, or `.checked(:tests)` outside of a test environment), the type alias accepts all values at runtime, similar to `T.anything`. Like with `.checked` on a `sig`, Sorbet always uses the real type when doing static checks, regardless of the runtime checked level.
 
 When omitted, type aliases use the `T::Configuration.default_checked_level`, which defaults to `:always`. See [`.checked` on method signatures](runtime.md#checked-whether-to-check-in-the-first-place) for more. Note in particular that `.checked(:tests)` requires special setup, documented there.
 
-Note that `.checked` only affects runtime value checking: the actual type defined inside the block will still be used for things like runtime [override checking](override-checking.md).
+The `.checked` annotation only affects runtime value checking: the actual type defined inside the block will still be used for things like runtime [override checking](override-checking.md).
 
 ## What about type aliases for method signatures?
 
@@ -154,7 +156,7 @@ Note that types for lambdas and procs can be written in type aliases using [proc
 Some languages have recursive type aliases. For example, TypeScript allows writing type aliases like this one which vaguely describes the type of all JSON documents (example uses TypeScript syntax):
 
 ```typescript
-type JSON = null | number | string | JSON[] | {[arg: string]: JSON};
+type JSON = null | number | string | JSON[] | { [arg: string]: JSON };
 ```
 
 Sorbet does not support recursive type aliases. To have types that reference themselves, use [class types].

--- a/website/docs/type-aliases.md
+++ b/website/docs/type-aliases.md
@@ -103,6 +103,39 @@ def valid(x)
 end
 ```
 
+## `T.type_alias` and RBI files
+
+Type aliases defined in [RBI files](rbi.md) do not exist at runtime because RBI files are not loaded by the Ruby VM. For this reason, it's usually dangerous to put `T.type_alias` declarations in RBI files, because Sorbet would not catch code that actually uses it (e.g., inside a runtime-checked `sig`).
+
+To define a type alias that doesn't participate in runtime checking, a better alternative is to define the type alias in a Ruby source file with `.checked(:never)`:
+
+```ruby
+MyType = T.type_alias { T.any(Integer, String) }.checked(:never)
+```
+
+See below for more information on `.checked` in type aliases.
+
+## `.checked`: Controlling runtime checking
+
+Like [`.checked` on method signatures](runtime.md#checked-whether-to-check-in-the-first-place), type aliases allow configuring whether the type alias participates in runtime checking:
+
+```ruby
+# (1) Always validate (default)
+MyType = T.type_alias { T.any(Integer, String) }.checked(:always)
+
+# (2) Only validate in tests
+MyType = T.type_alias { T.any(Integer, String) }.checked(:tests)
+
+# (3) Never validate at runtime
+MyType = T.type_alias { T.any(Integer, String) }.checked(:never)
+```
+
+When a type alias is not checked (either `.checked(:never)`, or `.checked(:tests)` outside of a test environment), the type alias accepts all values at runtime, similar to `T.anything`. Like with `.checked` on a `sig`, Sorbet always uses the real type when doing static checks, regardless of the runtime checked level.
+
+When omitted, type aliases use the `T::Configuration.default_checked_level`, which defaults to `:always`. See [`.checked` on method signatures](runtime.md#checked-whether-to-check-in-the-first-place) for more. Note in particular that `.checked(:tests)` requires special setup, documented there.
+
+Note that `.checked` only affects runtime value checking: the actual type defined inside the block will still be used for things like runtime [override checking](override-checking.md).
+
 ## What about type aliases for method signatures?
 
 Sometimes a question arises like, "Is there a way to factor an entire method signature into a type alias, not just types for individual arguments?"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We recently ran into a case where

- A type alias was important to be checked statically (had implications
  for security)
- Was too expensive to be checked at runtime (ran on every log line in
  all code paths, and was a large and complicated union types)

We tried to work around this with an RBI type alias, so that the type
alias never contributes to bad performance, but that can't work 100%
because if anyone tries to reference that inside a non-RBI sig then it
has runtime implications.

We had to work around this with `const_set(:Foo, T.type_alias {
T.untyped })` to also make the constant appear defined in the runtime,
but it would be easier if there were a first-class way to make a runtime
type alias opt out of runtime checking.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.