### PR TITLE
Detect unspecified modules/classes in core RBIs

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1982,6 +1982,7 @@ void GlobalState::copyOptions(const core::GlobalState &other) {
     this->didYouMean = other.didYouMean;
     this->ensureCleanStrings = other.ensureCleanStrings;
     this->censorForSnapshotTests = other.censorForSnapshotTests;
+    this->loadedFromRBIBinaryPayload = other.loadedFromRBIBinaryPayload;
     this->sleepInSlowPathSeconds = other.sleepInSlowPathSeconds;
     this->cacheSensitiveOptions = other.cacheSensitiveOptions;
     this->ruby3KeywordArgs = other.ruby3KeywordArgs;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -548,6 +548,10 @@ public:
     bool ensureCleanStrings = false;
     bool censorForSnapshotTests = false;
 
+    // True when this GlobalState was loaded from the binary payload.
+    // False when it was loaded from the core RBI sources (i.e. we're running under `sorbet-orig` to build the payload.)
+    bool loadedFromRBIBinaryPayload = false;
+
     std::optional<int> sleepInSlowPathSeconds = std::nullopt;
 
     std::unique_ptr<GlobalState> deepCopyGlobalState(bool keepId = false) const;

--- a/payload/binary/BUILD
+++ b/payload/binary/BUILD
@@ -90,6 +90,7 @@ genrule(
     $(location //main:sorbet-orig) \
         --silence-dev-message \
         --no-error-count \
+        --color=always \
         --store-state $(location state-payload-raw-symbol-table),$(location state-payload-raw-name-table),$(location state-payload-raw-file-table)
     """,
     tools = ["//main:sorbet-orig"],

--- a/payload/payload.cc
+++ b/payload/payload.cc
@@ -18,9 +18,11 @@ void createInitialGlobalState(core::GlobalState &gs, const realmain::options::Op
     if (PAYLOAD_EMPTY) {
         Timer timeit(gs.tracer(), "read_global_state.source");
         sorbet::rbi::populateRBIsInto(gs);
+        gs.loadedFromRBIBinaryPayload = false;
     } else {
         Timer timeit(gs.tracer(), "read_global_state.binary");
         core::serialize::Serializer::loadGlobalState(gs, PAYLOAD_SYMBOL_TABLE, PAYLOAD_NAME_TABLE, PAYLOAD_FILE_TABLE);
+        gs.loadedFromRBIBinaryPayload = true;
     }
     ENFORCE(gs.utf8NamesUsed() < core::GlobalState::PAYLOAD_MAX_UTF8_NAME_COUNT,
             "Payload defined `{}` UTF8 names, which is greater than the expected maximum of `{}`. Consider updating "

--- a/rbi/stdlib/rubygems.rbi
+++ b/rbi/stdlib/rubygems.rbi
@@ -3247,7 +3247,7 @@ class Gem::StreamUI
   def download_reporter(*args); end
 end
 
-class Gem::Stream::UI::SilentProgressReporter
+class Gem::StreamUI::SilentProgressReporter
   def count; end
 
   def initialize(out_stream, size, initial_message, terminal_message = nil); end
@@ -3257,7 +3257,7 @@ class Gem::Stream::UI::SilentProgressReporter
   def done; end
 end
 
-class Gem::Stream::UI::SimpleProgressReporter
+class Gem::StreamUI::SimpleProgressReporter
   include Gem::DefaultUserInteraction
 
   def count; end
@@ -3269,7 +3269,7 @@ class Gem::Stream::UI::SimpleProgressReporter
   def done; end
 end
 
-class Gem::Stream::UI::VerboseProgressReporter
+class Gem::StreamUI::VerboseProgressReporter
   include Gem::DefaultUserInteraction
 
   def count; end
@@ -3281,7 +3281,7 @@ class Gem::Stream::UI::VerboseProgressReporter
   def done; end
 end
 
-class Gem::Stream::UI::SilentDownloadReporter
+class Gem::StreamUI::SilentDownloadReporter
   def initialize(out_stream, *args); end
 
   def fetch(filename, filesize); end
@@ -3291,7 +3291,7 @@ class Gem::Stream::UI::SilentDownloadReporter
   def done; end
 end
 
-class Gem::Stream::UI::ThreadedDownloadReporter
+class Gem::StreamUI::ThreadedDownloadReporter
   MUTEX = Mutex.new
 
   def file_name; end

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -1,6 +1,7 @@
 #include "common/timers/Timer.h"
 #include "core/Names.h"
 #include "core/core.h"
+#include "core/errors/internal.h"
 #include "core/errors/resolver.h"
 #include "resolver/resolver.h"
 #include <vector>
@@ -284,6 +285,16 @@ void Resolver::finalizeAncestors(core::GlobalState &gs) {
     }
     for (auto ref : gs.newClassOrModules()) {
         if (!ref.data(gs)->isClassModuleSet()) {
+            if (!gs.loadedFromRBIBinaryPayload) { // We're running in `sorbet-orig`
+                if (auto e = gs.beginError(ref.data(gs)->loc(), core::errors::Internal::InternalError)) {
+                    e.setHeader("The core RBIs referenced `{}`, but did not explicitly declare it as a class or module",
+                                ref.show(gs));
+
+                    e.addErrorNote("Make sure the namespace is correct. If it is, declare it explicitly with "
+                                   "`{}` or `{}` in the core RBIs.",
+                                   "class " + ref.show(gs), "module " + ref.show(gs));
+                }
+            }
             // we did not see a declaration for this type not did we see it used. Default to module.
             ref.data(gs)->setIsModule(true);
             ref.data(gs)->singletonClass(gs); // force singleton class into existence


### PR DESCRIPTION
### Motivation

The core RBI files should be complete, and not rely on this fallback logic:

https://github.com/sorbet/sorbet/blob/96ae9a87357593d9a369a9f66e8a1bfcce2c05a8/resolver/GlobalPass.cc#L285-L288

This PR adds diagnostics when this fallback is hit from `sorbet-orig`. They look like:

```
https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/rubygems.rbi#L3294: The core RBIs referenced Gem::Stream, but did not explicitly declare it as a class or module 1001
    3294 |class Gem::Stream::UI::ThreadedDownloadReporter
                ^^^^^^^^^^^
  Note:
    Make sure the namespace is correct. If it is, declare it explicitly with class Gem::Stream or module Gem::Stream in the core RBIs.

https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/rubygems.rbi#L3294: The core RBIs referenced Gem::Stream::UI, but did not explicitly declare it as a class or module 1001
    3294 |class Gem::Stream::UI::ThreadedDownloadReporter
                ^^^^^^^^^^^^^^^
  Note:
    Make sure the namespace is correct. If it is, declare it explicitly with class Gem::Stream::UI or module Gem::Stream::UI in the core RBIs.
```

This PR then also fixes the issues surfaced by that check (`Gem::Stream::UI` doesn't exist. It should be [`Gem::StreamUI`](https://docs.ruby-lang.org/en/master/Gem/StreamUI.html)).

### Test plan

I don't know how to test this.