### PR TITLE
Route sig coercion failures through sig_builder_error_handler

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -428,11 +428,15 @@ module T::Private::Methods
   # Executes the `sig` block, and converts the resulting Declaration
   # to a Signature.
   def self.run_sig(method_name, original_method, declaration_block)
+    loc = declaration_block.loc
+
     current_declaration =
       begin
         run_builder(declaration_block)
-      rescue DeclBuilder::BuilderError => e
-        T::Configuration.sig_builder_error_handler(e, declaration_block.loc)
+      # A `CoerceError` can escape the sig block itself, because combinators like
+      # `T.nilable` coerce their arguments eagerly.
+      rescue DeclBuilder::BuilderError, T::Utils::CoerceError => e
+        T::Configuration.sig_builder_error_handler(e, loc)
         nil
       end
 
@@ -441,7 +445,7 @@ module T::Private::Methods
 
     signature =
       if current_declaration
-        build_sig(method_name, original_method, current_declaration)
+        build_sig(method_name, original_method, current_declaration, loc)
       else
         Signature.new_untyped(method: original_method)
       end
@@ -476,7 +480,7 @@ module T::Private::Methods
     decl
   end
 
-  def self.build_sig(method_name, original_method, current_declaration)
+  def self.build_sig(method_name, original_method, current_declaration, loc)
     begin
       signature = Signature.new(
         method: original_method,
@@ -493,6 +497,12 @@ module T::Private::Methods
 
       SignatureValidation.validate(signature)
       signature
+    # A bad type annotation is a problem with how the `sig` was written, not
+    # with how it lines up against other sigs, so it belongs to the builder
+    # handler rather than the validation one.
+    rescue T::Utils::CoerceError => e
+      T::Configuration.sig_builder_error_handler(e, loc)
+      Signature.new_untyped(method: original_method)
     rescue => e
       super_method = original_method.super_method
       super_signature = signature_for_method(super_method) if super_method

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
@@ -102,8 +102,8 @@ module T::Private::Methods
   sig {params(declaration_block: DeclarationBlock).returns(T::Private::Methods::Declaration)}
   def self.run_builder(declaration_block); end
 
-  sig {params(method_name: Symbol, original_method: UnboundMethod, current_declaration: T::Private::Methods::Declaration).returns(T::Private::Methods::Signature)}
-  def self.build_sig(method_name, original_method, current_declaration); end
+  sig {params(method_name: Symbol, original_method: UnboundMethod, current_declaration: T::Private::Methods::Declaration, loc: T.nilable(Thread::Backtrace::Location)).returns(T::Private::Methods::Signature)}
+  def self.build_sig(method_name, original_method, current_declaration, loc); end
 
   sig {params(method: T.any(Method, UnboundMethod)).returns(T.nilable(T::Private::Methods::Signature))}
   def self.signature_for_method(method); end

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -2,6 +2,11 @@
 # typed: true
 
 module T::Utils
+  # Raised when `T::Utils.coerce` is handed something that isn't a type. When
+  # this happens while a `sig` is being built, it is rescued and reported
+  # through `T::Configuration.sig_builder_error_handler`.
+  class CoerceError < StandardError; end
+
   module Private
     # NOTE: the Module and SimplePairUnion branches of this method are inlined
     # for speed in several hot paths. The `T.cast` / `T.let` / `T.bind` /
@@ -33,11 +38,15 @@ module T::Utils
       elsif val.is_a?(::T::Enum)
         T::Types::TEnum.new(val)
       elsif val.is_a?(::String)
-        raise "Invalid String literal for type constraint. Must be an #{T::Types::Base}, a " \
-              "class/module, or an array. Got a String with value `#{val}`."
+        raise CoerceError.new(
+          "Invalid String literal for type constraint. Must be an #{T::Types::Base}, a " \
+          "class/module, or an array. Got a String with value `#{val}`."
+        )
       else
-        raise "Invalid value for type constraint. Must be an #{T::Types::Base}, a " \
-              "class/module, or an array. Got a `#{val.class}`."
+        raise CoerceError.new(
+          "Invalid value for type constraint. Must be an #{T::Types::Base}, a " \
+          "class/module, or an array. Got a `#{val.class}`."
+        )
       end
       # rubocop:enable Style/CaseLikeIf
     end

--- a/gems/sorbet-runtime/test/types/configuration.rb
+++ b/gems/sorbet-runtime/test/types/configuration.rb
@@ -33,6 +33,10 @@ module Opus::Types::Test
       include Readable
     end
 
+    # An instance where a class was meant, i.e. the mistake from
+    # https://github.com/sorbet/sorbet/issues/2673
+    NOT_A_TYPE = Object.new
+
     describe 'inline_type_error_handler' do
       describe 'when in default state' do
         it 'T.must raises an error' do
@@ -148,6 +152,17 @@ module Opus::Types::Test
             "You can't call .void after calling .returns."
           )
         end
+
+        it 'raises an error for a value that is not a type' do
+          @mod.sig { returns(NOT_A_TYPE) }
+          def @mod.foo
+            :bar
+          end
+          ex = assert_raises(ArgumentError) do
+            @mod.foo
+          end
+          assert_includes(ex.message, "Invalid value for type constraint")
+        end
       end
 
       describe 'when overridden' do
@@ -168,6 +183,33 @@ module Opus::Types::Test
               location.is_a?(Thread::Backtrace::Location)
           end
           @mod.sig { returns(Symbol).void }
+          def @mod.foo
+            :bar
+          end
+          assert_equal(:bar, @mod.foo)
+        end
+
+        it 'handles a value that is not a type' do
+          CustomReceiver.expects(:receive).once.with do |error, location|
+            error.is_a?(T::Utils::CoerceError) &&
+              error.message.include?("Invalid value for type constraint") &&
+              location.is_a?(Thread::Backtrace::Location)
+          end
+          @mod.sig { returns(NOT_A_TYPE) }
+          def @mod.foo
+            :bar
+          end
+          assert_equal(:bar, @mod.foo)
+        end
+
+        # `T.nilable` and friends coerce eagerly, so this one blows up while the
+        # sig block is still running, not while the signature is being built.
+        it 'handles a value that is not a type inside a type combinator' do
+          CustomReceiver.expects(:receive).once.with do |error, location|
+            error.is_a?(T::Utils::CoerceError) &&
+              location.is_a?(Thread::Backtrace::Location)
+          end
+          @mod.sig { returns(T.nilable(NOT_A_TYPE)) }
           def @mod.foo
             :bar
           end

--- a/gems/sorbet-runtime/test/types/props/decorator.rb
+++ b/gems/sorbet-runtime/test/types/props/decorator.rb
@@ -116,7 +116,7 @@ class Opus::Types::Test::Props::DecoratorTest < Critic::Unit::UnitTest
     end
 
     it 'Validates you pass a type' do
-      assert_prop_error(/Invalid String literal for type constraint.*Got a String with value `goat`/, error: RuntimeError) do
+      assert_prop_error(/Invalid String literal for type constraint.*Got a String with value `goat`/, error: T::Utils::CoerceError) do
         prop :foo, "goat"
       end
     end

--- a/gems/sorbet-runtime/test/types/utils.rb
+++ b/gems/sorbet-runtime/test/types/utils.rb
@@ -19,6 +19,22 @@ module Opus::Types::Test
       end
     end
 
+    describe 'T::Utils.coerce' do
+      it 'raises a CoerceError for a value that is not a type' do
+        ex = assert_raises(T::Utils::CoerceError) do
+          T::Utils.coerce(Object.new)
+        end
+        assert_includes(ex.message, 'Invalid value for type constraint')
+      end
+
+      it 'raises a CoerceError for a String literal' do
+        ex = assert_raises(T::Utils::CoerceError) do
+          T::Utils.coerce('nope')
+        end
+        assert_includes(ex.message, 'Invalid String literal for type constraint')
+      end
+    end
+
     describe 'T::Utils.signature_for_method' do
       it 'returns nil on methods without sigs' do
         c = Class.new do


### PR DESCRIPTION
Reworked per @jez's review: the `T::Configuration.coerce_error_handler` from the first revision is gone entirely. There is no new public handler — coercion failures during `sig` construction are now reported through the existing `sig_builder_error_handler`.

### What changed

1. **`T::Utils::CoerceError < StandardError`** (new). The two failure sites in `T::Utils.coerce` raise it instead of a bare `raise "..."`. Base class mirrors `DeclBuilder::BuilderError`.

2. **Rescued in two places, both routing to `sig_builder_error_handler`:**
   - `run_sig`, added to the existing `rescue DeclBuilder::BuilderError` — this is the spot you pointed at.
   - `build_sig`, ahead of the existing blanket `rescue => e`.

When the handler swallows the error, the method gets a `Signature.new_untyped` and stays callable, exactly as it already does for a `BuilderError`.

### Why the second rescue was necessary

The repro from #2673 does not actually fail inside `run_builder`. `sig { returns(X) }` stores `X` raw and only coerces later, in `Signature.new` — i.e. inside `build_sig`, whose blanket `rescue => e` catches it first. So adding `CoerceError` only to the `run_sig` rescue would leave the original issue untouched; it would keep landing in `sig_validation_error_handler`.

The `run_sig` rescue is still needed on its own, because eager combinators blow up earlier:

```ruby
sig { returns(T.nilable(X)) }   # T.nilable coerces immediately -> raises inside the sig block
```

On master that one escapes *every* handler.

Since a bad type literal is a problem with how the `sig` was written rather than with how it lines up against other sigs, `build_sig` now sends `CoerceError` to the builder handler and leaves everything else on the validation handler. Happy to move it back under `sig_validation_error_handler` if you'd rather keep that boundary — it's a two-line change.

### Behavior

Measured on master vs this branch:

| scenario | master | this PR |
|---|---|---|
| `returns(X)`, no handler | `RuntimeError` | `ArgumentError` with `path:lineno:` prefix |
| `returns(X)`, `sig_builder_error_handler` swallows | still raises | method runs, sig is untyped |
| `returns(T.nilable(X))`, no handler | `RuntimeError` | `ArgumentError` with `path:lineno:` prefix |
| `returns(T.nilable(X))`, `sig_builder_error_handler` swallows | escapes all handlers | method runs, sig is untyped |
| `params(x: X)` / `bind(X)`, handler swallows | still raises | method runs |
| override or abstract impl whose parent sig is bad | still raises | method runs |
| incompatible override | `sig_validation_error_handler` | unchanged |
| `.void` after `.returns` | `sig_builder_error_handler` | unchanged |
| `T.cast` / `T.let` / `T::Utils.coerce` / `prop` with a bad literal | `RuntimeError` | `CoerceError`, still raises |

A sibling method with a good `sig` in the same module keeps enforcing its types.

Nothing outside `sig` construction became recoverable: `T::Utils.coerce("not a type")` still raises, per your point that there's no sensible value to hand back there.

### Breaking changes

- **`rescue RuntimeError` around a coerce failure no longer catches it.** `rescue => e` / `StandardError` still do.
- **`sig_validation_error_handler` no longer sees coercion failures from `sig`.** On master it was the only way to survive #2673, so anyone using it as an escape hatch has to move to `sig_builder_error_handler`.
- With no handler configured, a bad type literal in a `sig` now raises `ArgumentError` prefixed with `path:lineno: Error interpreting sig:` instead of a raw `RuntimeError`, matching how every other builder error surfaces.

### Motivation

Fixes #2673. `T::Utils.coerce` raised a bare, un-interceptable `RuntimeError`, so one stray value in a `sig` took down production with no recourse.

The broader "audit every `raise` in sorbet-runtime" idea from that issue is intentionally out of scope here.

### Test plan

New tests in `test/types/utils.rb`: `T::Utils.coerce` raises `CoerceError` for a non-type value and for a String literal.

New tests in `test/types/configuration.rb`, under `sig_builder_error_handler`: the default handler raises for a value that isn't a type; an overridden handler receives a `CoerceError` plus a `Thread::Backtrace::Location` and the method stays callable, both for `returns(X)` and for `returns(T.nilable(X))` (the case that fails while the sig block is still running).

`test/types/props/decorator.rb`: the existing "Validates you pass a type" test now expects `T::Utils::CoerceError` instead of `RuntimeError`.

Reverting only `lib/` and keeping the tests turns all six of those red, so they do pin the behavior.

`bundle exec rake test` in `gems/sorbet-runtime`: 1000 runs / 8 failures, against a 995 runs / 8 failures baseline on master — same set (`SerializableTest`, `StructValidationTest`), all `inspect`-format drift under Ruby 4.0.4 and unrelated to this change.

### Note on the diff

`build_sig` takes a `loc` parameter now (`_methods.rbi` updated to match; it has a single caller). That means the `Thread::Backtrace::Location` stays reachable through `build_sig` rather than being dropped just before it, so the "Release location information sooner" line releases it a bit later than it used to. Let me know if you want that structured differently.
