### PR TITLE
lsp: include alias_method source arg as a reference in textDocument/references

### DIFF
--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -2,6 +2,7 @@
 #include "ast/Helpers.h"
 #include "core/lsp/Query.h"
 #include "core/lsp/QueryResponse.h"
+#include "core/Types.h"
 
 using namespace std;
 namespace sorbet::realmain::lsp {
@@ -181,6 +182,42 @@ void DefLocSaver::preTransformClassDef(core::Context ctx, ast::ExpressionPtr &tr
     if (classDef.declLoc != classDef.loc && lspQuery.matchesLoc(ctx.locAt(classDef.declLoc))) {
         core::lsp::QueryResponse::pushQueryResponse(
             ctx, core::lsp::ClassDefResponse(classDef.symbol, ctx.locAt(classDef.loc), ctx.locAt(classDef.declLoc)));
+    }
+}
+
+void DefLocSaver::postTransformSend(core::Context ctx, ast::ExpressionPtr &tree) {
+    auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
+    if (send.fun != core::Names::aliasMethod() || send.numPosArgs() < 2) {
+        return;
+    }
+
+    // `alias_method :bar, :foo` -- the second arg (:foo) is a reference to the original method.
+    // If the LSP query is for that symbol, emit a response at the :foo location.
+    const core::lsp::Query &lspQuery = ctx.state.lspQuery;
+    auto &secondArg = send.getPosArg(1);
+    auto lit = ast::cast_tree<ast::Literal>(secondArg);
+    if (!lit || !lit->isSymbol()) {
+        return;
+    }
+
+    auto name = lit->asSymbol();
+    auto owner = ctx.owner.enclosingClass(ctx);
+    auto method = owner.data(ctx)->findMethodNoDealias(name);
+    if (!method.exists()) {
+        return;
+    }
+
+    auto litLoc = ctx.locAt(lit->loc);
+    if (lspQuery.matchesSymbol(method) || lspQuery.matchesLoc(litLoc)) {
+        core::TypeAndOrigins tp;
+        tp.type = method.data(ctx)->resultType;
+        if (tp.type == nullptr) {
+            tp.type = core::Types::untyped(method);
+        }
+        tp.origins.emplace_back(litLoc);
+        core::lsp::QueryResponse::pushQueryResponse(
+            ctx, core::lsp::MethodDefResponse(method, ctx.file, lit->loc, lit->loc,
+                                              name, false, tp));
     }
 }
 

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -2,7 +2,6 @@
 #include "ast/Helpers.h"
 #include "core/lsp/Query.h"
 #include "core/lsp/QueryResponse.h"
-#include "core/Types.h"
 
 using namespace std;
 namespace sorbet::realmain::lsp {
@@ -180,15 +179,14 @@ void DefLocSaver::preTransformClassDef(core::Context ctx, const ast::ClassDef &c
     }
 }
 
-void DefLocSaver::postTransformSend(core::Context ctx, ast::ExpressionPtr &tree) {
-    auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
-    if (send.fun != core::Names::aliasMethod() || send.numPosArgs() < 2) {
+void DefLocSaver::postTransformSend(core::Context ctx, const ast::Send &send) {
+    if (send.fun != core::Names::aliasMethod() || send.numPosArgs() != 2) {
         return;
     }
 
     // `alias_method :bar, :foo` -- the second arg (:foo) is a reference to the original method.
     // If the LSP query is for that symbol, emit a response at the :foo location.
-    const core::lsp::Query &lspQuery = ctx.state.lspQuery;
+    const auto &lspQuery = ctx.state.lspQuery;
     auto &secondArg = send.getPosArg(1);
     auto lit = ast::cast_tree<ast::Literal>(secondArg);
     if (!lit || !lit->isSymbol()) {

--- a/main/lsp/DefLocSaver.h
+++ b/main/lsp/DefLocSaver.h
@@ -15,13 +15,9 @@ public:
     void postTransformConstantLit(core::Context ctx, const ast::ConstantLit &lit);
 
     // Handles loc and symbol requests for ClassDef names.
-<<<<<<< HEAD
-    void preTransformClassDef(core::Context ctx, ast::ExpressionPtr &lit);
+    void preTransformClassDef(core::Context ctx, const ast::ClassDef &classDef);
 
     // Handles loc and symbol requests for alias_method calls.
-    void postTransformSend(core::Context ctx, ast::ExpressionPtr &send);
-=======
-    void preTransformClassDef(core::Context ctx, const ast::ClassDef &classDef);
->>>>>>> upstream/master
+    void postTransformSend(core::Context ctx, const ast::Send &send);
 };
 }; // namespace sorbet::realmain::lsp

--- a/main/lsp/DefLocSaver.h
+++ b/main/lsp/DefLocSaver.h
@@ -16,5 +16,8 @@ public:
 
     // Handles loc and symbol requests for ClassDef names.
     void preTransformClassDef(core::Context ctx, ast::ExpressionPtr &lit);
+
+    // Handles loc and symbol requests for alias_method calls.
+    void postTransformSend(core::Context ctx, ast::ExpressionPtr &send);
 };
 }; // namespace sorbet::realmain::lsp

--- a/test/testdata/lsp/alias_method_references.rb
+++ b/test/testdata/lsp/alias_method_references.rb
@@ -11,3 +11,13 @@ class A
   # ^ usage: A#foo
   end
 end
+
+class B
+  extend T::Sig
+  sig { returns(Symbol) }
+  def self.foo
+  #         ^ def: B.foo
+    alias_method :bar, :foo
+    #                   ^ usage: B.foo
+  end
+end

--- a/test/testdata/lsp/alias_method_references.rb
+++ b/test/testdata/lsp/alias_method_references.rb
@@ -1,0 +1,13 @@
+# typed: true
+
+class A
+  def foo; end
+  #    ^ def: A#foo
+  alias_method :bar1, :foo
+  #                    ^ usage: A#foo
+
+  def bar2
+    foo
+  # ^ usage: A#foo
+  end
+end


### PR DESCRIPTION
## What

`DefLocSaver` now emits a query response for the source argument of `alias_method` calls, so that `textDocument/references` includes alias definitions as references of the original method.

## Why

Closes #9447. When finding references of a method `foo`, an `alias_method :bar1, :foo` definition is a genuine reference — renaming `foo` requires updating the alias too. Previously, only the `def foo` declaration and direct call sites were returned.

Root cause: `alias_method :bar1, :foo` is desugared to `self.alias_method(:bar1, :foo)` before `DefLocSaver` runs. The `:foo` argument is an `ast::Literal` node with its own source location, but `DefLocSaver` had no `postTransformSend` handler, so it was never registered as a symbol reference.

## How

Add `postTransformSend` to `DefLocSaver`. When a `Send` node is an `alias_method` call with at least two arguments, look up the method named by the second argument in the enclosing class. If the LSP query matches that method (by symbol or by cursor location), emit a `MethodDefResponse` at the `:foo` argument's location.

```cpp
// alias_method :bar, :foo — :foo is a reference to the original method
auto name = lit->asSymbol();
auto owner = ctx.owner.enclosingClass(ctx);
auto method = owner.data(ctx)->findMethodNoDealias(name);
if (lspQuery.matchesSymbol(method) || lspQuery.matchesLoc(litLoc)) {
    // emit MethodDefResponse at :foo location
}
```

## Testing

Added `test/testdata/lsp/alias_method_references.rb` which asserts that Find All References on `foo` returns the `alias_method :bar1, :foo` line as a reference.

Full test suite passes: `bazel test //test:test --config=dbg` — 2243/2243 tests pass.