### PR TITLE
sorbet-runtime: Remove vm_prop_serde

### DIFF
--- a/gems/sorbet-runtime/Rakefile
+++ b/gems/sorbet-runtime/Rakefile
@@ -20,11 +20,6 @@ task :test do
   require_tests
 end
 
-task :test_vm_serde do
-  T::Configuration.enable_vm_prop_serde
-  require_tests
-end
-
 task :rubocop do
   # For some reason, using RuboCop::RakeTask causes our test suite to run a
   # bazillion times. I'm guessing that something about RuboCop::RakeTask is

--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -70,38 +70,6 @@ module T::Configuration
     @include_value_in_type_errors = true
   end
 
-  # Whether VM-defined prop serialization/deserialization routines can be enabled.
-  #
-  # @return [T::Boolean]
-  def self.can_enable_vm_prop_serde?
-    T::Props::Private::DeserializerGenerator.respond_to?(:generate2)
-  end
-
-  @use_vm_prop_serde = false
-  # Whether to use VM-defined prop serialization/deserialization routines.
-  #
-  # The default is to use runtime codegen inside sorbet-runtime itself.
-  #
-  # @return [T::Boolean]
-  def self.use_vm_prop_serde?
-    @use_vm_prop_serde || false
-  end
-
-  # Enable using VM-defined prop serialization/deserialization routines.
-  #
-  # This method is likely to break things outside of Stripe's systems.
-  def self.enable_vm_prop_serde
-    if !can_enable_vm_prop_serde?
-      hard_assert_handler('Ruby VM is not setup to use VM-defined prop serde')
-    end
-    @use_vm_prop_serde = true
-  end
-
-  # Disable using VM-defined prop serialization/deserialization routines.
-  def self.disable_vm_prop_serde
-    @use_vm_prop_serde = false
-  end
-
   # Configure the default checked level for a sig with no explicit `.checked`
   # builder. When unset, the default checked level is `:always`.
   #

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -226,13 +226,8 @@ module T::Props::Serializable::DecoratorMethods
     rules[:serialized_form] = serialized_form
     res = super
     prop_by_serialized_forms[serialized_form] = prop
-    if T::Configuration.use_vm_prop_serde?
-      enqueue_lazy_vm_method_definition!(:__t_props_generated_serialize) { generate_serialize2 }
-      enqueue_lazy_vm_method_definition!(:__t_props_generated_deserialize) { generate_deserialize2 }
-    else
-      enqueue_lazy_method_definition!(:__t_props_generated_serialize) { generate_serialize_source }
-      enqueue_lazy_method_definition!(:__t_props_generated_deserialize) { generate_deserialize_source }
-    end
+    enqueue_lazy_method_definition!(:__t_props_generated_serialize) { generate_serialize_source }
+    enqueue_lazy_method_definition!(:__t_props_generated_deserialize) { generate_deserialize_source }
     res
   end
 
@@ -242,18 +237,6 @@ module T::Props::Serializable::DecoratorMethods
 
   private def generate_deserialize_source
     T::Props::Private::DeserializerGenerator.generate(
-      props,
-      props_with_defaults || {},
-    )
-  end
-
-  private def generate_serialize2
-    T::Props::Private::SerializerGenerator.generate2(decorated_class, props)
-  end
-
-  private def generate_deserialize2
-    T::Props::Private::DeserializerGenerator.generate2(
-      decorated_class,
       props,
       props_with_defaults || {},
     )

--- a/gems/sorbet-runtime/test/types/configuration.rb
+++ b/gems/sorbet-runtime/test/types/configuration.rb
@@ -367,28 +367,6 @@ module Opus::Types::Test
           assert_equal('T.let: Expected type Integer, got type String', e.message.split("\n").first)
         end
       end
-
-      describe 'enable_vm_prop_serde' do
-        it "fails if the VM doesn't support it" do
-          return if T::Configuration.can_enable_vm_prop_serde?
-
-          assert_raises(RuntimeError) do
-            T::Configuration.enable_vm_prop_serde
-          end
-        end
-
-        it "succeeds if the VM does support it" do
-          return unless T::Configuration.can_enable_vm_prop_serde?
-
-          was_enabled = T::Configuration.use_vm_prop_serde?
-
-          begin
-            T::Configuration.enable_vm_prop_serde
-          ensure
-            T::Configuration.disable_vm_prop_serde unless was_enabled
-          end
-        end
-      end
     end
 
     describe 'default_checked_level=' do


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

These `generate2` methods were Sorbet Compiler-specific methods, which
have since been deleted. There's no need to keep them around, and there
are no references in Stripe's internal codebase.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests