### PR TITLE
Type Thread#value as T.untyped rather than Object

### DIFF
--- a/rbi/core/thread.rbi
+++ b/rbi/core/thread.rbi
@@ -809,7 +809,10 @@ class Thread < Object
   # b = Thread.new { raise 'something went wrong' }
   # b.value   #=> RuntimeError: something went wrong
   # ```
-  sig {returns(Object)}
+  # This returns whatever the thread's block returned, which is not necessarily
+  # an `Object` (e.g. it may return a `BasicObject`), so the return type is
+  # `T.untyped`.
+  sig {returns(T.untyped)}
   def value; end
 
   # Marks a given thread as eligible for scheduling, however it may still remain

--- a/test/testdata/rbi/thread_value.rb
+++ b/test/testdata/rbi/thread_value.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+# `Thread#value` returns whatever the block returned, which is not necessarily
+# an `Object` (a block may return a `BasicObject`), so it is typed `T.untyped`
+# rather than `Object`.
+T.reveal_type(Thread.new { 2 + 2 }.value) # error: Revealed type: `T.untyped`
+T.reveal_type(Thread.new { BasicObject.new }.value) # error: Revealed type: `T.untyped`

--- a/test/testdata/rbi/thread_value.rb
+++ b/test/testdata/rbi/thread_value.rb
@@ -3,5 +3,12 @@
 # `Thread#value` returns whatever the block returned, which is not necessarily
 # an `Object` (a block may return a `BasicObject`), so it is typed `T.untyped`
 # rather than `Object`.
-T.reveal_type(Thread.new { 2 + 2 }.value) # error: Revealed type: `T.untyped`
-T.reveal_type(Thread.new { BasicObject.new }.value) # error: Revealed type: `T.untyped`
+int_thread = Thread.new { 2 + 2 }
+T.reveal_type(int_thread.value) # error: Revealed type: `T.untyped`
+
+basic_thread = Thread.new { BasicObject.new }
+T.reveal_type(basic_thread.value) # error: Revealed type: `T.untyped`
+
+# `T.untyped` keeps the common case ergonomic (no cast needed):
+res = int_thread.value + 1
+T.reveal_type(res) # error: Revealed type: `T.untyped`


### PR DESCRIPTION
Changes the return type of `Thread#value` from `Object` to `T.untyped`.

### Motivation

A thread's `value` is whatever its block returned, and a block can return a value that is not an `Object`. For example, a `BasicObject` is not an `Object`:

```ruby
Thread.new { BasicObject.new }.value
```

So annotating `Thread#value` as returning `Object` is unsound.

The technically-correct supertype of every possible block return is `BasicObject`, but that is excessively narrow to be useful: `BasicObject` lacks nearly every method, so callers would be forced to cast the result before doing anything with it. For example, this should just work without a cast:

```ruby
Thread.new { 1 + 1 }.value + 1
```

`T.untyped` removes the unsound `Object` claim while keeping the common case ergonomic. (Fully tying `value` to the block's return type would require making `Thread` generic, which is a larger, breaking change and is out of scope here.)

### Test plan

See included automated test (`test/testdata/rbi/thread_value.rb`).
