### PR TITLE
Dir.glob takes Pathname in addition to String

### DIFF
--- a/rbi/core/dir.rbi
+++ b/rbi/core/dir.rbi
@@ -288,7 +288,7 @@ class Dir < Object
   # ```
   sig do
     params(
-        pattern: T.any(String, T::Array[String]),
+        pattern: T.any(String, Pathname, T::Array[T.any(String, Pathname)]),
         flags: T.nilable(Integer),
         opts: T.nilable(T::Hash[Symbol, String]),
     )
@@ -296,7 +296,7 @@ class Dir < Object
   end
   sig do
     params(
-        pattern: T.any(String, T::Array[String]),
+        pattern: T.any(String, Pathname, T::Array[T.any(String, Pathname)]),
         flags: T.nilable(Integer),
         opts: T.nilable(T::Hash[Symbol, String]),
         blk: T.proc.params(arg0: String).returns(BasicObject),
@@ -305,7 +305,7 @@ class Dir < Object
   end
   sig do
     params(
-        pattern: T.any(String, T::Array[String]),
+        pattern: T.any(String, Pathname, T::Array[T.any(String, Pathname)]),
         opts: T.nilable(T::Hash[Symbol, String]),
         blk: T.proc.params(arg0: String).returns(BasicObject),
     )
@@ -313,7 +313,7 @@ class Dir < Object
   end
   sig do
     params(
-        pattern: T.any(String, T::Array[String]),
+        pattern: T.any(String, Pathname, T::Array[T.any(String, Pathname)]),
         opts: T.nilable(T::Hash[Symbol, String]),
     )
     .returns(T::Array[String])

--- a/test/testdata/rbi/dir.rb
+++ b/test/testdata/rbi/dir.rb
@@ -11,3 +11,15 @@ def test_dir_brackets
   end
   Dir[Pathname.new('.')]
 end
+
+sig {returns(T::Array[String])}
+def test_dir_glob
+  Dir.glob('*.rb')
+  Dir.glob(['*.rb', '*.h'])
+  Dir.glob(Pathname.new('.'))
+  Dir.glob([Pathname.new('a'), 'b'])
+  Dir.glob(Pathname.new('.')) do |match|
+    T.assert_type!(match, String)
+  end
+  Dir.glob('*.rb')
+end


### PR DESCRIPTION
- `Dir.glob` can take `Pathname` via a `to_path` call

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

- Type checking errors when passing a `Pathname` to `Dir.glob`

### Test plan

- See included tests