### PR TITLE
Make DefLocSaver use a const tree walk

### DIFF
--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -6,9 +6,7 @@
 using namespace std;
 namespace sorbet::realmain::lsp {
 
-void DefLocSaver::postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
-    auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
-
+void DefLocSaver::postTransformMethodDef(core::Context ctx, const ast::MethodDef &methodDef) {
     const core::lsp::Query &lspQuery = ctx.state.lspQuery;
     bool lspQueryMatch = lspQuery.matchesLoc(ctx.locAt(methodDef.declLoc)) || lspQuery.matchesSymbol(methodDef.symbol);
 
@@ -49,8 +47,7 @@ void DefLocSaver::postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &
     }
 }
 
-void DefLocSaver::postTransformUnresolvedIdent(core::Context ctx, ast::ExpressionPtr &tree) {
-    auto &id = ast::cast_tree_nonnull<ast::UnresolvedIdent>(tree);
+void DefLocSaver::postTransformUnresolvedIdent(core::Context ctx, const ast::UnresolvedIdent &id) {
     if (id.kind == ast::UnresolvedIdent::Kind::Instance || id.kind == ast::UnresolvedIdent::Kind::Class) {
         core::ClassOrModuleRef klass;
         // Logic originally from `unresolvedIdent2Local` in `builder_walk.cc`, then modified.
@@ -95,7 +92,7 @@ core::MethodRef enclosingMethodFromContext(core::Context ctx) {
     }
 }
 
-void matchesQuery(core::Context ctx, ast::ConstantLit *lit, const core::lsp::Query &lspQuery,
+void matchesQuery(core::Context ctx, const ast::ConstantLit *lit, const core::lsp::Query &lspQuery,
                   core::SymbolRef symbolBeforeDealias) {
     // Iterate. Ensures that we match "Foo" in "Foo::Bar" references.
     auto symbol = symbolBeforeDealias.dealias(ctx);
@@ -152,14 +149,12 @@ bool shouldLeaveAncestorForIDE(const ast::ExpressionPtr &anc) {
 
 } // namespace
 
-void DefLocSaver::postTransformConstantLit(core::Context ctx, ast::ExpressionPtr &tree) {
-    auto &lit = ast::cast_tree_nonnull<ast::ConstantLit>(tree);
+void DefLocSaver::postTransformConstantLit(core::Context ctx, const ast::ConstantLit &lit) {
     const core::lsp::Query &lspQuery = ctx.state.lspQuery;
     matchesQuery(ctx, &lit, lspQuery, lit.symbol());
 }
 
-void DefLocSaver::preTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
-    auto &classDef = ast::cast_tree_nonnull<ast::ClassDef>(tree);
+void DefLocSaver::preTransformClassDef(core::Context ctx, const ast::ClassDef &classDef) {
     const core::lsp::Query &lspQuery = ctx.state.lspQuery;
     if (ast::isa_tree<ast::EmptyTree>(classDef.name)) {
         ENFORCE(classDef.symbol == core::Symbols::root());

--- a/main/lsp/DefLocSaver.h
+++ b/main/lsp/DefLocSaver.h
@@ -7,14 +7,14 @@ namespace sorbet::realmain::lsp {
 class DefLocSaver {
 public:
     // Handles loc and symbol requests for method definitions.
-    void postTransformMethodDef(core::Context ctx, ast::ExpressionPtr &methodDef);
+    void postTransformMethodDef(core::Context ctx, const ast::MethodDef &methodDef);
     // Handles loc and symbol requests for instance variables.
-    void postTransformUnresolvedIdent(core::Context ctx, ast::ExpressionPtr &id);
+    void postTransformUnresolvedIdent(core::Context ctx, const ast::UnresolvedIdent &id);
 
     // Handles loc and symbol requests for constants.
-    void postTransformConstantLit(core::Context ctx, ast::ExpressionPtr &lit);
+    void postTransformConstantLit(core::Context ctx, const ast::ConstantLit &lit);
 
     // Handles loc and symbol requests for ClassDef names.
-    void preTransformClassDef(core::Context ctx, ast::ExpressionPtr &lit);
+    void preTransformClassDef(core::Context ctx, const ast::ClassDef &classDef);
 };
 }; // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -955,7 +955,7 @@ void tryApplyDefLocSaver(const core::GlobalState &gs, vector<ast::ParsedFile> &i
     for (auto &t : indexedCopies) {
         DefLocSaver defLocSaver;
         core::Context ctx(gs, core::Symbols::root(), t.file);
-        ast::TreeWalk::apply(ctx, defLocSaver, t.tree);
+        ast::ConstTreeWalk::apply(ctx, defLocSaver, t.tree);
     }
 }
 } // namespace


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

DefLocSaver does not mutate the tree.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests, compiler