### PR TITLE
Use a hard assert for the `foreign:` proc

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -631,7 +631,7 @@ class T::Props::Decorator
     end
 
     unless foreign.is_a?(Proc)
-      T::Configuration.soft_assert_handler(<<~MESSAGE, storytime: {prop: prop_name, value: foreign}, notify: 'jerry')
+      T::Configuration.hard_assert_handler(<<~MESSAGE, storytime: {prop: prop_name, value: foreign})
         Please use a Proc that returns a model class instead of the model class itself as the argument to `foreign`. In other words:
 
           instead of `prop :foo, String, foreign: FooModel`

--- a/gems/sorbet-runtime/test/types/props/_props.rb
+++ b/gems/sorbet-runtime/test/types/props/_props.rb
@@ -266,13 +266,12 @@ class Opus::Types::Test::Props::PropsTest < Critic::Unit::UnitTest
     end
 
     it 'disallows non-proc arguments' do
-      T::Configuration.expects(:soft_assert_handler).with do |msg, _|
-        msg.include?('Please use a Proc that returns a model class instead')
-      end.times(1)
-
-      Class.new(TestForeignProps) do
-        prop :foreign3, String, foreign: MyTestModel
+      exn = assert_raises do
+        Class.new(TestForeignProps) do
+          prop :foreign3, String, foreign: MyTestModel
+        end
       end
+      assert_includes(exn.message, 'Please use a Proc that returns a model class instead')
     end
   end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This has been around for ages, we may as well remove the soft assertion.

I was looking at whether wanted to document hard_assert_handler and soft_assert_handler, but the only places we're using those are

- in T::Props code for Stripe-specific concepts, like foreign
- in T::Enum for some string conversion stuff

I would love to get rid of all of these instead of documenting them. I don't think that we should ever go replace all `raise` with `hard_assert_handler`, for example.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Stripe's tests won't catch this, soft assertions already fail CI.

I did a search over the past 24 hours of logs and didn't get any results, I hope
that's good enough confidence. In any case, this should still show up at deploy
time because people should not be defining props after code loading.