### PR TITLE
ENFORCE that we don't set a resolved constant to StubModule

### DIFF
--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -1478,6 +1478,7 @@ public:
     }
 
     void setSymbol(core::SymbolRef symbol) {
+        ENFORCE(symbol != core::Symbols::StubModule());
         storage.setSymbol(symbol);
     }
 


### PR DESCRIPTION
This should never happen, and it would be great to know if it is in one of our tests.

### Motivation
Making invariants explicit.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
