### PR TITLE
Delete always-true check

### DIFF
--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -331,10 +331,7 @@ void Resolver::finalizeAncestors(core::GlobalState &gs) {
                     ref.data(gs)->setSuperClass(core::Symbols::Object());
                 }
             } else {
-                if (!core::Symbols::BasicObject().data(gs)->derivesFrom(gs, ref) &&
-                    core::Symbols::BasicObject() != ref) {
-                    ref.data(gs)->setSuperClass(core::Symbols::Sorbet_Private_Static_ImplicitModuleSuperClass());
-                }
+                ref.data(gs)->setSuperClass(core::Symbols::Sorbet_Private_Static_ImplicitModuleSuperClass());
             }
         }
     }

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -331,6 +331,9 @@ void Resolver::finalizeAncestors(core::GlobalState &gs) {
                     ref.data(gs)->setSuperClass(core::Symbols::Object());
                 }
             } else {
+                ENFORCE(ref.data(gs)->isModule());
+                ENFORCE(!ref.data(gs)->superClass().exists() || ref.data(gs)->superClass() == core::Symbols::todo());
+
                 ref.data(gs)->setSuperClass(core::Symbols::Sorbet_Private_Static_ImplicitModuleSuperClass());
             }
         }


### PR DESCRIPTION
### Motivation

Just a random thing I ran into.

The only things that can get here are `Module`s, which are always a subclass of `BasicObject`, and never equal to `BasicObject`

### Test plan

Pure refactor.