### PR TITLE
sorbet-runtime: Convert deserialization error to hard error

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
+++ b/gems/sorbet-runtime/lib/types/props/private/deserializer_generator.rb
@@ -52,26 +52,7 @@ module T::Props
             SerdeTransform::Mode::DESERIALIZE,
             'val'
           )
-          transformed_val = if transformation
-            # Rescuing exactly NoMethodError is intended as a temporary hack
-            # to preserve the semantics from before codegen. More generally
-            # we are inconsistent about typechecking on deser and need to decide
-            # our strategy here.
-            <<~RUBY
-              begin
-                #{transformation}
-              rescue NoMethodError => e
-                raise_deserialization_error(
-                  #{prop.inspect},
-                  val,
-                  e,
-                )
-                val
-              end
-            RUBY
-          else
-            'val'
-          end
+          transformed_val = transformation || 'val'
 
           nil_handler = generate_nil_handler(
             prop: prop,

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -156,19 +156,6 @@ module T::Props::Serializable
     @_required_props_missing_from_deserialize << prop
     nil
   end
-
-  private def raise_deserialization_error(prop_name, value, orig_error)
-    T::Configuration.hard_assert_handler(
-      'Deserialization error (probably unexpected stored type)',
-      storytime: {
-        klass: self.class,
-        prop: prop_name,
-        value: value,
-        error: orig_error.message,
-        notify: 'djudd'
-      }
-    )
-  end
 end
 
 ##############################################

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -158,7 +158,7 @@ module T::Props::Serializable
   end
 
   private def raise_deserialization_error(prop_name, value, orig_error)
-    T::Configuration.soft_assert_handler(
+    T::Configuration.hard_assert_handler(
       'Deserialization error (probably unexpected stored type)',
       storytime: {
         klass: self.class,

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -237,7 +237,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     it 'is only soft-assert by default for prop deserialize error' do
       msg_string = nil
       extra_hash = nil
-      T::Configuration.soft_assert_handler = proc do |msg, extra|
+      T::Configuration.hard_assert_handler = proc do |msg, extra|
         msg_string = msg
         extra_hash = extra
       end
@@ -251,10 +251,12 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal(MySerializable, storytime[:klass])
       assert_equal(:foo, storytime[:prop])
       assert_equal("Won't respond like hash", storytime[:value])
+    ensure
+      T::Configuration.hard_assert_handler = nil
     end
 
     it 'includes relevant generated code on deserialize when we raise' do
-      T::Configuration.soft_assert_handler = proc do |msg, extra|
+      T::Configuration.hard_assert_handler = proc do |msg, extra|
         raise "#{msg} #{extra.inspect}"
       end
 
@@ -265,6 +267,8 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_includes(e.message.tr("`", "'"), "undefined method 'transform_values'")
       assert_includes(e.message, "foo")
       assert_includes(e.message, "val.transform_values {|v| T::Props::Utils.deep_clone(v)}")
+    ensure
+      T::Configuration.hard_assert_handler = nil
     end
 
     it 'includes relevant generated code on serialize' do
@@ -786,7 +790,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     it 'raises deserialize errors when props with an array of a custom subtype store the wrong datatype' do
       msg_string = nil
       extra_hash = nil
-      T::Configuration.soft_assert_handler = proc do |msg, extra|
+      T::Configuration.hard_assert_handler = proc do |msg, extra|
         msg_string = msg
         extra_hash = extra
       end
@@ -802,6 +806,8 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal(:array, storytime[:prop])
       assert_equal(obj, storytime[:value])
       assert_includes(storytime[:error].tr("`", "'"), "undefined method 'map'")
+    ensure
+      T::Configuration.hard_assert_handler = nil
     end
 
     it 'round trips as hash key' do
@@ -822,7 +828,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     it 'raises deserialize errors when props with a hash with keys of a custom subtype store the wrong datatype' do
       msg_string = nil
       extra_hash = nil
-      T::Configuration.soft_assert_handler = proc do |msg, extra|
+      T::Configuration.hard_assert_handler = proc do |msg, extra|
         msg_string = msg
         extra_hash = extra
       end
@@ -838,6 +844,8 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal(:hash_key, storytime[:prop])
       assert_equal(obj, storytime[:value])
       assert_includes(storytime[:error].tr("`", "'"), "undefined method 'transform_keys'")
+    ensure
+      T::Configuration.hard_assert_handler = nil
     end
 
     it 'round trips as hash value' do
@@ -858,7 +866,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     it 'raises deserialize errors when props with a hash with values of a custom subtype store the wrong datatype' do
       msg_string = nil
       extra_hash = nil
-      T::Configuration.soft_assert_handler = proc do |msg, extra|
+      T::Configuration.hard_assert_handler = proc do |msg, extra|
         msg_string = msg
         extra_hash = extra
       end
@@ -874,6 +882,8 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal(:hash_value, storytime[:prop])
       assert_equal(obj, storytime[:value])
       assert_includes(storytime[:error].tr("`", "'"), "undefined method 'transform_values'")
+    ensure
+      T::Configuration.hard_assert_handler = nil
     end
 
     it 'round trips as hash key and value' do
@@ -894,7 +904,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     it 'raises deserialize errors when props with a hash with keys/values of a custom subtype store the wrong datatype' do
       msg_string = nil
       extra_hash = nil
-      T::Configuration.soft_assert_handler = proc do |msg, extra|
+      T::Configuration.hard_assert_handler = proc do |msg, extra|
         msg_string = msg
         extra_hash = extra
       end
@@ -910,6 +920,8 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       assert_equal(:hash_both, storytime[:prop])
       assert_equal(obj, storytime[:value])
       assert_includes(storytime[:error].tr("`", "'"), "undefined method 'each_with_object'")
+    ensure
+      T::Configuration.hard_assert_handler = nil
     end
   end
 
@@ -986,7 +998,7 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     it 'raises deserialize errors' do
       msg_string = nil
       extra_hash = nil
-      T::Configuration.soft_assert_handler = proc do |msg, extra|
+      T::Configuration.hard_assert_handler = proc do |msg, extra|
         msg_string = msg
         extra_hash = extra
       end
@@ -997,6 +1009,8 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       end
 
       assert_includes(e.message, "value must be enumerable")
+    ensure
+      T::Configuration.hard_assert_handler = nil
     end
   end
 

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -234,41 +234,22 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
   end
 
   describe 'error message' do
-    it 'is only soft-assert by default for prop deserialize error' do
-      msg_string = nil
-      extra_hash = nil
-      T::Configuration.hard_assert_handler = proc do |msg, extra|
-        msg_string = msg
-        extra_hash = extra
+    it 'raises NoMethodError for prop deserialize error' do
+      e = assert_raises(NoMethodError) do
+        MySerializable.from_hash({'foo' => "Won't respond like hash"})
       end
 
-      result = MySerializable.from_hash({'foo' => "Won't respond like hash"})
-      assert_equal("Won't respond like hash", result.foo)
-
-      refute_nil(msg_string)
-      refute_nil(extra_hash)
-      storytime = extra_hash[:storytime]
-      assert_equal(MySerializable, storytime[:klass])
-      assert_equal(:foo, storytime[:prop])
-      assert_equal("Won't respond like hash", storytime[:value])
-    ensure
-      T::Configuration.hard_assert_handler = nil
+      assert_includes(e.message.tr("`", "'"), "undefined method 'transform_values'")
     end
 
     it 'includes relevant generated code on deserialize when we raise' do
-      T::Configuration.hard_assert_handler = proc do |msg, extra|
-        raise "#{msg} #{extra.inspect}"
-      end
-
-      e = assert_raises(RuntimeError) do
+      e = assert_raises(NoMethodError) do
         MySerializable.from_hash({'foo' => "Won't respond like hash"})
       end
 
       assert_includes(e.message.tr("`", "'"), "undefined method 'transform_values'")
       assert_includes(e.message, "foo")
       assert_includes(e.message, "val.transform_values {|v| T::Props::Utils.deep_clone(v)}")
-    ensure
-      T::Configuration.hard_assert_handler = nil
     end
 
     it 'includes relevant generated code on serialize' do
@@ -788,26 +769,11 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     end
 
     it 'raises deserialize errors when props with an array of a custom subtype store the wrong datatype' do
-      msg_string = nil
-      extra_hash = nil
-      T::Configuration.hard_assert_handler = proc do |msg, extra|
-        msg_string = msg
-        extra_hash = extra
+      e = assert_raises(NoMethodError) do
+        CustomTypeStruct.from_hash({'array' => CustomType.new})
       end
 
-      obj = CustomType.new
-      result = CustomTypeStruct.from_hash({'array' => obj})
-      assert_equal(obj, result.array)
-
-      refute_nil(msg_string)
-      refute_nil(extra_hash)
-      storytime = extra_hash[:storytime]
-      assert_equal(CustomTypeStruct, storytime[:klass])
-      assert_equal(:array, storytime[:prop])
-      assert_equal(obj, storytime[:value])
-      assert_includes(storytime[:error].tr("`", "'"), "undefined method 'map'")
-    ensure
-      T::Configuration.hard_assert_handler = nil
+      assert_includes(e.message.tr("`", "'"), "undefined method 'map'")
     end
 
     it 'round trips as hash key' do
@@ -826,26 +792,11 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     end
 
     it 'raises deserialize errors when props with a hash with keys of a custom subtype store the wrong datatype' do
-      msg_string = nil
-      extra_hash = nil
-      T::Configuration.hard_assert_handler = proc do |msg, extra|
-        msg_string = msg
-        extra_hash = extra
+      e = assert_raises(NoMethodError) do
+        CustomTypeStruct.from_hash({'hash_key' => 'not a hash'})
       end
 
-      obj = 'not a hash'
-      result = CustomTypeStruct.from_hash({'hash_key' => obj})
-      assert_equal('not a hash', result.hash_key)
-
-      refute_nil(msg_string)
-      refute_nil(extra_hash)
-      storytime = extra_hash[:storytime]
-      assert_equal(CustomTypeStruct, storytime[:klass])
-      assert_equal(:hash_key, storytime[:prop])
-      assert_equal(obj, storytime[:value])
-      assert_includes(storytime[:error].tr("`", "'"), "undefined method 'transform_keys'")
-    ensure
-      T::Configuration.hard_assert_handler = nil
+      assert_includes(e.message.tr("`", "'"), "undefined method 'transform_keys'")
     end
 
     it 'round trips as hash value' do
@@ -864,26 +815,11 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     end
 
     it 'raises deserialize errors when props with a hash with values of a custom subtype store the wrong datatype' do
-      msg_string = nil
-      extra_hash = nil
-      T::Configuration.hard_assert_handler = proc do |msg, extra|
-        msg_string = msg
-        extra_hash = extra
+      e = assert_raises(NoMethodError) do
+        CustomTypeStruct.from_hash({'hash_value' => 'not a hash'})
       end
 
-      obj = 'not a hash'
-      result = CustomTypeStruct.from_hash({'hash_value' => obj})
-      assert_equal('not a hash', result.hash_value)
-
-      refute_nil(msg_string)
-      refute_nil(extra_hash)
-      storytime = extra_hash[:storytime]
-      assert_equal(CustomTypeStruct, storytime[:klass])
-      assert_equal(:hash_value, storytime[:prop])
-      assert_equal(obj, storytime[:value])
-      assert_includes(storytime[:error].tr("`", "'"), "undefined method 'transform_values'")
-    ensure
-      T::Configuration.hard_assert_handler = nil
+      assert_includes(e.message.tr("`", "'"), "undefined method 'transform_values'")
     end
 
     it 'round trips as hash key and value' do
@@ -902,26 +838,11 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     end
 
     it 'raises deserialize errors when props with a hash with keys/values of a custom subtype store the wrong datatype' do
-      msg_string = nil
-      extra_hash = nil
-      T::Configuration.hard_assert_handler = proc do |msg, extra|
-        msg_string = msg
-        extra_hash = extra
+      e = assert_raises(NoMethodError) do
+        CustomTypeStruct.from_hash({'hash_both' => 'not a hash'})
       end
 
-      obj = 'not a hash'
-      result = CustomTypeStruct.from_hash({'hash_both' => obj})
-      assert_equal('not a hash', result.hash_both)
-
-      refute_nil(msg_string)
-      refute_nil(extra_hash)
-      storytime = extra_hash[:storytime]
-      assert_equal(CustomTypeStruct, storytime[:klass])
-      assert_equal(:hash_both, storytime[:prop])
-      assert_equal(obj, storytime[:value])
-      assert_includes(storytime[:error].tr("`", "'"), "undefined method 'each_with_object'")
-    ensure
-      T::Configuration.hard_assert_handler = nil
+      assert_includes(e.message.tr("`", "'"), "undefined method 'each_with_object'")
     end
   end
 

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -917,21 +917,12 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
     end
 
     it 'raises deserialize errors' do
-      msg_string = nil
-      extra_hash = nil
-      T::Configuration.hard_assert_handler = proc do |msg, extra|
-        msg_string = msg
-        extra_hash = extra
-      end
-
       obj = CustomType.new
       e = assert_raises(TypeError) do
         CustomSetPropStruct.from_hash({'set' => obj})
       end
 
       assert_includes(e.message, "value must be enumerable")
-    ensure
-      T::Configuration.hard_assert_handler = nil
     end
   end
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

There are only 4 unique instances of this across all of Stripe's
production systems in the last 7 days, and they originated from
manually-run, internal-only workflows. I'm going to upgrade this to a
hard error.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Stripe employees can see the log results here: <http://go/J1OZr2tV>