### PR TITLE
Improve Dir RBI signatures to match Ruby 3 & 4

### DIFF
--- a/rbi/core/dir.rbi
+++ b/rbi/core/dir.rbi
@@ -75,14 +75,21 @@ class Dir < Object
   # ```ruby
   # Dir.children("testdir")   #=> ["config.h", "main.rb"]
   # ```
-  def self.children(*_); end
+  sig do
+    params(
+        dir: T.any(String, Pathname),
+        encoding: T.nilable(T.any(String, Encoding)),
+    )
+    .returns(T::Array[String])
+  end
+  def self.children(dir, encoding: T.unsafe(nil)); end
 
   # Changes this process's idea of the file system root. Only a privileged
   # process may make this call. Not available on all platforms. On Unix systems,
   # see `chroot(2)` for more information.
   sig do
     params(
-        arg0: String,
+        arg0: T.any(String, Pathname),
     )
     .returns(Integer)
   end
@@ -93,7 +100,7 @@ class Dir < Object
   # if the directory isn't empty.
   sig do
     params(
-        arg0: String,
+        arg0: T.any(String, Pathname),
     )
     .returns(Integer)
   end
@@ -114,11 +121,32 @@ class Dir < Object
   # Got config.h
   # Got main.rb
   # ```
-  def self.each_child(*_, &blk); end
+  sig do
+    params(
+        dir: T.any(String, Pathname),
+        encoding: T.nilable(T.any(String, Encoding)),
+        blk: T.proc.params(arg0: String).returns(BasicObject),
+    )
+    .returns(NilClass)
+  end
+  sig do
+    params(
+        dir: T.any(String, Pathname),
+        encoding: T.nilable(T.any(String, Encoding)),
+    )
+    .returns(T::Enumerator[String])
+  end
+  def self.each_child(dir, encoding: T.unsafe(nil), &blk); end
 
   # Returns `true` if the named file is an empty directory, `false` if it is not
   # a directory or non-empty.
-  def self.empty?(_); end
+  sig do
+    params(
+        arg0: T.any(String, Pathname),
+    )
+    .returns(T::Boolean)
+  end
+  def self.empty?(arg0); end
 
   # Returns an array containing all of the filenames in the given directory.
   # Will raise a
@@ -134,11 +162,11 @@ class Dir < Object
   sig do
     params(
         arg0: T.any(String, Pathname),
-        arg1: Encoding,
+        encoding: T.nilable(T.any(String, Encoding)),
     )
     .returns(T::Array[String])
   end
-  def self.entries(arg0, arg1=T.unsafe(nil)); end
+  def self.entries(arg0, encoding: T.unsafe(nil)); end
 
   # Returns `true` if the named file is a directory, `false` otherwise.
   sig do
@@ -169,7 +197,7 @@ class Dir < Object
   sig do
     params(
         dir: T.any(String, Pathname),
-        arg0: Encoding,
+        encoding: T.nilable(T.any(String, Encoding)),
         blk: T.proc.params(arg0: String).returns(BasicObject),
     )
     .returns(NilClass)
@@ -177,11 +205,11 @@ class Dir < Object
   sig do
     params(
         dir: T.any(String, Pathname),
-        arg0: Encoding,
+        encoding: T.nilable(T.any(String, Encoding)),
     )
     .returns(T::Enumerator[String])
   end
-  def self.foreach(dir, arg0=T.unsafe(nil), &blk); end
+  def self.foreach(dir, encoding: T.unsafe(nil), &blk); end
 
   # Returns the path to the current working directory of this process as a
   # string.
@@ -363,19 +391,19 @@ class Dir < Object
   sig do
     params(
         arg0: T.any(String, Pathname),
-        arg1: Encoding,
+        encoding: T.nilable(T.any(String, Encoding)),
     )
     .returns(Dir)
   end
   sig do
     type_parameters(:U).params(
         arg0: T.any(String, Pathname),
-        arg1: Encoding,
+        encoding: T.nilable(T.any(String, Encoding)),
         blk: T.proc.params(arg0: Dir).returns(T.type_parameter(:U)),
     )
     .returns(T.type_parameter(:U))
   end
-  def self.open(arg0, arg1=T.unsafe(nil), &blk); end
+  def self.open(arg0, encoding: T.unsafe(nil), &blk); end
 
   # Returns the path to the current working directory of this process as a
   # string.
@@ -468,12 +496,12 @@ class Dir < Object
 
   sig do
     params(
-        arg0: String,
-        arg1: Encoding,
+        arg0: T.any(String, Pathname),
+        encoding: T.nilable(T.any(String, Encoding)),
     )
     .void
   end
-  def initialize(arg0, arg1=T.unsafe(nil)); end
+  def initialize(arg0, encoding: T.unsafe(nil)); end
 
   # Return a string describing this
   # [`Dir`](https://docs.ruby-lang.org/en/2.7.0/Dir.html) object.

--- a/rbi/core/dir.rbi
+++ b/rbi/core/dir.rbi
@@ -318,7 +318,8 @@ class Dir < Object
     params(
         pattern: T.any(String, Pathname, T::Array[T.any(String, Pathname)]),
         flags: T.nilable(Integer),
-        opts: T.nilable(T::Hash[Symbol, String]),
+        base: T.nilable(T.any(String, Pathname)),
+        sort: T::Boolean,
     )
     .returns(T::Array[String])
   end
@@ -326,27 +327,13 @@ class Dir < Object
     params(
         pattern: T.any(String, Pathname, T::Array[T.any(String, Pathname)]),
         flags: T.nilable(Integer),
-        opts: T.nilable(T::Hash[Symbol, String]),
+        base: T.nilable(T.any(String, Pathname)),
+        sort: T::Boolean,
         blk: T.proc.params(arg0: String).returns(BasicObject),
     )
     .returns(NilClass)
   end
-  sig do
-    params(
-        pattern: T.any(String, Pathname, T::Array[T.any(String, Pathname)]),
-        opts: T.nilable(T::Hash[Symbol, String]),
-        blk: T.proc.params(arg0: String).returns(BasicObject),
-    )
-    .returns(NilClass)
-  end
-  sig do
-    params(
-        pattern: T.any(String, Pathname, T::Array[T.any(String, Pathname)]),
-        opts: T.nilable(T::Hash[Symbol, String]),
-    )
-    .returns(T::Array[String])
-  end
-  def self.glob(pattern, flags=T.unsafe(nil), opts=T.unsafe(nil), &blk); end
+  def self.glob(pattern, flags=T.unsafe(nil), base: T.unsafe(nil), sort: T.unsafe(nil), &blk); end
 
   # Returns the home directory of the current user or the named user if given.
   sig do
@@ -442,6 +429,16 @@ class Dir < Object
   end
   def self.unlink(arg0); end
 
+  # Returns an array containing all of the filenames except for "." and ".." in
+  # this directory.
+  #
+  # ```ruby
+  # d = Dir.new("testdir")
+  # d.children   #=> ["config.h", "main.rb"]
+  # ```
+  sig {returns(T::Array[String])}
+  def children(); end
+
   # Closes the directory stream. Calling this method on closed
   # [`Dir`](https://docs.ruby-lang.org/en/2.7.0/Dir.html) object is ignored
   # since Ruby 2.3.
@@ -479,6 +476,24 @@ class Dir < Object
   end
   sig {returns(T::Enumerator[String])}
   def each(&blk); end
+
+  # Calls the block once for each entry except for "." and ".." in this
+  # directory, passing the filename of each entry as a parameter to the block.
+  #
+  # If no block is given, an enumerator is returned instead.
+  #
+  # ```ruby
+  # d = Dir.new("testdir")
+  # d.each_child  {|x| puts "Got #{x}" }
+  # ```
+  sig do
+    params(
+        blk: T.proc.params(arg0: String).returns(BasicObject),
+    )
+    .returns(T.self_type)
+  end
+  sig {returns(T::Enumerator[String])}
+  def each_child(&blk); end
 
   # Returns the file descriptor used in *dir*.
   #
@@ -618,9 +633,8 @@ class Dir < Object
         pattern: T.any(String, Pathname),
         base: T.nilable(T.any(String, Pathname)),
         sort: T::Boolean,
-        blk: T.nilable(T.proc.params(arg0: String).returns(BasicObject))
     )
     .returns(T::Array[String])
   end
-  def self.[](*pattern, base: nil, sort: true, &blk); end
+  def self.[](*pattern, base: nil, sort: true); end
 end

--- a/test/testdata/rbi/dir.rb
+++ b/test/testdata/rbi/dir.rb
@@ -23,3 +23,76 @@ def test_dir_glob
   end
   Dir.glob('*.rb')
 end
+
+sig {params(enc: T.nilable(Encoding)).void}
+def test_dir_children(enc)
+  T.assert_type!(Dir.children('.'), T::Array[String])
+  T.assert_type!(Dir.children(Pathname.new('.')), T::Array[String])
+  # encoding: accepts an Encoding, a String name, or nil
+  Dir.children('.', encoding: Encoding::UTF_8)
+  Dir.children('.', encoding: 'UTF-8')
+  Dir.children('.', encoding: nil)
+  Dir.children('.', encoding: enc)
+end
+
+sig {void}
+def test_dir_each_child
+  Dir.each_child(Pathname.new('.')) do |child|
+    T.assert_type!(child, String)
+  end
+  Dir.each_child('.', encoding: Encoding::UTF_8) {|child| child}
+  Dir.each_child('.', encoding: 'UTF-8') {|child| child}
+  Dir.each_child('.', encoding: nil) {|child| child}
+  T.assert_type!(Dir.each_child('.'), T::Enumerator[String])
+end
+
+sig {void}
+def test_dir_entries
+  T.assert_type!(Dir.entries('.'), T::Array[String])
+  T.assert_type!(Dir.entries(Pathname.new('.')), T::Array[String])
+  Dir.entries('.', encoding: Encoding::UTF_8)
+  Dir.entries('.', encoding: 'UTF-8')
+  Dir.entries('.', encoding: nil)
+end
+
+sig {void}
+def test_dir_foreach
+  Dir.foreach(Pathname.new('.')) do |entry|
+    T.assert_type!(entry, String)
+  end
+  Dir.foreach('.', encoding: Encoding::UTF_8) {|entry| entry}
+  Dir.foreach('.', encoding: 'UTF-8') {|entry| entry}
+  Dir.foreach('.', encoding: nil) {|entry| entry}
+  T.assert_type!(Dir.foreach('.'), T::Enumerator[String])
+end
+
+sig {void}
+def test_dir_open
+  T.assert_type!(Dir.open('.'), Dir)
+  T.assert_type!(Dir.open(Pathname.new('.'), encoding: Encoding::UTF_8), Dir)
+  T.assert_type!(Dir.open('.', encoding: 'UTF-8'), Dir)
+  T.assert_type!(Dir.open('.', encoding: nil), Dir)
+  result = Dir.open('.') do |dir|
+    T.assert_type!(dir, Dir)
+    42
+  end
+  T.assert_type!(result, Integer)
+end
+
+sig {void}
+def test_dir_new
+  T.assert_type!(Dir.new('.'), Dir)
+  T.assert_type!(Dir.new(Pathname.new('.')), Dir)
+  T.assert_type!(Dir.new('.', encoding: Encoding::UTF_8), Dir)
+  T.assert_type!(Dir.new('.', encoding: 'UTF-8'), Dir)
+  T.assert_type!(Dir.new('.', encoding: nil), Dir)
+end
+
+sig {void}
+def test_dir_empty_and_delete
+  T.assert_type!(Dir.empty?('.'), T::Boolean)
+  T.assert_type!(Dir.empty?(Pathname.new('.')), T::Boolean)
+  T.assert_type!(Dir.delete('x'), Integer)
+  T.assert_type!(Dir.delete(Pathname.new('x')), Integer)
+  T.assert_type!(Dir.chroot(Pathname.new('/')), Integer)
+end

--- a/test/testdata/rbi/dir.rb
+++ b/test/testdata/rbi/dir.rb
@@ -6,10 +6,15 @@ sig {returns(T::Array[String])}
 def test_dir_brackets
   Dir['a', 'b']
   Dir['a', base: '.']
-  Dir['/*'] do |match|
-    T.assert_type!(match, String)
-  end
+  Dir['/*']
   Dir[Pathname.new('.')]
+end
+
+sig {void}
+def test_dir_brackets_no_block
+  # Dir.[] does not yield (unlike Dir.glob); a block is silently ignored at
+  # runtime, so passing one is a latent bug. Sorbet flags it.
+  Dir['*'] { |f| f } # error: does not take a block
 end
 
 sig {returns(T::Array[String])}
@@ -21,6 +26,10 @@ def test_dir_glob
   Dir.glob(Pathname.new('.')) do |match|
     T.assert_type!(match, String)
   end
+  Dir.glob('*.rb', base: 'lib')
+  Dir.glob('*.rb', base: Pathname.new('lib'))
+  Dir.glob('*.rb', sort: false)
+  Dir.glob('*.rb', File::FNM_DOTMATCH, base: 'lib', sort: true)
   Dir.glob('*.rb')
 end
 
@@ -28,7 +37,6 @@ sig {params(enc: T.nilable(Encoding)).void}
 def test_dir_children(enc)
   T.assert_type!(Dir.children('.'), T::Array[String])
   T.assert_type!(Dir.children(Pathname.new('.')), T::Array[String])
-  # encoding: accepts an Encoding, a String name, or nil
   Dir.children('.', encoding: Encoding::UTF_8)
   Dir.children('.', encoding: 'UTF-8')
   Dir.children('.', encoding: nil)
@@ -86,6 +94,20 @@ def test_dir_new
   T.assert_type!(Dir.new('.', encoding: Encoding::UTF_8), Dir)
   T.assert_type!(Dir.new('.', encoding: 'UTF-8'), Dir)
   T.assert_type!(Dir.new('.', encoding: nil), Dir)
+end
+
+sig {params(dir: Dir).void}
+def test_dir_instance_children(dir)
+  T.assert_type!(dir.children, T::Array[String])
+end
+
+sig {params(dir: Dir).void}
+def test_dir_instance_each_child(dir)
+  dir.each_child do |child|
+    T.assert_type!(child, String)
+  end
+  T.assert_type!(dir.each_child {|child| child}, Dir)
+  T.assert_type!(dir.each_child, T::Enumerator[String])
 end
 
 sig {void}


### PR DESCRIPTION
## Summary

Corrects and completes the Dir core RBI so its signatures match real Ruby behavior. Every change was verified against the RBS core signatures shipped for both Ruby 3 (rbs v1.8.1) and Ruby 4 (rbs master), the CRuby dir.c/file.c sources, and confirmed by building Sorbet and type-checking test/testdata/rbi/dir.rb.

- Follows: https://github.com/sorbet/sorbet/pull/10427

## ⚠️ Breaking change (intended)

Dir.[] no longer accepts a block. Dir["*"] { |f| ... } now fails to type-check (Method 'Dir.[]' does not take a block).

- Rationale: unlike Dir.glob, Dir.[] silently ignores a block at runtime (confirmed: Dir["/tmp/*"] { } never yields; the method has no block parameter). Any such block is dead code — the author almost certainly expected glob-like iteration, so this is a latent bug Sorbet now surfaces.
- Migration: use Dir.glob(pattern) { |f| ... } for iteration, or drop the block if you only need the returned Array.

## Non-breaking changes

New instance methods (present since Ruby 2.6, previously missing — only the self. versions existed):
- Dir#children → T::Array[String]
- Dir#each_child → block → T.self_type; no block → T::Enumerator[String]

encoding: is a keyword, and accepts more than Encoding:
- entries, foreach, open, and Dir#initialize modeled encoding as a positional arg — Ruby takes it as a keyword, so Dir.foreach(dir, encoding: enc) was wrongly rejected. Fixed to keyword.
- All encoding: params widened from Encoding to T.nilable(T.any(String, Encoding)) — Ruby accepts an Encoding, a String name ('UTF-8'), or nil.

Pathname on path arguments (consistency with sibling methods that already accepted it):
- delete, chroot, and Dir#initialize path arg: String → T.any(String, Pathname).

Typed previously-untyped methods (def self.foo(*_)): children, each_child, empty?.

Dir.glob options: replaced the positional opts: T::Hash[Symbol, String] overloads (which mistyped sort: as String and couldn't express a Pathname base:) with keyword base: T.nilable(T.any(String, Pathname)) and sort: T::Boolean, collapsing four overloads into two. Now consistent with Dir.[] and RBS (?int flags, ?base: path?, ?sort: bool).

## Tests

Added comprehensive coverage in test/testdata/rbi/dir.rb for every touched method: String/Pathname paths, Encoding/String-name/nil encodings, block vs. no-block forms, glob base:/sort: keywords, the new instance methods, and an inline # error: assertion that Dir.[] rejects a block.