### PR TITLE
Make an error for singleton class methods in Command

### DIFF
--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -21,6 +21,7 @@ inline constexpr ErrorClass ContravariantHasAttachedClass{3514, StrictLevel::Fal
 inline constexpr ErrorClass DuplicateProp{3515, StrictLevel::True};
 inline constexpr ErrorClass VoidAttrReader{3516, StrictLevel::True};
 inline constexpr ErrorClass PropBadOverride{3517, StrictLevel::False};
+inline constexpr ErrorClass CommandSingletonMethod{3518, StrictLevel::False};
 
 // Let's reserve 3550-3569 for RBS related errors
 inline constexpr ErrorClass RBSSyntaxError{3550, StrictLevel::False};

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -319,6 +319,8 @@ NameDef names[] = {
     {"Encryptable", "Encryptable", true},
     {"EncryptedValue", "EncryptedValue", true},
     {"Command", "Command", true},
+    {"configureCommand", "configure_command"},
+    {"loggingDisabled_p", "logging_disabled?"},
     {"Enum", "Enum", true},
 
     {"ActiveRecord", "ActiveRecord", true},

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -12,6 +12,8 @@ using namespace std;
 
 namespace sorbet::rewriter {
 
+namespace {
+
 bool isCommand(const ast::ClassDef *klass) {
     if (klass->kind != ast::ClassDef::Kind::Class || klass->ancestors.empty()) {
         return false;
@@ -23,6 +25,18 @@ bool isCommand(const ast::ClassDef *klass) {
     };
     return ASTUtil::isRootScopedSyntacticConstant(klass->ancestors.front(), opusCommand);
 }
+
+bool allowedSingletonMethod(core::NameRef name) {
+    switch (name.rawId()) {
+        case core::Names::configureCommand().rawId():
+        case core::Names::loggingDisabled_p().rawId():
+            return true;
+        default:
+            return false;
+    }
+}
+
+} // namespace
 
 void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
     if (ctx.state.cacheSensitiveOptions.runningUnderAutogen) {
@@ -44,7 +58,7 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
             continue;
         }
 
-        if (mdef->flags.isSelfMethod) {
+        if (mdef->flags.isSelfMethod && !allowedSingletonMethod(mdef->name)) {
             if (auto e = ctx.beginIndexerError(mdef->declLoc, core::errors::Rewriter::CommandSingletonMethod)) {
                 e.setHeader("Commands must only define instance methods, but `{}` is a singleton class method",
                             mdef->name.show(ctx));

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -4,6 +4,7 @@
 #include "core/Context.h"
 #include "core/Names.h"
 #include "core/core.h"
+#include "core/errors/rewriter.h"
 #include "rewriter/rewriter.h"
 #include "rewriter/util/Util.h"
 
@@ -42,15 +43,18 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
         if (mdef == nullptr) {
             continue;
         }
+
+        if (mdef->flags.isSelfMethod) {
+            continue;
+        }
+
         if (mdef->name == core::Names::call()) {
             i = &stat - &klass->rhs.front();
             call = mdef;
             callptr = &stat;
         }
 
-        if (!mdef->flags.isSelfMethod) {
-            instanceMethods.push_back(pair(mdef->name, mdef->loc.copyWithZeroLength()));
-        }
+        instanceMethods.push_back(pair(mdef->name, mdef->loc.copyWithZeroLength()));
     }
 
     // If we didn't find a `call` method, or if it was the first statement (and

--- a/rewriter/Command.cc
+++ b/rewriter/Command.cc
@@ -45,6 +45,20 @@ void Command::run(core::MutableContext ctx, ast::ClassDef *klass) {
         }
 
         if (mdef->flags.isSelfMethod) {
+            if (auto e = ctx.beginIndexerError(mdef->declLoc, core::errors::Rewriter::CommandSingletonMethod)) {
+                e.setHeader("Commands must only define instance methods, but `{}` is a singleton class method",
+                            mdef->name.show(ctx));
+                if (mdef->name == core::Names::call()) {
+                    auto expected = "def self.call"sv;
+                    auto replaceLoc = ctx.locAt(mdef->declLoc).adjustLen(ctx, 0, expected.size());
+                    if (replaceLoc.source(ctx) == expected) {
+                        e.replaceWith("Convert to instance method", replaceLoc, "def call");
+                    }
+                    e.addErrorNote("Define `{}` as an instance method in a Command; "
+                                   "it will be callable as a singleton class method",
+                                   mdef->name.show(ctx));
+                }
+            }
             continue;
         }
 

--- a/test/testdata/rewriter/command.rb
+++ b/test/testdata/rewriter/command.rb
@@ -98,12 +98,12 @@ end
 
 class BadCommand < Opus::Command
   sig {params(x: Integer).returns(String)}
-  def self.call(x)
+  def self.call(x) # error: Commands must only define instance methods, but `call` is a singleton class method
     x.to_s
   end
 
   sig {params(x: Integer).returns(String)}
-  def self.foo(x)
+  def self.foo(x) # error: Commands must only define instance methods, but `foo` is a singleton class method
     x.to_s
   end
 end

--- a/test/testdata/rewriter/command.rb.autocorrects.exp
+++ b/test/testdata/rewriter/command.rb.autocorrects.exp
@@ -99,12 +99,12 @@ end
 
 class BadCommand < Opus::Command
   sig {params(x: Integer).returns(String)}
-  def self.call(x)
+  def call(x) # error: Commands must only define instance methods, but `call` is a singleton class method
     x.to_s
   end
 
   sig {params(x: Integer).returns(String)}
-  def self.foo(x)
+  def self.foo(x) # error: Commands must only define instance methods, but `foo` is a singleton class method
     x.to_s
   end
 end

--- a/test/testdata/rewriter/command.rb.autocorrects.exp
+++ b/test/testdata/rewriter/command.rb.autocorrects.exp
@@ -1,3 +1,4 @@
+# -- test/testdata/rewriter/command.rb --
 # typed: true
 class Opus::Command
   extend T::Sig
@@ -23,12 +24,12 @@ end
 
 T.assert_type!(OtherCommand.call("8"), Integer)
 
-class NotACommand < Llamas::Opus::Command # error: Unable to resolve constant
+class NotACommand < Class::Opus::Command # error: Unable to resolve constant
   extend T::Sig
 
   sig {params(x: String).returns(Integer)}
   def call(x)
-    Integer(x) # error: Method `Integer` does not exist on `NotACommand`
+    self.class.Integer(x) # error: Method `Integer` does not exist on `NotACommand`
   end
 end
 
@@ -107,3 +108,4 @@ class BadCommand < Opus::Command
     x.to_s
   end
 end
+# ------------------------------

--- a/test/testdata/rewriter/command.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/command.rb.rewrite-tree.exp
@@ -196,4 +196,34 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <self>.private(:call, :foo)
   end
+
+  class <emptyTree>::<C BadCommand><<C <todo sym>>> < (<emptyTree>::<C Opus>::<C Command>)
+    <self>.sig() do ||
+      <self>.params(:x, <emptyTree>::<C Integer>).returns(<emptyTree>::<C String>)
+    end
+
+    def self.call<<todo method>>(x, &<blk>)
+      x.to_s()
+    end
+
+    <self>.sig() do ||
+      <self>.params(:x, <emptyTree>::<C Integer>).returns(<emptyTree>::<C String>)
+    end
+
+    def self.call<<todo method>>(x, &<blk>)
+      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+    end
+
+    <self>.sig() do ||
+      <self>.params(:x, <emptyTree>::<C Integer>).returns(<emptyTree>::<C String>)
+    end
+
+    def self.foo<<todo method>>(x, &<blk>)
+      x.to_s()
+    end
+
+    <runtime method definition of self.call>
+
+    <runtime method definition of self.foo>
+  end
 end

--- a/test/testdata/rewriter/command.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/command.rb.rewrite-tree.exp
@@ -210,14 +210,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.params(:x, <emptyTree>::<C Integer>).returns(<emptyTree>::<C String>)
     end
 
-    def self.call<<todo method>>(x, &<blk>)
-      ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
-    end
-
-    <self>.sig() do ||
-      <self>.params(:x, <emptyTree>::<C Integer>).returns(<emptyTree>::<C String>)
-    end
-
     def self.foo<<todo method>>(x, &<blk>)
       x.to_s()
     end

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -493,6 +493,16 @@ end
 
 This error indicates that the `override` argument passed to a `prop` or `const` is ill-formed. See [prop overrides](override-checking.md#overrides-and-the-prop-dsl).
 
+## 3518
+
+> This error is specific to a Stripe-specific library called `Opus::Command`.
+
+`Opus::Command` subclasses cannot have singleton class methods. The intention behind a command is to expose a single public method, which is achieved by implementing a `def call` instance method, and letting the `Opus::Command` library forward public calls to the singleton class `call` method to the instance method `call` that the command defines.
+
+To define private helper functions in the implementation of a command, use instance methods.
+
+To define multiple public methods in a single namespace, do not use `Opus::Command` and instead define a normal Ruby class or module. Alternatively, create multiple commands, one per public method.
+
 ## 3550
 
 > This error is specific to RBS support when using the `--enable-experimental-rbs-comments` flag.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is checked in the runtime in Stripe's codebase. We want to make sure to
check it statically as well.

It would be nice to do this in a Stripe-internal RuboCop, but we already have
this pass in Sorbet so let's just keep it here. If we ever remove the Command
rewriter (e.g. because we have a type system feature that models forwarding args
from a singleton class method to an instance method), then we'd want another
solution to this problem, but this is cheap enough right now.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Commits show before/middle/after