### PR TITLE
Use `--parser=prism` when updating `testdata/rbs/` expected outputs

### DIFF
--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -134,7 +134,7 @@ for this_src in "${rb_src[@]}" DUMMY; do
     args=()
 
     case "${srcs[0]}" in
-      test/prism_regression/*)
+      test/prism_regression/*|test/testdata/rbs/*)
         args+=("--parser=prism")
         ;;
     esac


### PR DESCRIPTION


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Running `tools/scripts/update_testdata_exp.sh` on an RBS fixture (like `test/testdata/rbs/signatures_type_aliases.rb`) generates an empty `.rewrite-tree.exp`, I believe because the RBS rewriter now requires prism after #10285

This PR adds `test/testdata/rbs/*` to the cases that require `--parser=prism` 

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

`.rewrite-tree.exp` files are generated correctly

<details><summary>demo</summary>

https://github.com/user-attachments/assets/9f294df4-16a9-4dfa-aee2-8bfb71e74bc9

</details> 
