### PR TITLE
Add `Proc#<<` and `Proc#>>` to `rbi/core/proc.rbi`

### DIFF
--- a/rbi/core/proc.rbi
+++ b/rbi/core/proc.rbi
@@ -364,11 +364,35 @@ class Proc < Object
   sig {params(blk: Proc).returns(T.attached_class)}
   def self.new(&blk); end
 
+  # Returns a proc that is the composition of this proc and the given *g*. The
+  # returned proc takes a variable number of arguments, calls *g* with them then
+  # calls this proc with the result.
+  #
+  # ```ruby
+  # f = proc {|x| x * x }
+  # g = proc {|x| x + x }
+  # p (f << g).call(2) #=> 16
+  # ```
+  sig {params(g: T.untyped).returns(Proc)}
+  def <<(g); end
+
   # Invokes the block with `obj` as the proc's parameter like
   # [`Proc#call`](https://docs.ruby-lang.org/en/2.7.0/Proc.html#method-i-call).
   # This allows a proc object to be the target of a `when` clause in a case
   # statement.
   def ===(*_); end
+
+  # Returns a proc that is the composition of this proc and the given *g*. The
+  # returned proc takes a variable number of arguments, calls this proc with
+  # them then calls *g* with the result.
+  #
+  # ```ruby
+  # f = proc {|x| x * x }
+  # g = proc {|x| x + x }
+  # p (f >> g).call(2) #=> 8
+  # ```
+  sig {params(g: T.untyped).returns(Proc)}
+  def >>(g); end
 
   # Returns the number of mandatory arguments. If the block is declared to take
   # no arguments, returns 0. If the block is known to take exactly n arguments,

--- a/test/testdata/rbi/proc.rb
+++ b/test/testdata/rbi/proc.rb
@@ -6,6 +6,11 @@ extend T::Sig
 my_proc = Proc.new {}
 T.reveal_type(my_proc) # error: type: `Proc`
 
+square = ->(x) { x * x }
+double = ->(x) { x + x }
+T.reveal_type(square << double) # error: type: `Proc`
+T.reveal_type(square >> double) # error: type: `Proc`
+
 sig {params(f: T.proc.params(x: Integer).void).void}
 def example(f)
   f.call(0) do # error: `Proc1#call` does not take a block


### PR DESCRIPTION
### Motivation

Ruby 2.6 added the proc-composition operators `Proc#<<` and `Proc#>>`, but they were missing from Sorbet's core RBI, so calling either on a `Proc` failed with "Method `<<` does not exist on `Proc`" (7003).

This adds both, mirroring the existing `Method#<<` / `Method#>>` definitions in [`rbi/core/method.rbi`](https://github.com/sorbet/sorbet/blob/master/rbi/core/method.rbi). The parameter is left as `T.untyped` (these accept anything that responds to `call`, matching `Method`), while the return type is `Proc`, since both operators always return a `Proc`. See the Ruby docs for [`Proc#<<`](https://docs.ruby-lang.org/en/2.7.0/Proc.html#method-i-3C-3C) and [`Proc#>>`](https://docs.ruby-lang.org/en/2.7.0/Proc.html#method-i-3E-3E). `Method#<<` / `Method#>>` are left as `T.untyped` for now; tightening all four together would be a reasonable follow-up.

Fixes #9656.

### Test plan

Added a case to `test/testdata/rbi/proc.rb` exercising `Proc#<<` and `Proc#>>` (both now reveal `Proc`).
