### PR TITLE
Recover alias signatures from the stub, not the signature registry

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -347,8 +347,15 @@ module T::Private::Methods
     current_declaration.mod = mod
 
     original_method = mod.instance_method(method_name)
+    # Memoizes the built signature in a variable shared between the `sig_block`
+    # and the stub below. It is set whenever the block runs -- on the stub's first
+    # invocation, or earlier via `run_all_sig_blocks`/`finalize!`. Because an
+    # alias of this method shares this same stub (and so this same closure), the
+    # alias can recover the signature from here when its stub runs, without
+    # consulting the `@signatures_by_method` registry.
+    built_sig = nil
     sig_block = lambda do
-      T::Private::Methods.run_sig(method_name, original_method, current_declaration)
+      built_sig = T::Private::Methods.run_sig(method_name, original_method, current_declaration)
     end
 
     # Always replace the original method with this wrapper,
@@ -362,6 +369,7 @@ module T::Private::Methods
         self,
         original_method,
         __callee__ || raise("Unknown __callee__ for method without a signature"),
+        built_sig,
       )
 
       # Should be the same logic as CallValidation.wrap_method_if_needed but we
@@ -388,8 +396,11 @@ module T::Private::Methods
     end
   end
 
-  def self._handle_missing_method_signature(receiver, original_method, callee)
-    method_sig = T::Private::Methods.signature_for_method(original_method)
+  # `method_sig` is the signature recovered from the stub's closure (the block has
+  # already run, here or via `run_all_sig_blocks`, which is the only way we reach
+  # this slow path). It lets us re-wrap aliases without reading the
+  # `@signatures_by_method` registry.
+  def self._handle_missing_method_signature(receiver, original_method, callee, method_sig)
     if !method_sig
       raise "`sig` not present for method `#{callee}` on #{receiver.inspect} but you're trying to run it anyways. " \
         "This should only be executed if you used `alias_method` to grab a handle to a method after `sig`ing it, but that clearly isn't what you are doing. " \

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
@@ -94,7 +94,7 @@ module T::Private::Methods
   def self._on_method_added(hook_mod, mod, method_name); end
 
   sig {params(receiver: Object, original_method: UnboundMethod, callee: Symbol).returns(T::Private::Methods::Signature)}
-  def self._handle_missing_method_signature(receiver, original_method, callee); end
+  def self._handle_missing_method_signature(receiver, original_method, callee, method_sig); end
 
   sig {params(method_name: Symbol, original_method: UnboundMethod, declaration_block: DeclarationBlock).returns(T::Private::Methods::Signature)}
   def self.run_sig(method_name, original_method, declaration_block); end

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -91,6 +91,32 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         assert_operator(allocs, :<, 5) if check_alloc_counts
       end
 
+      it 'resolves an alias signature from the stub, not the @signatures_by_method registry' do
+        klass = Class.new do
+          extend T::Sig
+          sig { params(x: Symbol).returns(Symbol) }
+          def foo(x=:foo)
+            x
+          end
+          alias_method :bar, :foo
+        end
+
+        # Run foo's sig block directly (as run_all_sig_blocks / finalize! does),
+        # so the alias's first call takes the `_handle_missing_method_signature`
+        # path -- then drop this class's registry entries to prove that path
+        # recovers the signature from the stub (`built_sig`) rather than the
+        # registry.
+        T::Private::Methods.run_sig_block_for_method(klass.instance_method(:foo))
+        registry = T::Private::Methods.instance_variable_get(:@signatures_by_method)
+        registry.keys.grep(/\A#{klass.object_id}#/).each { |key| registry.delete(key) }
+
+        # First call to the alias; must still resolve and validate.
+        assert_equal(:foo, klass.new.bar)
+        assert_raises(TypeError) do
+          klass.new.bar(1)
+        end
+      end
+
       it 'handles alias_method without runtime checking' do
         klass = Class.new do
           extend T::Sig


### PR DESCRIPTION
When a sig'd method is aliased before its first call, the alias shares the original's lazy stub. On the alias's first call (after the original's sig block was already drained -- e.g. by the original being called, or by `run_all_sig_blocks`), the stub fell into `_handle_missing_method_signature`, which looked the signature up in the `@signatures_by_method` registry. That made the registry load-bearing for runtime dispatch, not just introspection.

Memoizing the built signature in a variable that the `sig_block` and stub share solves this problem more simply. The block sets it whenever it runs (via the stub or `run_all_sig_blocks`), and because an alias shares the same stub closure, the alias recovers the signature from there. So `_handle_missing_method_signature` takes it as a parameter instead of reading it from the registry.

The registry is still populated (so that introspection via `T::Utils.signature_for_method`, the `Method#parameters` patch, and `all_checked_tests_sigs` continue to work) but it's no longer consulted on the alias dispatch path. That allow apps that runs all sig blocks after boot with checked level `never` to clear the `@signatures_by_method` registry if they want to.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
At Shopify we run all sig blocks after boot with checked level `never`. This essentially unwraps all methods and renders the `@signatures_by_method` registry needless. Moreover, that registry holds megabytes of data in memory that is essentially dead weight for our use case.

Ideally, we could just clear that registry after running all sig blocks, but we can't sincealiased methods don't have their own signature blocks, and running all sig blocks only unwrap the original method. If an aliased method is ever called, it currently relies on the `@signatures_by_method` registry to know how to unwrap itself.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
