### PR TITLE
Validate `prop`/`const`/`attr` names and report `BadAttrArg` in `typed: false`

### DIFF
--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -3,7 +3,7 @@
 #include "core/Error.h"
 
 namespace sorbet::core::errors::Rewriter {
-inline constexpr ErrorClass BadAttrArg{3501, StrictLevel::True};
+inline constexpr ErrorClass BadAttrArg{3501, StrictLevel::False};
 // inline constexpr ErrorClass BadWrapInstance{3502, StrictLevel::True};
 inline constexpr ErrorClass PrivateMethodMismatch{3503, StrictLevel::False};
 inline constexpr ErrorClass BadAttrType{3504, StrictLevel::True};

--- a/rewriter/Prop.cc
+++ b/rewriter/Prop.cc
@@ -243,6 +243,9 @@ optional<PropInfo> parseProp(core::MutableContext ctx, const ast::Send *send) {
             return nullopt;
         }
         ret.name = sym->asSymbol();
+        if (!ASTUtil::validAttrName(ctx, sym->loc, ret.name)) {
+            return nullopt;
+        }
         ENFORCE(ctx.locAt(sym->loc).exists());
         ENFORCE(!ctx.locAt(sym->loc).source(ctx).value().empty() && ctx.locAt(sym->loc).source(ctx).value()[0] == ':');
         ret.nameLoc = core::LocOffsets{sym->loc.beginPos() + 1, sym->loc.endPos()};

--- a/rewriter/util/Util.cc
+++ b/rewriter/util/Util.cc
@@ -326,9 +326,7 @@ ast::ExpressionPtr ASTUtil::thunkBody(core::MutableContext ctx, ast::ExpressionP
     return std::move(block->body);
 }
 
-namespace {
-
-bool validAttrName(core::MutableContext ctx, core::LocOffsets loc, core::NameRef name) {
+bool ASTUtil::validAttrName(core::MutableContext ctx, core::LocOffsets loc, core::NameRef name) {
     auto shortName = name.shortName(ctx);
 
     auto validName = !shortName.empty() && (isalpha(shortName.front()) || shortName.front() == '_') &&
@@ -346,8 +344,6 @@ bool validAttrName(core::MutableContext ctx, core::LocOffsets loc, core::NameRef
 
     return validName;
 }
-
-} // namespace
 
 pair<core::NameRef, core::LocOffsets> ASTUtil::getAttrName(core::MutableContext ctx, core::NameRef attrFun,
                                                            const ast::ExpressionPtr &name) {

--- a/rewriter/util/Util.h
+++ b/rewriter/util/Util.h
@@ -47,8 +47,8 @@ public:
     static std::pair<core::NameRef, core::LocOffsets> getAttrName(core::MutableContext ctx, core::NameRef attrFun,
                                                                   const ast::ExpressionPtr &name);
 
-    /// Returns true if `name` is a valid Ruby method name (non-empty, starts with alpha or _, all alphanumeric or _).
-    /// Emits a BadAttrArg error and returns false if invalid.
+    // Approximates the validations that `attr_reader` does for attribute names.
+    // Emits a BadAttrArg error and returns false if invalid.
     static bool validAttrName(core::MutableContext ctx, core::LocOffsets loc, core::NameRef name);
 
     // Test if `expr` is a chain of `UnresolvedConstantLit` trees with names equal to `constantName`.

--- a/rewriter/util/Util.h
+++ b/rewriter/util/Util.h
@@ -47,6 +47,10 @@ public:
     static std::pair<core::NameRef, core::LocOffsets> getAttrName(core::MutableContext ctx, core::NameRef attrFun,
                                                                   const ast::ExpressionPtr &name);
 
+    /// Returns true if `name` is a valid Ruby method name (non-empty, starts with alpha or _, all alphanumeric or _).
+    /// Emits a BadAttrArg error and returns false if invalid.
+    static bool validAttrName(core::MutableContext ctx, core::LocOffsets loc, core::NameRef name);
+
     // Test if `expr` is a chain of `UnresolvedConstantLit` trees with names equal to `constantName`.
     //
     // 1. Opus::Command as `expr` would match {Constants::Opus(), Constants::Command()}

--- a/test/testdata/rewriter/attr_bad_string_false.rb
+++ b/test/testdata/rewriter/attr_bad_string_false.rb
@@ -3,3 +3,5 @@ attr :'foo-bar' # error: Bad attribute name `foo-bar`
 attr_reader :'left-right' # error: Bad attribute name `left-right`
 attr_writer :'baz-qux' # error: Bad attribute name `baz-qux`
 attr_accessor :'a-b' # error: Bad attribute name `a-b`
+attr :"" # error: Attribute names must be non-empty
+attr 10 # error: Argument to `attr` must be a Symbol or String

--- a/test/testdata/rewriter/attr_bad_string_false.rb
+++ b/test/testdata/rewriter/attr_bad_string_false.rb
@@ -1,0 +1,5 @@
+# typed: false
+attr :'foo-bar' # error: Bad attribute name `foo-bar`
+attr_reader :'left-right' # error: Bad attribute name `left-right`
+attr_writer :'baz-qux' # error: Bad attribute name `baz-qux`
+attr_accessor :'a-b' # error: Bad attribute name `a-b`

--- a/test/testdata/rewriter/prop_bad_name.rb
+++ b/test/testdata/rewriter/prop_bad_name.rb
@@ -1,0 +1,8 @@
+# typed: false
+
+class A
+  include T::Props
+
+  const :'foo-bar', Integer # error: Bad attribute name `foo-bar`
+  prop :'left-right', String # error: Bad attribute name `left-right`
+end

--- a/test/testdata/rewriter/prop_duplicated.rb
+++ b/test/testdata/rewriter/prop_duplicated.rb
@@ -13,7 +13,6 @@ class A < T::Struct
   const :age, Float
 # ^^^^^^^^^^^^^^^^^ error: The `const :age` is defined multiple times
 
-  prop :"foo 'bar", Integer
-  prop :"foo 'bar", Integer
-# ^^^^^^^^^^^^^^^^^^^^^^^^^ error: The `prop :"foo \'bar"` is defined multiple times
+  prop :"foo 'bar", Integer # error: Bad attribute name `foo 'bar`
+  prop :"foo 'bar", Integer # error: Bad attribute name `foo 'bar`
 end

--- a/test/testdata/rewriter/prop_duplicated.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop_duplicated.rb.rewrite-tree.exp
@@ -1,14 +1,13 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C A><<C <todo sym>>> < (<emptyTree>::<C T>::<C Struct>)
     ::T::Sig::WithoutRuntime.sig() do ||
-      <self>.params(:name, <emptyTree>::<C String>, :age, <emptyTree>::<C Integer>, :"foo \'bar", <emptyTree>::<C Integer>).void()
+      <self>.params(:name, <emptyTree>::<C String>, :age, <emptyTree>::<C Integer>).void()
     end
 
-    def initialize<<todo method>>(name:, age:, foo 'bar:, &<blk>)
+    def initialize<<todo method>>(name:, age:, &<blk>)
       begin
         @name = <cast:let>(name, <todo sym>, <emptyTree>::<C String>)
         @age = <cast:let>(age, <todo sym>, <emptyTree>::<C Integer>)
-        @foo 'bar = <cast:let>(foo 'bar, <todo sym>, <emptyTree>::<C Integer>)
         nil
       end
     end
@@ -37,22 +36,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       @age = arg0
     end
 
-    ::T::Sig::WithoutRuntime.sig() do ||
-      <self>.returns(<emptyTree>::<C Integer>)
-    end
-
-    def foo 'bar<<todo method>>(&<blk>)
-      @foo 'bar
-    end
-
-    ::T::Sig::WithoutRuntime.sig() do ||
-      <self>.params(:arg0, <emptyTree>::<C Integer>).returns(<emptyTree>::<C Integer>)
-    end
-
-    def foo 'bar=<<todo method>>(arg0, &<blk>)
-      @foo 'bar = arg0
-    end
-
     <runtime method definition of initialize>
 
     <self>.const(:name, <emptyTree>::<C String>)
@@ -72,10 +55,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.const(:age, <emptyTree>::<C Float>)
 
     <self>.prop(:"foo \'bar", <emptyTree>::<C Integer>)
-
-    <runtime method definition of foo 'bar>
-
-    <runtime method definition of foo 'bar=>
 
     <self>.prop(:"foo \'bar", <emptyTree>::<C Integer>)
   end

--- a/test/testdata/rewriter/quoted_symbol_error.rb
+++ b/test/testdata/rewriter/quoted_symbol_error.rb
@@ -3,10 +3,10 @@
 class A < T::Struct
   prop :'foo', Integer
   prop :"bar", Integer
-  prop :"", Integer
+  prop :"", Integer # error: Attribute names must be non-empty
   prop :"#{A.name}", Integer
 end
 
-a = A.new(foo: 0, bar: 1) # error: Missing required keyword argument `` for method `A#initialize`
+a = A.new(foo: 0, bar: 1)
 a.foo = '' # error: Assigning a value to `foo` that does not match expected type `Integer`
 a.bar = '' # error: Assigning a value to `bar` that does not match expected type `Integer`


### PR DESCRIPTION
This change does three things:

1. **Hoists `validAttrName` into `ASTUtil`** (`rewriter/util/Util.{cc,h}`).
   It was a file-local helper in an anonymous namespace, used only by
   `getAttrName` for `attr_*`. It's now a public static method so `prop`/`const`
   can reuse the same validation.

2. **Calls `validAttrName` from `parseProp`** (`rewriter/Prop.cc`). Right after
   the prop's name symbol is read, an invalid name now emits a `BadAttrArg`
   error and returns `nullopt`, so the prop is rejected before any accessors or
   `initialize` keyword args are generated from it. Previously `prop`/`const`
   names were never validated at all.

3. **Lowers `BadAttrArg` (3501) from `StrictLevel::True` to `StrictLevel::False`**
   (`core/errors/rewriter.h`) so these errors surface in `# typed: false` files.

User-visible: lowering `BadAttrArg` affects all three messages it backs
("Bad attribute name", "Attribute names must be non-empty", "Argument to `attr`
must be a Symbol or String"). Existing `# typed: false` files containing such
code — none of which is valid at runtime — will newly report errors.

### Motivation

Closes #6315. Ruby raises at runtime for invalid method names, but Sorbet
reported nothing. The issue asks for these to be caught as `# typed: false`
errors so static analysis matches runtime behavior.

### Test plan

See included automated tests:
- `test/testdata/rewriter/attr_bad_string_false.rb` — invalid `attr_*` names in `# typed: false`
- `test/testdata/rewriter/prop_bad_name.rb` — invalid `prop`/`const` names in `# typed: false`
- Updated `quoted_symbol_error.rb` and `prop_duplicated.rb` to assert the corrected behavior
