### PR TITLE
Introduce `package_private!`

### DIFF
--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -400,14 +400,15 @@ public:
         bool isDeclaredInPackage : 1;
         bool isExported : 1;
         bool isBehaviorDefining : 1;
+        bool isPackagePrivate : 1;
 
-        constexpr static uint16_t NUMBER_OF_FLAGS = 12;
+        constexpr static uint16_t NUMBER_OF_FLAGS = 13;
         constexpr static uint16_t VALID_BITS_MASK = (1 << NUMBER_OF_FLAGS) - 1;
 
         Flags() noexcept
             : isClass(false), isModule(false), isAbstract(false), isInterface(false), isLinearizationComputed(false),
               isFinal(false), isSealed(false), isPrivate(false), isDeclared(false), isDeclaredInPackage(false),
-              isExported(false), isBehaviorDefining(false) {}
+              isExported(false), isBehaviorDefining(false), isPackagePrivate(false) {}
 
         uint16_t serialize() const {
             static_assert(sizeof(Flags) == sizeof(uint16_t));

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -128,6 +128,7 @@ NameDef names[] = {
     {"returns"},
     {"packagePrivate", "package_private"},
     {"packagePrivateClassMethod", "package_private_class_method"},
+    {"declarePackagePrivate", "package_private!"},
     {"void_", "void"},
     {"VOID", "VOID", true},
     {"checked"},

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -95,6 +95,13 @@ class SymbolFinder {
         }
 
         switch (send->fun.rawId()) {
+            case core::Names::declarePackagePrivate().rawId(): {
+                // This is special if we're using package mode
+                if (!ctx.state.packageDB().enabled()) {
+                    break;
+                }
+                [[fallthrough]];
+            }
             case core::Names::declareFinal().rawId():
             case core::Names::declareSealed().rawId():
             case core::Names::declareInterface().rawId():
@@ -1415,6 +1422,16 @@ private:
                     e.replaceWith("Change `interface!` to `abstract!`", ctx.locAt(mod.loc), "abstract!");
                 }
             }
+        }
+        if (fun == core::Names::declarePackagePrivate()) {
+            // TODO(gdritter): Add something here when we switch to
+            // public-by-default! Right now, this is redundant because
+            // we're already private-by-default, and even setting
+            // `isExported` to `false` will get overruled by later
+            // changes. But once we switch, this is where we will make
+            // the change.
+
+            // symbolData->flags.isExported = false;
         }
     }
 

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -1424,14 +1424,7 @@ private:
             }
         }
         if (fun == core::Names::declarePackagePrivate()) {
-            // TODO(gdritter): Add something here when we switch to
-            // public-by-default! Right now, this is redundant because
-            // we're already private-by-default, and even setting
-            // `isExported` to `false` will get overruled by later
-            // changes. But once we switch, this is where we will make
-            // the change.
-
-            // symbolData->flags.isExported = false;
+            symbolData->flags.isPackagePrivate = true;
         }
     }
 

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -49,6 +49,36 @@ core::ClassOrModuleRef getScopeForPackage(const core::GlobalState &gs, absl::Spa
     return result;
 }
 
+class PropagatePrivacy final {
+    void recursiveSetPrivate(core::MutableContext ctx, core::ClassOrModuleRef klass) {
+        klass.data(ctx)->flags.isPackagePrivate = true;
+
+        // recurse onto relevant children
+        for (auto &[_, child] : klass.data(ctx)->members()) {
+            if (child.isClassOrModule()) {
+                auto childRef = child.asClassOrModuleRef();
+                if (childRef.data(ctx)->flags.isPackagePrivate) {
+                    // if it's already private, we don't need to keep
+                    // recursing: either it's already been done, or it will be
+                    // done when we come across the definition of this one
+                    return;
+                }
+                recursiveSetPrivate(ctx, childRef);
+            }
+        }
+    }
+
+public:
+    void postTransformClassDef(core::MutableContext ctx, const ast::ClassDef &tree) {
+        auto klass = tree.symbol;
+        // if it's not package-private, then there's nothing to do
+        if (!klass.data(ctx)->flags.isPackagePrivate) {
+            return;
+        }
+        recursiveSetPrivate(ctx, klass);
+    }
+};
+
 // For each __package.rb file, traverse the resolved tree and apply the visibility annotations to the symbols.
 class PropagateVisibility final {
     core::packages::PackageInfo &package;
@@ -445,6 +475,10 @@ public:
 
     static void run(core::GlobalState &gs, const ast::ParsedFile &f) {
         if (!f.file.data(gs).isPackage(gs)) {
+            // this is a source file, not a package, so we do the much simpler privacy propagation pass
+            core::MutableContext ctx{gs, core::Symbols::root(), f.file};
+            PropagatePrivacy pass;
+            ast::ConstShallowWalk::apply(ctx, pass, f.tree);
             return;
         }
 

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -394,6 +394,11 @@ public:
                                       ctx.locAt(send.loc), "{}",
                                       fmt::map_join(lines, "\n  ", [](string_view line) { return line; }));
                     }
+                } else if (klassData->flags.isPackagePrivate) {
+                    if (auto e = ctx.beginError(send.loc, core::errors::Packager::InvalidExport)) {
+                        e.setHeader("Constant `{}` is declared `{}` and cannot be exported", sym.show(ctx),
+                                    "package_private!");
+                    }
                 }
 
                 checkExportPackage(ctx, send.loc, sym);
@@ -635,12 +640,16 @@ public:
         }
 
         bool isExported = pkg.locs.exportAll.exists();
+        bool isPackagePrivate = false;
         if (litSymbol.isClassOrModule()) {
-            isExported = isExported || litSymbol.asClassOrModuleRef().data(ctx)->flags.isExported;
+            auto flags = litSymbol.asClassOrModuleRef().data(ctx)->flags;
+            isExported = isExported || flags.isExported;
+            isPackagePrivate = flags.isPackagePrivate;
         } else if (litSymbol.isFieldOrStaticField()) {
             isExported = isExported || litSymbol.asFieldRef().data(ctx)->flags.isExported;
         }
         isExported = isExported || db.allowRelaxedPackagerChecksFor(this->package.mangledName());
+        isExported = isExported && !isPackagePrivate;
         bool definesBehavior =
             !litSymbol.isClassOrModule() || litSymbol.asClassOrModuleRef().data(ctx)->flags.isBehaviorDefining;
         auto *import = this->package.importsPackage(otherPackage);
@@ -726,7 +735,12 @@ public:
                     }
                 }
 
-                if (!isExported && !wasImported) {
+                if (isPackagePrivate) {
+                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
+                        e.setHeader("`{}` resolves but is declared `{}` in `{}`", litSymbol.show(ctx),
+                                    "package_private", pkg.show(ctx));
+                    }
+                } else if (!isExported && !wasImported) {
                     if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
                         e.setHeader("`{}` resolves but is not exported from `{}` and `{}` is not imported",
                                     litSymbol.show(ctx), pkg.show(ctx), pkg.show(ctx));

--- a/test/testdata/packager/package_private/__package.rb
+++ b/test/testdata/packager/package_private/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# enable-packager: true
+
+class Root < PackageSpec
+  prelude!
+end

--- a/test/testdata/packager/package_private/dest/__package.rb
+++ b/test/testdata/packager/package_private/dest/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# enable-packager: true
+
+class Dest < PackageSpec
+  import Source
+end

--- a/test/testdata/packager/package_private/dest/__package.rb
+++ b/test/testdata/packager/package_private/dest/__package.rb
@@ -2,5 +2,6 @@
 # enable-packager: true
 
 class Dest < PackageSpec
+  import Nested
   import Source
 end

--- a/test/testdata/packager/package_private/dest/_impl.rb
+++ b/test/testdata/packager/package_private/dest/_impl.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+module Dest
+  # TODO(gdritter): when we switch to public-by-default, the following error whould be removed
+  Source::Public # error: `Source::Public` resolves but is not exported
+  Source::Private # error: `Source::Private` resolves but is not exported
+end

--- a/test/testdata/packager/package_private/dest/_impl.rb
+++ b/test/testdata/packager/package_private/dest/_impl.rb
@@ -4,6 +4,11 @@ module Dest
   Source::Public
   Source::Private # error: `Source::Private` resolves but is declared `package_private` in `Source`
 
+  Nested::Outer
   Nested::Outer::InnerPublic
   Nested::Outer::InnerPrivate # error: `Nested::Outer::InnerPrivate` resolves but is declared `package_private` in `Nested`
+
+  Nested::PrivateOuter # error: `Source::Private` resolves but is declared `package_private` in `Source`
+  Nested::PrivateOuter::InnerThing # error: `Source::Private` resolves but is declared `package_private` in `Source`
+  Nested::PrivateOuter::InnerOtherThing # error: `Source::Private` resolves but is declared `package_private` in `Source`
 end

--- a/test/testdata/packager/package_private/dest/_impl.rb
+++ b/test/testdata/packager/package_private/dest/_impl.rb
@@ -3,4 +3,7 @@
 module Dest
   Source::Public
   Source::Private # error: `Source::Private` resolves but is declared `package_private` in `Source`
+
+  Nested::Outer::InnerPublic
+  Nested::Outer::InnerPrivate # error: `Nested::Outer::InnerPrivate` resolves but is declared `package_private` in `Nested`
 end

--- a/test/testdata/packager/package_private/dest/_impl.rb
+++ b/test/testdata/packager/package_private/dest/_impl.rb
@@ -8,7 +8,7 @@ module Dest
   Nested::Outer::InnerPublic
   Nested::Outer::InnerPrivate # error: `Nested::Outer::InnerPrivate` resolves but is declared `package_private` in `Nested`
 
-  Nested::PrivateOuter # error: `Source::Private` resolves but is declared `package_private` in `Source`
-  Nested::PrivateOuter::InnerThing # error: `Source::Private` resolves but is declared `package_private` in `Source`
-  Nested::PrivateOuter::InnerOtherThing # error: `Source::Private` resolves but is declared `package_private` in `Source`
+  Nested::PrivateOuter # error: `Nested::PrivateOuter` resolves but is declared `package_private` in `Nested`
+  Nested::PrivateOuter::InnerThing # error: `Nested::PrivateOuter::InnerThing` resolves but is not exported from `Nested`
+  Nested::PrivateOuter::InnerOtherThing # error: `Nested::PrivateOuter::InnerOtherThing` resolves but is declared `package_private` in `Nested`
 end

--- a/test/testdata/packager/package_private/dest/_impl.rb
+++ b/test/testdata/packager/package_private/dest/_impl.rb
@@ -1,7 +1,6 @@
 # typed: strict
 
 module Dest
-  # TODO(gdritter): when we switch to public-by-default, the following error whould be removed
-  Source::Public # error: `Source::Public` resolves but is not exported
-  Source::Private # error: `Source::Private` resolves but is not exported
+  Source::Public
+  Source::Private # error: `Source::Private` resolves but is declared `package_private` in `Source`
 end

--- a/test/testdata/packager/package_private/dest/_impl.rb
+++ b/test/testdata/packager/package_private/dest/_impl.rb
@@ -9,6 +9,6 @@ module Dest
   Nested::Outer::InnerPrivate # error: `Nested::Outer::InnerPrivate` resolves but is declared `package_private` in `Nested`
 
   Nested::PrivateOuter # error: `Nested::PrivateOuter` resolves but is declared `package_private` in `Nested`
-  Nested::PrivateOuter::InnerThing # error: `Nested::PrivateOuter::InnerThing` resolves but is not exported from `Nested`
+  Nested::PrivateOuter::InnerThing # error: `Nested::PrivateOuter::InnerThing` resolves but is declared `package_private` in `Nested`
   Nested::PrivateOuter::InnerOtherThing # error: `Nested::PrivateOuter::InnerOtherThing` resolves but is declared `package_private` in `Nested`
 end

--- a/test/testdata/packager/package_private/exporter/__package.rb
+++ b/test/testdata/packager/package_private/exporter/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# enable-packager: true
+
+class Exporter < PackageSpec
+  export Exporter::Private # error: Constant `Exporter::Private` is declared `package_private!` and cannot be exported
+end

--- a/test/testdata/packager/package_private/exporter/_impl.rb
+++ b/test/testdata/packager/package_private/exporter/_impl.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Exporter::Private
+  package_private!
+end

--- a/test/testdata/packager/package_private/nested/__package.rb
+++ b/test/testdata/packager/package_private/nested/__package.rb
@@ -2,5 +2,5 @@
 # enable-packager: true
 
 class Nested < PackageSpec
-  export Nested::Outer
+  export_all!
 end

--- a/test/testdata/packager/package_private/nested/__package.rb
+++ b/test/testdata/packager/package_private/nested/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# enable-packager: true
+
+class Nested < PackageSpec
+  export Nested::Outer
+end

--- a/test/testdata/packager/package_private/nested/_impl.rb
+++ b/test/testdata/packager/package_private/nested/_impl.rb
@@ -9,4 +9,15 @@ module Nested
       package_private!
     end
   end
+
+  module PrivateOuter
+    package_private!
+
+    module InnerThing
+    end
+
+    module InnerOtherThing
+      package_private!
+    end
+  end
 end

--- a/test/testdata/packager/package_private/nested/_impl.rb
+++ b/test/testdata/packager/package_private/nested/_impl.rb
@@ -1,0 +1,12 @@
+# typed: strict
+
+module Nested
+  module Outer
+    module InnerPublic
+    end
+
+    module InnerPrivate
+      package_private!
+    end
+  end
+end

--- a/test/testdata/packager/package_private/root.rbi
+++ b/test/testdata/packager/package_private/root.rbi
@@ -1,0 +1,6 @@
+# typed: strict
+
+class ::Module < ::Object
+  sig { void }
+  def package_private!; end
+end

--- a/test/testdata/packager/package_private/source/__package.rb
+++ b/test/testdata/packager/package_private/source/__package.rb
@@ -2,4 +2,5 @@
 # enable-packager: true
 
 class Source < PackageSpec
+  export_all!
 end

--- a/test/testdata/packager/package_private/source/__package.rb
+++ b/test/testdata/packager/package_private/source/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+# enable-packager: true
+
+class Source < PackageSpec
+end

--- a/test/testdata/packager/package_private/source/_impl.rb
+++ b/test/testdata/packager/package_private/source/_impl.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+class Source::Public
+end
+
+class Source::Private
+  package_private!
+end


### PR DESCRIPTION
This introduces `package_private!`, an annotation for the packaging system which marks the enclosing class or module as being not-exportable.

Right now, this has two pieces of relevant behavior with respect to the packager
- Firstly, if a class or module is marked `package_private!` and it is referenced directly by an `export`, then there is an error that indicates the constant cannot be exported.
- Secondly, if a class or module is marked `package_private!` and it is used in another package, regardless of whether it's imported or not, it produces an error that indicates the constant is not permissible in that context, and does not supply any sort of autocorrect.

Right now, this is fairly redundant, but eventually we plan to get rid of the private-by-default behavior and switch to public-by-default with this serving to enforce privacy.

### Motivation
Given how pervasively we use autocorrect mechanisms to introduce exports, we have ended up with a system which is not private-by-default, it's public-by-default-but-with-extra-toil. Exports are also a huge source of complexity for packaging and autocorrects and they take up space in memory. Moving to a public-by-default-with-opt-in-enforcement world gives us a better story around modularity than we have now while also reducing implementation complexity.

This is the first step in a multi-step process, as introducing this will allow us to start using the annotation in relevant places, at which point we can stop enforcing the export behavior, remove the exports, and finally remove its implementation here.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
