### PR TITLE
sorbet-runtime: Convert a hard assert to a `raise`

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/decorator.rb
+++ b/gems/sorbet-runtime/lib/types/props/decorator.rb
@@ -591,10 +591,7 @@ class T::Props::Decorator
     @class.send(:define_method, force_fk_method) do |allow_direct_mutation: nil|
       loaded_foreign = send(fk_method, allow_direct_mutation: allow_direct_mutation)
       if !loaded_foreign
-        T::Configuration.hard_assert_handler(
-          'Failed to load foreign model',
-          storytime: {method: force_fk_method, class: self.class}
-        )
+        raise("Failed to load foreign model method=#{force_fk_method} class=#{self.class}")
       end
       loaded_foreign
     end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Will have to supercede #10430 for the time being.

We can't actually get rid of the logic to do `foreign` from sorbet-runtime by moving it into Stripe's codebase, because there are modules (mixins) that do nothing other than `include T::Props` that expect to be able to define foreign props.

Maybe we can revisit that once we fully migrate to foreign loaders.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.