### PR TITLE
sorbet-runtime: Remove a hard_assert_handler call

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -631,7 +631,7 @@ class T::Props::Decorator
     end
 
     unless foreign.is_a?(Proc)
-      T::Configuration.hard_assert_handler(<<~MESSAGE, storytime: {prop: prop_name, value: foreign})
+      raise ArgumentError.new(<<~MESSAGE)
         Please use a Proc that returns a model class instead of the model class itself as the argument to `foreign`. In other words:
 
           instead of `prop :foo, String, foreign: FooModel`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm on a mission to remove as many hard and soft assertion handlers from
Sorbet.

There are no instances of this in production at Stripe. I just upgraded
this from a soft to a hard error, but we may as well just keep going and
make it an ArgumentError.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Searched the logs in Stripe's production system.