### PR TITLE
Fix runtime override check for overrides that fold positionals into `*rest`

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/signature_validation.rb
@@ -256,16 +256,23 @@ module T::Private::Methods::SignatureValidation
     #
     # An index loop avoids allocating a pair array per positional arg.
     # Iterating to super's length is deliberate: extra override positionals
-    # go unchecked, and when the override has a rest param and fewer named
-    # args than the base, the missing positions are checked as nil name/type.
+    # go unchecked, and when the override folds the remaining base positionals
+    # into a rest param, each is checked against the rest param's type
+    # (validate_override_shape guarantees such a rest param exists here).
     super_arg_types = super_signature.arg_types
     arg_types = signature.arg_types
+    rest_type = signature.rest_type
     index = 0
     while index < super_arg_types.length
       super_type = super_arg_types.fetch(index)[1]
       pair = arg_types[index]
-      name = pair && pair[0]
-      type = pair && pair[1]
+      if pair
+        name = pair[0]
+        type = pair[1]
+      else
+        name = signature.rest_name
+        type = rest_type
+      end
       if !super_type.subtype_of?(type)
         raise "Incompatible type for arg ##{index + 1} (`#{name}`) in signature for #{mode_noun} of method " \
               "`#{signature.method_name}`:\n" \

--- a/gems/sorbet-runtime/test/types/validate_override_types.rb
+++ b/gems/sorbet-runtime/test/types/validate_override_types.rb
@@ -95,10 +95,24 @@ module Opus::Types::Test
       assert_includes(err.message, "Incompatible type for arg `kw` in signature for override of method `foo`")
     end
 
-    it "raises if an override declares a rest param but fewer named positionals than the base" do
-      # The override's *rest skips the arity shape check, and the positional
-      # type walk pads the missing positions with nil (name and type): the
-      # base's second arg type is checked against nil and must still raise.
+    it "succeeds if an override folds extra base positionals into a contravariant rest param" do
+      base = Class.new do
+        extend T::Sig
+        sig { overridable.params(a: BaseFoo1, b: SubFoo2).returns(BaseFoo3) }
+        def foo(a, b); end
+      end
+      klass = Class.new(base) do
+        extend T::Sig
+        sig { override.params(a: BaseFoo1, rest: BaseFoo2).returns(BaseFoo3) }
+        def foo(a, *rest)
+          BaseFoo3.new
+        end
+      end
+
+      klass.new.foo(BaseFoo1.new, SubFoo2.new)
+    end
+
+    it "raises if an override's rest param type is not a supertype of a folded base positional" do
       base = Class.new do
         extend T::Sig
         sig { overridable.params(a: BaseFoo1, b: BaseFoo2).returns(BaseFoo3) }
@@ -106,7 +120,7 @@ module Opus::Types::Test
       end
       klass = Class.new(base) do
         extend T::Sig
-        sig { override.params(a: BaseFoo1, rest: BaseFoo2).returns(BaseFoo3) }
+        sig { override.params(a: BaseFoo1, rest: SubFoo2).returns(BaseFoo3) }
         def foo(a, *rest); end
       end
 
@@ -114,7 +128,7 @@ module Opus::Types::Test
         klass.new.foo(BaseFoo1.new, BaseFoo2.new)
       end
 
-      assert_includes(err.message, "Incompatible type for arg #2 (``) in signature for override of method `foo`")
+      assert_includes(err.message, "Incompatible type for arg #2 (`rest`) in signature for override of method `foo`")
     end
 
     it "raises if the return type is contravariant" do


### PR DESCRIPTION
### Motivation

`sorbet-runtime` raises a false `Incompatible type for arg #N (``)` override error when a child overrides a parent method by collapsing several fixed positional parameters into a single rest (`*args`) parameter:

```ruby
class Base
  extend T::Sig
  sig { overridable.params(a: Integer, b: Integer).void }
  def foo(a, b); end
end

class Child < Base
  extend T::Sig
  sig { override.params(a: Integer, rest: Integer).void }
  def foo(a, *rest); end
end
```

The child accepts at least as much as the parent, so this is valid by Liskov substitution, and `srb tc` already accepts it. Only the runtime check disagreed. `validate_override_types` walked the parent's positional types and, for the positions the override folds into its rest parameter, compared the base type against a `nil` slot, which produced the spurious error. The runtime now checks those positions against the override's rest parameter type, so it matches the static checker.

Fixes #10370.

### Test plan

See the included automated tests in `gems/sorbet-runtime/test/types/validate_override_types.rb`: a case where the override folds extra base positionals into a contravariant rest param now passes, and a case where the rest param's type is not a supertype of a folded base positional still raises (now reporting `arg #2 (`rest`)` instead of an empty name).
