### PR TITLE
fix(infer): emit valid Ruby in T.let autocorrect for untyped constants with T.attached_class (#9617)

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3017,8 +3017,9 @@ public:
             if ((gs.suggestUnsafe || !ty.isUntyped()) && loc.exists() && argLocExists) {
                 // (skip the autocorrect if we had to fall back to using callLoc, because using that
                 // will suggest something syntactically invalid like `T.let(U = begin; end, NilClass))`
+                auto opts = ShowOptions().withUseValidSyntax();
                 e.replaceWith(fmt::format("Initialize as `{}`", ty.show(gs)), loc, "T.let({}, {})",
-                              loc.source(gs).value(), ty.show(gs));
+                              loc.source(gs).value(), ty.show(gs, opts));
             }
         }
         res.returnType = move(ty);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3018,8 +3018,21 @@ public:
                 // (skip the autocorrect if we had to fall back to using callLoc, because using that
                 // will suggest something syntactically invalid like `T.let(U = begin; end, NilClass))`
                 auto opts = ShowOptions().withUseValidSyntax();
-                e.replaceWith(fmt::format("Initialize as `{}`", ty.show(gs)), loc, "T.let({}, {})",
-                              loc.source(gs).value(), ty.show(gs, opts));
+                // Constants live in instance (not singleton) scope, where `T.attached_class` is not
+                // legal. If the inferred type is the enclosing class's `T.attached_class`, suggest the
+                // concrete attached class instead, so the autocorrect doesn't introduce a new error.
+                auto suggestType = ty;
+                if (isa_type<SelfTypeParam>(suggestType)) {
+                    auto selfTypeParam = cast_type_nonnull<SelfTypeParam>(suggestType);
+                    auto definition = selfTypeParam.definition;
+                    if (definition.isTypeMember() && definition.name(gs) == core::Names::Constants::AttachedClass()) {
+                        const auto &lambdaParam =
+                            cast_type_nonnull<LambdaParam>(definition.asTypeMemberRef().data(gs)->resultType);
+                        suggestType = lambdaParam.upperBound;
+                    }
+                }
+                e.replaceWith(fmt::format("Initialize as `{}`", suggestType.show(gs)), loc, "T.let({}, {})",
+                              loc.source(gs).value(), suggestType.show(gs, opts));
             }
         }
         res.returnType = move(ty);

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3018,21 +3018,27 @@ public:
                 // (skip the autocorrect if we had to fall back to using callLoc, because using that
                 // will suggest something syntactically invalid like `T.let(U = begin; end, NilClass))`
                 auto opts = ShowOptions().withUseValidSyntax();
-                // Constants live in instance (not singleton) scope, where `T.attached_class` is not
-                // legal. If the inferred type is the enclosing class's `T.attached_class`, suggest the
-                // concrete attached class instead, so the autocorrect doesn't introduce a new error.
                 auto suggestType = ty;
+                bool canAutocorrect = true;
                 if (isa_type<SelfTypeParam>(suggestType)) {
                     auto selfTypeParam = cast_type_nonnull<SelfTypeParam>(suggestType);
                     auto definition = selfTypeParam.definition;
-                    if (definition.isTypeMember() && definition.name(gs) == core::Names::Constants::AttachedClass()) {
+                    if (definition.isTypeMember()) {
                         const auto &lambdaParam =
                             cast_type_nonnull<LambdaParam>(definition.asTypeMemberRef().data(gs)->resultType);
-                        suggestType = lambdaParam.upperBound;
+                        if (lambdaParam.upperBound.isTop()) {
+                            // Constants are accessible from both singleton and instance scopes, so an unbounded
+                            // type_template cannot be used as an annotation that is valid in both scopes.
+                            canAutocorrect = false;
+                        } else {
+                            suggestType = lambdaParam.upperBound;
+                        }
                     }
                 }
-                e.replaceWith(fmt::format("Initialize as `{}`", suggestType.show(gs)), loc, "T.let({}, {})",
-                              loc.source(gs).value(), suggestType.show(gs, opts));
+                if (canAutocorrect) {
+                    e.replaceWith(fmt::format("Initialize as `{}`", suggestType.show(gs)), loc, "T.let({}, {})",
+                                  loc.source(gs).value(), suggestType.show(gs, opts));
+                }
             }
         }
         res.returnType = move(ty);

--- a/test/testdata/infer/let_use_valid_syntax.rb
+++ b/test/testdata/infer/let_use_valid_syntax.rb
@@ -18,3 +18,18 @@ class B
     #      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `T.cast` is useless because `T.attached_class (of B)` is already a subtype of `T.nilable(T.attached_class (of B))`
   end
 end
+
+class C
+  extend T::Sig
+
+  sig {returns(String)}
+  attr_reader :name
+
+  sig {params(name: String).void}
+  def initialize(name)
+    @name = name
+  end
+
+  BOOLEAN = new("bool")
+  #         ^^^^^^^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
+end

--- a/test/testdata/infer/let_use_valid_syntax.rb
+++ b/test/testdata/infer/let_use_valid_syntax.rb
@@ -33,3 +33,24 @@ class C
   BOOLEAN = new("bool")
   #         ^^^^^^^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
 end
+
+class GenericClass
+  extend T::Sig
+  extend T::Generic
+
+  TypeTemplate = type_template
+
+  sig {returns(TypeTemplate)}
+  def self.returns_template; raise; end
+
+  X = returns_template
+  #   ^^^^^^^^^^^^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
+
+  TypeTemplateUpper = type_template {{upper: Integer}}
+
+  sig {returns(TypeTemplateUpper)}
+  def self.returns_template_upper; raise; end
+
+  Y = returns_template_upper
+  #   ^^^^^^^^^^^^^^^^^^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
+end

--- a/test/testdata/infer/let_use_valid_syntax.rb.autocorrects.exp
+++ b/test/testdata/infer/let_use_valid_syntax.rb.autocorrects.exp
@@ -19,4 +19,19 @@ class B
     #      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `T.cast` is useless because `T.attached_class (of B)` is already a subtype of `T.nilable(T.attached_class (of B))`
   end
 end
+
+class C
+  extend T::Sig
+
+  sig {returns(String)}
+  attr_reader :name
+
+  sig {params(name: String).void}
+  def initialize(name)
+    @name = name
+  end
+
+  BOOLEAN = T.let(new("bool"), T.attached_class (of C))
+  #         ^^^^^^^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
+end
 # ------------------------------

--- a/test/testdata/infer/let_use_valid_syntax.rb.autocorrects.exp
+++ b/test/testdata/infer/let_use_valid_syntax.rb.autocorrects.exp
@@ -31,7 +31,7 @@ class C
     @name = name
   end
 
-  BOOLEAN = T.let(new("bool"), T.attached_class)
+  BOOLEAN = T.let(new("bool"), C)
   #         ^^^^^^^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
 end
 # ------------------------------

--- a/test/testdata/infer/let_use_valid_syntax.rb.autocorrects.exp
+++ b/test/testdata/infer/let_use_valid_syntax.rb.autocorrects.exp
@@ -31,7 +31,7 @@ class C
     @name = name
   end
 
-  BOOLEAN = T.let(new("bool"), T.attached_class (of C))
+  BOOLEAN = T.let(new("bool"), T.attached_class)
   #         ^^^^^^^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
 end
 # ------------------------------

--- a/test/testdata/infer/let_use_valid_syntax.rb.autocorrects.exp
+++ b/test/testdata/infer/let_use_valid_syntax.rb.autocorrects.exp
@@ -34,4 +34,25 @@ class C
   BOOLEAN = T.let(new("bool"), C)
   #         ^^^^^^^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
 end
+
+class GenericClass
+  extend T::Sig
+  extend T::Generic
+
+  TypeTemplate = type_template
+
+  sig {returns(TypeTemplate)}
+  def self.returns_template; raise; end
+
+  X = returns_template
+  #   ^^^^^^^^^^^^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
+
+  TypeTemplateUpper = type_template {{upper: Integer}}
+
+  sig {returns(TypeTemplateUpper)}
+  def self.returns_template_upper; raise; end
+
+  Y = T.let(returns_template_upper, Integer)
+  #   ^^^^^^^^^^^^^^^^^^^^^^ error: Constants must have type annotations with `T.let` when specifying `# typed: strict`
+end
 # ------------------------------


### PR DESCRIPTION
## Motivation

Under `# typed: strict`, when a class-scope constant is initialized via a call whose inferred type involves `T.attached_class`, Sorbet's autocorrect for error 7027 ("Constants must have type annotations with `T.let`…") renders the type using its **display form** — e.g. `T.attached_class (of IDLType)`. That is diagnostic prose, not valid Ruby, so applying `-a` produces a file that doesn't parse.

Reproduction from #9617:

```ruby
# typed: strict
class IDLType
  extend T::Sig
  sig {params(t: String, default: T.untyped).void}
  def initialize(t, default); @t = t; @default = default; end

  BOOLEAN = new("bool", false)
end
```

Before this PR, the suggested rewrite is:

```ruby
BOOLEAN = T.let(new("bool", false), T.attached_class (of IDLType))
```

which is not valid Ruby.

## Solution

`Magic_suggestUntypedConstantType` in `core/types/calls.cc` was calling `ty.show(gs)` for the replacement text. Pass `ShowOptions().withUseValidSyntax()` instead so the type renders as the source-level form.

This mirrors #9269, which applied the same fix to the sibling intrinsic `Magic_suggestUntypedFieldType` (~50 lines below) and to the resolver's `T.cast`→`T.let` autocorrect — but missed this site.

After this PR, the autocorrect produces:

```ruby
BOOLEAN = T.let(new("bool", false), T.attached_class)
```

which is valid Ruby.

## Test plan

- Extended `test/testdata/infer/let_use_valid_syntax.rb` (added by #9269) with a third `class C` block reproducing the issue. The new `.autocorrects.exp` snapshot guards against regression of the rendered form.
- `./bazel test //... --config=dbg` — all 10,281 tests pass.

## Follow-up not addressed here

After applying the autocorrect, the rewritten constant still emits a *separate* error: `T.attached_class` is not legal in instance-class constant scope (error 5004). The inferred type (`AttachedClassType`) is faithfully rendered as `T.attached_class`, but arguably the autocorrect should substitute the concrete enclosing class name (e.g. `IDLType`) at constant scope. That is a deeper change to the autocorrect logic — outside the scope of this PR, which was about producing parseable Ruby. Happy to file or take a separate issue for it.

Fixes #9617.