### PR TITLE
Set `initialized` at the end of the Init slow path

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -778,8 +778,6 @@ pair<bool, core::packages::Stratum> LSPTypechecker::runSlowPath(LSPFileUpdates &
                         // Close and copy the global kvstore, so that we have unique access for the rest of the session.
                         this->sessionCache = cache::SessionCache::make(std::move(ownedKvstore), *this->config->logger,
                                                                        this->config->opts);
-
-                        this->initialized = true;
                     }
                 }
 
@@ -890,6 +888,11 @@ pair<bool, core::packages::Stratum> LSPTypechecker::runSlowPath(LSPFileUpdates &
 
         return this->lastStratum;
     });
+
+    if (mode == SlowPathMode::Init) {
+        // TODO: if we start supporting preemption in the init path, we'll need to rethink what this boolean means.
+        this->initialized = true;
+    }
 
     gs->lspQuery = core::lsp::Query::noQuery();
 


### PR DESCRIPTION
If we have an empty set of strata, we can fail to set `LSPTypechecker::initialized` to true on the init path. There's no reason to update it in the middle of the package graph though, as the initialization slow path blocks everything until it completes. This PR sets it at the end instead, to ensure that it's always set during initialization.

### Motivation
Simplification.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Pure refactor.
