### PR TITLE
Add sigs for Proc#<< and Proc#>>

### DIFF
--- a/rbi/core/proc.rbi
+++ b/rbi/core/proc.rbi
@@ -370,6 +370,30 @@ class Proc < Object
   # statement.
   def ===(*_); end
 
+  # Returns a proc that is the composition of this proc and the given *g*. The
+  # returned proc takes a variable number of arguments, calls *g* with them then
+  # calls this proc with the result.
+  #
+  # ```ruby
+  # f = proc {|x| x * x }
+  # g = proc {|x| x + x }
+  # p (f << g).call(2) #=> 16
+  # ```
+  sig {params(g: T.untyped).returns(T.untyped)}
+  def <<(g); end
+
+  # Returns a proc that is the composition of this proc and the given *g*. The
+  # returned proc takes a variable number of arguments, calls this proc with
+  # them then calls *g* with the result.
+  #
+  # ```ruby
+  # f = proc {|x| x * x }
+  # g = proc {|x| x + x }
+  # p (f >> g).call(2) #=> 8
+  # ```
+  sig {params(g: T.untyped).returns(T.untyped)}
+  def >>(g); end
+
   # Returns the number of mandatory arguments. If the block is declared to take
   # no arguments, returns 0. If the block is known to take exactly n arguments,
   # returns n. If the block has optional arguments, returns -n-1, where n is the

--- a/test/testdata/rbi/proc.rb
+++ b/test/testdata/rbi/proc.rb
@@ -20,3 +20,9 @@ end
 
 example(f)
 #       ^ error: Expected `T.proc.params(arg0: Integer).void` but found `T.proc.params(arg0: T.untyped, arg1: T.untyped).returns(T.untyped)` for argument `f`
+
+# Proc#<< and Proc#>> compose two callables (added in Ruby 2.6).
+square = ->(x) { x * x }
+double = ->(x) { x + x }
+square << double
+square >> double


### PR DESCRIPTION
## What does this PR do?

Adds RBI definitions for `Proc#<<` and `Proc#>>`, the function-composition operators introduced in Ruby 2.6.0, to `rbi/core/proc.rbi`. Both are typed `sig {params(g: T.untyped).returns(T.untyped)}`.

## Why was this PR needed?

These two methods were never added to `proc.rbi`, so Sorbet reports false "Method does not exist" errors (7003) on valid code that composes procs, and even suggests the unrelated `Module#<` / `Module#>` operators. The typing mirrors the existing `Method#<<` / `Method#>>` definitions already in `rbi/core/method.rbi` for the same operators on a sibling callable class, which keeps the two consistent and correctly allows the non-Proc callables (a `Method`, or anything responding to `call`) that Ruby accepts at runtime.

## What are the relevant issue numbers?

Closes #9656

## Does this PR meet the acceptance criteria?

- [x] Tests added for new/changed behavior (regression test in `test/testdata/rbi/proc.rb`)
- [x] All tests passing
- [x] Follows project style guide
- [x] No breaking changes introduced
- [ ] Documentation updated (if applicable) — n/a