### PR TITLE
WIP: Render a `__package.rb` closer to the canonical format when inserting imports and exports to a package that current has neither.

### DIFF
--- a/packager/GenPackages.cc
+++ b/packager/GenPackages.cc
@@ -261,7 +261,33 @@ void GenPackages::run(core::GlobalState &gs) {
             missingTypes.push_back(fmt::format("`{}`s", "visible_to"));
         }
 
-        if (autocorrects.size() == 1) {
+        if (autocorrects.empty()) {
+            continue;
+        }
+
+        if (importsAutocorrect && exportsAutocorrect && pkgInfo.importedPackageNames.empty() &&
+            pkgInfo.exports_.empty()) {
+            auto existingContentsLoc =
+                core::Loc(pkgInfo.file, pkgInfo.locs.loc)
+                    .adjust(gs, pkgInfo.locs.declLoc.length() + 1, -1 * (int32_t) "end"sv.size());
+            auto newContents =
+                pkgInfo.renderPackageRbContents(gs, computeNewImports(gs, pkgInfo), move(toExport[pkgName]));
+
+            string header;
+            if (missingTypes.size() == 2) {
+                header = fmt::format("`{}` is missing {} and {}", pkgInfo.show(gs), missingTypes[0], missingTypes[1]);
+            } else {
+                header = fmt::format("`{}` is missing {}, {} and {}", pkgInfo.show(gs), missingTypes[0],
+                                     missingTypes[1], missingTypes[2]);
+            }
+
+            if (auto e = gs.beginError(pkgInfo.declLoc(), core::errors::Packager::IncorrectPackageRB)) {
+                e.setHeader("{}", header);
+                bool isDidYouMean = false;
+                bool hideEdit = true;
+                e.addAutocorrect({"Update __package.rb", {{existingContentsLoc, newContents}}, isDidYouMean, hideEdit});
+            }
+        } else if (autocorrects.size() == 1) {
             if (auto e = gs.beginError(pkgInfo.declLoc(), core::errors::Packager::IncorrectPackageRB)) {
                 e.setHeader("`{}` is missing {}", pkgInfo.show(gs), missingTypes[0]);
                 e.addAutocorrect(move(autocorrects[0]));
@@ -297,11 +323,6 @@ void GenPackages::run(core::GlobalState &gs) {
         } else if (autocorrects.size() > 3) {
             ENFORCE(false);
         }
-        // TODO(neil): for a file with no imports or exports, if both imports and exports are missing, we'll produce
-        // something like:
-        //   export MyPkg::Foo
-        //   import OtherPkg
-        // because e < i
         // TODO(neil): we should also delete imports that are unused but have a modularity error here
     }
 }

--- a/test/cli/package-gen-packages-test-packages/B/__package.rb
+++ b/test/cli/package-gen-packages-test-packages/B/__package.rb
@@ -8,4 +8,5 @@ class B < PackageSpec
 
   visible_to A
   visible_to G
+  visible_to PackageWithNoImportsExports
 end

--- a/test/cli/package-gen-packages-test-packages/C/__package.rb
+++ b/test/cli/package-gen-packages-test-packages/C/__package.rb
@@ -7,6 +7,7 @@ class C < PackageSpec
   import A
   import AnotherPack
   import D
+  import PackageWithNoImportsExports
 
   visible_to DoesNotExist
   visible_to AlsoDoesNotExist::*

--- a/test/cli/package-gen-packages-test-packages/C/app.rb
+++ b/test/cli/package-gen-packages-test-packages/C/app.rb
@@ -8,6 +8,7 @@ module C
       puts F::CONSTANT_FROM_F
       puts G::CONSTANT_FROM_G
       puts AnotherPackage::CONSTANT
+      puts PackageWithNoImportsExports::App
 
       puts B::CONSTANT_FROM_B
       puts E::CONSTANT_FROM_E

--- a/test/cli/package-gen-packages-test-packages/PackageWithNoImportsExports/__package.rb
+++ b/test/cli/package-gen-packages-test-packages/PackageWithNoImportsExports/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+class PackageWithNoImportsExports < PackageSpec
+  layer 'util'
+  strict_dependencies 'dag'
+end

--- a/test/cli/package-gen-packages-test-packages/PackageWithNoImportsExports/app.rb
+++ b/test/cli/package-gen-packages-test-packages/PackageWithNoImportsExports/app.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+
+class PackageWithNoImportsExports::App
+  puts B::CONSTANT_FROM_B
+end

--- a/test/cli/package-gen-packages-test-packages/test.out
+++ b/test/cli/package-gen-packages-test-packages/test.out
@@ -19,10 +19,6 @@ PackageWithNoImportsExports/__package.rb:3: `PackageWithNoImportsExports` is mis
      3 |class PackageWithNoImportsExports < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    PackageWithNoImportsExports/__package.rb:5: Inserted `export PackageWithNoImportsExports::App
-      import B`
-     5 |  strict_dependencies 'dag'
-                                   ^
 
 PackageWithIgnore/__package.rb:3: `PackageWithIgnore` is missing imports https://srb.help/3734
      3 |class PackageWithIgnore < PackageSpec
@@ -244,8 +240,10 @@ end
 class PackageWithNoImportsExports < PackageSpec
   layer 'util'
   strict_dependencies 'dag'
-  export PackageWithNoImportsExports::App
+
+  # strict_dependencies 'dag':
   import B
+  export PackageWithNoImportsExports::App
 end
 ##############################
 ###### Package directed ######
@@ -256,10 +254,6 @@ PackageWithNoImportsExports/__package.rb:3: `PackageWithNoImportsExports` is mis
      3 |class PackageWithNoImportsExports < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    PackageWithNoImportsExports/__package.rb:5: Inserted `export PackageWithNoImportsExports::App
-      import B`
-     5 |  strict_dependencies 'dag'
-                                   ^
 
 PackageWithIgnore/__package.rb:3: `PackageWithIgnore` is missing imports https://srb.help/3734
      3 |class PackageWithIgnore < PackageSpec
@@ -486,6 +480,8 @@ end
 class PackageWithNoImportsExports < PackageSpec
   layer 'util'
   strict_dependencies 'dag'
-  export PackageWithNoImportsExports::App
+
+  # strict_dependencies 'dag':
   import B
+  export PackageWithNoImportsExports::App
 end

--- a/test/cli/package-gen-packages-test-packages/test.out
+++ b/test/cli/package-gen-packages-test-packages/test.out
@@ -15,6 +15,15 @@ A/__package.rb:3: `A` is missing imports https://srb.help/3734
      5 |  layer 'app'
                      ^
 
+PackageWithNoImportsExports/__package.rb:3: `PackageWithNoImportsExports` is missing imports and exports https://srb.help/3734
+     3 |class PackageWithNoImportsExports < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    PackageWithNoImportsExports/__package.rb:5: Inserted `export PackageWithNoImportsExports::App
+      import B`
+     5 |  strict_dependencies 'dag'
+                                   ^
+
 PackageWithIgnore/__package.rb:3: `PackageWithIgnore` is missing imports https://srb.help/3734
      3 |class PackageWithIgnore < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -22,14 +31,6 @@ PackageWithIgnore/__package.rb:3: `PackageWithIgnore` is missing imports https:/
     PackageWithIgnore/__package.rb:5: Inserted `import F`
      5 |  layer 'util'
                       ^
-
-G/__package.rb:3: `G` is missing exports https://srb.help/3734
-     3 |class G < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    G/__package.rb:8: Inserted `export G::ANOTHER_CONSTANT_FROM_G`
-     8 |
-        ^
 
 B/__package.rb:3: `B` is missing `visible_to`s https://srb.help/3734
      3 |class B < PackageSpec
@@ -39,6 +40,14 @@ B/__package.rb:3: `B` is missing `visible_to`s https://srb.help/3734
       visible_to D`
      9 |  visible_to A
                       ^
+
+G/__package.rb:3: `G` is missing exports https://srb.help/3734
+     3 |class G < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    G/__package.rb:8: Inserted `export G::ANOTHER_CONSTANT_FROM_G`
+     8 |
+        ^
 
 C/__package.rb:7: Layering violation: cannot import `A` (in layer `app`) from `C` (in layer `util`) https://srb.help/3726
      7 |  import A
@@ -65,11 +74,11 @@ C/__package.rb:3: `C` is missing imports and `visible_to`s https://srb.help/3734
       import E`
      9 |  import D
                   ^
-    C/__package.rb:11: Deleted
-    11 |  visible_to DoesNotExist
-        ^^^^^^^^^^^^^^^^^^^^^^^^^
     C/__package.rb:12: Deleted
-    12 |  visible_to AlsoDoesNotExist::*
+    12 |  visible_to DoesNotExist
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
+    C/__package.rb:13: Deleted
+    13 |  visible_to AlsoDoesNotExist::*
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
@@ -87,14 +96,6 @@ E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
     10 |  visible_to AlsoDoesNotExist::*
                                         ^
 
-D/test/__package.rb:3: `Test::D` is missing imports https://srb.help/3734
-     3 |class Test::D < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    D/test/__package.rb:9: Inserted `import E`
-     9 |  import D, uses_internals: true
-                                        ^
-
 D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://srb.help/3734
      3 |class D::ANestedPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -102,6 +103,14 @@ D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://
     D/ANestedPackage/__package.rb:5: Inserted `export D::ANestedPackage::Foo`
      5 |  layer 'util'
                       ^
+
+D/test/__package.rb:3: `Test::D` is missing imports https://srb.help/3734
+     3 |class Test::D < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    D/test/__package.rb:9: Inserted `import E`
+     9 |  import D, uses_internals: true
+                                        ^
 
 D/__package.rb:3: `D` is missing exports https://srb.help/3734
      3 |class D < PackageSpec
@@ -136,7 +145,7 @@ C/app.rb:9: Package `G` includes explicit visibility modifiers and cannot be imp
                    ^^^^^^^^^^^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
-Errors: 12
+Errors: 13
 
 ###### cat B/__package.rb ######
 # typed: strict
@@ -151,6 +160,7 @@ class B < PackageSpec
   visible_to C
   visible_to D
   visible_to G
+  visible_to PackageWithNoImportsExports
 end
 
 ###### cat C/__package.rb ######
@@ -166,6 +176,7 @@ class C < PackageSpec
   import D
   import D::ANestedPackage
   import E
+  import PackageWithNoImportsExports
 
 end
 
@@ -226,11 +237,30 @@ class PackageWithIgnore < PackageSpec
   layer 'util'
   import F
 end
+
+###### cat PackageWithNoImportsExports/__package.rb ######
+# typed: strict
+
+class PackageWithNoImportsExports < PackageSpec
+  layer 'util'
+  strict_dependencies 'dag'
+  export PackageWithNoImportsExports::App
+  import B
+end
 ##############################
 ###### Package directed ######
 ##############################
 
 ###### Running gen-packages ######
+PackageWithNoImportsExports/__package.rb:3: `PackageWithNoImportsExports` is missing imports and exports https://srb.help/3734
+     3 |class PackageWithNoImportsExports < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    PackageWithNoImportsExports/__package.rb:5: Inserted `export PackageWithNoImportsExports::App
+      import B`
+     5 |  strict_dependencies 'dag'
+                                   ^
+
 PackageWithIgnore/__package.rb:3: `PackageWithIgnore` is missing imports https://srb.help/3734
      3 |class PackageWithIgnore < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -273,11 +303,11 @@ C/__package.rb:3: `C` is missing imports and `visible_to`s https://srb.help/3734
       import E`
      9 |  import D
                   ^
-    C/__package.rb:11: Deleted
-    11 |  visible_to DoesNotExist
-        ^^^^^^^^^^^^^^^^^^^^^^^^^
     C/__package.rb:12: Deleted
-    12 |  visible_to AlsoDoesNotExist::*
+    12 |  visible_to DoesNotExist
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
+    C/__package.rb:13: Deleted
+    13 |  visible_to AlsoDoesNotExist::*
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
@@ -295,14 +325,6 @@ E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
     10 |  visible_to AlsoDoesNotExist::*
                                         ^
 
-D/test/__package.rb:3: `Test::D` is missing imports https://srb.help/3734
-     3 |class Test::D < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    D/test/__package.rb:9: Inserted `import E`
-     9 |  import D, uses_internals: true
-                                        ^
-
 D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://srb.help/3734
      3 |class D::ANestedPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -310,6 +332,14 @@ D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://
     D/ANestedPackage/__package.rb:5: Inserted `export D::ANestedPackage::Foo`
      5 |  layer 'util'
                       ^
+
+D/test/__package.rb:3: `Test::D` is missing imports https://srb.help/3734
+     3 |class Test::D < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    D/test/__package.rb:9: Inserted `import E`
+     9 |  import D, uses_internals: true
+                                        ^
 
 D/__package.rb:3: `D` is missing exports https://srb.help/3734
      3 |class D < PackageSpec
@@ -357,7 +387,7 @@ C/app.rb:9: Package `G` includes explicit visibility modifiers and cannot be imp
                    ^^^^^^^^^^^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
-Errors: 11
+Errors: 12
 
 ###### cat B/__package.rb ######
 # typed: strict
@@ -372,6 +402,7 @@ class B < PackageSpec
   visible_to C
   visible_to D
   visible_to G
+  visible_to PackageWithNoImportsExports
 end
 
 ###### cat C/__package.rb ######
@@ -387,6 +418,7 @@ class C < PackageSpec
   import D
   import D::ANestedPackage
   import E
+  import PackageWithNoImportsExports
 
 end
 
@@ -446,4 +478,14 @@ class PackageWithIgnore < PackageSpec
   strict_dependencies 'false'
   layer 'util'
   import F
+end
+
+###### cat PackageWithNoImportsExports/__package.rb ######
+# typed: strict
+
+class PackageWithNoImportsExports < PackageSpec
+  layer 'util'
+  strict_dependencies 'dag'
+  export PackageWithNoImportsExports::App
+  import B
 end

--- a/test/cli/package-gen-packages-test-packages/test.sh
+++ b/test/cli/package-gen-packages-test-packages/test.sh
@@ -55,6 +55,10 @@ echo
 echo "###### cat PackageWithIgnore/__package.rb ######"
 cat PackageWithIgnore/__package.rb
 
+echo
+echo "###### cat PackageWithNoImportsExports/__package.rb ######"
+cat PackageWithNoImportsExports/__package.rb
+
 echo "##############################"
 echo "###### Package directed ######"
 echo "##############################"
@@ -100,3 +104,7 @@ cat D/test/__package.rb
 echo
 echo "###### cat PackageWithIgnore/__package.rb ######"
 cat PackageWithIgnore/__package.rb
+
+echo
+echo "###### cat PackageWithNoImportsExports/__package.rb ######"
+cat PackageWithNoImportsExports/__package.rb

--- a/test/cli/package-gen-packages/B/__package.rb
+++ b/test/cli/package-gen-packages/B/__package.rb
@@ -8,4 +8,5 @@ class B < PackageSpec
 
   visible_to A
   visible_to G
+  visible_to PackageWithNoImportsExports
 end

--- a/test/cli/package-gen-packages/C/__package.rb
+++ b/test/cli/package-gen-packages/C/__package.rb
@@ -7,6 +7,7 @@ class C < PackageSpec
   import A
   import AnotherPack
   import D
+  import PackageWithNoImportsExports
 
   visible_to DoesNotExist
   visible_to AlsoDoesNotExist::*

--- a/test/cli/package-gen-packages/C/app.rb
+++ b/test/cli/package-gen-packages/C/app.rb
@@ -8,6 +8,7 @@ module C
       puts F::CONSTANT_FROM_F
       puts G::CONSTANT_FROM_G
       puts AnotherPackage::CONSTANT
+      puts PackageWithNoImportsExports::App
 
       puts B::CONSTANT_FROM_B
       puts E::CONSTANT_FROM_E

--- a/test/cli/package-gen-packages/PackageWithNoImportsExports/__package.rb
+++ b/test/cli/package-gen-packages/PackageWithNoImportsExports/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+class PackageWithNoImportsExports < PackageSpec
+  layer 'util'
+  strict_dependencies 'dag'
+end

--- a/test/cli/package-gen-packages/PackageWithNoImportsExports/app.rb
+++ b/test/cli/package-gen-packages/PackageWithNoImportsExports/app.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+
+class PackageWithNoImportsExports::App
+  puts B::CONSTANT_FROM_B
+end

--- a/test/cli/package-gen-packages/test.out
+++ b/test/cli/package-gen-packages/test.out
@@ -19,10 +19,6 @@ PackageWithNoImportsExports/__package.rb:3: `PackageWithNoImportsExports` is mis
      3 |class PackageWithNoImportsExports < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    PackageWithNoImportsExports/__package.rb:5: Inserted `export PackageWithNoImportsExports::App
-      import B`
-     5 |  strict_dependencies 'dag'
-                                   ^
 
 PackageWithIgnore/__package.rb:3: `PackageWithIgnore` is missing imports https://srb.help/3734
      3 |class PackageWithIgnore < PackageSpec
@@ -227,8 +223,10 @@ end
 class PackageWithNoImportsExports < PackageSpec
   layer 'util'
   strict_dependencies 'dag'
-  export PackageWithNoImportsExports::App
+
+  # strict_dependencies 'dag':
   import B
+  export PackageWithNoImportsExports::App
 end
 ##############################
 ###### Package directed ######
@@ -239,10 +237,6 @@ PackageWithNoImportsExports/__package.rb:3: `PackageWithNoImportsExports` is mis
      3 |class PackageWithNoImportsExports < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    PackageWithNoImportsExports/__package.rb:5: Inserted `export PackageWithNoImportsExports::App
-      import B`
-     5 |  strict_dependencies 'dag'
-                                   ^
 
 PackageWithIgnore/__package.rb:3: `PackageWithIgnore` is missing imports https://srb.help/3734
      3 |class PackageWithIgnore < PackageSpec
@@ -458,6 +452,8 @@ end
 class PackageWithNoImportsExports < PackageSpec
   layer 'util'
   strict_dependencies 'dag'
-  export PackageWithNoImportsExports::App
+
+  # strict_dependencies 'dag':
   import B
+  export PackageWithNoImportsExports::App
 end

--- a/test/cli/package-gen-packages/test.out
+++ b/test/cli/package-gen-packages/test.out
@@ -15,12 +15,30 @@ A/__package.rb:3: `A` is missing imports https://srb.help/3734
      5 |  layer 'app'
                      ^
 
+PackageWithNoImportsExports/__package.rb:3: `PackageWithNoImportsExports` is missing imports and exports https://srb.help/3734
+     3 |class PackageWithNoImportsExports < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    PackageWithNoImportsExports/__package.rb:5: Inserted `export PackageWithNoImportsExports::App
+      import B`
+     5 |  strict_dependencies 'dag'
+                                   ^
+
 PackageWithIgnore/__package.rb:3: `PackageWithIgnore` is missing imports https://srb.help/3734
      3 |class PackageWithIgnore < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     PackageWithIgnore/__package.rb:5: Inserted `import F`
      5 |  layer 'util'
+                      ^
+
+B/__package.rb:3: `B` is missing `visible_to`s https://srb.help/3734
+     3 |class B < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    B/__package.rb:9: Inserted `visible_to C
+      visible_to D`
+     9 |  visible_to A
                       ^
 
 G/__package.rb:3: `G` is missing exports https://srb.help/3734
@@ -30,6 +48,209 @@ G/__package.rb:3: `G` is missing exports https://srb.help/3734
     G/__package.rb:8: Inserted `export G::ANOTHER_CONSTANT_FROM_G`
      8 |
         ^
+
+C/__package.rb:7: Layering violation: cannot import `A` (in layer `app`) from `C` (in layer `util`) https://srb.help/3726
+     7 |  import A
+          ^^^^^^^^
+    C/__package.rb:5: `C`'s `layer` declared here
+     5 |  layer 'util'
+                ^^^^^^
+    A/__package.rb:5: `A`'s `layer` declared here
+     5 |  layer 'app'
+                ^^^^^
+
+C/__package.rb:3: `C` is missing imports and `visible_to`s https://srb.help/3734
+     3 |class C < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    C/__package.rb:8: Deleted
+     8 |  import AnotherPack
+        ^^^^^^^^^^^^^^^^^^^^
+    C/__package.rb:8: Inserted `import AnotherPackage
+      import B`
+     8 |  import AnotherPack
+                            ^
+    C/__package.rb:9: Inserted `import D::ANestedPackage
+      import E`
+     9 |  import D
+                  ^
+    C/__package.rb:12: Deleted
+    12 |  visible_to DoesNotExist
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
+    C/__package.rb:13: Deleted
+    13 |  visible_to AlsoDoesNotExist::*
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
+     3 |class E < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    E/__package.rb:9: Deleted
+     9 |  visible_to DoesNotExis
+        ^^^^^^^^^^^^^^^^^^^^^^^^
+    E/__package.rb:10: Deleted
+    10 |  visible_to AlsoDoesNotExist::*
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    E/__package.rb:10: Inserted `visible_to 'tests'
+      visible_to C`
+    10 |  visible_to AlsoDoesNotExist::*
+                                        ^
+
+D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://srb.help/3734
+     3 |class D::ANestedPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    D/ANestedPackage/__package.rb:5: Inserted `export D::ANestedPackage::Foo`
+     5 |  layer 'util'
+                      ^
+
+D/__package.rb:3: `D` is missing imports and exports https://srb.help/3734
+     3 |class D < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    D/__package.rb:7: Inserted `test_import E`
+     7 |  import B
+                  ^
+    D/__package.rb:9: Deleted
+     9 |  export D::ANestedPackage::Foo
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    D/__package.rb:10: Deleted
+    10 |  export D::EnumFromD::Variant
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    D/__package.rb:9: Inserted `export D::CONSTANT_FROM_D
+      export D::ClassFromD
+      export D::EnumFromD`
+     9 |  export D::ANestedPackage::Foo
+                                       ^
+
+C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
+     8 |      puts F::CONSTANT_FROM_F
+                   ^^^^^^^^^^^^^^^^^^
+    C/__package.rb:3: Enclosing package declared here
+     3 |class C < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+    F/__package.rb:4: `F` must be at least `strict_dependencies 'dag'` but is currently `strict_dependencies 'layered'`
+     4 |  strict_dependencies 'layered'
+                              ^^^^^^^^^
+  Note:
+    `F::CONSTANT_FROM_F`'s package is not imported
+
+C/app.rb:9: Package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3723
+     9 |      puts G::CONSTANT_FROM_G
+                   ^^^^^^^^^^^^^^^^^^
+  Note:
+    Please consult with the owning team before adding a `visible_to` line to the package `G`
+Errors: 12
+
+###### cat B/__package.rb ######
+# typed: strict
+
+class B < PackageSpec
+  strict_dependencies 'dag'
+  layer 'util'
+
+  export B::CONSTANT_FROM_B
+
+  visible_to A
+  visible_to C
+  visible_to D
+  visible_to G
+  visible_to PackageWithNoImportsExports
+end
+
+###### cat C/__package.rb ######
+# typed: strict
+
+class C < PackageSpec
+  strict_dependencies 'dag'
+  layer 'util'
+
+  import A
+  import AnotherPackage
+  import B
+  import D
+  import D::ANestedPackage
+  import E
+  import PackageWithNoImportsExports
+
+end
+
+###### cat D/__package.rb ######
+# typed: strict
+
+class D < PackageSpec
+  strict_dependencies 'dag'
+  layer 'util'
+
+  import B
+  test_import E
+  export D::AlreadyExportedClass
+  export D::CONSTANT_FROM_D
+  export D::ClassFromD
+  export D::EnumFromD
+end
+
+###### cat D/ANestedPackage/__package.rb ######
+# typed: strict
+
+class D::ANestedPackage < PackageSpec
+  strict_dependencies 'dag'
+  layer 'util'
+  export D::ANestedPackage::Foo
+end
+
+###### cat E/__package.rb ######
+# typed: strict
+
+class E < PackageSpec
+  strict_dependencies 'dag'
+  layer 'util'
+
+  export E::CONSTANT_FROM_E
+
+  visible_to 'tests'
+  visible_to C
+end
+
+###### cat PackageWithIgnore/__package.rb ######
+# typed: strict
+
+class PackageWithIgnore < PackageSpec
+  strict_dependencies 'false'
+  layer 'util'
+  import F
+end
+
+###### cat PackageWithNoImportsExports/__package.rb ######
+# typed: strict
+
+class PackageWithNoImportsExports < PackageSpec
+  layer 'util'
+  strict_dependencies 'dag'
+  export PackageWithNoImportsExports::App
+  import B
+end
+##############################
+###### Package directed ######
+##############################
+
+###### Running gen-packages ######
+PackageWithNoImportsExports/__package.rb:3: `PackageWithNoImportsExports` is missing imports and exports https://srb.help/3734
+     3 |class PackageWithNoImportsExports < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    PackageWithNoImportsExports/__package.rb:5: Inserted `export PackageWithNoImportsExports::App
+      import B`
+     5 |  strict_dependencies 'dag'
+                                   ^
+
+PackageWithIgnore/__package.rb:3: `PackageWithIgnore` is missing imports https://srb.help/3734
+     3 |class PackageWithIgnore < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    PackageWithIgnore/__package.rb:5: Inserted `import F`
+     5 |  layer 'util'
+                      ^
 
 B/__package.rb:3: `B` is missing `visible_to`s https://srb.help/3734
      3 |class B < PackageSpec
@@ -65,11 +286,11 @@ C/__package.rb:3: `C` is missing imports and `visible_to`s https://srb.help/3734
       import E`
      9 |  import D
                   ^
-    C/__package.rb:11: Deleted
-    11 |  visible_to DoesNotExist
-        ^^^^^^^^^^^^^^^^^^^^^^^^^
     C/__package.rb:12: Deleted
-    12 |  visible_to AlsoDoesNotExist::*
+    12 |  visible_to DoesNotExist
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
+    C/__package.rb:13: Deleted
+    13 |  visible_to AlsoDoesNotExist::*
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
@@ -87,6 +308,14 @@ E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
     10 |  visible_to AlsoDoesNotExist::*
                                         ^
 
+D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://srb.help/3734
+     3 |class D::ANestedPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    D/ANestedPackage/__package.rb:5: Inserted `export D::ANestedPackage::Foo`
+     5 |  layer 'util'
+                      ^
+
 D/__package.rb:3: `D` is missing imports and exports https://srb.help/3734
      3 |class D < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
@@ -97,6 +326,12 @@ D/__package.rb:3: `D` is missing imports and exports https://srb.help/3734
     D/__package.rb:9: Deleted
      9 |  export D::ANestedPackage::Foo
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    D/__package.rb:9: Deleted
+     9 |  export D::ANestedPackage::Foo
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    D/__package.rb:10: Deleted
+    10 |  export D::EnumFromD::Variant
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     D/__package.rb:10: Deleted
     10 |  export D::EnumFromD::Variant
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -106,13 +341,18 @@ D/__package.rb:3: `D` is missing imports and exports https://srb.help/3734
      9 |  export D::ANestedPackage::Foo
                                        ^
 
-D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://srb.help/3734
-     3 |class D::ANestedPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    D/ANestedPackage/__package.rb:5: Inserted `export D::ANestedPackage::Foo`
-     5 |  layer 'util'
-                      ^
+A/constants.rb:5: Unable to resolve constant `G` https://srb.help/5002
+     5 |  puts G::ANOTHER_CONSTANT_FROM_G
+               ^
+    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#LCENSORED: `T` defined here
+    NN |module T
+        ^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/gc.rbi#LCENSORED: `GC` defined here
+    NN |module GC
+        ^^^^^^^^^
+    A/constants.rb:3: `A` defined here
+     3 |module A
+        ^^^^^^^^
 
 C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
      8 |      puts F::CONSTANT_FROM_F
@@ -146,6 +386,7 @@ class B < PackageSpec
   visible_to C
   visible_to D
   visible_to G
+  visible_to PackageWithNoImportsExports
 end
 
 ###### cat C/__package.rb ######
@@ -161,6 +402,7 @@ class C < PackageSpec
   import D
   import D::ANestedPackage
   import E
+  import PackageWithNoImportsExports
 
 end
 
@@ -209,213 +451,13 @@ class PackageWithIgnore < PackageSpec
   layer 'util'
   import F
 end
-##############################
-###### Package directed ######
-##############################
 
-###### Running gen-packages ######
-PackageWithIgnore/__package.rb:3: `PackageWithIgnore` is missing imports https://srb.help/3734
-     3 |class PackageWithIgnore < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    PackageWithIgnore/__package.rb:5: Inserted `import F`
-     5 |  layer 'util'
-                      ^
-
-B/__package.rb:3: `B` is missing `visible_to`s https://srb.help/3734
-     3 |class B < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    B/__package.rb:9: Inserted `visible_to C
-      visible_to D`
-     9 |  visible_to A
-                      ^
-
-C/__package.rb:7: Layering violation: cannot import `A` (in layer `app`) from `C` (in layer `util`) https://srb.help/3726
-     7 |  import A
-          ^^^^^^^^
-    C/__package.rb:5: `C`'s `layer` declared here
-     5 |  layer 'util'
-                ^^^^^^
-    A/__package.rb:5: `A`'s `layer` declared here
-     5 |  layer 'app'
-                ^^^^^
-
-C/__package.rb:3: `C` is missing imports and `visible_to`s https://srb.help/3734
-     3 |class C < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    C/__package.rb:8: Deleted
-     8 |  import AnotherPack
-        ^^^^^^^^^^^^^^^^^^^^
-    C/__package.rb:8: Inserted `import AnotherPackage
-      import B`
-     8 |  import AnotherPack
-                            ^
-    C/__package.rb:9: Inserted `import D::ANestedPackage
-      import E`
-     9 |  import D
-                  ^
-    C/__package.rb:11: Deleted
-    11 |  visible_to DoesNotExist
-        ^^^^^^^^^^^^^^^^^^^^^^^^^
-    C/__package.rb:12: Deleted
-    12 |  visible_to AlsoDoesNotExist::*
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-E/__package.rb:3: `E` is missing `visible_to`s https://srb.help/3734
-     3 |class E < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    E/__package.rb:9: Deleted
-     9 |  visible_to DoesNotExis
-        ^^^^^^^^^^^^^^^^^^^^^^^^
-    E/__package.rb:10: Deleted
-    10 |  visible_to AlsoDoesNotExist::*
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    E/__package.rb:10: Inserted `visible_to 'tests'
-      visible_to C`
-    10 |  visible_to AlsoDoesNotExist::*
-                                        ^
-
-D/__package.rb:3: `D` is missing imports and exports https://srb.help/3734
-     3 |class D < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    D/__package.rb:7: Inserted `test_import E`
-     7 |  import B
-                  ^
-    D/__package.rb:9: Deleted
-     9 |  export D::ANestedPackage::Foo
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    D/__package.rb:9: Deleted
-     9 |  export D::ANestedPackage::Foo
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    D/__package.rb:10: Deleted
-    10 |  export D::EnumFromD::Variant
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    D/__package.rb:10: Deleted
-    10 |  export D::EnumFromD::Variant
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    D/__package.rb:9: Inserted `export D::CONSTANT_FROM_D
-      export D::ClassFromD
-      export D::EnumFromD`
-     9 |  export D::ANestedPackage::Foo
-                                       ^
-
-D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://srb.help/3734
-     3 |class D::ANestedPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    D/ANestedPackage/__package.rb:5: Inserted `export D::ANestedPackage::Foo`
-     5 |  layer 'util'
-                      ^
-
-A/constants.rb:5: Unable to resolve constant `G` https://srb.help/5002
-     5 |  puts G::ANOTHER_CONSTANT_FROM_G
-               ^
-    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#LCENSORED: `T` defined here
-    NN |module T
-        ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/gc.rbi#LCENSORED: `GC` defined here
-    NN |module GC
-        ^^^^^^^^^
-    A/constants.rb:3: `A` defined here
-     3 |module A
-        ^^^^^^^^
-
-C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
-     8 |      puts F::CONSTANT_FROM_F
-                   ^^^^^^^^^^^^^^^^^^
-    C/__package.rb:3: Enclosing package declared here
-     3 |class C < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^
-    F/__package.rb:4: `F` must be at least `strict_dependencies 'dag'` but is currently `strict_dependencies 'layered'`
-     4 |  strict_dependencies 'layered'
-                              ^^^^^^^^^
-  Note:
-    `F::CONSTANT_FROM_F`'s package is not imported
-
-C/app.rb:9: Package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3723
-     9 |      puts G::CONSTANT_FROM_G
-                   ^^^^^^^^^^^^^^^^^^
-  Note:
-    Please consult with the owning team before adding a `visible_to` line to the package `G`
-Errors: 10
-
-###### cat B/__package.rb ######
+###### cat PackageWithNoImportsExports/__package.rb ######
 # typed: strict
 
-class B < PackageSpec
-  strict_dependencies 'dag'
+class PackageWithNoImportsExports < PackageSpec
   layer 'util'
-
-  export B::CONSTANT_FROM_B
-
-  visible_to A
-  visible_to C
-  visible_to D
-  visible_to G
-end
-
-###### cat C/__package.rb ######
-# typed: strict
-
-class C < PackageSpec
   strict_dependencies 'dag'
-  layer 'util'
-
-  import A
-  import AnotherPackage
+  export PackageWithNoImportsExports::App
   import B
-  import D
-  import D::ANestedPackage
-  import E
-
-end
-
-###### cat D/__package.rb ######
-# typed: strict
-
-class D < PackageSpec
-  strict_dependencies 'dag'
-  layer 'util'
-
-  import B
-  test_import E
-  export D::AlreadyExportedClass
-  export D::CONSTANT_FROM_D
-  export D::ClassFromD
-  export D::EnumFromD
-end
-
-###### cat D/ANestedPackage/__package.rb ######
-# typed: strict
-
-class D::ANestedPackage < PackageSpec
-  strict_dependencies 'dag'
-  layer 'util'
-  export D::ANestedPackage::Foo
-end
-
-###### cat E/__package.rb ######
-# typed: strict
-
-class E < PackageSpec
-  strict_dependencies 'dag'
-  layer 'util'
-
-  export E::CONSTANT_FROM_E
-
-  visible_to 'tests'
-  visible_to C
-end
-
-###### cat PackageWithIgnore/__package.rb ######
-# typed: strict
-
-class PackageWithIgnore < PackageSpec
-  strict_dependencies 'false'
-  layer 'util'
-  import F
 end

--- a/test/cli/package-gen-packages/test.sh
+++ b/test/cli/package-gen-packages/test.sh
@@ -51,6 +51,10 @@ echo
 echo "###### cat PackageWithIgnore/__package.rb ######"
 cat PackageWithIgnore/__package.rb
 
+echo
+echo "###### cat PackageWithNoImportsExports/__package.rb ######"
+cat PackageWithNoImportsExports/__package.rb
+
 echo "##############################"
 echo "###### Package directed ######"
 echo "##############################"
@@ -92,3 +96,7 @@ cat E/__package.rb
 echo
 echo "###### cat PackageWithIgnore/__package.rb ######"
 cat PackageWithIgnore/__package.rb
+
+echo
+echo "###### cat PackageWithNoImportsExports/__package.rb ######"
+cat PackageWithNoImportsExports/__package.rb


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Review commit-by-commit.

Previously, because "e" < "i", `mergeAdjecentEdits` would put the `export` line first. The way I fixed it here is to essentially just render the entire `__package.rb` from scratch (similar to what we do in `--strict`), since that will respect the correct order.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Render in the right order.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
