### PR TITLE
Tag wall_time timer with build version in release builds

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -499,6 +499,8 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
                                  cxxopts::value<string>()->default_value(empty.statsdPrefix), "<prefix>");
     options.add_options(section)("statsd-port", "StatsD server port",
                                  cxxopts::value<int>()->default_value(fmt::format("{}", empty.statsdPort)), "<port>");
+    options.add_options(section)("statsd-tag-revision", "Tags some metrics with the revision Sorbet was built from",
+                                 cxxopts::value<bool>()->default_value(fmt::format("{}", empty.statsdTagRevision)));
     options.add_options(section)("metrics-extra-tags", "Extra tags to include in every statsd metric, comma separated.",
                                  cxxopts::value<string>()->default_value(""), "<key1>=<value1>,<key2>=<value2>");
     // }}}
@@ -1203,6 +1205,7 @@ void readOptions(Options &opts,
         opts.statsdHost = raw["statsd-host"].as<string>();
         opts.statsdPort = raw["statsd-port"].as<int>();
         opts.statsdPrefix = raw["statsd-prefix"].as<string>();
+        opts.statsdTagRevision = raw["statsd-tag-revision"].as<bool>();
         opts.metricsSha = raw["metrics-sha"].as<string>();
         opts.metricsFile = raw["metrics-file"].as<string>();
         opts.metricsRepo = raw["metrics-repo"].as<string>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -243,6 +243,7 @@ struct Options {
     std::string statsdHost;
     std::string statsdPrefix = "ruby_typer.unknown";
     int statsdPort = 8200;
+    bool statsdTagRevision = true;
 
     std::string metricsFile;
     std::string metricsRepo = "none";

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -579,6 +579,12 @@ int realmain(int argc, char *argv[]) {
 #endif
     } else {
         Timer timeall(logger, "wall_time");
+        if constexpr (sorbet::is_release_build) {
+            if (opts.statsdTagRevision) {
+                timeall.setTag("version", sorbet::build_scm_revision);
+            }
+        }
+
         vector<core::FileRef> inputFiles;
         logger->trace("Files: ");
 

--- a/website/docs/cli-ref.md
+++ b/website/docs/cli-ref.md
@@ -185,6 +185,8 @@ Usage:
       --statsd-host <host>      StatsD sever hostname (default: "")
       --statsd-prefix <prefix>  StatsD prefix (default: ruby_typer.unknown)
       --statsd-port <port>      StatsD server port (default: 8200)
+      --statsd-tag-revision     Tags some metrics with the revision Sorbet was built from
+                                (default: true)
       --metrics-extra-tags <key1>=<value1>,<key2>=<value2>
                                 Extra tags to include in every statsd metric, comma
                                 separated. (default: "")


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I want to be able to filter our metrics for the most recently deployed version.

This could have potential bad consequences if this tag ends up counting as a
"high cardinality" tag. I hope it's fine, because the sorbet version doesn't
change _that_ often. We still might want to put this behind a flag in case
either we or other Sorbet users can't tolerate the high cardinality of this
metric.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Was planning on testing in prod