### PR TITLE
Fix `data` field null pointer crash

### DIFF
--- a/main/lsp/requests/code_action.cc
+++ b/main/lsp/requests/code_action.cc
@@ -238,11 +238,26 @@ unique_ptr<ResponseMessage> CodeActionTask::runRequest(LSPTypecheckerDelegate &t
     bool canResolveLazily = config.getClientConfig().clientCodeActionResolveEditSupport &&
                             config.getClientConfig().clientCodeActionDataSupport;
 
+    auto createMissingMethodCodeAction = [&](const core::lsp::SendResponse *resp) {
+        auto action = make_unique<CodeAction>(fmt::format("Create missing method", resp->callerSideName.show(gs)));
+        action->kind = CodeActionKind::Refactor;
+        if (canResolveLazily) {
+            action->data = make_unique<CodeActionData>(move(params));
+        } else {
+            auto workspaceEdit = make_unique<WorkspaceEdit>();
+            auto edits = create_missing_method::getCreateMissingMethodEdits(typechecker, config, *resp);
+            workspaceEdit->documentChanges = move(edits);
+            action->edit = move(workspaceEdit);
+        }
+        return action;
+    };
     if (loc.beginPos() == loc.endPos()) {
         // No selection
 
         // Generate "Move method" code actions only for class method definitions
         if (queryResult.error == nullptr) {
+            // Since these are disjoint if branches, we may miss case where two code actions should be shown but we only
+            // show one. We must do this so that we don't need to clone params.
             if (auto *def = hasLoneMethodResponse(gs, queryResult.responses)) {
                 unique_ptr<CodeAction> action;
                 if (def->symbol.data(gs)->owner.data(gs)->isSingletonClass(gs)) {
@@ -340,6 +355,9 @@ unique_ptr<ResponseMessage> CodeActionTask::runRequest(LSPTypecheckerDelegate &t
                     action->data = move(data);
                     result.emplace_back(move(action));
                 }
+            } else if (auto *resp = create_missing_method::isMissingMethodResponse(gs, queryResult.responses);
+                       resp && config.opts.lspCreateMissingMethodEnabled) {
+                result.push_back(createMissingMethodCodeAction(resp));
             }
         }
     } else {
@@ -389,26 +407,9 @@ unique_ptr<ResponseMessage> CodeActionTask::runRequest(LSPTypecheckerDelegate &t
                 // TODO(neil): trigger a rename for newVariable
             }
         }
-    }
-
-    if (config.opts.lspCreateMissingMethodEnabled) {
-        // We allow displaying this code action even with a selection because this code action is only triggered with an
-        // error, and the lsp test runner will first query for code actions using the error range.
-        // If we don't accept selections, then the lsp test runner will fail.
-        // TODO(bshu): maybe update the test runner since this code action doesn't really make sense with selections?
-        if (auto *resp = create_missing_method::isMissingMethodResponse(gs, queryResult.responses)) {
-            auto action = make_unique<CodeAction>(fmt::format("Create missing method", resp->callerSideName.show(gs)));
-            action->kind = CodeActionKind::Refactor;
-            if (canResolveLazily) {
-                action->data = make_unique<CodeActionData>(move(params));
-            } else {
-                auto workspaceEdit = make_unique<WorkspaceEdit>();
-                auto edits = create_missing_method::getCreateMissingMethodEdits(typechecker, config, *resp);
-                workspaceEdit->documentChanges = move(edits);
-                action->edit = move(workspaceEdit);
-            }
-
-            result.emplace_back(move(action));
+        if (auto *resp = create_missing_method::isMissingMethodResponse(gs, queryResult.responses);
+            resp && config.opts.lspCreateMissingMethodEnabled) {
+            result.push_back(createMissingMethodCodeAction(resp));
         }
     }
 

--- a/main/lsp/requests/code_action.h
+++ b/main/lsp/requests/code_action.h
@@ -7,6 +7,9 @@
 namespace sorbet::realmain::lsp {
 class CodeActionParams;
 class CodeActionTask final : public LSPRequestTask {
+    // WARNING: we currently do not support more than one lazily resolved code action since that would require copying
+    // params which we don't support
+    // TODO(bshu): investigate using shared pointers instead of unique pointers for lsp types
     std::unique_ptr<CodeActionParams> params;
 
 public:


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
If a lazily resolved code action is triggered simultaneously with create missing method, which is also lazily resolved, we move `params` twice. To solve this, we will only choose one code action instead of two. We should investigate using `shared_ptr` so that we can copy `params` and thus show more than one lazily resolved code action to the user. 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
https://github.com/sorbet/sorbet/compare/jez-repro-crash

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
