### PR TITLE
LSP: don't corrupt URIs for files outside the first input directory

### DIFF
--- a/main/lsp/BUILD
+++ b/main/lsp/BUILD
@@ -192,6 +192,24 @@ cc_test(
 )
 
 cc_test(
+    name = "lsp_configuration_test",
+    size = "small",
+    srcs = ["test/lsp_configuration_test.cc"],
+    linkstatic = select({
+        "//tools/config:linkshared": 0,
+        "//conditions:default": 1,
+    }),
+    visibility = ["//tools:__pkg__"],
+    deps = [
+        "lsp",
+        "//payload",
+        "//test/helpers",
+        "@doctest//doctest",
+        "@doctest//doctest:main",
+    ],
+)
+
+cc_test(
     name = "lsp_preprocessor_test",
     size = "small",
     srcs = ["test/lsp_preprocessor_test.cc"],

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -1,4 +1,5 @@
 #include "main/lsp/LSPConfiguration.h"
+#include "absl/algorithm/container.h"
 #include "absl/strings/escaping.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_join.h"
@@ -138,12 +139,32 @@ void LSPConfiguration::setClientConfig(const shared_ptr<const LSPClientConfigura
     this->clientConfig = clientConfig;
 }
 
+namespace {
+
+// Returns true if `prefix` is a whole-path-component prefix of `path` (e.g. "." is a prefix of
+// "./foo.rb" but not of ".gitignore").
+bool isPathPrefix(string_view path, string_view prefix) {
+    if (prefix.empty()) {
+        return true;
+    }
+    return absl::StartsWith(path, prefix) &&
+           (path.length() == prefix.length() || path[prefix.length()] == '/');
+}
+
+} // namespace
+
 string LSPConfiguration::localName2Remote(string_view filePath) const {
-    ENFORCE(absl::StartsWith(filePath, rootPath));
+    // With multiple input directories (--forcibly-silence-lsp-multiple-dir-error), rootPath is the
+    // first input directory, and files from the other directories are named relative to the
+    // working directory rather than to rootPath. Those names are already relative URIs.
+    ENFORCE(isPathPrefix(filePath, rootPath) || opts.forciblySilenceLspMultipleDirError);
     assertHasClientConfig();
-    string_view relativeUri = filePath.substr(rootPath.length());
-    if (relativeUri.at(0) == '/') {
-        relativeUri = relativeUri.substr(1);
+    string_view relativeUri = filePath;
+    if (isPathPrefix(filePath, rootPath)) {
+        relativeUri = filePath.substr(rootPath.length());
+        if (!relativeUri.empty() && relativeUri.at(0) == '/') {
+            relativeUri = relativeUri.substr(1);
+        }
     }
 
     // Special case: Root uri is '' (happens in Monaco)
@@ -202,6 +223,19 @@ string LSPConfiguration::remoteName2Local(string_view encodedUri) const {
     if (isHttps) {
         return path;
     } else if (rootPath.length() > 0) {
+        // With multiple input directories, files under directories other than the first are named
+        // relative to the working directory rather than under rootPath, so return the path as-is
+        // to match how those files were indexed.
+        if (opts.forciblySilenceLspMultipleDirError) {
+            for (size_t i = 1; i < opts.rawInputDirNames.size(); i++) {
+                if (isPathPrefix(path, opts.rawInputDirNames[i])) {
+                    return path;
+                }
+            }
+            if (absl::c_find(opts.rawInputFileNames, path) != opts.rawInputFileNames.end()) {
+                return path;
+            }
+        }
         return absl::StrCat(rootPath, "/", path);
     } else {
         // Special case: Folder is '' (current directory)

--- a/main/lsp/test/lsp_configuration_test.cc
+++ b/main/lsp/test/lsp_configuration_test.cc
@@ -1,0 +1,81 @@
+#include "doctest/doctest.h"
+// has to go first as it violates our requirements
+
+#include "main/lsp/LSPConfiguration.h"
+#include "main/lsp/LSPMessage.h"
+#include "main/lsp/LSPOutput.h"
+#include "main/lsp/json_types.h"
+#include "spdlog/sinks/null_sink.h"
+#include "test/helpers/MockFileSystem.h"
+#include <memory>
+
+using namespace std;
+
+namespace sorbet::realmain::lsp::test {
+
+namespace {
+
+auto nullSink = make_shared<spdlog::sinks::null_sink_mt>();
+auto logger = make_shared<spdlog::logger>("console", nullSink);
+
+constexpr string_view rootUri = "file:///workspace"sv;
+
+options::Options makeMultiDirOptions() {
+    options::Options opts;
+    opts.rawInputDirNames.emplace_back(".");
+    opts.rawInputDirNames.emplace_back("nested");
+    opts.rawInputFileNames.emplace_back("also/included.rbi");
+    opts.forciblySilenceLspMultipleDirError = true;
+    opts.runLSP = true;
+    opts.fs = make_shared<sorbet::test::MockFileSystem>(".");
+    return opts;
+}
+
+options::Options makeSingleDirOptions(string_view rootPath) {
+    options::Options opts;
+    opts.rawInputDirNames.emplace_back(string(rootPath));
+    opts.runLSP = true;
+    opts.fs = make_shared<sorbet::test::MockFileSystem>(rootPath);
+    return opts;
+}
+
+shared_ptr<LSPConfiguration> makeConfig(const options::Options &opts) {
+    auto config = make_shared<LSPConfiguration>(opts, make_shared<LSPOutputToVector>(), logger, false);
+    InitializeParams initParams(string(rootUri), make_unique<ClientCapabilities>());
+    config->setClientConfig(make_shared<LSPClientConfiguration>(initParams));
+    config->markInitialized();
+    return config;
+}
+
+} // namespace
+
+TEST_CASE("URIConversionWithMultipleInputDirs") {
+    auto opts = makeMultiDirOptions();
+    auto config = makeConfig(opts);
+
+    // Files under the first input dir (".") are indexed with a "./" prefix.
+    CHECK_EQ("file:///workspace/foo.rb", config->localName2Remote("./foo.rb"));
+    CHECK_EQ("./foo.rb", config->remoteName2Local("file:///workspace/foo.rb"));
+
+    // Files under the other input dirs are indexed relative to the working directory; the leading
+    // path component must not be stripped (https://github.com/sorbet/sorbet/issues/10443).
+    CHECK_EQ("file:///workspace/nested/bar.rb", config->localName2Remote("nested/bar.rb"));
+    CHECK_EQ("nested/bar.rb", config->remoteName2Local("file:///workspace/nested/bar.rb"));
+
+    // Files passed via --file behave like files from the other input dirs.
+    CHECK_EQ("file:///workspace/also/included.rbi", config->localName2Remote("also/included.rbi"));
+    CHECK_EQ("also/included.rbi", config->remoteName2Local("file:///workspace/also/included.rbi"));
+
+    // "." must only match as a whole path component, not dotfiles.
+    CHECK_EQ("file:///workspace/.rubocop.yml", config->localName2Remote("./.rubocop.yml"));
+}
+
+TEST_CASE("URIConversionWithSingleInputDir") {
+    auto opts = makeSingleDirOptions("myroot");
+    auto config = makeConfig(opts);
+
+    CHECK_EQ("file:///workspace/foo.rb", config->localName2Remote("myroot/foo.rb"));
+    CHECK_EQ("myroot/foo.rb", config->remoteName2Local("file:///workspace/foo.rb"));
+}
+
+} // namespace sorbet::realmain::lsp::test

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -72,6 +72,7 @@ compilation_database(
         "//main/lsp:generate_lsp_messages",
         "//main/lsp:generate_lsp_messages_test",
         "//main/lsp:lsp",
+        "//main/lsp:lsp_configuration_test",
         "//main/lsp:lsp_file_updates_test",
         "//main/lsp:lsp_preprocessor_test",
         "//main/lsp:lsp_test",


### PR DESCRIPTION
With multiple input directories (via `--forcibly-silence-lsp-multiple-dir-error`), `rootPath` is the first input directory, but files from the other directories are indexed relative to the working directory, not under `rootPath`. When the first directory is `.`, `localName2Remote` unconditionally stripped `rootPath.length()` characters off the front of every path, eating the first character of paths from the other dirs (`vendor/...` became `endor/...`) — the only guard was an `ENFORCE`, which is compiled out in release builds.

This changes `localName2Remote` to only strip `rootPath` when it's a whole-path-component prefix of the file path, and gives `remoteName2Local` the mirror-image fix: when the multi-dir flag is set and the incoming URI's path falls under one of the other input dirs (or matches a `--file` input), return it as-is so it matches how the file was indexed and `uri2FileRef` can find it.

### Motivation

Fixes #10443 — in a monorepo where an app typechecks itself plus a few vendored engine gems (`--dir .`, `--dir vendor/gems/foo/lib`, ...), go-to-definition into the vendored gems opens a nonexistent `endor/gems/...` path in VS Code.

### Test plan

See included automated tests (`main/lsp/test/lsp_configuration_test.cc`, new). They cover both conversion directions for files under the first dir, files under the other dirs, `--file` inputs, the dotfile edge case (`.` must not match `.rubocop.yml` as a prefix), and a single-input-dir regression case. The new test fails against master and passes with this change; the other `main/lsp` unit tests pass in a `--config=dbg` build (so the adjusted `ENFORCE` is exercised).