### PR TITLE
Don't mark methods defined inside blocks as implicitly private

### DIFF
--- a/core/FoundDefinitions.h
+++ b/core/FoundDefinitions.h
@@ -171,11 +171,19 @@ struct FoundMethod final {
         bool isAttrBestEffortUIOnly : 1 = false;
         bool discardDef : 1 = false;
         bool genericPropGetter : 1 = false;
+        // True if this method definition was lexically nested inside a block
+        // (e.g. `Foo.class_eval do ... end` or `Class.new do ... end`).
+        // Set by the Flatten rewriter pass (which hoists method defs out of blocks,
+        // losing the lexical nesting information) and used by Namer to avoid treating
+        // such defs as implicitly-private top-level definitions.
+        // See https://github.com/sorbet/sorbet/issues/10436
+        // See https://github.com/sorbet/sorbet/issues/10452
+        bool isInsideBlock : 1 = false;
 
         bool operator==(const Flags &other) const noexcept {
             return isSelfMethod == other.isSelfMethod && isRewriterSynthesized == other.isRewriterSynthesized &&
                    isAttrBestEffortUIOnly == other.isAttrBestEffortUIOnly && discardDef == other.discardDef &&
-                   genericPropGetter == other.genericPropGetter;
+                   genericPropGetter == other.genericPropGetter && isInsideBlock == other.isInsideBlock;
         }
 
         bool operator!=(const Flags &other) const noexcept {

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1129,8 +1129,15 @@ private:
 
         // Methods defined at the top level default to private (on Object)
         // Also, the `initialize` method defaults to private
+        //
+        // Methods that were lexically nested inside a block (e.g. `Range.class_eval do ... end` or
+        // `Class.new do ... end`) are excluded from the top-level heuristic: in Ruby, the default
+        // visibility inside such blocks is public, and marking them private here would clobber the
+        // visibility of methods like `Object#==` or `Module#name` for the entire program.
+        // See https://github.com/sorbet/sorbet/issues/10452 and
+        // https://github.com/sorbet/sorbet/issues/10436
         auto implicitlyPrivate =
-            (ctx.owner.enclosingClass(ctx) == core::Symbols::root()) ||
+            (ctx.owner.enclosingClass(ctx) == core::Symbols::root() && !method.flags.isInsideBlock) ||
             (!symbol.data(ctx)->owner.data(ctx)->attachedClass(ctx).exists() && name == core::Names::initialize());
         if (implicitlyPrivate) {
             symbol.data(ctx)->flags.isPrivate = true;

--- a/rewriter/Flatten.cc
+++ b/rewriter/Flatten.cc
@@ -159,6 +159,12 @@ class FlattenWalk {
     // need to move to the end, so we keep that below on the stack.
     vector<ClassScope> classScopes;
 
+    // How many blocks we are currently lexically nested inside of (e.g. `Foo.class_eval do ... end`).
+    // Method defs found inside blocks are flagged so that later passes (Namer) don't treat them as
+    // ordinary top-level definitions, which would incorrectly mark them implicitly private.
+    // See https://github.com/sorbet/sorbet/issues/10452
+    uint32_t blockDepth = 0;
+
     // compute the new scope information.
     ScopeInfo computeScopeInfo(ScopeType scopeType) {
         auto &methods = curMethodSet();
@@ -347,8 +353,23 @@ public:
         }
     }
 
+    void preTransformBlock(core::Context ctx, ast::ExpressionPtr &tree) {
+        blockDepth++;
+    }
+
+    void postTransformBlock(core::Context ctx, ast::ExpressionPtr &tree) {
+        ENFORCE(blockDepth > 0);
+        blockDepth--;
+    }
+
     void preTransformMethodDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &methodDef = ast::cast_tree_nonnull<ast::MethodDef>(tree);
+        if (blockDepth > 0) {
+            // This method def is lexically nested inside a block (e.g. `Foo.class_eval do ... end`).
+            // Flatten is about to hoist it out of the block, which loses that information, so record
+            // it on the flags for Namer to consult when computing implicit visibility.
+            methodDef.flags.isInsideBlock = true;
+        }
         // add a new scope for this method def
         curMethodSet().pushScope(computeScopeInfo(methodDef.flags.isSelfMethod ? ScopeType::StaticMethodScope
                                                                                : ScopeType::InstanceMethodScope));

--- a/test/testdata/infer/def_inside_block_visibility.rb
+++ b/test/testdata/infer/def_inside_block_visibility.rb
@@ -1,0 +1,34 @@
+# typed: true
+
+# Regression tests for https://github.com/sorbet/sorbet/issues/10452 and
+# https://github.com/sorbet/sorbet/issues/10436
+#
+# Method defs lexically nested inside blocks used to be treated like ordinary
+# top-level defs and marked implicitly private, which clobbered the visibility
+# of methods like `Object#==` and `Module#name` for the entire program.
+# In Ruby, the default visibility inside `class_eval`/`Class.new` blocks is
+# public, so these defs must not be marked private.
+
+Range.class_eval do
+  def ==(other)
+    super(other)
+  end
+end
+
+(1..5) == (1..5)
+nil == (1..5)
+
+runtime_klass = Class.new do
+  def self.name
+    "RuntimeKlass"
+  end
+end
+
+class MyAnotherClass
+  def something
+    self.class.name
+  end
+end
+
+puts runtime_klass.name
+puts MyAnotherClass.name


### PR DESCRIPTION
Method defs lexically nested inside blocks (e.g. `Range.class_eval do ... end` or `Class.new do ... end`) at the top level were treated like ordinary top-level defs and marked implicitly private on `Object`. This clobbered the visibility of methods like `Object#==` and `Module#name` for the entire program, producing spurious 7031 errors on unrelated call sites (`nil == x`, `SomeClass.name`).

In Ruby, the default method visibility inside such blocks is public: redefining a method via `class_eval` makes it public regardless of its previous visibility, so the implicit-private heuristic only applies to genuinely top-level defs.

The lexical nesting information is recorded in the Flatten rewriter pass (before it hoists method defs out of blocks, which loses that information) via a new `isInsideBlock` flag on `FoundMethod::Flags`, and consulted by Namer when computing implicit visibility.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Fixes #10452
Fixes #10436

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
