### PR TITLE
Remove top-level `Rakefile`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,0 @@
-task default: %w[test]
-
-task :test do
-  puts "Run 'bazel test //... --config=dbg' to run the tests. More details in README file."
-end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was added by an external contributor to make the project "more
friendly to Ruby contributors." (See #1614)

In practice, this just gets in the way of my tab completion when I type
`R<TAB>` expecting to be able to open the README.md.

I don't think people should be blindly expect that there's a `Rakefile`
and be able to get off with developing--you should have to read the
README.md and the CONTRIBUTING.md guide. A little friction is okay.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.