### PR TITLE
[rewriter] Don't error on `described_class` synthesized over a non-class constant

### DIFF
--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -264,6 +264,10 @@ INSN(Send) : public Instruction, private core::TrailingObjects<Send, LocalRef, c
 
 public:
     bool isPrivateOk;
+    // Mirrors `ast::Send::Flags::isRewriterSynthesized`: true when this call was synthesized by a
+    // rewriter pass rather than written by the user. Threaded into `core::DispatchArgs` so
+    // intrinsics can suppress diagnostics the user can't act on.
+    bool isRewriterSynthesized = false;
     const uint16_t numPosArgs;
     core::NameRef fun;
     VariableUseSite recv;
@@ -330,6 +334,11 @@ public:
 
         SlotInit<LocalRef> refs;
         SlotInit<core::LocOffsets> locs;
+
+        SendInitializer &setRewriterSynthesized(bool value) {
+            snd->isRewriterSynthesized = value;
+            return *this;
+        }
 
         InstructionPtr asInsnPtr() && {
             ENFORCE(refs.current == refs.end, "must have initialized all send arguments");

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -689,6 +689,7 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::ExpressionPtr &what, Ba
                 const size_t numArgs = s.numNonBlockArgs();
                 auto snd =
                     Send::make(recv, s.recv.loc(), s.fun, s.funLoc, s.numPosArgs(), !!s.flags.isPrivateOk, numArgs);
+                snd.setRewriterSynthesized(!!s.flags.isRewriterSynthesized);
 
                 for (auto &exp : s.posArgs()) {
                     LocalRef temp = cctx.newTemporary(core::Names::statTemp());

--- a/core/Types.h
+++ b/core/Types.h
@@ -213,7 +213,12 @@ public:
      * integer values. This is what `unwrapType` does, it turns the value-level
      * expression back into a type-level one.
      */
-    static TypePtr unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp);
+    // When `suppressErrors` is true, a non-type (bare value) argument silently returns
+    // `T.untyped` instead of reporting `Unexpected bare ... value found in type position` (7009).
+    // Used by callers that already report (or intentionally tolerate) a non-type argument
+    // elsewhere -- e.g. `T.class_of`, where type-syntax parsing is the canonical place to report a
+    // non-class argument, so re-reporting here would be a duplicate.
+    static TypePtr unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp, bool suppressErrors = false);
 
     // Converts type syntax like `GenericClass[Arg0, Arg1]` into a TypePtr.
     //
@@ -1074,6 +1079,12 @@ struct DispatchArgs {
     // unreported errors is expensive!
     bool suppressErrors;
     NameRef enclosingMethodForSuper;
+    // True when the originating call was synthesized by a rewriter pass (i.e. the user did not
+    // write it). Intrinsics may use this to suppress diagnostics the user can't act on -- e.g.
+    // `T.class_of` over a value constant in the RSpec rewriter's synthesized `described_class` sig.
+    // Set directly on the constructed args (see infer/environment.cc) rather than via the
+    // constructor, so the common construction sites stay unchanged.
+    bool isRewriterSynthesized = false;
 
     DispatchArgs(NameRef name, const CallLocs &locs, uint16_t numPosArgs,
                  InlinedVector<const TypeAndOrigins *, 2> &args, const TypePtr &selfType,

--- a/core/Types.h
+++ b/core/Types.h
@@ -213,12 +213,10 @@ public:
      * integer values. This is what `unwrapType` does, it turns the value-level
      * expression back into a type-level one.
      */
-    // When `suppressErrors` is true, a non-type (bare value) argument silently returns
-    // `T.untyped` instead of reporting `Unexpected bare ... value found in type position` (7009).
-    // Used by callers that already report (or intentionally tolerate) a non-type argument
-    // elsewhere -- e.g. `T.class_of`, where type-syntax parsing is the canonical place to report a
-    // non-class argument, so re-reporting here would be a duplicate.
-    static TypePtr unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp, bool suppressErrors = false);
+    // When `tolerateBareValue` is true, a non-type argument silently returns `T.untyped` instead of
+    // reporting error 7009. See `rewriter/Minitest.cc`'s `described_class` synthesis for why a
+    // caller might want that.
+    static TypePtr unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp, bool tolerateBareValue = false);
 
     // Converts type syntax like `GenericClass[Arg0, Arg1]` into a TypePtr.
     //
@@ -1079,17 +1077,15 @@ struct DispatchArgs {
     // unreported errors is expensive!
     bool suppressErrors;
     NameRef enclosingMethodForSuper;
-    // True when the originating call was synthesized by a rewriter pass (i.e. the user did not
-    // write it). Intrinsics may use this to suppress diagnostics the user can't act on -- e.g.
-    // `T.class_of` over a value constant in the RSpec rewriter's synthesized `described_class` sig.
-    // Set directly on the constructed args (see infer/environment.cc) rather than via the
-    // constructor, so the common construction sites stay unchanged.
+    // True when the originating call was synthesized by a rewriter pass. See
+    // `rewriter/Minitest.cc`'s `described_class` synthesis for the motivating case.
     bool isRewriterSynthesized = false;
 
     DispatchArgs(NameRef name, const CallLocs &locs, uint16_t numPosArgs,
                  InlinedVector<const TypeAndOrigins *, 2> &args, const TypePtr &selfType,
                  const TypeAndOrigins &fullType, const TypePtr &thisType, const SendAndBlockLink *block,
-                 Loc originForUninitialized, bool isPrivateOk, bool suppressErrors, NameRef enclosingMethodForSuper);
+                 Loc originForUninitialized, bool isPrivateOk, bool suppressErrors, NameRef enclosingMethodForSuper,
+                 bool isRewriterSynthesized = false);
     DispatchArgs(const DispatchArgs &) = delete;
     DispatchArgs &operator=(const DispatchArgs &) = delete;
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2020,16 +2020,11 @@ public:
         }
 
         // The argument to `T.class_of(...)` is a value, but has a type meaning. That means we need
-        // to  `unwrapType` to handle things like type aliases and constant literal types.
-        //
-        // For rewriter-synthesized calls, suppress the `Unexpected bare ... value found in type
-        // position` (7009) that a non-type argument would otherwise produce here: the user did not
-        // write this `T.class_of`, so the error is unactionable. This is what lets the RSpec
-        // rewriter's synthesized `described_class` sig over a value constant degrade to `T.untyped`
-        // rather than erroring. (For user-written `T.class_of`, a non-class argument is reported
-        // during type-syntax parsing as error 5004, so we keep reporting here as before.)
-        auto unwrappedType =
-            Types::unwrapType(gs, args.argLoc(0), args.args[0]->type, /*suppressErrors*/ args.isRewriterSynthesized);
+        // to `unwrapType` to handle things like type aliases and constant literal types. For
+        // rewriter-synthesized calls, tolerate a non-type argument instead of reporting error 7009;
+        // see `rewriter/Minitest.cc`'s `described_class` synthesis for why.
+        auto unwrappedType = Types::unwrapType(gs, args.argLoc(0), args.args[0]->type,
+                                               /*tolerateBareValue*/ args.isRewriterSynthesized);
         auto mustExist = false;
         auto classSymbol = unwrapSymbol(gs, unwrappedType, mustExist);
         if (!classSymbol.exists()) {

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2021,7 +2021,15 @@ public:
 
         // The argument to `T.class_of(...)` is a value, but has a type meaning. That means we need
         // to  `unwrapType` to handle things like type aliases and constant literal types.
-        auto unwrappedType = Types::unwrapType(gs, args.argLoc(0), args.args[0]->type);
+        //
+        // For rewriter-synthesized calls, suppress the `Unexpected bare ... value found in type
+        // position` (7009) that a non-type argument would otherwise produce here: the user did not
+        // write this `T.class_of`, so the error is unactionable. This is what lets the RSpec
+        // rewriter's synthesized `described_class` sig over a value constant degrade to `T.untyped`
+        // rather than erroring. (For user-written `T.class_of`, a non-class argument is reported
+        // during type-syntax parsing as error 5004, so we keep reporting here as before.)
+        auto unwrappedType =
+            Types::unwrapType(gs, args.argLoc(0), args.args[0]->type, /*suppressErrors*/ args.isRewriterSynthesized);
         auto mustExist = false;
         auto classSymbol = unwrapSymbol(gs, unwrappedType, mustExist);
         if (!classSymbol.exists()) {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -976,7 +976,7 @@ core::ClassOrModuleRef Types::getRepresentedClass(const GlobalState &gs, const T
     return singleton.data(gs)->attachedClass(gs);
 }
 
-TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
+TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp, bool suppressErrors) {
     if (auto metaType = cast_type<MetaType>(tp)) {
         return metaType->wrapped;
     }
@@ -991,18 +991,20 @@ TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
 
         auto attachedClass = classType.symbol.data(gs)->attachedClass(gs);
         if (!attachedClass.exists()) {
-            if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
-                e.setHeader("Unexpected bare `{}` value found in type position", tp.show(gs));
-                if (classType.symbol == core::Symbols::T_Types_Base() ||
-                    classType.symbol.data(gs)->derivesFrom(gs, core::Symbols::T_Types_Base())) {
-                    // T::Types::Base is the parent class for runtime type objects.
-                    // Give a more helpful error message
-                    e.addErrorNote("Sorbet only allows statically-analyzable types in type positions.\n"
-                                   "    To compute new runtime types, you must explicitly wrap with `{}`",
-                                   "T.unsafe");
-                    auto locSource = loc.source(gs);
-                    if (locSource.has_value()) {
-                        e.replaceWith("Wrap in `T.unsafe`", loc, "T.unsafe({})", locSource.value());
+            if (!suppressErrors) {
+                if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
+                    e.setHeader("Unexpected bare `{}` value found in type position", tp.show(gs));
+                    if (classType.symbol == core::Symbols::T_Types_Base() ||
+                        classType.symbol.data(gs)->derivesFrom(gs, core::Symbols::T_Types_Base())) {
+                        // T::Types::Base is the parent class for runtime type objects.
+                        // Give a more helpful error message
+                        e.addErrorNote("Sorbet only allows statically-analyzable types in type positions.\n"
+                                       "    To compute new runtime types, you must explicitly wrap with `{}`",
+                                       "T.unsafe");
+                        auto locSource = loc.source(gs);
+                        if (locSource.has_value()) {
+                            e.replaceWith("Wrap in `T.unsafe`", loc, "T.unsafe({})", locSource.value());
+                        }
                     }
                 }
             }
@@ -1016,8 +1018,10 @@ TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
     if (auto appType = cast_type<AppliedType>(tp)) {
         ClassOrModuleRef attachedClass = appType->klass.data(gs)->attachedClass(gs);
         if (!attachedClass.exists()) {
-            if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
-                e.setHeader("Unexpected bare `{}` value found in type position", tp.show(gs));
+            if (!suppressErrors) {
+                if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
+                    e.setHeader("Unexpected bare `{}` value found in type position", tp.show(gs));
+                }
             }
             return Types::untypedUntracked();
         }
@@ -1029,20 +1033,22 @@ TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
         vector<TypePtr> unwrappedValues;
         unwrappedValues.reserve(shapeType->values.size());
         for (auto &value : shapeType->values) {
-            unwrappedValues.emplace_back(unwrapType(gs, loc, value));
+            unwrappedValues.emplace_back(unwrapType(gs, loc, value, suppressErrors));
         }
         return make_type<ShapeType>(shapeType->keys, move(unwrappedValues));
     } else if (auto tupleType = cast_type<TupleType>(tp)) {
         vector<TypePtr> unwrappedElems;
         unwrappedElems.reserve(tupleType->elems.size());
         for (auto &elem : tupleType->elems) {
-            unwrappedElems.emplace_back(unwrapType(gs, loc, elem));
+            unwrappedElems.emplace_back(unwrapType(gs, loc, elem, suppressErrors));
         }
         return make_type<TupleType>(move(unwrappedElems));
     }
 
-    if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
-        e.setHeader("Unexpected bare `{}` value found in type position", tp.show(gs));
+    if (!suppressErrors) {
+        if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
+            e.setHeader("Unexpected bare `{}` value found in type position", tp.show(gs));
+        }
     }
     return Types::untypedUntracked();
 }

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -976,7 +976,7 @@ core::ClassOrModuleRef Types::getRepresentedClass(const GlobalState &gs, const T
     return singleton.data(gs)->attachedClass(gs);
 }
 
-TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp, bool suppressErrors) {
+TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp, bool tolerateBareValue) {
     if (auto metaType = cast_type<MetaType>(tp)) {
         return metaType->wrapped;
     }
@@ -991,7 +991,7 @@ TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp, boo
 
         auto attachedClass = classType.symbol.data(gs)->attachedClass(gs);
         if (!attachedClass.exists()) {
-            if (!suppressErrors) {
+            if (!tolerateBareValue) {
                 if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
                     e.setHeader("Unexpected bare `{}` value found in type position", tp.show(gs));
                     if (classType.symbol == core::Symbols::T_Types_Base() ||
@@ -1018,7 +1018,7 @@ TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp, boo
     if (auto appType = cast_type<AppliedType>(tp)) {
         ClassOrModuleRef attachedClass = appType->klass.data(gs)->attachedClass(gs);
         if (!attachedClass.exists()) {
-            if (!suppressErrors) {
+            if (!tolerateBareValue) {
                 if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
                     e.setHeader("Unexpected bare `{}` value found in type position", tp.show(gs));
                 }
@@ -1033,19 +1033,19 @@ TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp, boo
         vector<TypePtr> unwrappedValues;
         unwrappedValues.reserve(shapeType->values.size());
         for (auto &value : shapeType->values) {
-            unwrappedValues.emplace_back(unwrapType(gs, loc, value, suppressErrors));
+            unwrappedValues.emplace_back(unwrapType(gs, loc, value, tolerateBareValue));
         }
         return make_type<ShapeType>(shapeType->keys, move(unwrappedValues));
     } else if (auto tupleType = cast_type<TupleType>(tp)) {
         vector<TypePtr> unwrappedElems;
         unwrappedElems.reserve(tupleType->elems.size());
         for (auto &elem : tupleType->elems) {
-            unwrappedElems.emplace_back(unwrapType(gs, loc, elem, suppressErrors));
+            unwrappedElems.emplace_back(unwrapType(gs, loc, elem, tolerateBareValue));
         }
         return make_type<TupleType>(move(unwrappedElems));
     }
 
-    if (!suppressErrors) {
+    if (!tolerateBareValue) {
         if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
             e.setHeader("Unexpected bare `{}` value found in type position", tp.show(gs));
         }
@@ -1186,10 +1186,11 @@ DispatchArgs::DispatchArgs(NameRef name, const CallLocs &locs, uint16_t numPosAr
                            InlinedVector<const TypeAndOrigins *, 2> &args, const TypePtr &selfType,
                            const TypeAndOrigins &fullType, const TypePtr &thisType, const SendAndBlockLink *block,
                            Loc originForUninitialized, bool isPrivateOk, bool suppressErrors,
-                           NameRef enclosingMethodForSuper)
+                           NameRef enclosingMethodForSuper, bool isRewriterSynthesized)
     : name(name), locs(locs), numPosArgs(numPosArgs), args(args), selfType(selfType), fullType(fullType),
       thisType(thisType), block(block), originForUninitialized(originForUninitialized), isPrivateOk(isPrivateOk),
-      suppressErrors(suppressErrors), enclosingMethodForSuper(enclosingMethodForSuper) {}
+      suppressErrors(suppressErrors), enclosingMethodForSuper(enclosingMethodForSuper),
+      isRewriterSynthesized(isRewriterSynthesized) {}
 
 Loc DispatchArgs::argsLoc(const GlobalState &gs) const {
     if (!locs.args.empty()) {
@@ -1238,17 +1239,35 @@ Loc DispatchArgs::argsLoc(const GlobalState &gs) const {
 }
 
 DispatchArgs DispatchArgs::withSelfAndThisRef(const TypePtr &newSelfRef) const {
-    return DispatchArgs{name,        locs,           numPosArgs,
-                        args,        newSelfRef,     fullType,
-                        newSelfRef,  block,          originForUninitialized,
-                        isPrivateOk, suppressErrors, enclosingMethodForSuper};
+    return DispatchArgs{name,
+                        locs,
+                        numPosArgs,
+                        args,
+                        newSelfRef,
+                        fullType,
+                        newSelfRef,
+                        block,
+                        originForUninitialized,
+                        isPrivateOk,
+                        suppressErrors,
+                        enclosingMethodForSuper,
+                        isRewriterSynthesized};
 }
 
 DispatchArgs DispatchArgs::withThisRef(const TypePtr &newThisRef) const {
-    return DispatchArgs{name,        locs,           numPosArgs,
-                        args,        selfType,       fullType,
-                        newThisRef,  block,          originForUninitialized,
-                        isPrivateOk, suppressErrors, enclosingMethodForSuper};
+    return DispatchArgs{name,
+                        locs,
+                        numPosArgs,
+                        args,
+                        selfType,
+                        fullType,
+                        newThisRef,
+                        block,
+                        originForUninitialized,
+                        isPrivateOk,
+                        suppressErrors,
+                        enclosingMethodForSuper,
+                        isRewriterSynthesized};
 }
 
 DispatchResult DispatchResult::merge(const GlobalState &gs, DispatchResult::Combinator kind, DispatchResult &&left,

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1054,6 +1054,7 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                                                 recvType.type,   send.link.data(inWhat).get(),
                                                 ownerLoc,        send.isPrivateOk,
                                                 suppressErrors,  inWhat.symbol.data(ctx)->name};
+                dispatchArgs.isRewriterSynthesized = send.isRewriterSynthesized;
                 auto dispatched = recvType.type.dispatchCall(ctx, dispatchArgs);
 
                 auto it = &dispatched;

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -750,13 +750,8 @@ optional<core::ClassOrModuleRef> parseTClassOf(core::Context ctx, const ast::Sen
     // Only meaningful to dealias once we've ruled out a type alias / type member.
     auto sym = (isTypeAlias || isTypeMember) ? maybeAliased : maybeAliased.dealias(ctx);
     if (isTypeAlias || isTypeMember || sym.isStaticField(ctx)) {
-        // For a rewriter-synthesized `T.class_of`, the argument is whatever constant the user wrote
-        // elsewhere, not in a type position, so none of these are actionable. For example, the
-        // RSpec rewriter synthesizes `sig { returns(T.class_of(arg)) }` for `described_class` from
-        // `describe arg`; when `arg` is bound to a value (`Foo = SomeStruct.new`), a `T.type_alias`,
-        // or a `T.type_member` rather than a class/module, there is nothing the user can fix at the
-        // `T.class_of` site. Degrade silently to `T.untyped` instead of emitting an unactionable
-        // error. A real class/module argument still resolves to the precise `T.class_of(Klass)`.
+        // For a rewriter-synthesized `T.class_of`, none of these are actionable by the user; see
+        // `rewriter/Minitest.cc`'s `described_class` synthesis for why.
         if (!send.flags.isRewriterSynthesized) {
             if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
                 e.setHeader("T.class_of can't be used with a {}", isTypeAlias    ? "T.type_alias"

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -745,25 +745,25 @@ optional<core::ClassOrModuleRef> parseTClassOf(core::Context ctx, const ast::Sen
         return core::Symbols::untyped();
     }
     auto maybeAliased = obj->symbol();
-    if (maybeAliased.isTypeAlias(ctx)) {
-        if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
-            e.setHeader("T.class_of can't be used with a T.type_alias");
-            maybeSuggestTClass(ctx, e, send.loc, obj->loc());
-        }
-        return core::Symbols::untyped();
-    }
-    if (maybeAliased.isTypeMember()) {
-        if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
-            e.setHeader("T.class_of can't be used with a T.type_member");
-            maybeSuggestTClass(ctx, e, send.loc, obj->loc());
-        }
-        return core::Symbols::untyped();
-    }
-    auto sym = maybeAliased.dealias(ctx);
-    if (sym.isStaticField(ctx)) {
-        if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
-            e.setHeader("T.class_of can't be used with a constant field");
-            maybeSuggestTClass(ctx, e, send.loc, obj->loc());
+    auto isTypeAlias = maybeAliased.isTypeAlias(ctx);
+    auto isTypeMember = maybeAliased.isTypeMember();
+    // Only meaningful to dealias once we've ruled out a type alias / type member.
+    auto sym = (isTypeAlias || isTypeMember) ? maybeAliased : maybeAliased.dealias(ctx);
+    if (isTypeAlias || isTypeMember || sym.isStaticField(ctx)) {
+        // For a rewriter-synthesized `T.class_of`, the argument is whatever constant the user wrote
+        // elsewhere, not in a type position, so none of these are actionable. For example, the
+        // RSpec rewriter synthesizes `sig { returns(T.class_of(arg)) }` for `described_class` from
+        // `describe arg`; when `arg` is bound to a value (`Foo = SomeStruct.new`), a `T.type_alias`,
+        // or a `T.type_member` rather than a class/module, there is nothing the user can fix at the
+        // `T.class_of` site. Degrade silently to `T.untyped` instead of emitting an unactionable
+        // error. A real class/module argument still resolves to the precise `T.class_of(Klass)`.
+        if (!send.flags.isRewriterSynthesized) {
+            if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                e.setHeader("T.class_of can't be used with a {}", isTypeAlias    ? "T.type_alias"
+                                                                  : isTypeMember ? "T.type_member"
+                                                                                 : "constant field");
+                maybeSuggestTClass(ctx, e, send.loc, obj->loc());
+            }
         }
         return core::Symbols::untyped();
     }

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -830,11 +830,13 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::
                 ast::cast_tree_nonnull<ast::MethodDef>(describedClassMethod).flags.discardDef = true;
                 // `arg` may be a constant bound to a value rather than a class/module (e.g.
                 // `KyJohnsonCountyOlf = ReferenceData::DepositKey.new(...)`, common in RSpec
-                // permutation specs). `T.class_of(<value constant>)` would otherwise raise error
-                // 5004 ("T.class_of can't be used with a constant field") -- an error the user
-                // can't act on, since they didn't write the `T.class_of`. Mark the synthesized
-                // send so the resolver degrades it to `T.untyped` silently instead. A real class
-                // arg still resolves to the precise `T.class_of(Klass)`.
+                // permutation specs), or to a `T.type_alias`/`T.type_member`. `T.class_of(arg)`
+                // would otherwise raise an error (5004 in type syntax, 7009 in infer) that the user
+                // can't act on, since they didn't write the `T.class_of`. Mark the synthesized send
+                // so both of those sites degrade it to `T.untyped` silently instead (see their
+                // `isRewriterSynthesized` checks in resolver/type_syntax/type_syntax.cc and
+                // core/types/calls.cc). A real class/module arg still resolves to the precise
+                // `T.class_of(Klass)`.
                 auto classOfType = ast::MK::ClassOf(methodLoc, arg.deepCopy());
                 ast::cast_tree_nonnull<ast::Send>(classOfType).flags.isRewriterSynthesized = true;
                 auto sig = ast::MK::Sig0(methodLoc, std::move(classOfType));

--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -828,7 +828,16 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::
                 auto describedClassMethod =
                     ast::MK::SyntheticMethod0(arg.loc(), methodLoc, core::Names::describedClass(), arg.deepCopy());
                 ast::cast_tree_nonnull<ast::MethodDef>(describedClassMethod).flags.discardDef = true;
-                auto sig = ast::MK::Sig0(methodLoc, ast::MK::ClassOf(methodLoc, arg.deepCopy()));
+                // `arg` may be a constant bound to a value rather than a class/module (e.g.
+                // `KyJohnsonCountyOlf = ReferenceData::DepositKey.new(...)`, common in RSpec
+                // permutation specs). `T.class_of(<value constant>)` would otherwise raise error
+                // 5004 ("T.class_of can't be used with a constant field") -- an error the user
+                // can't act on, since they didn't write the `T.class_of`. Mark the synthesized
+                // send so the resolver degrades it to `T.untyped` silently instead. A real class
+                // arg still resolves to the precise `T.class_of(Klass)`.
+                auto classOfType = ast::MK::ClassOf(methodLoc, arg.deepCopy());
+                ast::cast_tree_nonnull<ast::Send>(classOfType).flags.isRewriterSynthesized = true;
+                auto sig = ast::MK::Sig0(methodLoc, std::move(classOfType));
                 classBody.emplace_back(std::move(sig));
                 classBody.emplace_back(std::move(describedClassMethod));
             }

--- a/test/testdata/rewriter/rspec_describe.rb
+++ b/test/testdata/rewriter/rspec_describe.rb
@@ -328,3 +328,50 @@ RSpec.describe :user_symbol, :slow do
     result
   end
 end
+
+# Test `describe` with a constant bound to a *value* (not a class or module).
+# RSpec permutation specs commonly `describe` such constants, e.g.
+# `describe ReferenceData::DepositKey::KyJohnsonCountyOlf` where the constant is
+# `= SomeClass.new`. `T.class_of(<value>)` is invalid, so rather than reporting
+# "T.class_of can't be used with a constant field" (5004) or a bare-value-in-type
+# error (7009) on a `T.class_of` the user never wrote, the synthesized
+# `described_class` degrades to `T.untyped`.
+class SomeValueClass; end
+SOME_VALUE_CONSTANT = SomeValueClass.new
+
+RSpec.describe SOME_VALUE_CONSTANT do
+  it "does not error on a value-constant describe arg" do
+    T.reveal_type(described_class) # error: Revealed type: `T.untyped`
+    described_class.anything_at_all
+  end
+end
+
+# Nested `describe` over a value constant behaves the same as the top-level case.
+RSpec.describe UserClass do
+  describe SOME_VALUE_CONSTANT do
+    it "value-constant nested describe does not error" do
+      T.reveal_type(described_class) # error: Revealed type: `T.untyped`
+    end
+  end
+end
+
+# A `T.type_alias` constant is handled the same way as a value constant: the
+# synthesized `T.class_of(<type alias>)` would otherwise report "T.class_of
+# can't be used with a T.type_alias" (5004), which the user can't act on, so it
+# degrades to `T.untyped`. (RSpec specs describe type aliases in practice, e.g.
+# `describe Payments::Types::TransmissionRecord`.)
+MyTypeAlias = T.type_alias { T.any(Integer, String) }
+
+RSpec.describe MyTypeAlias do
+  it "does not error on a type-alias describe arg" do
+    T.reveal_type(described_class) # error: Revealed type: `T.untyped`
+  end
+end
+
+RSpec.describe UserClass do
+  describe MyTypeAlias do
+    it "type-alias nested describe does not error" do
+      T.reveal_type(described_class) # error: Revealed type: `T.untyped`
+    end
+  end
+end

--- a/test/testdata/rewriter/rspec_describe.rb
+++ b/test/testdata/rewriter/rspec_describe.rb
@@ -329,13 +329,8 @@ RSpec.describe :user_symbol, :slow do
   end
 end
 
-# Test `describe` with a constant bound to a *value* (not a class or module).
-# RSpec permutation specs commonly `describe` such constants, e.g.
-# `describe ReferenceData::DepositKey::KyJohnsonCountyOlf` where the constant is
-# `= SomeClass.new`. `T.class_of(<value>)` is invalid, so rather than reporting
-# "T.class_of can't be used with a constant field" (5004) or a bare-value-in-type
-# error (7009) on a `T.class_of` the user never wrote, the synthesized
-# `described_class` degrades to `T.untyped`.
+# `describe` over a constant bound to a value (not a class/module) should degrade
+# `described_class` to `T.untyped` rather than error; see rewriter/Minitest.cc.
 class SomeValueClass; end
 SOME_VALUE_CONSTANT = SomeValueClass.new
 
@@ -355,11 +350,7 @@ RSpec.describe UserClass do
   end
 end
 
-# A `T.type_alias` constant is handled the same way as a value constant: the
-# synthesized `T.class_of(<type alias>)` would otherwise report "T.class_of
-# can't be used with a T.type_alias" (5004), which the user can't act on, so it
-# degrades to `T.untyped`. (RSpec specs describe type aliases in practice, e.g.
-# `describe Payments::Types::TransmissionRecord`.)
+# A `T.type_alias` constant is handled the same way as a value constant (see above).
 MyTypeAlias = T.type_alias { T.any(Integer, String) }
 
 RSpec.describe MyTypeAlias do
@@ -371,6 +362,20 @@ end
 RSpec.describe UserClass do
   describe MyTypeAlias do
     it "type-alias nested describe does not error" do
+      T.reveal_type(described_class) # error: Revealed type: `T.untyped`
+    end
+  end
+end
+
+# A `T.type_member` constant is handled the same way (see above). Unlike a value
+# constant or type alias, a type member can only be referenced from within the
+# class/module that defines it, so the describe block is nested there.
+class HasTypeMember
+  extend T::Generic
+  SomeTypeMember = type_member
+
+  RSpec.describe SomeTypeMember do
+    it "does not error on a type-member describe arg" do
       T.reveal_type(described_class) # error: Revealed type: `T.untyped`
     end
   end

--- a/test/testdata/rewriter/rspec_describe.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_describe.rb.rewrite-tree.exp
@@ -567,4 +567,108 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <runtime method definition of result>
     end
   end
+
+  class <emptyTree>::<C SomeValueClass><<C <todo sym>>> < (::<todo sym>)
+  end
+
+  <emptyTree>::<C SOME_VALUE_CONSTANT> = <cast:<assume type>>(<emptyTree>::<C SomeValueClass>.new(), <todo sym>, <emptyTree>::<C SomeValueClass>)
+
+  begin
+    <emptyTree>::<C SOME_VALUE_CONSTANT>
+    class <emptyTree>::<C <describe 'SOME_VALUE_CONSTANT'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      def <it 'does not error on a value-constant describe arg'><<todo method>>(&<blk>)
+        begin
+          <emptyTree>::<C T>.reveal_type(<self>.described_class())
+          <self>.described_class().anything_at_all()
+        end
+      end
+
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.returns(::T.class_of(<emptyTree>::<C SOME_VALUE_CONSTANT>))
+      end
+
+      def described_class<<todo method>>(&<blk>)
+        <emptyTree>::<C SOME_VALUE_CONSTANT>
+      end
+    end
+  end
+
+  begin
+    <emptyTree>::<C UserClass>
+    class <emptyTree>::<C <describe 'UserClass'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.returns(::T.class_of(<emptyTree>::<C UserClass>))
+      end
+
+      def described_class<<todo method>>(&<blk>)
+        <emptyTree>::<C UserClass>
+      end
+
+      <emptyTree>::<C SOME_VALUE_CONSTANT>
+
+      class <emptyTree>::<C <describe 'SOME_VALUE_CONSTANT'>><<C <todo sym>>> < (<self>)
+        def <it 'value-constant nested describe does not error'><<todo method>>(&<blk>)
+          <emptyTree>::<C T>.reveal_type(<self>.described_class())
+        end
+
+        ::T::Sig::WithoutRuntime.sig() do ||
+          <self>.returns(::T.class_of(<emptyTree>::<C SOME_VALUE_CONSTANT>))
+        end
+
+        def described_class<<todo method>>(&<blk>)
+          <emptyTree>::<C SOME_VALUE_CONSTANT>
+        end
+      end
+    end
+  end
+
+  <emptyTree>::<C MyTypeAlias> = <emptyTree>::<C T>.type_alias() do ||
+    <emptyTree>::<C T>.any(<emptyTree>::<C Integer>, <emptyTree>::<C String>)
+  end
+
+  begin
+    <emptyTree>::<C MyTypeAlias>
+    class <emptyTree>::<C <describe 'MyTypeAlias'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      def <it 'does not error on a type-alias describe arg'><<todo method>>(&<blk>)
+        <emptyTree>::<C T>.reveal_type(<self>.described_class())
+      end
+
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.returns(::T.class_of(<emptyTree>::<C MyTypeAlias>))
+      end
+
+      def described_class<<todo method>>(&<blk>)
+        <emptyTree>::<C MyTypeAlias>
+      end
+    end
+  end
+
+  begin
+    <emptyTree>::<C UserClass>
+    class <emptyTree>::<C <describe 'UserClass'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+      ::T::Sig::WithoutRuntime.sig() do ||
+        <self>.returns(::T.class_of(<emptyTree>::<C UserClass>))
+      end
+
+      def described_class<<todo method>>(&<blk>)
+        <emptyTree>::<C UserClass>
+      end
+
+      <emptyTree>::<C MyTypeAlias>
+
+      class <emptyTree>::<C <describe 'MyTypeAlias'>><<C <todo sym>>> < (<self>)
+        def <it 'type-alias nested describe does not error'><<todo method>>(&<blk>)
+          <emptyTree>::<C T>.reveal_type(<self>.described_class())
+        end
+
+        ::T::Sig::WithoutRuntime.sig() do ||
+          <self>.returns(::T.class_of(<emptyTree>::<C MyTypeAlias>))
+        end
+
+        def described_class<<todo method>>(&<blk>)
+          <emptyTree>::<C MyTypeAlias>
+        end
+      end
+    end
+  end
 end

--- a/test/testdata/rewriter/rspec_describe.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/rspec_describe.rb.rewrite-tree.exp
@@ -671,4 +671,27 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
   end
+
+  class <emptyTree>::<C HasTypeMember><<C <todo sym>>> < (::<todo sym>)
+    <self>.extend(<emptyTree>::<C T>::<C Generic>)
+
+    <emptyTree>::<C SomeTypeMember> = <self>.type_member()
+
+    begin
+      <emptyTree>::<C SomeTypeMember>
+      class <emptyTree>::<C <describe 'SomeTypeMember'>><<C <todo sym>>> < (<emptyTree>::<C RSpec>::<C Core>::<C ExampleGroup>)
+        def <it 'does not error on a type-member describe arg'><<todo method>>(&<blk>)
+          <emptyTree>::<C T>.reveal_type(<self>.described_class())
+        end
+
+        ::T::Sig::WithoutRuntime.sig() do ||
+          <self>.returns(::T.class_of(<emptyTree>::<C SomeTypeMember>))
+        end
+
+        def described_class<<todo method>>(&<blk>)
+          <emptyTree>::<C SomeTypeMember>
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Motivation

The experimental RSpec rewriter synthesizes `sig { returns(T.class_of(arg)) }` for `described_class` when `describe`/`context` is given a constant argument (#10257). That's correct when `arg` is a class or module, but breaks when `arg` is a constant that **is not a class/module** — a value, a `T.type_alias`, or a `T.type_member`:

```ruby
module ReferenceData
  module DepositKey
    KyJohnsonCountyOlf = DepositKey.new(...)         # value constant
  end
end
RSpec.describe ReferenceData::DepositKey::KyJohnsonCountyOlf do ... end

module Payments::Types
  TransmissionRecord = T.type_alias { T.any(AchPayment, WirePayment) }  # type alias
end
RSpec.describe Payments::Types::TransmissionRecord do ... end
```

`T.class_of(<non-class>)` is invalid, so the synthesized sig produces errors the user can't act on (they never wrote the `T.class_of`):

- **5004** `T.class_of can't be used with a {constant field, T.type_alias, T.type_member}` (type-syntax)
- **7009** `Unexpected bare ... value found in type position` (inference, when the synthesized sig block is checked)

This pattern is common in RSpec permutation specs and currently forces those files all the way to `# typed: ignore`. Fixes #10441.

## What this does

Suppress both errors **only** for rewriter-synthesized `T.class_of`, degrading `described_class` to `T.untyped` for any non-class argument, while keeping the precise `T.class_of(Klass)` for a real class/module. User-written `T.class_of(<non-class>)` is unchanged.

- Mark the synthesized `T.class_of` send `isRewriterSynthesized` (`rewriter/Minitest.cc`).
- `type_syntax`: for a rewriter-synthesized `T.class_of`, skip the 5004 error across all three non-class cases — value constant, `T.type_alias`, `T.type_member` (still returns `untyped`).
- Thread `isRewriterSynthesized` from `cfg::Send` into `core::DispatchArgs` (mirroring `isPrivateOk`); `T_class_of` passes it to `Types::unwrapType` via a new `tolerateBareValue` flag that silences the 7009 bare-value-in-type-position error.

This follows the same `ast::Send::Flags` → `cfg::Send` → `DispatchArgs` plumbing already used for `isPrivateOk` (#4363) and `suppressErrors` (#3641) — routing a narrow, single-consumer signal through `DispatchArgs` into an intrinsic is an established pattern here, not a new one.

## Tests

- Added `describe`/nested-`describe` cases to `test/testdata/rewriter/rspec_describe.rb` for all three non-class cases — value constant, `T.type_alias`, and `T.type_member` — asserting `described_class` reveals `T.untyped` with no 5004/7009 (golden regenerated).
- `fuzz_class_of_static_field` still reports 5004 + 7009 for user-written `T.class_of` over a constant field, type alias, and type member — confirming user-facing behavior is unchanged.
- Full curated test suite (`bazel test test`) passes (2253/2253).

Refs #10257.
