### PR TITLE
Drop pending `sig` block when method is redefined

### DIFF
--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -404,27 +404,6 @@ module T::Configuration
     end
   end
 
-  @warn_handler = nil
-  # Set a handler for warnings
-  #
-  # sorbet-runtime generally only reports warnings in places where the Ruby VM
-  # would also report a warning (e.g., for method redefinitions).
-  #
-  # The signature of a custom handler should match the signature of Ruby's
-  # `Warning.warn` method.
-  def self.warn_handler=(value)
-    validate_lambda_given!(value)
-    @warn_handler = value
-  end
-
-  def self.warn_handler(...)
-    if @warn_handler
-      @warn_handler.call(...)
-    else
-      Warning.warn(...)
-    end
-  end
-
   @scalar_types = nil
   # Set a list of class strings that are to be considered scalar.
   #   (pass nil to reset to default behavior)

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -404,6 +404,27 @@ module T::Configuration
     end
   end
 
+  @warn_handler = nil
+  # Set a handler for warnings
+  #
+  # sorbet-runtime generally only reports warnings in places where the Ruby VM
+  # would also report a warning (e.g., for method redefinitions).
+  #
+  # The signature of a custom handler should match the signature of Ruby's
+  # `Warning.warn` method.
+  def self.warn_handler=(value)
+    validate_lambda_given!(value)
+    @warn_handler = value
+  end
+
+  def self.warn_handler(...)
+    if @warn_handler
+      @warn_handler.call(...)
+    else
+      Warning.warn(...)
+    end
+  end
+
   @scalar_types = nil
   # Set a list of class strings that are to be considered scalar.
   #   (pass nil to reset to default behavior)

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -319,7 +319,11 @@ module T::Private::Methods
       return
     end
 
+    key = method_owner_and_name_to_key(mod, method_name)
     if current_declaration.nil?
+      if (_old_sig = @sig_wrappers.delete(key))
+        $stderr.puts("sorbet-runtime: Dropping unevaluated signature for #{mod}##{method_name} because it was redefined!")
+      end
       return
     end
 
@@ -355,7 +359,6 @@ module T::Private::Methods
     # which is called only on the *first* invocation.
     # This wrapper is very slow, so it will subsequently re-wrap with a much faster wrapper
     # (or unwrap back to the original method).
-    key = method_owner_and_name_to_key(mod, method_name)
     T::Private::ClassUtils.replace_method(original_method, mod, method_name) do |*args, &blk|
       method_sig = T::Private::Methods.maybe_run_sig_block_for_key(key)
       method_sig ||= T::Private::Methods._handle_missing_method_signature(

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -321,9 +321,23 @@ module T::Private::Methods
 
     key = method_owner_and_name_to_key(mod, method_name)
     if current_declaration.nil?
-      if (_old_sig = @sig_wrappers.delete(key))
-        $stderr.puts("sorbet-runtime: Dropping unevaluated signature for #{mod}##{method_name} because it was redefined!")
+      # Drop any existing sig, because the `sig_block` closes over the
+      # `original_method` at the time that the sig wrapper was registered, and
+      # forcing the sig would thus redefine the the redefined method back to
+      # the original method.
+      old_sig = @sig_wrappers.delete(key)
+
+      if old_sig && $VERBOSE
+        # We can probably get away with not printing any location information
+        # (like the Ruby VM would for method redefinition warnings) because the
+        # Ruby VM itself will have printed the location information in its
+        # method redefinition warning (and it does that faster, using functions
+        # that constult the CFP directly).
+        T::Configuration.warn_handler(
+          "sorbet-runtime: warning: Dropping unevaluated signature for #{mod}##{method_name} because it was redefined\n"
+        )
       end
+
       return
     end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -327,13 +327,15 @@ module T::Private::Methods
       # the original method.
       old_sig = @sig_wrappers.delete(key)
 
+      # Ruby only reports method redefinitions if `$VERBOSE` is truthy. Let's
+      # do the same for sigs.
       if old_sig && $VERBOSE
         # We can probably get away with not printing any location information
         # (like the Ruby VM would for method redefinition warnings) because the
         # Ruby VM itself will have printed the location information in its
         # method redefinition warning (and it does that faster, using functions
         # that constult the CFP directly).
-        T::Configuration.warn_handler(
+        Warning.warn(
           "sorbet-runtime: warning: Dropping unevaluated signature for #{mod}##{method_name} because it was redefined\n"
         )
       end

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -979,6 +979,19 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     ], unique_method_redefinitions.sort)
   end
 
+  it 'drops an un-evaluated sig if the method is redefined' do
+    klass = Class.new do
+      extend T::Sig
+      sig { returns(Integer) }
+      def foo; 0; end
+
+      define_method(:foo) { "not an int" }
+    end
+
+    assert_equal("not an int", klass.new.foo)
+    assert_nil(T::Utils.signature_for_method(klass.instance_method(:foo)))
+  end
+
   it "can mark a class abstract! even if it defines a method called method" do
     Class.new do
       extend T::Helpers


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

If a method is redefined but its `sig` has not yet run, the `sig`'s wrapper
method will still hold a reference to the `original_method` in the closure, and
will use that method to call the underlying method when the `sig`'s block is
eventually forced. If the method with a `sig` is redefined before that happens,
that means it will get transparently redefined back to the original method,
which is counterintuitive: people expect the redefined method to take
precedence, like it would if there had been no runtime signatures.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.