### PR TITLE
Restrict symbol table prefix copying

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -219,6 +219,11 @@ bool LSPTypechecker::typecheck(unique_ptr<LSPFileUpdates> updates, WorkerPool &w
 
             filesTypechecked = move(result.filesTypechecked);
 
+            // Remember where in the package graph we're making this change, as that will determine how much we can
+            // copy on the next slow path.
+            this->fastPathEditStratum =
+                std::min(this->fastPathEditStratum, this->getFileStratumMapping().getStratumForFiles(filesTypechecked));
+
             ENFORCE(updates->updatedFiles.empty());
             ENFORCE(updates->updatedFileRefs.empty());
 
@@ -421,10 +426,11 @@ namespace {
 // means that we can't reuse the symbol table.
 core::packages::Stratum determineStartingStratum(const core::GlobalState &gs,
                                                  const vector<core::packages::Stratum> &fileToStratum,
-                                                 const core::packages::Stratum lastStratum,
+                                                 const core::packages::Stratum fastPathEditStratum,
                                                  const LSPFileUpdates &update) {
-    // We start by assuming we can copy the whole previous symbol table.
-    auto editStratum = lastStratum;
+    // We start by assuming we can copy up to the last fast path edit stratum, as that may have introduced new
+    // symbols.
+    auto editStratum = fastPathEditStratum;
 
     int ix = -1;
     for (auto &file : update.updatedFiles) {
@@ -567,7 +573,7 @@ pair<bool, core::packages::Stratum> LSPTypechecker::runSlowPath(LSPFileUpdates &
     if (cancelable) {
         timeit.setTag("cancelable", "true");
 
-        startingStratum = determineStartingStratum(*this->gs, this->fileToStratum, this->lastStratum, updates);
+        startingStratum = determineStartingStratum(*this->gs, this->fileToStratum, this->fastPathEditStratum, updates);
 
         auto savedGS =
             std::exchange(this->gs, pipeline::copyForSlowPath(*this->gs, this->config->opts, startingStratum));
@@ -579,7 +585,7 @@ pair<bool, core::packages::Stratum> LSPTypechecker::runSlowPath(LSPFileUpdates &
 
         this->cancellationUndoState =
             make_unique<UndoState>(std::move(savedGS), std::move(this->indexedFinalGS), move(this->fileToStratum),
-                                   this->lastStratum, this->workspaceFiles, updates.epoch);
+                                   this->lastStratum, this->fastPathEditStratum, this->workspaceFiles, updates.epoch);
     } else {
         timeit.setTag("cancelable", "false");
     }
@@ -707,6 +713,7 @@ pair<bool, core::packages::Stratum> LSPTypechecker::runSlowPath(LSPFileUpdates &
         const auto numStrata = strata.strata.size();
         this->fileToStratum = move(strata.fileToStratum);
         this->lastStratum = core::packages::Stratum(numStrata - 1);
+        this->fastPathEditStratum = this->lastStratum;
         this->gs->preallocateForStrata(numStrata);
 
         // Determine which stratum this edit will be checked at, so that we have a good reference for when to switch
@@ -900,7 +907,7 @@ pair<bool, core::packages::Stratum> LSPTypechecker::runSlowPath(LSPFileUpdates &
         // arbitrarily long time. The next update will be responsible for freeing the underlying UndoState after it
         // makes use of the epoch field to determine additional files to include in the edit.
         cancellationUndoState->restore(this->gs, this->indexedFinalGS, this->fileToStratum, this->lastStratum,
-                                       this->workspaceFiles);
+                                       this->fastPathEditStratum, this->workspaceFiles);
         logger->debug("[Typechecker] Typecheck run for epoch {} was canceled.", updates.epoch);
     }
 

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -106,6 +106,12 @@ class LSPTypechecker final {
 
     core::packages::Stratum lastStratum;
 
+    /**
+     * This is the stratum of the last fast-path edit, tracked so that we don't miss additive updates to existing
+     * packages.
+     */
+    core::packages::Stratum fastPathEditStratum;
+
     enum class SlowPathMode {
         Init,
         Cancelable,

--- a/main/lsp/UndoState.cc
+++ b/main/lsp/UndoState.cc
@@ -10,19 +10,21 @@ using namespace std;
 namespace sorbet::realmain::lsp {
 UndoState::UndoState(unique_ptr<core::GlobalState> evictedGs, UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS,
                      vector<core::packages::Stratum> fileToStratum, core::packages::Stratum lastStratum,
-                     const vector<core::FileRef> &workspaceFiles, uint32_t epoch)
+                     core::packages::Stratum fastPathEditStratum, const vector<core::FileRef> &workspaceFiles,
+                     uint32_t epoch)
     : evictedGs(move(evictedGs)), evictedIndexedFinalGS(std::move(evictedIndexedFinalGS)),
-      fileToStratum{move(fileToStratum)}, lastStratum{lastStratum}, initialWorkspaceFilesSize{workspaceFiles.size()},
-      epoch(epoch) {}
+      fileToStratum{move(fileToStratum)}, lastStratum{lastStratum}, fastPathEditStratum{fastPathEditStratum},
+      initialWorkspaceFilesSize{workspaceFiles.size()}, epoch(epoch) {}
 
 void UndoState::restore(unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast::ParsedFile> &indexedFinalGS,
                         vector<core::packages::Stratum> &fileToStratum, core::packages::Stratum &lastStratum,
-                        vector<core::FileRef> &workspaceFiles) {
+                        core::packages::Stratum &fastPathEditStratum, vector<core::FileRef> &workspaceFiles) {
     indexedFinalGS = std::move(evictedIndexedFinalGS);
     gs = move(evictedGs);
 
     fileToStratum = move(this->fileToStratum);
     lastStratum = this->lastStratum;
+    fastPathEditStratum = this->fastPathEditStratum;
 
     if (workspaceFiles.size() != this->initialWorkspaceFilesSize) {
         workspaceFiles.erase(workspaceFiles.begin() + this->initialWorkspaceFilesSize, workspaceFiles.end());

--- a/main/lsp/UndoState.h
+++ b/main/lsp/UndoState.h
@@ -25,6 +25,9 @@ class UndoState final {
     // The id of the last stratum in the previous slow path.
     const core::packages::Stratum lastStratum;
 
+    // The id of the stratum that the last fast-path edit took place in.
+    const core::packages::Stratum fastPathEditStratum;
+
     // The size of the workspaceFiles vector when the slow path started. Tracked so that we can roll back additions to
     // the vector from new files added in the canceled edit.
     const size_t initialWorkspaceFilesSize;
@@ -35,14 +38,15 @@ public:
 
     UndoState(std::unique_ptr<core::GlobalState> evictedGs, UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS,
               std::vector<core::packages::Stratum> fileToStratum, core::packages::Stratum lastStratum,
-              const std::vector<core::FileRef> &workspaceFiles, uint32_t epoch);
+              core::packages::Stratum fastPathEditStratum, const std::vector<core::FileRef> &workspaceFiles,
+              uint32_t epoch);
 
     /**
      * Undoes the slow path changes represented by this class.
      */
     void restore(std::unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast::ParsedFile> &indexedFinalGS,
                  std::vector<core::packages::Stratum> &fileToStratum, core::packages::Stratum &lastStratum,
-                 std::vector<core::FileRef> &workspaceFiles);
+                 core::packages::Stratum &fastPathEditStratum, std::vector<core::FileRef> &workspaceFiles);
 
     /**
      * Retrieves the evicted global state.

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -1408,7 +1408,6 @@ TEST_CASE_FIXTURE(ProtocolTest, "FastPathAfterSlowPathRestarts") {
 
     // Make a slow path edit to Root::Foo::A
     {
-        assertErrorDiagnostics(send(*openFile(files[1].first, files[1].second)), {});
         assertErrorDiagnostics(send(*openFile(files[3].first, files[3].second)), {});
 
         // Make a slow path modification to an existing file.
@@ -1447,6 +1446,9 @@ TEST_CASE_FIXTURE(ProtocolTest, "FastPathAfterSlowPathRestarts") {
             // We're modifying package `Root::Foo`, which means we don't need to typecheck `Root` again.
             CHECK_EQ(params->startingStratum, 1);
         }
+
+        // As the fast path edit to `a.rb` will restrict the prefix we can copy to, open it after the slow path edit.
+        assertErrorDiagnostics(send(*openFile(files[1].first, files[1].second)), {});
     }
 
     // The following cases all happen in stratum 0 to ensure that the copied prefix is functioning as we would expect.
@@ -1564,8 +1566,8 @@ TEST_CASE_FIXTURE(ProtocolTest, "ErrorsRemainAfterSlowPathRestart") {
                                       2));
 
         // We should see a starting and ending slow path message, with the end message indicating that the slow path
-        // started from stratum 1
-        REQUIRE_EQ(resps.size(), 3);
+        // started from stratum 0. The messages inbetween are errors on both `Root::A` and `Root::Foo::A`
+        REQUIRE_EQ(resps.size(), 4);
         {
             auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps[0]->asNotification().params);
             CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
@@ -1573,12 +1575,14 @@ TEST_CASE_FIXTURE(ProtocolTest, "ErrorsRemainAfterSlowPathRestart") {
         }
 
         {
-            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps[2]->asNotification().params);
+            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps[3]->asNotification().params);
             CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
             CHECK_EQ(params->status, SorbetTypecheckRunStatus::Ended);
 
-            // We're modifying package `Root::Foo`, which means we don't need to typecheck `Root` again.
-            CHECK_EQ(params->startingStratum, 1);
+            // We're modifying package `Root::Foo`, which means that idealy we don't need to typecheck `Root` again.
+            // However, we made a fast-path edit to `Root::A` but don't have enough information to know that it's not an
+            // additive edit, and as a result need to check its package again.
+            CHECK_EQ(params->startingStratum, 0);
         }
 
         assertErrorDiagnostics(move(resps), {


### PR DESCRIPTION
We don't take into account the last stratum where a fast-path edit took place when determining what prefix of the symbol table we can copy, which can cause problems if an additive edit takes place in the fast path.

This PR implements a behavior that we discussed a while back, where we restrict the stratum that we could copy to as the minimum of the stratum from the last fast path edit and that of the current slow path edit. This has some drawbacks, as even opening a file will cause this to restrict the stratum we can copy to, but I think we can work around this by using the hashes we compute to better classify edits in the future.

### Motivation
Fixing potential crashes in package-directed LSP.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
