### PR TITLE
sorbet-runtime: Dead soft assertion in prop deserialization

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
@@ -52,26 +52,7 @@ module T::Props
             SerdeTransform::Mode::DESERIALIZE,
             'val'
           )
-          transformed_val = if transformation
-            # Rescuing exactly NoMethodError is intended as a temporary hack
-            # to preserve the semantics from before codegen. More generally
-            # we are inconsistent about typechecking on deser and need to decide
-            # our strategy here.
-            <<~RUBY
-              begin
-                #{transformation}
-              rescue NoMethodError => e
-                raise_deserialization_error(
-                  #{prop.inspect},
-                  val,
-                  e,
-                )
-                val
-              end
-            RUBY
-          else
-            'val'
-          end
+          transformed_val = transformation || 'val'
 
           nil_handler = generate_nil_handler(
             prop: prop,

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -156,19 +156,6 @@ module T::Props::Serializable
     @_required_props_missing_from_deserialize << prop
     nil
   end
-
-  private def raise_deserialization_error(prop_name, value, orig_error)
-    T::Configuration.soft_assert_handler(
-      'Deserialization error (probably unexpected stored type)',
-      storytime: {
-        klass: self.class,
-        prop: prop_name,
-        value: value,
-        error: orig_error.message,
-        notify: 'djudd'
-      }
-    )
-  end
 end
 
 ##############################################


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There are no instances of this in Stripe's codebase, I'm going to remove
it, and in effect turn it into a hard error.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Searched all Stripe production logs for instances of this soft assertion, found no instances.