### PR TITLE
Enable colour when running `sorbet-orig`

### DIFF
--- a/payload/binary/BUILD
+++ b/payload/binary/BUILD
@@ -90,6 +90,7 @@ genrule(
     $(location //main:sorbet-orig) \
         --silence-dev-message \
         --no-error-count \
+        --color=always \
         --store-state $(location state-payload-raw-symbol-table),$(location state-payload-raw-name-table),$(location state-payload-raw-file-table)
     """,
     tools = ["//main:sorbet-orig"],


### PR DESCRIPTION
### Motivation

It's just nicer.

<img width="1539" height="809" alt="Image" src="https://github.com/user-attachments/assets/868b15e7-4883-4309-9a9e-773a8b1fc3ae" />

Bazel already colourizes its output anyway, so I don't see any downsides. Split out from #10442

### Test plan

None.