### PR TITLE
Eagerly set superclass of `module`s

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -244,6 +244,7 @@ InlinedVector<core::ClassOrModuleRef, 4> ParentLinearizationInformation::fullLin
 ClassOrModuleRef enterModuleSymbol(GlobalState &gs, ClassOrModuleRef owner, NameRef name) {
     auto module = gs.enterClassOrModuleSymbol(Loc::none(), owner, name);
     module.data(gs)->setIsModule(true);
+    module.data(gs)->setSuperClass(core::Symbols::Sorbet_Private_Static_ImplicitModuleSuperClass());
     return module;
 }
 } // namespace
@@ -267,7 +268,7 @@ ClassOrModuleRef GlobalState::synthesizeClass(NameRef name, uint32_t superclass,
 }
 
 ClassOrModuleRef GlobalState::synthesizeModule(NameRef name) {
-    auto superclass = uint32_t{0};
+    auto superclass = Symbols::Sorbet_Private_Static_ImplicitModuleSuperClass().id();
     return synthesizeClass(name, superclass, true);
 }
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -353,7 +353,7 @@ void GlobalState::initEmpty() {
     ENFORCE_NO_TIMER(klass == Symbols::NilClass());
     klass = synthesizeClass(core::Names::Constants::Untyped(), 0);
     ENFORCE_NO_TIMER(klass == Symbols::untyped());
-    klass = synthesizeClass(core::Names::Constants::T(), Symbols::todo().id(), true);
+    klass = synthesizeClass(core::Names::Constants::T(), 0, true);
     ENFORCE_NO_TIMER(klass == Symbols::T());
     klass = klass.data(*this)->singletonClass(*this);
     ENFORCE_NO_TIMER(klass == Symbols::TSingleton());

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -394,11 +394,11 @@ void GlobalState::initEmpty() {
     ENFORCE_NO_TIMER(klass == Symbols::Complex());
     klass = synthesizeClass(core::Names::Constants::Rational());
     ENFORCE_NO_TIMER(klass == Symbols::Rational());
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Array());
+    klass = enterModuleSymbol(*this, Symbols::T(), core::Names::Constants::Array());
     ENFORCE_NO_TIMER(klass == Symbols::T_Array());
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Hash());
+    klass = enterModuleSymbol(*this, Symbols::T(), core::Names::Constants::Hash());
     ENFORCE_NO_TIMER(klass == Symbols::T_Hash());
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Proc());
+    klass = enterModuleSymbol(*this, Symbols::T(), core::Names::Constants::Proc());
     ENFORCE_NO_TIMER(klass == Symbols::T_Proc());
     klass = synthesizeClass(core::Names::Constants::Proc());
     ENFORCE_NO_TIMER(klass == Symbols::Proc());
@@ -412,7 +412,7 @@ void GlobalState::initEmpty() {
     ENFORCE_NO_TIMER(klass == Symbols::File());
     klass = synthesizeClass(core::Names::Constants::Sorbet());
     ENFORCE_NO_TIMER(klass == Symbols::Sorbet());
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::Sorbet(), core::Names::Constants::Private());
+    klass = enterModuleSymbol(*this, Symbols::Sorbet(), core::Names::Constants::Private());
     ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private());
     klass = enterModuleSymbol(*this, Symbols::Sorbet_Private(), core::Names::Constants::Static());
     ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private_Static());
@@ -428,19 +428,19 @@ void GlobalState::initEmpty() {
                                      core::Names::Constants::StubSuperClass());
     klass.data(*this)->setIsModule(false);
     ENFORCE_NO_TIMER(klass == Symbols::StubSuperClass());
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Enumerable());
+    klass = enterModuleSymbol(*this, Symbols::T(), core::Names::Constants::Enumerable());
     ENFORCE_NO_TIMER(klass == Symbols::T_Enumerable());
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Range());
+    klass = enterModuleSymbol(*this, Symbols::T(), core::Names::Constants::Range());
     ENFORCE_NO_TIMER(klass == Symbols::T_Range());
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Set());
+    klass = enterModuleSymbol(*this, Symbols::T(), core::Names::Constants::Set());
     ENFORCE_NO_TIMER(klass == Symbols::T_Set());
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Void());
+    klass = enterModuleSymbol(*this, Symbols::Sorbet_Private_Static(), core::Names::Constants::Void());
     ENFORCE_NO_TIMER(klass == Symbols::void_());
     klass = synthesizeClass(core::Names::Constants::TypeAlias(), 0);
     ENFORCE_NO_TIMER(klass == Symbols::typeAliasTemp());
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T(), Names::Constants::Configuration());
+    klass = enterModuleSymbol(*this, Symbols::T(), Names::Constants::Configuration());
     ENFORCE_NO_TIMER(klass == Symbols::T_Configuration());
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Generic());
+    klass = enterModuleSymbol(*this, Symbols::T(), core::Names::Constants::Generic());
     ENFORCE_NO_TIMER(klass == Symbols::T_Generic());
     klass = enterClassOrModuleSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Tuple());
     klass.data(*this)->setIsModule(false);
@@ -448,8 +448,7 @@ void GlobalState::initEmpty() {
     klass = enterClassOrModuleSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Shape());
     klass.data(*this)->setIsModule(false);
     ENFORCE_NO_TIMER(klass == Symbols::Shape());
-    klass =
-        enterClassOrModuleSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::Subclasses());
+    klass = enterModuleSymbol(*this, Symbols::Sorbet_Private_Static(), core::Names::Constants::Subclasses());
     ENFORCE_NO_TIMER(klass == Symbols::Subclasses());
     klass = enterClassOrModuleSymbol(Loc::none(), Symbols::Sorbet_Private_Static(),
                                      core::Names::Constants::ImplicitModuleSuperclass());
@@ -482,7 +481,7 @@ void GlobalState::initEmpty() {
     ENFORCE_NO_TIMER(
         typeParameter ==
         Symbols::Sorbet_Private_Static_ReturnTypeInference_guessed_type_type_parameter_holder_tparam_covariant());
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Sig());
+    klass = enterModuleSymbol(*this, Symbols::T(), core::Names::Constants::Sig());
     ENFORCE_NO_TIMER(klass == Symbols::T_Sig());
 
     // A magic non user-creatable class with methods to keep state between passes
@@ -496,7 +495,7 @@ void GlobalState::initEmpty() {
     ENFORCE_NO_TIMER(method == Symbols::Sorbet_Private_Static_badAliasMethodStub());
 
     // T::Helpers
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Helpers());
+    klass = enterModuleSymbol(*this, Symbols::T(), core::Names::Constants::Helpers());
     ENFORCE_NO_TIMER(klass == Symbols::T_Helpers());
 
     // SigBuilder magic class
@@ -510,11 +509,11 @@ void GlobalState::initEmpty() {
 
     klass = synthesizeClass(core::Names::Constants::Enumerator());
     ENFORCE_NO_TIMER(klass == Symbols::Enumerator());
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Enumerator());
+    klass = enterModuleSymbol(*this, Symbols::T(), core::Names::Constants::Enumerator());
     ENFORCE_NO_TIMER(klass == Symbols::T_Enumerator());
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T_Enumerator(), core::Names::Constants::Lazy());
+    klass = enterModuleSymbol(*this, Symbols::T_Enumerator(), core::Names::Constants::Lazy());
     ENFORCE_NO_TIMER(klass == Symbols::T_Enumerator_Lazy());
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T_Enumerator(), core::Names::Constants::Chain());
+    klass = enterModuleSymbol(*this, Symbols::T_Enumerator(), core::Names::Constants::Chain());
     ENFORCE_NO_TIMER(klass == Symbols::T_Enumerator_Chain());
 
     klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Struct());
@@ -547,19 +546,18 @@ void GlobalState::initEmpty() {
     klass.data(*this)->setIsModule(false);
     ENFORCE_NO_TIMER(klass == Symbols::Enumerator_Chain());
 
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T(), Names::Constants::Private());
+    klass = enterModuleSymbol(*this, Symbols::T(), Names::Constants::Private());
     ENFORCE_NO_TIMER(klass == Symbols::T_Private());
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T_Private(), Names::Constants::Types());
+    klass = enterModuleSymbol(*this, Symbols::T_Private(), Names::Constants::Types());
     ENFORCE_NO_TIMER(klass == Symbols::T_Private_Types());
     klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T_Private_Types(), Names::Constants::Void());
     klass.data(*this)->setIsModule(false);
     ENFORCE_NO_TIMER(klass == Symbols::T_Private_Types_Void());
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T_Private_Types_Void(), Names::Constants::VOID());
-    klass.data(*this)->setIsModule(true); // explicitly set isModule so we can immediately call singletonClass
+    klass = enterModuleSymbol(*this, Symbols::T_Private_Types_Void(), Names::Constants::VOID());
     ENFORCE_NO_TIMER(klass == Symbols::T_Private_Types_Void_VOID());
     klass = klass.data(*this)->singletonClass(*this);
     ENFORCE_NO_TIMER(klass == Symbols::T_Private_Types_Void_VOIDSingleton());
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T_Private(), Names::Constants::Methods());
+    klass = enterModuleSymbol(*this, Symbols::T_Private(), Names::Constants::Methods());
     ENFORCE_NO_TIMER(klass == Symbols::T_Private_Methods());
     klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T_Private_Methods(), Names::Constants::DeclBuilder());
     klass.data(*this)->setIsModule(false);
@@ -583,7 +581,7 @@ void GlobalState::initEmpty() {
         enterMethod(*this, Symbols::T_Sig_WithoutRuntimeSingleton(), Names::sig()).defaultArg(Names::arg0()).build();
     ENFORCE_NO_TIMER(method == Symbols::sigWithoutRuntime());
 
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::root(), Names::Constants::PackageSpecRegistry());
+    klass = enterModuleSymbol(*this, Symbols::root(), Names::Constants::PackageSpecRegistry());
     ENFORCE_NO_TIMER(klass == Symbols::PackageSpecRegistry());
 
     // Ensure that we propagate packageRegistryOwner information by making PackageSpecRegistry own itself in the
@@ -613,13 +611,13 @@ void GlobalState::initEmpty() {
     ENFORCE_NO_TIMER(method == Symbols::rootStaticInit());
 
     // Magic classes for special proc bindings
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::Magic(), core::Names::Constants::BindToAttachedClass());
+    klass = enterModuleSymbol(*this, Symbols::Magic(), core::Names::Constants::BindToAttachedClass());
     ENFORCE_NO_TIMER(klass == Symbols::MagicBindToAttachedClass());
 
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::Magic(), core::Names::Constants::BindToSelfType());
+    klass = enterModuleSymbol(*this, Symbols::Magic(), core::Names::Constants::BindToSelfType());
     ENFORCE_NO_TIMER(klass == Symbols::MagicBindToSelfType());
 
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Types());
+    klass = enterModuleSymbol(*this, Symbols::T(), core::Names::Constants::Types());
     ENFORCE_NO_TIMER(klass == Symbols::T_Types());
 
     klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T_Types(), core::Names::Constants::Base());
@@ -630,10 +628,10 @@ void GlobalState::initEmpty() {
     klass.data(*this)->setIsModule(false);
     ENFORCE_NO_TIMER(klass == Symbols::Data());
 
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Class());
+    klass = enterModuleSymbol(*this, Symbols::T(), core::Names::Constants::Class());
     ENFORCE_NO_TIMER(klass == Symbols::T_Class());
 
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Module());
+    klass = enterModuleSymbol(*this, Symbols::T(), core::Names::Constants::Module());
     ENFORCE_NO_TIMER(klass == Symbols::T_Module());
 
     method = enterMethod(*this, Symbols::T_Generic(), Names::squareBrackets()).repeatedTopArg(Names::args()).build();
@@ -847,7 +845,7 @@ void GlobalState::initEmpty() {
                  .untypedArg(Names::arg0())
                  .buildWithResult(Types::declBuilderForProcsSingletonClass());
 
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::Magic(), core::Names::Constants::UntypedSource());
+    klass = enterModuleSymbol(*this, Symbols::Magic(), core::Names::Constants::UntypedSource());
     ENFORCE_NO_TIMER(klass == Symbols::Magic_UntypedSource());
 
     field = enterFieldSymbol(Loc::none(), Symbols::Magic_UntypedSource(), core::Names::super());

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -261,6 +261,11 @@ ClassOrModuleRef GlobalState::synthesizeClass(NameRef name, uint32_t superclass,
     return symRef;
 }
 
+ClassOrModuleRef GlobalState::synthesizeModule(NameRef name) {
+    auto superclass = uint32_t{0};
+    return synthesizeClass(name, superclass, true);
+}
+
 atomic<int> globalStateIdCounter(1);
 const int Symbols::MAX_PROC_ARITY;
 
@@ -353,7 +358,7 @@ void GlobalState::initEmpty() {
     ENFORCE_NO_TIMER(klass == Symbols::NilClass());
     klass = synthesizeClass(core::Names::Constants::Untyped(), 0);
     ENFORCE_NO_TIMER(klass == Symbols::untyped());
-    klass = synthesizeClass(core::Names::Constants::T(), 0, true);
+    klass = synthesizeModule(core::Names::Constants::T());
     ENFORCE_NO_TIMER(klass == Symbols::T());
     klass = klass.data(*this)->singletonClass(*this);
     ENFORCE_NO_TIMER(klass == Symbols::TSingleton());
@@ -364,7 +369,7 @@ void GlobalState::initEmpty() {
     ENFORCE_NO_TIMER(klass == Symbols::BasicObject());
     method = enterMethod(*this, Symbols::BasicObject(), Names::initialize()).build();
     ENFORCE_NO_TIMER(method == Symbols::BasicObject_initialize());
-    klass = synthesizeClass(core::Names::Constants::Kernel(), 0, true);
+    klass = synthesizeModule(core::Names::Constants::Kernel());
     ENFORCE_NO_TIMER(klass == Symbols::Kernel());
     klass = synthesizeClass(core::Names::Constants::Range());
     ENFORCE_NO_TIMER(klass == Symbols::Range());
@@ -392,7 +397,7 @@ void GlobalState::initEmpty() {
     ENFORCE_NO_TIMER(klass == Symbols::T_Proc());
     klass = synthesizeClass(core::Names::Constants::Proc());
     ENFORCE_NO_TIMER(klass == Symbols::Proc());
-    klass = synthesizeClass(core::Names::Constants::Enumerable(), 0, true);
+    klass = synthesizeModule(core::Names::Constants::Enumerable());
     ENFORCE_NO_TIMER(klass == Symbols::Enumerable());
     klass = synthesizeClass(core::Names::Constants::Set());
     ENFORCE_NO_TIMER(klass == Symbols::Set());
@@ -519,7 +524,7 @@ void GlobalState::initEmpty() {
     klass.data(*this)->setIsModule(false);
     ENFORCE_NO_TIMER(klass == Symbols::T_Struct());
 
-    klass = synthesizeClass(core::Names::Constants::Singleton(), 0, true);
+    klass = synthesizeModule(core::Names::Constants::Singleton());
     ENFORCE_NO_TIMER(klass == Symbols::Singleton());
 
     klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T(), core::Names::Constants::Enum());

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -241,6 +241,11 @@ InlinedVector<core::ClassOrModuleRef, 4> ParentLinearizationInformation::fullLin
     return res;
 }
 
+ClassOrModuleRef enterModuleSymbol(GlobalState &gs, ClassOrModuleRef owner, NameRef name) {
+    auto module = gs.enterClassOrModuleSymbol(Loc::none(), owner, name);
+    module.data(gs)->setIsModule(true);
+    return module;
+}
 } // namespace
 
 ClassOrModuleRef GlobalState::synthesizeClass(NameRef name, uint32_t superclass, bool isModule) {
@@ -409,22 +414,15 @@ void GlobalState::initEmpty() {
     ENFORCE_NO_TIMER(klass == Symbols::Sorbet());
     klass = enterClassOrModuleSymbol(Loc::none(), Symbols::Sorbet(), core::Names::Constants::Private());
     ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private());
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::Sorbet_Private(), core::Names::Constants::Static());
-    klass.data(*this)->setIsModule(true); // explicitly set isModule so we can immediately call singletonClass
+    klass = enterModuleSymbol(*this, Symbols::Sorbet_Private(), core::Names::Constants::Static());
     ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private_Static());
     klass = Symbols::Sorbet_Private_Static().data(*this)->singletonClass(*this);
     ENFORCE_NO_TIMER(klass == Symbols::Sorbet_Private_StaticSingleton());
-    klass =
-        enterClassOrModuleSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::StubModule());
-    klass.data(*this)->setIsModule(true);
+    klass = enterModuleSymbol(*this, Symbols::Sorbet_Private_Static(), core::Names::Constants::StubModule());
     ENFORCE_NO_TIMER(klass == Symbols::StubModule());
-    klass =
-        enterClassOrModuleSymbol(Loc::none(), Symbols::Sorbet_Private_Static(), core::Names::Constants::StubMixin());
-    klass.data(*this)->setIsModule(true);
+    klass = enterModuleSymbol(*this, Symbols::Sorbet_Private_Static(), core::Names::Constants::StubMixin());
     ENFORCE_NO_TIMER(klass == Symbols::StubMixin());
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::Sorbet_Private_Static(),
-                                     core::Names::Constants::PlaceholderMixin());
-    klass.data(*this)->setIsModule(true);
+    klass = enterModuleSymbol(*this, Symbols::Sorbet_Private_Static(), core::Names::Constants::PlaceholderMixin());
     ENFORCE_NO_TIMER(klass == Symbols::PlaceholderMixin());
     klass = enterClassOrModuleSymbol(Loc::none(), Symbols::Sorbet_Private_Static(),
                                      core::Names::Constants::StubSuperClass());
@@ -507,8 +505,7 @@ void GlobalState::initEmpty() {
     klass = Symbols::DeclBuilderForProcs().data(*this)->singletonClass(*this);
     ENFORCE_NO_TIMER(klass == Symbols::DeclBuilderForProcsSingleton());
 
-    klass = enterClassOrModuleSymbol(Loc::none(), Symbols::T_Sig(), core::Names::Constants::WithoutRuntime());
-    klass.data(*this)->setIsModule(true); // explicitly set isModule so we can immediately call singletonClass
+    klass = enterModuleSymbol(*this, Symbols::T_Sig(), core::Names::Constants::WithoutRuntime());
     ENFORCE_NO_TIMER(klass == Symbols::T_Sig_WithoutRuntime());
 
     klass = synthesizeClass(core::Names::Constants::Enumerator());

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -849,14 +849,6 @@ void GlobalState::initEmpty() {
     method = enterMethod(*this, Symbols::DeclBuilderForProcsSingleton(), Names::typeParameters())
                  .untypedArg(Names::arg0())
                  .buildWithResult(Types::declBuilderForProcsSingletonClass());
-    // Some of these are Modules
-    Symbols::StubModule().data(*this)->setIsModule(true);
-    Symbols::T().data(*this)->setIsModule(true);
-    Symbols::StubMixin().data(*this)->setIsModule(true);
-
-    // Some of these are Classes
-    Symbols::StubSuperClass().data(*this)->setIsModule(false);
-    Symbols::StubSuperClass().data(*this)->setSuperClass(Symbols::Object());
 
     klass = enterClassOrModuleSymbol(Loc::none(), Symbols::Magic(), core::Names::Constants::UntypedSource());
     ENFORCE_NO_TIMER(klass == Symbols::Magic_UntypedSource());

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -791,6 +791,7 @@ private:
     void expandNames(uint32_t utf8NameSize, uint32_t constantNameSize, uint32_t uniqueNameSize);
 
     ClassOrModuleRef synthesizeClass(NameRef nameID, uint32_t superclass = Symbols::todo().id(), bool isModule = false);
+    ClassOrModuleRef synthesizeModule(NameRef name);
 
     SymbolRef lookupSymbolWithKind(ClassOrModuleRef owner, NameRef name, SymbolRef::Kind kind,
                                    SymbolRef defaultReturnValue, bool ignoreKind = false) const;

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1263,9 +1263,20 @@ private:
                                        bool willDeleteOldDefs, ClassBehaviorLocsMap &classBehaviorLocs) {
         auto symbol = getClassSymbol(ctx, state, klass);
 
-        if (klass.classKind == core::FoundClass::Kind::Class && !symbol.data(ctx)->superClass().exists() &&
-            symbol != core::Symbols::BasicObject()) {
-            symbol.data(ctx)->setSuperClass(core::Symbols::todo());
+        switch (klass.classKind) {
+            case core::FoundClass::Kind::Class: {
+                if (!symbol.data(ctx)->superClass().exists() && symbol != core::Symbols::BasicObject()) {
+                    symbol.data(ctx)->setSuperClass(core::Symbols::todo());
+                }
+                break;
+            }
+            case core::FoundClass::Kind::Module: {
+                symbol.data(ctx)->setSuperClass(core::Symbols::Sorbet_Private_Static_ImplicitModuleSuperClass());
+                break;
+            }
+            case core::FoundClass::Kind::Unknown: {
+                break;
+            }
         }
 
         const bool isUnknown = klass.classKind == core::FoundClass::Kind::Unknown;

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -286,6 +286,7 @@ void Resolver::finalizeAncestors(core::GlobalState &gs) {
         if (!ref.data(gs)->isClassModuleSet()) {
             // we did not see a declaration for this type not did we see it used. Default to module.
             ref.data(gs)->setIsModule(true);
+            ref.data(gs)->setSuperClass(core::Symbols::Sorbet_Private_Static_ImplicitModuleSuperClass());
             ref.data(gs)->singletonClass(gs); // force singleton class into existence
         }
     }
@@ -326,15 +327,11 @@ void Resolver::finalizeAncestors(core::GlobalState &gs) {
                 ref.data(gs)->setSuperClass(singletonSuperClass);
             }
         } else {
-            if (ref.data(gs)->isClass()) {
-                if (core::Symbols::BasicObject() != ref && core::Symbols::top() != ref) {
-                    ref.data(gs)->setSuperClass(core::Symbols::Object());
-                }
-            } else {
-                ENFORCE(ref.data(gs)->isModule());
-                ENFORCE(!ref.data(gs)->superClass().exists());
-
-                ref.data(gs)->setSuperClass(core::Symbols::Sorbet_Private_Static_ImplicitModuleSuperClass());
+            ENFORCE(!ref.data(gs)->isModule(),
+                    "Modules should have a superclass upon creation, so it shouldn't need anything finalized here.");
+            ENFORCE(ref.data(gs)->isClass());
+            if (core::Symbols::BasicObject() != ref && core::Symbols::top() != ref) {
+                ref.data(gs)->setSuperClass(core::Symbols::Object());
             }
         }
     }

--- a/resolver/GlobalPass.cc
+++ b/resolver/GlobalPass.cc
@@ -332,7 +332,7 @@ void Resolver::finalizeAncestors(core::GlobalState &gs) {
                 }
             } else {
                 ENFORCE(ref.data(gs)->isModule());
-                ENFORCE(!ref.data(gs)->superClass().exists() || ref.data(gs)->superClass() == core::Symbols::todo());
+                ENFORCE(!ref.data(gs)->superClass().exists());
 
                 ref.data(gs)->setSuperClass(core::Symbols::Sorbet_Private_Static_ImplicitModuleSuperClass());
             }


### PR DESCRIPTION
### Motivation

Stacked on #10440 and #10442.

Many of the modules created in `GlobalState::initEmpty()` get created in an unspecified state (not known to be a class or module specifically), with a mix of empty and `Symbols::todo()` as their superclass.

This PR simplifies their state by just initializing them with `core::Symbols::Sorbet_Private_Static_ImplicitModuleSuperClass()` as their superclass, right from the start.

### Test plan

Pure refactor.
