### PR TITLE
Fix `for` loop variable type after the loop (#10265)

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1908,9 +1908,9 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     auto collectionAssign =
                         MK::Assign(loc, MK::Local(locZeroLen, collectionTempName), node2TreeImpl(dctx, for_->expr));
 
-                    // `<Magic>.<element-or-nil>(<forTemp>$1)` types as `T.nilable(<element type>)`, or
-                    // `T.untyped` if the collection doesn't respond to `first` (Ruby's `for` only
-                    // requires `each`, so a missing `first` must not be an error).
+                    // `<Magic>.<element-or-nil>(<forTemp>$1)` types as `T.nilable(<element type>)`,
+                    // where the element type comes from the declared block parameter type of the
+                    // collection's `each`, or `T.untyped` if `each` has no signature.
                     auto seedRhs = MK::Send1(loc, MK::Magic(locZeroLen), core::Names::elementOrNil(), locZeroLen,
                                              MK::Local(loc, collectionTempName));
 

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1801,25 +1801,43 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 }
 
                 ExpressionPtr block; // the body to the `each` loop we'll create
+
+                // In Ruby, `for` loops don't define a new scope (the way a block passed to `each` would),
+                // so the loop variable(s) continue to exist after the end of the loop, holding `nil` if the
+                // collection was empty. Because the block parameters in the desugared `each` call are
+                // block-local, we additionally seed the loop variable(s) in the enclosing scope from
+                // `<collection>.first`, guarded by an opaque condition, so that their post-loop type is
+                // `T.nilable(<element type>)` instead of `NilClass`.
+                // See https://github.com/sorbet/sorbet/issues/10265
+                unique_ptr<parser::Node> seedLhs;
                 if (canProvideNiceDesugar) {
                     MethodDef::PARAMS_store params;
-                    if (parser::isa_node<parser::LVarLhs>(forLoopVar.get())) { // single local
+                    if (auto *lvar = parser::cast_node<parser::LVarLhs>(forLoopVar.get())) { // single local
                         // Desugar:
-                        //     for a in []
+                        //     for a in <coll>
                         // into:
-                        //     [].each { |a| ... }
+                        //     <forTemp>$1 = <coll>
+                        //     a = <forTemp>$1.first() if <opaque condition>
+                        //     <forTemp>$1.each { |a| ... }
+                        seedLhs = make_unique<parser::LVarLhs>(lvar->loc, lvar->name);
 
                         auto localVar = node2TreeImpl(dctx, forLoopVar);
                         params.emplace_back(move(localVar));
                     } else if (auto *mlhs = parser::cast_node<parser::Mlhs>(forLoopVar.get())) { // mlhs of all locals
                         // Desugar:
-                        //     for a, b, c in []
+                        //     for a, b, c in <coll>
                         // into:
-                        //     [].each { |a, b, c| ... }
+                        //     <forTemp>$1 = <coll>
+                        //     a, b, c = <forTemp>$1.first() if <opaque condition>
+                        //     <forTemp>$1.each { |a, b, c| ... }
+                        parser::NodeVec seedVars;
                         for (auto &c : mlhs->exprs) {
-                            ENFORCE(parser::isa_node<parser::LVarLhs>(c.get()));
+                            auto *lvar = parser::cast_node<parser::LVarLhs>(c.get());
+                            ENFORCE(lvar != nullptr);
+                            seedVars.emplace_back(make_unique<parser::LVarLhs>(lvar->loc, lvar->name));
                             params.emplace_back(node2TreeImpl(dctx, c));
                         }
+                        seedLhs = make_unique<parser::Mlhs>(mlhs->loc, move(seedVars));
                     } else {
                         unreachable("Expected the `forLoopVar` to be either a LVarLhs or Mlhs");
                     }
@@ -1878,8 +1896,47 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     block = MK::Block(loc, move(loopBody), move(params));
                 }
 
-                auto res =
-                    MK::Send0Block(loc, node2TreeImpl(dctx, for_->expr), core::Names::each(), locZeroLen, move(block));
+                ExpressionPtr res;
+                if (canProvideNiceDesugar) {
+                    ENFORCE(seedLhs != nullptr);
+
+                    // Evaluate the collection expression once, into a temporary, so that we can
+                    // reference it both to seed the loop variable(s) and to call `each` on it.
+                    core::NameRef collectionTempName = dctx.freshNameUnique(core::Names::forTemp());
+                    auto collectionAssign =
+                        MK::Assign(loc, MK::Local(loc, collectionTempName), node2TreeImpl(dctx, for_->expr));
+
+                    unique_ptr<parser::Node> firstRecv = make_unique<parser::LVar>(loc, collectionTempName);
+                    unique_ptr<parser::Node> firstSend = make_unique<parser::Send>(
+                        loc, move(firstRecv), core::Names::first(), locZeroLen, parser::NodeVec{});
+
+                    unique_ptr<parser::Node> seedAssignNode;
+                    if (parser::isa_node<parser::Mlhs>(seedLhs.get())) {
+                        seedAssignNode = make_unique<parser::Masgn>(loc, move(seedLhs), move(firstSend));
+                    } else {
+                        seedAssignNode = make_unique<parser::Assign>(loc, move(seedLhs), move(firstSend));
+                    }
+                    auto seedAssign = node2TreeImpl(dctx, seedAssignNode);
+
+                    // Guard the seed assignment behind an opaque (untyped) condition. This makes the
+                    // post-loop type of the loop variable(s) be the lub of "possibly uninitialized"
+                    // (`NilClass`) and the seed's type, i.e. `T.nilable(<element type>)`. The lub also
+                    // conveniently drops overly-precise literal types (e.g. `Integer(1)` from calling
+                    // `first` on a tuple like `[1, 2, 3]`), which would otherwise cause spurious
+                    // dead-code errors after the loop.
+                    auto seedIf = MK::If(loc, MK::UntypedNil(locZeroLen), move(seedAssign), MK::EmptyTree());
+
+                    auto eachSend = MK::Send0Block(loc, MK::Local(loc, collectionTempName), core::Names::each(),
+                                                   locZeroLen, move(block));
+
+                    InsSeq::STATS_store stats;
+                    stats.emplace_back(move(collectionAssign));
+                    stats.emplace_back(move(seedIf));
+                    res = MK::InsSeq(loc, move(stats), move(eachSend));
+                } else {
+                    res = MK::Send0Block(loc, node2TreeImpl(dctx, for_->expr), core::Names::each(), locZeroLen,
+                                         move(block));
+                }
                 result = move(res);
             },
             [&](parser::Integer *integer) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1902,9 +1902,11 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
 
                     // Evaluate the collection expression once, into a temporary, so that we can
                     // reference it both to seed the loop variable(s) and to call `each` on it.
+                    // The synthesized lhs gets a zero-length loc so that tooling (e.g. extract to
+                    // variable) doesn't attribute the whole `for` loop to it.
                     core::NameRef collectionTempName = dctx.freshNameUnique(core::Names::forTemp());
                     auto collectionAssign =
-                        MK::Assign(loc, MK::Local(loc, collectionTempName), node2TreeImpl(dctx, for_->expr));
+                        MK::Assign(loc, MK::Local(locZeroLen, collectionTempName), node2TreeImpl(dctx, for_->expr));
 
                     // `<Magic>.<element-or-nil>(<forTemp>$1)` types as `T.nilable(<element type>)`, or
                     // `T.untyped` if the collection doesn't respond to `first` (Ruby's `for` only
@@ -1914,7 +1916,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
 
                     ExpressionPtr seedAssign;
                     if (auto *mlhs = parser::cast_node<parser::Mlhs>(seedLhs.get())) {
-                        seedAssign = desugarMlhs(dctx, loc, mlhs, move(seedRhs));
+                        seedAssign = desugarMlhs(dctx, locZeroLen, mlhs, move(seedRhs));
                     } else {
                         seedAssign = MK::Assign(loc, node2TreeImpl(dctx, seedLhs), move(seedRhs));
                     }

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1806,7 +1806,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 // so the loop variable(s) continue to exist after the end of the loop, holding `nil` if the
                 // collection was empty. Because the block parameters in the desugared `each` call are
                 // block-local, we additionally seed the loop variable(s) in the enclosing scope from
-                // `<collection>.first`, guarded by an opaque condition, so that their post-loop type is
+                // `<Magic>.<element-or-nil>(<collection>)`, so that their post-loop type is
                 // `T.nilable(<element type>)` instead of `NilClass`.
                 // See https://github.com/sorbet/sorbet/issues/10265
                 unique_ptr<parser::Node> seedLhs;
@@ -1817,7 +1817,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         //     for a in <coll>
                         // into:
                         //     <forTemp>$1 = <coll>
-                        //     a = <forTemp>$1.first() if <opaque condition>
+                        //     a = ::<Magic>.<element-or-nil>(<forTemp>$1)
                         //     <forTemp>$1.each { |a| ... }
                         seedLhs = make_unique<parser::LVarLhs>(lvar->loc, lvar->name);
 
@@ -1828,7 +1828,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                         //     for a, b, c in <coll>
                         // into:
                         //     <forTemp>$1 = <coll>
-                        //     a, b, c = <forTemp>$1.first() if <opaque condition>
+                        //     a, b, c = ::<Magic>.<element-or-nil>(<forTemp>$1)
                         //     <forTemp>$1.each { |a, b, c| ... }
                         parser::NodeVec seedVars;
                         for (auto &c : mlhs->exprs) {
@@ -1906,32 +1906,25 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     auto collectionAssign =
                         MK::Assign(loc, MK::Local(loc, collectionTempName), node2TreeImpl(dctx, for_->expr));
 
-                    unique_ptr<parser::Node> firstRecv = make_unique<parser::LVar>(loc, collectionTempName);
-                    unique_ptr<parser::Node> firstSend = make_unique<parser::Send>(
-                        loc, move(firstRecv), core::Names::first(), locZeroLen, parser::NodeVec{});
+                    // `<Magic>.<element-or-nil>(<forTemp>$1)` types as `T.nilable(<element type>)`, or
+                    // `T.untyped` if the collection doesn't respond to `first` (Ruby's `for` only
+                    // requires `each`, so a missing `first` must not be an error).
+                    auto seedRhs = MK::Send1(loc, MK::Magic(locZeroLen), core::Names::elementOrNil(), locZeroLen,
+                                             MK::Local(loc, collectionTempName));
 
-                    unique_ptr<parser::Node> seedAssignNode;
-                    if (parser::isa_node<parser::Mlhs>(seedLhs.get())) {
-                        seedAssignNode = make_unique<parser::Masgn>(loc, move(seedLhs), move(firstSend));
+                    ExpressionPtr seedAssign;
+                    if (auto *mlhs = parser::cast_node<parser::Mlhs>(seedLhs.get())) {
+                        seedAssign = desugarMlhs(dctx, loc, mlhs, move(seedRhs));
                     } else {
-                        seedAssignNode = make_unique<parser::Assign>(loc, move(seedLhs), move(firstSend));
+                        seedAssign = MK::Assign(loc, node2TreeImpl(dctx, seedLhs), move(seedRhs));
                     }
-                    auto seedAssign = node2TreeImpl(dctx, seedAssignNode);
-
-                    // Guard the seed assignment behind an opaque (untyped) condition. This makes the
-                    // post-loop type of the loop variable(s) be the lub of "possibly uninitialized"
-                    // (`NilClass`) and the seed's type, i.e. `T.nilable(<element type>)`. The lub also
-                    // conveniently drops overly-precise literal types (e.g. `Integer(1)` from calling
-                    // `first` on a tuple like `[1, 2, 3]`), which would otherwise cause spurious
-                    // dead-code errors after the loop.
-                    auto seedIf = MK::If(loc, MK::UntypedNil(locZeroLen), move(seedAssign), MK::EmptyTree());
 
                     auto eachSend = MK::Send0Block(loc, MK::Local(loc, collectionTempName), core::Names::each(),
                                                    locZeroLen, move(block));
 
                     InsSeq::STATS_store stats;
                     stats.emplace_back(move(collectionAssign));
-                    stats.emplace_back(move(seedIf));
+                    stats.emplace_back(move(seedAssign));
                     res = MK::InsSeq(loc, move(stats), move(eachSend));
                 } else {
                     res = MK::Send0Block(loc, node2TreeImpl(dctx, for_->expr), core::Names::each(), locZeroLen,

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -2524,21 +2524,33 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             }
 
             ExpressionPtr block; // the body to the `each` loop we'll create
+
+            // In Ruby, `for` loops don't define a new scope (the way a block passed to `each` would),
+            // so the loop variable(s) continue to exist after the end of the loop, holding `nil` if the
+            // collection was empty. Because the block parameters in the desugared `each` call are
+            // block-local, we additionally seed the loop variable(s) in the enclosing scope from
+            // `<Magic>.<element-or-nil>(<collection>)`, so that their post-loop type is
+            // `T.nilable(<element type>)` instead of `NilClass`.
+            // See https://github.com/sorbet/sorbet/issues/10265
             if (canProvideNiceDesugar) {
                 ast::MethodDef::PARAMS_store params;
                 if (isa_node<pm_local_variable_target_node>(forLoopVar)) { // single local
                     // Desugar:
-                    //     for a in []
+                    //     for a in <coll>
                     // into:
-                    //     [].each { |a| ... }
+                    //     <forTemp>$1 = <coll>
+                    //     a = ::<Magic>.<element-or-nil>(<forTemp>$1)
+                    //     <forTemp>$1.each { |a| ... }
 
                     auto localVar = desugar(forLoopVar);
                     params.emplace_back(move(localVar));
                 } else if (auto *mlhs = down_cast<pm_multi_target_node>(forLoopVar)) { // mlhs of all locals
                     // Desugar:
-                    //     for a, b, c in []
+                    //     for a, b, c in <coll>
                     // into:
-                    //     [].each { |a, b, c| ... }
+                    //     <forTemp>$1 = <coll>
+                    //     a, b, c = ::<Magic>.<element-or-nil>(<forTemp>$1)
+                    //     <forTemp>$1.each { |a, b, c| ... }
                     auto targets = absl::MakeSpan(mlhs->lefts.nodes, mlhs->lefts.size);
                     for (auto *target : targets) {
                         ENFORCE(isa_node<pm_local_variable_target_node>(target));
@@ -2614,6 +2626,36 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             }
 
             auto locZeroLen = location.copyWithZeroLength();
+
+            if (canProvideNiceDesugar) {
+                // Evaluate the collection expression once, into a temporary, so that we can
+                // reference it both to seed the loop variable(s) and to call `each` on it.
+                core::NameRef collectionTempName = nextUniqueDesugarName(core::Names::forTemp());
+                auto collectionAssign =
+                    MK::Assign(location, MK::Local(location, collectionTempName), desugar(forNode->collection));
+
+                // `<Magic>.<element-or-nil>(<forTemp>$1)` types as `T.nilable(<element type>)`, or
+                // `T.untyped` if the collection doesn't respond to `first` (Ruby's `for` only
+                // requires `each`, so a missing `first` must not be an error).
+                auto seedRhs = MK::Send1(location, MK::Magic(locZeroLen), core::Names::elementOrNil(), locZeroLen,
+                                         MK::Local(location, collectionTempName));
+
+                ExpressionPtr seedAssign;
+                if (auto *mlhs = down_cast<pm_multi_target_node>(forLoopVar)) {
+                    seedAssign = desugarMlhs(location, mlhs, move(seedRhs));
+                } else {
+                    seedAssign = MK::Assign(location, desugar(forLoopVar), move(seedRhs));
+                }
+
+                auto eachSend = MK::Send0Block(location, MK::Local(location, collectionTempName), core::Names::each(),
+                                               locZeroLen, move(block));
+
+                ast::InsSeq::STATS_store stats;
+                stats.emplace_back(move(collectionAssign));
+                stats.emplace_back(move(seedAssign));
+                return MK::InsSeq(location, move(stats), move(eachSend));
+            }
+
             return MK::Send0Block(location, desugar(forNode->collection), core::Names::each(), locZeroLen, move(block));
         }
         case PM_FORWARDING_ARGUMENTS_NODE: { // The `...` argument in a method call, like `foo(...)`

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -2630,9 +2630,11 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             if (canProvideNiceDesugar) {
                 // Evaluate the collection expression once, into a temporary, so that we can
                 // reference it both to seed the loop variable(s) and to call `each` on it.
+                // The synthesized lhs gets a zero-length loc so that tooling (e.g. extract to
+                // variable) doesn't attribute the whole `for` loop to it.
                 core::NameRef collectionTempName = nextUniqueDesugarName(core::Names::forTemp());
                 auto collectionAssign =
-                    MK::Assign(location, MK::Local(location, collectionTempName), desugar(forNode->collection));
+                    MK::Assign(location, MK::Local(locZeroLen, collectionTempName), desugar(forNode->collection));
 
                 // `<Magic>.<element-or-nil>(<forTemp>$1)` types as `T.nilable(<element type>)`, or
                 // `T.untyped` if the collection doesn't respond to `first` (Ruby's `for` only
@@ -2642,7 +2644,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
 
                 ExpressionPtr seedAssign;
                 if (auto *mlhs = down_cast<pm_multi_target_node>(forLoopVar)) {
-                    seedAssign = desugarMlhs(location, mlhs, move(seedRhs));
+                    seedAssign = desugarMlhs(locZeroLen, mlhs, move(seedRhs));
                 } else {
                     seedAssign = MK::Assign(location, desugar(forLoopVar), move(seedRhs));
                 }

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -2636,9 +2636,9 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                 auto collectionAssign =
                     MK::Assign(location, MK::Local(locZeroLen, collectionTempName), desugar(forNode->collection));
 
-                // `<Magic>.<element-or-nil>(<forTemp>$1)` types as `T.nilable(<element type>)`, or
-                // `T.untyped` if the collection doesn't respond to `first` (Ruby's `for` only
-                // requires `each`, so a missing `first` must not be an error).
+                // `<Magic>.<element-or-nil>(<forTemp>$1)` types as `T.nilable(<element type>)`,
+                // where the element type comes from the declared block parameter type of the
+                // collection's `each`, or `T.untyped` if `each` has no signature.
                 auto seedRhs = MK::Send1(location, MK::Magic(locZeroLen), core::Names::elementOrNil(), locZeroLen,
                                          MK::Local(location, collectionTempName));
 

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -750,6 +750,11 @@ void GlobalState::initEmpty() {
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::nilForSafeNavigation())
                  .untypedArg(Names::arg0())
                  .buildWithResult(Types::nilClass());
+    // Synthesize <Magic>.<element-or-nil>(recv: T.untyped) => T.untyped
+    // Used when desugaring `for` loops to give the loop variable its post-loop type.
+    method = enterMethod(*this, Symbols::MagicSingleton(), Names::elementOrNil())
+                 .untypedArg(Names::arg0())
+                 .buildWithResultUntyped();
     // Synthesize <Magic>.<string-interpolate>(arg: *T.untyped) => String
     method = enterMethod(*this, Symbols::MagicSingleton(), Names::stringInterpolate())
                  .repeatedUntypedArg(Names::arg0())

--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -21,7 +21,7 @@ namespace sorbet::core {
 using namespace std;
 
 const int Symbols::MAX_SYNTHETIC_CLASS_SYMBOLS = 211;
-const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 53;
+const int Symbols::MAX_SYNTHETIC_METHOD_SYMBOLS = 54;
 const int Symbols::MAX_SYNTHETIC_FIELD_SYMBOLS = 20;
 const int Symbols::MAX_SYNTHETIC_TYPEPARAMETER_SYMBOLS = 6;
 const int Symbols::MAX_SYNTHETIC_TYPEMEMBER_SYMBOLS = 103;

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -431,6 +431,7 @@ NameDef names[] = {
     {"unresolvedAncestors", "<unresolved-ancestors>"},
     {"defineTopClassOrModule", "<define-top-class-or-module>"},
     {"nilForSafeNavigation", "<nil-for-safe-navigation>"},
+    {"elementOrNil", "<element-or-nil>"},
     {"checkAndAnd", "<check-and-and>"},
 
     {"isA_p", "is_a?"},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2500,16 +2500,16 @@ public:
 // <Magic>.<element-or-nil>(recv)
 //
 // Used when desugaring `for` loops. In Ruby, `for` doesn't define a new scope, so the loop
-// variable continues to exist after the loop, holding `nil` if the collection was empty. We
-// approximate that post-loop type by dispatching `first` on the collection and returning
-// `T.nilable(<result>)`.
+// variable continues to exist after the loop, holding `nil` if the collection was empty.
 //
-// Ruby's `for` only requires the collection to respond to `each`, so if the receiver doesn't
-// respond to `first` (an `each`-only class that doesn't include `Enumerable`), we silently fall
-// back to `T.untyped` instead of reporting a "method does not exist" error.
+// The element type is derived from what the collection's `each` yields: we simulate dispatching
+// `each` with a block and read the declared type of the block's parameter(s) -- the same
+// information inference uses to type block parameters. `each` is the only method `for` calls at
+// runtime, so this is the only source of type information that reflects what actually happens.
+// If `each` has no signature (or the receiver is untyped), we fall back to `T.untyped`.
 //
-// We also drop literal types (e.g. `Integer(1)` from `Tuple#first` on `[1, 2, 3]`), which would
-// otherwise cause spurious dead-code errors in comparisons after the loop.
+// We also drop literal types (e.g. from `for x in [1, 2, 3]`), which would otherwise cause
+// spurious dead-code errors in comparisons after the loop.
 class Magic_elementOrNil : public IntrinsicMethod {
 public:
     void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
@@ -2524,44 +2524,91 @@ public:
             return;
         }
 
-        // Special-case tuples: the loop can end early via `break`, so after the loop the variable
-        // may hold *any* element (or `nil`), not specifically the first one. For heterogeneous
-        // tuples like `[1, "one"]`, dispatching `first` would unsoundly yield `T.nilable(Integer)`;
-        // the union of the element types is the sound, precise answer.
-        if (auto tuple = cast_type<TupleType>(recv.type)) {
-            res.returnType = Types::any(gs, Types::nilClass(), Types::dropLiteral(gs, tuple->elementType(gs)));
-            return;
-        }
-
+        // Simulate `recv.each { |x| }`. Dispatching with a block link makes overload resolution
+        // pick the block-taking overload of `each` (instead of the `Enumerator`-returning one)
+        // and computes `blockPreType`, the block's declared proc type instantiated for this
+        // receiver's type arguments.
         InlinedVector<const TypeAndOrigins *, 2> sendArgs;
+        auto zeroLengthCallLoc = args.locs.call.copyWithZeroLength();
         CallLocs sendLocs{
             .file = args.locs.file,
             .call = args.locs.call,
             .receiver = args.locs.call,
-            .fun = args.locs.call.copyWithZeroLength(),
+            .fun = zeroLengthCallLoc,
             .args = absl::Span<const core::LocOffsets>(nullptr, 0),
         };
-        DispatchArgs innerArgs{Names::first(),
+        vector<ParamInfo::Flags> paramFlags;
+        paramFlags.emplace_back();
+        // The zero-length block loc also suppresses the "does not take a block" error when the
+        // collection's `each` is declared without a block parameter.
+        SendAndBlockLink link(Names::each(), zeroLengthCallLoc, move(paramFlags));
+        DispatchArgs innerArgs{Names::each(),
                                sendLocs,
                                0,
                                sendArgs,
                                recv.type,
                                recv,
                                recv.type,
-                               nullptr,
+                               &link,
                                args.originForUninitialized,
                                /* isPrivateOk */ false,
                                /* suppressErrors */ true,
                                core::NameRef::noName()};
         auto dispatched = recv.type.dispatchCall(gs, innerArgs);
-        // Intentionally drop `dispatched.main.errors`: a missing `first` is not an error here.
+        // Intentionally drop `dispatched.main.errors`: any problem with the `each` call itself
+        // (e.g. the method not existing) is reported on the `each` send the loop desugars to.
 
-        if (dispatched.returnType == nullptr || !dispatched.main.method.exists()) {
+        // What `each` yields is the parameter list of its block's proc type. Union and
+        // intersection receivers spread across `secondary` components; combine them the same way
+        // inference does for block parameters (see LoadYieldParams in infer).
+        TypePtr params;
+        auto *component = &dispatched;
+        while (component != nullptr) {
+            auto &blockPreType = component->main.blockPreType;
+            if (blockPreType != nullptr && !blockPreType.isBottom()) {
+                auto componentParams = Types::dropNil(gs, blockPreType).getCallArguments(gs, Names::call());
+                if (componentParams != nullptr) {
+                    if (params == nullptr) {
+                        params = componentParams;
+                    } else {
+                        switch (dispatched.secondaryKind) {
+                            case DispatchResult::Combinator::OR:
+                                params = Types::any(gs, params, componentParams);
+                                break;
+                            case DispatchResult::Combinator::AND:
+                                params = Types::all(gs, params, componentParams);
+                                break;
+                        }
+                    }
+                }
+            }
+            component = component->secondary.get();
+        }
+
+        if (params == nullptr) {
             res.returnType = Types::untypedUntracked();
             return;
         }
 
-        res.returnType = Types::any(gs, Types::nilClass(), Types::dropLiteral(gs, dispatched.returnType));
+        // `each` yielding a single value is the common case: the loop variable holds that value.
+        // For `each` yielding multiple values (`yield k, v`), keep the tuple: the seed for
+        // `for k, v in ...` destructures it exactly like the block parameters would.
+        TypePtr element;
+        if (auto tuple = cast_type<TupleType>(params)) {
+            if (tuple->elems.empty()) {
+                // `each` yields no values: the loop variable is never assigned.
+                res.returnType = Types::nilClass();
+                return;
+            } else if (tuple->elems.size() == 1) {
+                element = tuple->elems.front();
+            } else {
+                element = params;
+            }
+        } else {
+            element = params;
+        }
+
+        res.returnType = Types::any(gs, Types::nilClass(), Types::dropLiteral(gs, element));
     }
 } Magic_elementOrNil;
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -2497,6 +2497,74 @@ public:
     }
 } Magic_expandSplat;
 
+// <Magic>.<element-or-nil>(recv)
+//
+// Used when desugaring `for` loops. In Ruby, `for` doesn't define a new scope, so the loop
+// variable continues to exist after the loop, holding `nil` if the collection was empty. We
+// approximate that post-loop type by dispatching `first` on the collection and returning
+// `T.nilable(<result>)`.
+//
+// Ruby's `for` only requires the collection to respond to `each`, so if the receiver doesn't
+// respond to `first` (an `each`-only class that doesn't include `Enumerable`), we silently fall
+// back to `T.untyped` instead of reporting a "method does not exist" error.
+//
+// We also drop literal types (e.g. `Integer(1)` from `Tuple#first` on `[1, 2, 3]`), which would
+// otherwise cause spurious dead-code errors in comparisons after the loop.
+class Magic_elementOrNil : public IntrinsicMethod {
+public:
+    void apply(const GlobalState &gs, const DispatchArgs &args, DispatchResult &res) const override {
+        if (args.args.size() != 1) {
+            res.returnType = Types::untypedUntracked();
+            return;
+        }
+
+        auto &recv = *args.args.front();
+        if (recv.type.isUntyped()) {
+            res.returnType = recv.type;
+            return;
+        }
+
+        // Special-case tuples: the loop can end early via `break`, so after the loop the variable
+        // may hold *any* element (or `nil`), not specifically the first one. For heterogeneous
+        // tuples like `[1, "one"]`, dispatching `first` would unsoundly yield `T.nilable(Integer)`;
+        // the union of the element types is the sound, precise answer.
+        if (auto tuple = cast_type<TupleType>(recv.type)) {
+            res.returnType = Types::any(gs, Types::nilClass(), Types::dropLiteral(gs, tuple->elementType(gs)));
+            return;
+        }
+
+        InlinedVector<const TypeAndOrigins *, 2> sendArgs;
+        CallLocs sendLocs{
+            .file = args.locs.file,
+            .call = args.locs.call,
+            .receiver = args.locs.call,
+            .fun = args.locs.call.copyWithZeroLength(),
+            .args = absl::Span<const core::LocOffsets>(nullptr, 0),
+        };
+        DispatchArgs innerArgs{Names::first(),
+                               sendLocs,
+                               0,
+                               sendArgs,
+                               recv.type,
+                               recv,
+                               recv.type,
+                               nullptr,
+                               args.originForUninitialized,
+                               /* isPrivateOk */ false,
+                               /* suppressErrors */ true,
+                               core::NameRef::noName()};
+        auto dispatched = recv.type.dispatchCall(gs, innerArgs);
+        // Intentionally drop `dispatched.main.errors`: a missing `first` is not an error here.
+
+        if (dispatched.returnType == nullptr || !dispatched.main.method.exists()) {
+            res.returnType = Types::untypedUntracked();
+            return;
+        }
+
+        res.returnType = Types::any(gs, Types::nilClass(), Types::dropLiteral(gs, dispatched.returnType));
+    }
+} Magic_elementOrNil;
+
 class Magic_callWithSplat : public IntrinsicMethod {
     friend class Magic_callWithSplatAndBlockPass;
 
@@ -4665,6 +4733,7 @@ const vector<Intrinsic> intrinsics{
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::buildArray(), &Magic_buildArray},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::buildRange(), &Magic_buildRange},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::expandSplat(), &Magic_expandSplat},
+    {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::elementOrNil(), &Magic_elementOrNil},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::callWithSplat(), &Magic_callWithSplat},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::callWithBlockPass(), &Magic_callWithBlockPass},
     {Symbols::Magic(), Intrinsic::Kind::Singleton, Names::callWithSplatAndBlockPass(),

--- a/test/prism_regression/for_loop.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/for_loop.rb.desugar-tree-raw.exp
@@ -7,132 +7,276 @@ ClassDef{
       orig = nullptr
     }]
   rhs = [
-    Send{
-      flags = {}
-      recv = Send{
-        flags = {privateOk}
-        recv = Self
-        fun = <U a>
-        block = nullptr
-        pos_args = 0
-        args = [
-        ]
-      }
-      fun = <U each>
-      block = Block {
-        params = [
-          UnresolvedIdent{
-            kind = Local
-            name = <U x>
-          }
-        ]
-        body = EmptyTree
-      }
-      pos_args = 0
-      args = [
-      ]
-    }
-
-    Send{
-      flags = {}
-      recv = Send{
-        flags = {privateOk}
-        recv = Self
-        fun = <U a>
-        block = nullptr
-        pos_args = 0
-        args = [
-        ]
-      }
-      fun = <U each>
-      block = Block {
-        params = [
-          UnresolvedIdent{
-            kind = Local
-            name = <U x>
-          }
-        ]
-        body = Literal{ value = "one-liner" }
-      }
-      pos_args = 0
-      args = [
-      ]
-    }
-
-    Send{
-      flags = {}
-      recv = Send{
-        flags = {privateOk}
-        recv = Self
-        fun = <U a>
-        block = nullptr
-        pos_args = 0
-        args = [
-        ]
-      }
-      fun = <U each>
-      block = Block {
-        params = [
-          UnresolvedIdent{
-            kind = Local
-            name = <U x>
-          }
-        ]
-        body = InsSeq{
-          stats = [
-            Literal{ value = "two" }
-          ],
-          expr = Literal{ value = "lines" }
-        }
-      }
-      pos_args = 0
-      args = [
-      ]
-    }
-
-    Send{
-      flags = {}
-      recv = Send{
-        flags = {privateOk}
-        recv = Self
-        fun = <U a>
-        block = nullptr
-        pos_args = 0
-        args = [
-        ]
-      }
-      fun = <U each>
-      block = Block {
-        params = [
-          UnresolvedIdent{
-            kind = Local
-            name = <U x>
-          }
-        ]
-        body = EmptyTree
-      }
-      pos_args = 0
-      args = [
-      ]
-    }
-
-    Send{
-      flags = {}
-      recv = Send{
-        flags = {privateOk}
-        recv = Self
-        fun = <U a>
-        block = nullptr
-        pos_args = 0
-        args = [
-        ]
-      }
-      fun = <U each>
-      block = Block {
-        params = [
-          UnresolvedIdent{
+    InsSeq{
+      stats = [
+        Assign{
+          lhs = UnresolvedIdent{
             kind = Local
             name = <D <U forTemp> $2>
+          }
+          rhs = Send{
+            flags = {privateOk}
+            recv = Self
+            fun = <U a>
+            block = nullptr
+            pos_args = 0
+            args = [
+            ]
+          }
+        }
+        Assign{
+          lhs = UnresolvedIdent{
+            kind = Local
+            name = <U x>
+          }
+          rhs = Send{
+            flags = {}
+            recv = ConstantLit{
+              symbol = (class ::<Magic>)
+              orig = nullptr
+            }
+            fun = <U <element-or-nil>>
+            block = nullptr
+            pos_args = 1
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <D <U forTemp> $2>
+              }
+            ]
+          }
+        }
+      ],
+      expr = Send{
+        flags = {}
+        recv = UnresolvedIdent{
+          kind = Local
+          name = <D <U forTemp> $2>
+        }
+        fun = <U each>
+        block = Block {
+          params = [
+            UnresolvedIdent{
+              kind = Local
+              name = <U x>
+            }
+          ]
+          body = EmptyTree
+        }
+        pos_args = 0
+        args = [
+        ]
+      }
+    }
+
+    InsSeq{
+      stats = [
+        Assign{
+          lhs = UnresolvedIdent{
+            kind = Local
+            name = <D <U forTemp> $3>
+          }
+          rhs = Send{
+            flags = {privateOk}
+            recv = Self
+            fun = <U a>
+            block = nullptr
+            pos_args = 0
+            args = [
+            ]
+          }
+        }
+        Assign{
+          lhs = UnresolvedIdent{
+            kind = Local
+            name = <U x>
+          }
+          rhs = Send{
+            flags = {}
+            recv = ConstantLit{
+              symbol = (class ::<Magic>)
+              orig = nullptr
+            }
+            fun = <U <element-or-nil>>
+            block = nullptr
+            pos_args = 1
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <D <U forTemp> $3>
+              }
+            ]
+          }
+        }
+      ],
+      expr = Send{
+        flags = {}
+        recv = UnresolvedIdent{
+          kind = Local
+          name = <D <U forTemp> $3>
+        }
+        fun = <U each>
+        block = Block {
+          params = [
+            UnresolvedIdent{
+              kind = Local
+              name = <U x>
+            }
+          ]
+          body = Literal{ value = "one-liner" }
+        }
+        pos_args = 0
+        args = [
+        ]
+      }
+    }
+
+    InsSeq{
+      stats = [
+        Assign{
+          lhs = UnresolvedIdent{
+            kind = Local
+            name = <D <U forTemp> $4>
+          }
+          rhs = Send{
+            flags = {privateOk}
+            recv = Self
+            fun = <U a>
+            block = nullptr
+            pos_args = 0
+            args = [
+            ]
+          }
+        }
+        Assign{
+          lhs = UnresolvedIdent{
+            kind = Local
+            name = <U x>
+          }
+          rhs = Send{
+            flags = {}
+            recv = ConstantLit{
+              symbol = (class ::<Magic>)
+              orig = nullptr
+            }
+            fun = <U <element-or-nil>>
+            block = nullptr
+            pos_args = 1
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <D <U forTemp> $4>
+              }
+            ]
+          }
+        }
+      ],
+      expr = Send{
+        flags = {}
+        recv = UnresolvedIdent{
+          kind = Local
+          name = <D <U forTemp> $4>
+        }
+        fun = <U each>
+        block = Block {
+          params = [
+            UnresolvedIdent{
+              kind = Local
+              name = <U x>
+            }
+          ]
+          body = InsSeq{
+            stats = [
+              Literal{ value = "two" }
+            ],
+            expr = Literal{ value = "lines" }
+          }
+        }
+        pos_args = 0
+        args = [
+        ]
+      }
+    }
+
+    InsSeq{
+      stats = [
+        Assign{
+          lhs = UnresolvedIdent{
+            kind = Local
+            name = <D <U forTemp> $5>
+          }
+          rhs = Send{
+            flags = {privateOk}
+            recv = Self
+            fun = <U a>
+            block = nullptr
+            pos_args = 0
+            args = [
+            ]
+          }
+        }
+        Assign{
+          lhs = UnresolvedIdent{
+            kind = Local
+            name = <U x>
+          }
+          rhs = Send{
+            flags = {}
+            recv = ConstantLit{
+              symbol = (class ::<Magic>)
+              orig = nullptr
+            }
+            fun = <U <element-or-nil>>
+            block = nullptr
+            pos_args = 1
+            args = [
+              UnresolvedIdent{
+                kind = Local
+                name = <D <U forTemp> $5>
+              }
+            ]
+          }
+        }
+      ],
+      expr = Send{
+        flags = {}
+        recv = UnresolvedIdent{
+          kind = Local
+          name = <D <U forTemp> $5>
+        }
+        fun = <U each>
+        block = Block {
+          params = [
+            UnresolvedIdent{
+              kind = Local
+              name = <U x>
+            }
+          ]
+          body = EmptyTree
+        }
+        pos_args = 0
+        args = [
+        ]
+      }
+    }
+
+    Send{
+      flags = {}
+      recv = Send{
+        flags = {privateOk}
+        recv = Self
+        fun = <U a>
+        block = nullptr
+        pos_args = 0
+        args = [
+        ]
+      }
+      fun = <U each>
+      block = Block {
+        params = [
+          UnresolvedIdent{
+            kind = Local
+            name = <D <U forTemp> $6>
           }
         ]
         body = InsSeq{
@@ -142,17 +286,17 @@ ClassDef{
                 Assign{
                   lhs = UnresolvedIdent{
                     kind = Local
-                    name = <D <U <assignTemp>> $3>
+                    name = <D <U <assignTemp>> $7>
                   }
                   rhs = UnresolvedIdent{
                     kind = Local
-                    name = <D <U forTemp> $2>
+                    name = <D <U forTemp> $6>
                   }
                 }
                 Assign{
                   lhs = UnresolvedIdent{
                     kind = Local
-                    name = <D <U <assignTemp>> $4>
+                    name = <D <U <assignTemp>> $8>
                   }
                   rhs = Send{
                     flags = {}
@@ -166,7 +310,7 @@ ClassDef{
                     args = [
                       UnresolvedIdent{
                         kind = Local
-                        name = <D <U <assignTemp>> $3>
+                        name = <D <U <assignTemp>> $7>
                       }
                       Literal{ value = 2 }
                       Literal{ value = 0 }
@@ -182,7 +326,7 @@ ClassDef{
                     flags = {}
                     recv = UnresolvedIdent{
                       kind = Local
-                      name = <D <U <assignTemp>> $4>
+                      name = <D <U <assignTemp>> $8>
                     }
                     fun = <U []>
                     block = nullptr
@@ -197,13 +341,13 @@ ClassDef{
                     Assign{
                       lhs = UnresolvedIdent{
                         kind = Local
-                        name = <D <U <assignTemp>> $5>
+                        name = <D <U <assignTemp>> $9>
                       }
                       rhs = Send{
                         flags = {}
                         recv = UnresolvedIdent{
                           kind = Local
-                          name = <D <U <assignTemp>> $4>
+                          name = <D <U <assignTemp>> $8>
                         }
                         fun = <U []>
                         block = nullptr
@@ -216,7 +360,7 @@ ClassDef{
                     Assign{
                       lhs = UnresolvedIdent{
                         kind = Local
-                        name = <D <U <assignTemp>> $6>
+                        name = <D <U <assignTemp>> $10>
                       }
                       rhs = Send{
                         flags = {}
@@ -230,7 +374,7 @@ ClassDef{
                         args = [
                           UnresolvedIdent{
                             kind = Local
-                            name = <D <U <assignTemp>> $5>
+                            name = <D <U <assignTemp>> $9>
                           }
                           Literal{ value = 2 }
                           Literal{ value = 0 }
@@ -246,7 +390,7 @@ ClassDef{
                         flags = {}
                         recv = UnresolvedIdent{
                           kind = Local
-                          name = <D <U <assignTemp>> $6>
+                          name = <D <U <assignTemp>> $10>
                         }
                         fun = <U []>
                         block = nullptr
@@ -265,7 +409,7 @@ ClassDef{
                         flags = {}
                         recv = UnresolvedIdent{
                           kind = Local
-                          name = <D <U <assignTemp>> $6>
+                          name = <D <U <assignTemp>> $10>
                         }
                         fun = <U []>
                         block = nullptr
@@ -278,13 +422,13 @@ ClassDef{
                   ],
                   expr = UnresolvedIdent{
                     kind = Local
-                    name = <D <U <assignTemp>> $5>
+                    name = <D <U <assignTemp>> $9>
                   }
                 }
               ],
               expr = UnresolvedIdent{
                 kind = Local
-                name = <D <U <assignTemp>> $3>
+                name = <D <U <assignTemp>> $7>
               }
             }
           ],

--- a/test/testdata/desugar/for.rb
+++ b/test/testdata/desugar/for.rb
@@ -22,7 +22,7 @@ end
 class Main
     def self.main # error: does not have a `sig`
 
-        for a in A do # error: Method `first` does not exist on `T.class_of(A)`
+        for a in A do
             puts a.inspect
         end
         A.each do |*forTemp|
@@ -30,7 +30,7 @@ class Main
             puts a.inspect
         end
 
-        for a,b in A do # error: Method `first` does not exist on `T.class_of(A)`
+        for a,b in A do
             puts a.inspect
             puts b.inspect
         end

--- a/test/testdata/desugar/for.rb
+++ b/test/testdata/desugar/for.rb
@@ -22,7 +22,7 @@ end
 class Main
     def self.main # error: does not have a `sig`
 
-        for a in A do
+        for a in A do # error: Method `first` does not exist on `T.class_of(A)`
             puts a.inspect
         end
         A.each do |*forTemp|
@@ -30,7 +30,7 @@ class Main
             puts a.inspect
         end
 
-        for a,b in A do
+        for a,b in A do # error: Method `first` does not exist on `T.class_of(A)`
             puts a.inspect
             puts b.inspect
         end

--- a/test/testdata/desugar/for.rb.cfg-text.exp
+++ b/test/testdata/desugar/for.rb.cfg-text.exp
@@ -693,289 +693,327 @@ bb1[firstDead=-1]():
 method ::<Class:Main>#main {
 
 bb0[firstDead=-1]():
-    @a$105: T.untyped = alias <C <undeclared-field-stub>> (@a)
-    @@b$115: T.untyped = alias <C <undeclared-field-stub>> (@@b)
-    $c$125: T.untyped = alias <C <undeclared-field-stub>> ($c)
+    @a$132: T.untyped = alias <C <undeclared-field-stub>> (@a)
+    @@b$142: T.untyped = alias <C <undeclared-field-stub>> (@@b)
+    $c$152: T.untyped = alias <C <undeclared-field-stub>> ($c)
     <self>: T.class_of(Main) = cast(<self>: NilClass, T.class_of(Main));
     <cfgAlias>$5: T.class_of(A) = alias <C A>
-    <block-pre-call-temp>$6: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(A).each()
-    <selfRestore>$7: T.class_of(Main) = <self>
-    <unconditional> -> bb2
+    <cfgAlias>$9: T.class_of(T) = alias <C T>
+    <statTemp>$10: NilClass = nil
+    <ifTemp>$7: T.untyped = <cfgAlias>$9: T.class_of(T).unsafe(<statTemp>$10: NilClass)
+    <ifTemp>$7 -> (T.untyped ? bb2 : bb4)
 
 # backedges
-# - bb23
+# - bb29
 bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
 # - bb0
+bb2[firstDead=-1](<self>: T.class_of(Main), <cfgAlias>$5: T.class_of(A), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
+    a: T.untyped = <cfgAlias>$5: T.class_of(A).first()
+    <unconditional> -> bb4
+
+# backedges
+# - bb0
+# - bb2
+bb4[firstDead=-1](<self>: T.class_of(Main), <cfgAlias>$5: T.class_of(A), a: T.untyped, @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
+    <block-pre-call-temp>$13: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(A).each()
+    <selfRestore>$14: T.class_of(Main) = <self>
+    <unconditional> -> bb5
+
+# backedges
+# - bb4
+# - bb8
+bb5[firstDead=-1](<self>: T.class_of(Main), a: T.untyped, <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
+    # outerLoops: 1
+    <block-call> -> (NilClass ? bb8 : bb6)
+
+# backedges
 # - bb5
-bb2[firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$105: T.untyped, @@b$115: T.untyped, $c$125: T.untyped):
-    # outerLoops: 1
-    <block-call> -> (NilClass ? bb5 : bb3)
+bb6[firstDead=-1](a: T.untyped, <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
+    <statTemp>$3: T.untyped = Solve<<block-pre-call-temp>$13, each>
+    <self>: T.class_of(Main) = <selfRestore>$14
+    <cfgAlias>$23: T.class_of(A) = alias <C A>
+    <block-pre-call-temp>$24: Sorbet::Private::Static::Void = <cfgAlias>$23: T.class_of(A).each()
+    <selfRestore>$25: T.class_of(Main) = <self>
+    <unconditional> -> bb9
 
 # backedges
-# - bb2
-bb3[firstDead=-1](<block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$105: T.untyped, @@b$115: T.untyped, $c$125: T.untyped):
-    <statTemp>$3: T.untyped = Solve<<block-pre-call-temp>$6, each>
-    <self>: T.class_of(Main) = <selfRestore>$7
-    <cfgAlias>$16: T.class_of(A) = alias <C A>
-    <block-pre-call-temp>$17: Sorbet::Private::Static::Void = <cfgAlias>$16: T.class_of(A).each()
-    <selfRestore>$18: T.class_of(Main) = <self>
-    <unconditional> -> bb6
-
-# backedges
-# - bb2
-bb5[firstDead=6](<self>: T.class_of(Main), <block-pre-call-temp>$6: Sorbet::Private::Static::Void, <selfRestore>$7: T.class_of(Main), @a$105: T.untyped, @@b$115: T.untyped, $c$125: T.untyped):
+# - bb5
+bb8[firstDead=6](<self>: T.class_of(Main), a: T.untyped, <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf(each)
-    <blk>$8: T.untyped = load_yield_params(each)
-    a$1: T.untyped = yield_load_arg(0, <blk>$8: T.untyped)
-    <statTemp>$11: T.untyped = a$1: T.untyped.inspect()
-    <blockReturnTemp>$9: NilClass = <self>: T.class_of(Main).puts(<statTemp>$11: T.untyped)
-    <blockReturnTemp>$13: T.noreturn = blockreturn<each> <blockReturnTemp>$9: NilClass
-    <unconditional> -> bb2
+    <blk>$15: T.untyped = load_yield_params(each)
+    a$1: T.untyped = yield_load_arg(0, <blk>$15: T.untyped)
+    <statTemp>$18: T.untyped = a$1: T.untyped.inspect()
+    <blockReturnTemp>$16: NilClass = <self>: T.class_of(Main).puts(<statTemp>$18: T.untyped)
+    <blockReturnTemp>$20: T.noreturn = blockreturn<each> <blockReturnTemp>$16: NilClass
+    <unconditional> -> bb5
 
 # backedges
-# - bb3
+# - bb6
+# - bb12
+bb9[firstDead=-1](<self>: T.class_of(Main), a: T.untyped, <block-pre-call-temp>$24: Sorbet::Private::Static::Void, <selfRestore>$25: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
+    # outerLoops: 1
+    <block-call> -> (NilClass ? bb12 : bb10)
+
+# backedges
 # - bb9
-bb6[firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$17: Sorbet::Private::Static::Void, <selfRestore>$18: T.class_of(Main), @a$105: T.untyped, @@b$115: T.untyped, $c$125: T.untyped):
-    # outerLoops: 1
-    <block-call> -> (NilClass ? bb9 : bb7)
+bb10[firstDead=-1](a: T.untyped, <block-pre-call-temp>$24: Sorbet::Private::Static::Void, <selfRestore>$25: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
+    <statTemp>$21: T.untyped = Solve<<block-pre-call-temp>$24, each>
+    <self>: T.class_of(Main) = <selfRestore>$25
+    <cfgAlias>$48: T.class_of(A) = alias <C A>
+    <cfgAlias>$52: T.class_of(T) = alias <C T>
+    <statTemp>$53: NilClass = nil
+    <ifTemp>$50: T.untyped = <cfgAlias>$52: T.class_of(T).unsafe(<statTemp>$53: NilClass)
+    <ifTemp>$50 -> (T.untyped ? bb13 : bb15)
 
 # backedges
-# - bb6
-bb7[firstDead=-1](<block-pre-call-temp>$17: Sorbet::Private::Static::Void, <selfRestore>$18: T.class_of(Main), @a$105: T.untyped, @@b$115: T.untyped, $c$125: T.untyped):
-    <statTemp>$14: T.untyped = Solve<<block-pre-call-temp>$17, each>
-    <self>: T.class_of(Main) = <selfRestore>$18
-    <cfgAlias>$41: T.class_of(A) = alias <C A>
-    <block-pre-call-temp>$42: Sorbet::Private::Static::Void = <cfgAlias>$41: T.class_of(A).each()
-    <selfRestore>$43: T.class_of(Main) = <self>
-    <unconditional> -> bb10
-
-# backedges
-# - bb6
-bb9[firstDead=14](<self>: T.class_of(Main), <block-pre-call-temp>$17: Sorbet::Private::Static::Void, <selfRestore>$18: T.class_of(Main), @a$105: T.untyped, @@b$115: T.untyped, $c$125: T.untyped):
+# - bb9
+bb12[firstDead=14](<self>: T.class_of(Main), a: T.untyped, <block-pre-call-temp>$24: Sorbet::Private::Static::Void, <selfRestore>$25: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf(each)
-    <blk>$19: T.untyped = load_yield_params(each)
-    forTemp$2: T.untyped = yield_load_arg(0, <blk>$19: T.untyped)
-    <cfgAlias>$24: T.class_of(<Magic>) = alias <C <Magic>>
-    <assignTemp>$2$2: T.untyped = <cfgAlias>$24: T.class_of(<Magic>).<splat>(forTemp$2: T.untyped)
-    <cfgAlias>$28: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$30: Integer(1) = 1
-    <statTemp>$31: Integer(0) = 0
-    <assignTemp>$3$2: T.untyped = <cfgAlias>$28: T.class_of(<Magic>).<expand-splat>(<assignTemp>$2$2: T.untyped, <statTemp>$30: Integer(1), <statTemp>$31: Integer(0))
-    <statTemp>$34: Integer(0) = 0
-    a$2: T.untyped = <assignTemp>$3$2: T.untyped.[](<statTemp>$34: Integer(0))
-    <statTemp>$36: T.untyped = a$2: T.untyped.inspect()
-    <blockReturnTemp>$20: NilClass = <self>: T.class_of(Main).puts(<statTemp>$36: T.untyped)
-    <blockReturnTemp>$38: T.noreturn = blockreturn<each> <blockReturnTemp>$20: NilClass
-    <unconditional> -> bb6
+    <blk>$26: T.untyped = load_yield_params(each)
+    forTemp$2: T.untyped = yield_load_arg(0, <blk>$26: T.untyped)
+    <cfgAlias>$31: T.class_of(<Magic>) = alias <C <Magic>>
+    <assignTemp>$3$2: T.untyped = <cfgAlias>$31: T.class_of(<Magic>).<splat>(forTemp$2: T.untyped)
+    <cfgAlias>$35: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$37: Integer(1) = 1
+    <statTemp>$38: Integer(0) = 0
+    <assignTemp>$4$2: T.untyped = <cfgAlias>$35: T.class_of(<Magic>).<expand-splat>(<assignTemp>$3$2: T.untyped, <statTemp>$37: Integer(1), <statTemp>$38: Integer(0))
+    <statTemp>$41: Integer(0) = 0
+    a: T.untyped = <assignTemp>$4$2: T.untyped.[](<statTemp>$41: Integer(0))
+    <statTemp>$43: T.untyped = a: T.untyped.inspect()
+    <blockReturnTemp>$27: NilClass = <self>: T.class_of(Main).puts(<statTemp>$43: T.untyped)
+    <blockReturnTemp>$45: T.noreturn = blockreturn<each> <blockReturnTemp>$27: NilClass
+    <unconditional> -> bb9
 
 # backedges
-# - bb7
+# - bb10
+bb13[firstDead=-1](<self>: T.class_of(Main), <cfgAlias>$48: T.class_of(A), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
+    <assignTemp>$6: T.untyped = <cfgAlias>$48: T.class_of(A).first()
+    <cfgAlias>$58: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$60: Integer(2) = 2
+    <statTemp>$61: Integer(0) = 0
+    <assignTemp>$7: T.untyped = <cfgAlias>$58: T.class_of(<Magic>).<expand-splat>(<assignTemp>$6: T.untyped, <statTemp>$60: Integer(2), <statTemp>$61: Integer(0))
+    <statTemp>$64: Integer(0) = 0
+    a: T.untyped = <assignTemp>$7: T.untyped.[](<statTemp>$64: Integer(0))
+    <statTemp>$67: Integer(1) = 1
+    b: T.untyped = <assignTemp>$7: T.untyped.[](<statTemp>$67: Integer(1))
+    <unconditional> -> bb15
+
+# backedges
+# - bb10
 # - bb13
-bb10[firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Main), @a$105: T.untyped, @@b$115: T.untyped, $c$125: T.untyped):
-    # outerLoops: 1
-    <block-call> -> (NilClass ? bb13 : bb11)
-
-# backedges
-# - bb10
-bb11[firstDead=-1](<block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Main), @a$105: T.untyped, @@b$115: T.untyped, $c$125: T.untyped):
-    <statTemp>$39: T.untyped = Solve<<block-pre-call-temp>$42, each>
-    <self>: T.class_of(Main) = <selfRestore>$43
-    <cfgAlias>$56: T.class_of(A) = alias <C A>
-    <block-pre-call-temp>$57: Sorbet::Private::Static::Void = <cfgAlias>$56: T.class_of(A).each()
-    <selfRestore>$58: T.class_of(Main) = <self>
-    <unconditional> -> bb14
-
-# backedges
-# - bb10
-bb13[firstDead=9](<self>: T.class_of(Main), <block-pre-call-temp>$42: Sorbet::Private::Static::Void, <selfRestore>$43: T.class_of(Main), @a$105: T.untyped, @@b$115: T.untyped, $c$125: T.untyped):
-    # outerLoops: 1
-    <self>: T.class_of(Main) = loadSelf(each)
-    <blk>$44: T.untyped = load_yield_params(each)
-    a$3: T.untyped = yield_load_arg(0, <blk>$44: T.untyped)
-    b$3: T.untyped = yield_load_arg(1, <blk>$44: T.untyped)
-    <statTemp>$48: T.untyped = a$3: T.untyped.inspect()
-    <statTemp>$46: NilClass = <self>: T.class_of(Main).puts(<statTemp>$48: T.untyped)
-    <statTemp>$51: T.untyped = b$3: T.untyped.inspect()
-    <blockReturnTemp>$45: NilClass = <self>: T.class_of(Main).puts(<statTemp>$51: T.untyped)
-    <blockReturnTemp>$53: T.noreturn = blockreturn<each> <blockReturnTemp>$45: NilClass
-    <unconditional> -> bb10
-
-# backedges
-# - bb11
-# - bb17
-bb14[firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(Main), @a$105: T.untyped, @@b$115: T.untyped, $c$125: T.untyped):
-    # outerLoops: 1
-    <block-call> -> (NilClass ? bb17 : bb15)
-
-# backedges
-# - bb14
-bb15[firstDead=-1](<block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(Main), @a$105: T.untyped, @@b$115: T.untyped, $c$125: T.untyped):
-    <statTemp>$54: T.untyped = Solve<<block-pre-call-temp>$57, each>
-    <self>: T.class_of(Main) = <selfRestore>$58
-    <statTemp>$88: String("main") = "main"
-    <statTemp>$86: NilClass = <self>: T.class_of(Main).puts(<statTemp>$88: String("main"))
-    <cfgAlias>$91: T.class_of(A) = alias <C A>
-    <block-pre-call-temp>$92: Sorbet::Private::Static::Void = <cfgAlias>$91: T.class_of(A).each()
-    <selfRestore>$93: T.class_of(Main) = <self>
-    <unconditional> -> bb18
-
-# backedges
-# - bb14
-bb17[firstDead=18](<self>: T.class_of(Main), <block-pre-call-temp>$57: Sorbet::Private::Static::Void, <selfRestore>$58: T.class_of(Main), @a$105: T.untyped, @@b$115: T.untyped, $c$125: T.untyped):
-    # outerLoops: 1
-    <self>: T.class_of(Main) = loadSelf(each)
-    <blk>$59: T.untyped = load_yield_params(each)
-    forTemp$4: T.untyped = yield_load_arg(0, <blk>$59: T.untyped)
-    <cfgAlias>$64: T.class_of(<Magic>) = alias <C <Magic>>
-    <assignTemp>$4$4: T.untyped = <cfgAlias>$64: T.class_of(<Magic>).<splat>(forTemp$4: T.untyped)
-    <cfgAlias>$68: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$70: Integer(2) = 2
-    <statTemp>$71: Integer(0) = 0
-    <assignTemp>$5$4: T.untyped = <cfgAlias>$68: T.class_of(<Magic>).<expand-splat>(<assignTemp>$4$4: T.untyped, <statTemp>$70: Integer(2), <statTemp>$71: Integer(0))
-    <statTemp>$74: Integer(0) = 0
-    a$4: T.untyped = <assignTemp>$5$4: T.untyped.[](<statTemp>$74: Integer(0))
-    <statTemp>$77: Integer(1) = 1
-    b$4: T.untyped = <assignTemp>$5$4: T.untyped.[](<statTemp>$77: Integer(1))
-    <statTemp>$80: T.untyped = a$4: T.untyped.inspect()
-    <statTemp>$78: NilClass = <self>: T.class_of(Main).puts(<statTemp>$80: T.untyped)
-    <statTemp>$83: T.untyped = b$4: T.untyped.inspect()
-    <blockReturnTemp>$60: NilClass = <self>: T.class_of(Main).puts(<statTemp>$83: T.untyped)
-    <blockReturnTemp>$85: T.noreturn = blockreturn<each> <blockReturnTemp>$60: NilClass
-    <unconditional> -> bb14
+bb15[firstDead=-1](<self>: T.class_of(Main), a: T.untyped, <cfgAlias>$48: T.class_of(A), b: T.untyped, @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
+    <block-pre-call-temp>$69: Sorbet::Private::Static::Void = <cfgAlias>$48: T.class_of(A).each()
+    <selfRestore>$70: T.class_of(Main) = <self>
+    <unconditional> -> bb16
 
 # backedges
 # - bb15
-# - bb21
-bb18[firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$92: Sorbet::Private::Static::Void, <selfRestore>$93: T.class_of(Main), @a$105: T.untyped, @@b$115: T.untyped, $c$125: T.untyped):
+# - bb19
+bb16[firstDead=-1](<self>: T.class_of(Main), a: T.untyped, b: T.untyped, <block-pre-call-temp>$69: Sorbet::Private::Static::Void, <selfRestore>$70: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
     # outerLoops: 1
-    <block-call> -> (NilClass ? bb21 : bb19)
+    <block-call> -> (NilClass ? bb19 : bb17)
 
 # backedges
-# - bb18
-bb19[firstDead=-1](<block-pre-call-temp>$92: Sorbet::Private::Static::Void, <selfRestore>$93: T.class_of(Main), @a$105: T.untyped, @@b$115: T.untyped, $c$125: T.untyped):
-    <statTemp>$89: T.untyped = Solve<<block-pre-call-temp>$92, each>
-    <self>: T.class_of(Main) = <selfRestore>$93
-    <cfgAlias>$160: T.class_of(A) = alias <C A>
-    <block-pre-call-temp>$161: Sorbet::Private::Static::Void = <cfgAlias>$160: T.class_of(A).each()
-    <selfRestore>$162: T.class_of(Main) = <self>
-    <unconditional> -> bb22
+# - bb16
+bb17[firstDead=-1](a: T.untyped, b: T.untyped, <block-pre-call-temp>$69: Sorbet::Private::Static::Void, <selfRestore>$70: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
+    <statTemp>$46: T.untyped = Solve<<block-pre-call-temp>$69, each>
+    <self>: T.class_of(Main) = <selfRestore>$70
+    <cfgAlias>$83: T.class_of(A) = alias <C A>
+    <block-pre-call-temp>$84: Sorbet::Private::Static::Void = <cfgAlias>$83: T.class_of(A).each()
+    <selfRestore>$85: T.class_of(Main) = <self>
+    <unconditional> -> bb20
 
 # backedges
-# - bb18
-bb21[firstDead=42](<self>: T.class_of(Main), <block-pre-call-temp>$92: Sorbet::Private::Static::Void, <selfRestore>$93: T.class_of(Main), @a$105: T.untyped, @@b$115: T.untyped, $c$125: T.untyped):
+# - bb16
+bb19[firstDead=9](<self>: T.class_of(Main), a: T.untyped, b: T.untyped, <block-pre-call-temp>$69: Sorbet::Private::Static::Void, <selfRestore>$70: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf(each)
-    <blk>$94: T.untyped = load_yield_params(each)
-    forTemp$6$5: T.untyped = yield_load_arg(0, <blk>$94: T.untyped)
-    <cfgAlias>$100: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$102: Integer(5) = 5
-    <statTemp>$103: Integer(0) = 0
-    <assignTemp>$8$5: T.untyped = <cfgAlias>$100: T.class_of(<Magic>).<expand-splat>(forTemp$6$5: T.untyped, <statTemp>$102: Integer(5), <statTemp>$103: Integer(0))
-    <cfgAlias>$107: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$110: Integer(0) = 0
-    <statTemp>$108: T.untyped = <assignTemp>$8$5: T.untyped.[](<statTemp>$110: Integer(0))
-    <statTemp>$111: String("singleton class instance") = "singleton class instance"
-    <statTemp>$112: String("main") = "main"
-    <statTemp>$113: Symbol(:@a) = :@a
-    @a$105: T.untyped = <cfgAlias>$107: T.class_of(<Magic>).<suggest-field-type>(<statTemp>$108: T.untyped, <statTemp>$111: String("singleton class instance"), <statTemp>$112: String("main"), <statTemp>$113: Symbol(:@a))
-    <cfgAlias>$117: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$120: Integer(1) = 1
-    <statTemp>$118: T.untyped = <assignTemp>$8$5: T.untyped.[](<statTemp>$120: Integer(1))
-    <statTemp>$121: String("class") = "class"
-    <statTemp>$122: String("main") = "main"
-    <statTemp>$123: Symbol(:@@b) = :@@b
-    @@b$115: T.untyped = <cfgAlias>$117: T.class_of(<Magic>).<suggest-field-type>(<statTemp>$118: T.untyped, <statTemp>$121: String("class"), <statTemp>$122: String("main"), <statTemp>$123: Symbol(:@@b))
-    <statTemp>$127: Integer(2) = 2
-    $c$125: T.untyped = <assignTemp>$8$5: T.untyped.[](<statTemp>$127: Integer(2))
-    <statTemp>$130: Integer(3) = 3
-    d$5: T.untyped = <assignTemp>$8$5: T.untyped.[](<statTemp>$130: Integer(3))
-    <cfgAlias>$133: T.class_of(E) = alias <C E>
-    <statTemp>$136: Integer(4) = 4
-    <statTemp>$134: T.untyped = <assignTemp>$8$5: T.untyped.[](<statTemp>$136: Integer(4))
-    <statTemp>$131: T.untyped = <cfgAlias>$133: T.class_of(E).e=(<statTemp>$134: T.untyped)
-    <statTemp>$139: T.untyped = @a$105: T.untyped.inspect()
-    <statTemp>$137: NilClass = <self>: T.class_of(Main).puts(<statTemp>$139: T.untyped)
-    <statTemp>$143: T.untyped = @@b$115: T.untyped.inspect()
-    <statTemp>$141: NilClass = <self>: T.class_of(Main).puts(<statTemp>$143: T.untyped)
-    <statTemp>$147: T.untyped = $c$125: T.untyped.inspect()
-    <statTemp>$145: NilClass = <self>: T.class_of(Main).puts(<statTemp>$147: T.untyped)
-    <statTemp>$151: T.untyped = d$5: T.untyped.inspect()
-    <statTemp>$149: NilClass = <self>: T.class_of(Main).puts(<statTemp>$151: T.untyped)
-    <cfgAlias>$157: T.class_of(E) = alias <C E>
-    <statTemp>$155: T.untyped = <cfgAlias>$157: T.class_of(E).e()
-    <statTemp>$154: T.untyped = <statTemp>$155: T.untyped.inspect()
-    <blockReturnTemp>$95: NilClass = <self>: T.class_of(Main).puts(<statTemp>$154: T.untyped)
-    <blockReturnTemp>$158: T.noreturn = blockreturn<each> <blockReturnTemp>$95: NilClass
-    <unconditional> -> bb18
+    <blk>$71: T.untyped = load_yield_params(each)
+    a$3: T.untyped = yield_load_arg(0, <blk>$71: T.untyped)
+    b$3: T.untyped = yield_load_arg(1, <blk>$71: T.untyped)
+    <statTemp>$75: T.untyped = a$3: T.untyped.inspect()
+    <statTemp>$73: NilClass = <self>: T.class_of(Main).puts(<statTemp>$75: T.untyped)
+    <statTemp>$78: T.untyped = b$3: T.untyped.inspect()
+    <blockReturnTemp>$72: NilClass = <self>: T.class_of(Main).puts(<statTemp>$78: T.untyped)
+    <blockReturnTemp>$80: T.noreturn = blockreturn<each> <blockReturnTemp>$72: NilClass
+    <unconditional> -> bb16
 
 # backedges
-# - bb19
-# - bb25
-bb22[firstDead=-1](<self>: T.class_of(Main), @a$105: T.untyped, @@b$115: T.untyped, $c$125: T.untyped, <block-pre-call-temp>$161: Sorbet::Private::Static::Void, <selfRestore>$162: T.class_of(Main)):
+# - bb17
+# - bb23
+bb20[firstDead=-1](<self>: T.class_of(Main), a: T.untyped, b: T.untyped, <block-pre-call-temp>$84: Sorbet::Private::Static::Void, <selfRestore>$85: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
     # outerLoops: 1
-    <block-call> -> (NilClass ? bb25 : bb23)
+    <block-call> -> (NilClass ? bb23 : bb21)
 
 # backedges
-# - bb22
-bb23[firstDead=2](<block-pre-call-temp>$161: Sorbet::Private::Static::Void, <selfRestore>$162: T.class_of(Main)):
-    <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$161, each>
+# - bb20
+bb21[firstDead=-1](<block-pre-call-temp>$84: Sorbet::Private::Static::Void, <selfRestore>$85: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
+    <statTemp>$81: T.untyped = Solve<<block-pre-call-temp>$84, each>
+    <self>: T.class_of(Main) = <selfRestore>$85
+    <statTemp>$115: String("main") = "main"
+    <statTemp>$113: NilClass = <self>: T.class_of(Main).puts(<statTemp>$115: String("main"))
+    <cfgAlias>$118: T.class_of(A) = alias <C A>
+    <block-pre-call-temp>$119: Sorbet::Private::Static::Void = <cfgAlias>$118: T.class_of(A).each()
+    <selfRestore>$120: T.class_of(Main) = <self>
+    <unconditional> -> bb24
+
+# backedges
+# - bb20
+bb23[firstDead=18](<self>: T.class_of(Main), a: T.untyped, b: T.untyped, <block-pre-call-temp>$84: Sorbet::Private::Static::Void, <selfRestore>$85: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
+    # outerLoops: 1
+    <self>: T.class_of(Main) = loadSelf(each)
+    <blk>$86: T.untyped = load_yield_params(each)
+    forTemp$4: T.untyped = yield_load_arg(0, <blk>$86: T.untyped)
+    <cfgAlias>$91: T.class_of(<Magic>) = alias <C <Magic>>
+    <assignTemp>$8$4: T.untyped = <cfgAlias>$91: T.class_of(<Magic>).<splat>(forTemp$4: T.untyped)
+    <cfgAlias>$95: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$97: Integer(2) = 2
+    <statTemp>$98: Integer(0) = 0
+    <assignTemp>$9$4: T.untyped = <cfgAlias>$95: T.class_of(<Magic>).<expand-splat>(<assignTemp>$8$4: T.untyped, <statTemp>$97: Integer(2), <statTemp>$98: Integer(0))
+    <statTemp>$101: Integer(0) = 0
+    a: T.untyped = <assignTemp>$9$4: T.untyped.[](<statTemp>$101: Integer(0))
+    <statTemp>$104: Integer(1) = 1
+    b: T.untyped = <assignTemp>$9$4: T.untyped.[](<statTemp>$104: Integer(1))
+    <statTemp>$107: T.untyped = a: T.untyped.inspect()
+    <statTemp>$105: NilClass = <self>: T.class_of(Main).puts(<statTemp>$107: T.untyped)
+    <statTemp>$110: T.untyped = b: T.untyped.inspect()
+    <blockReturnTemp>$87: NilClass = <self>: T.class_of(Main).puts(<statTemp>$110: T.untyped)
+    <blockReturnTemp>$112: T.noreturn = blockreturn<each> <blockReturnTemp>$87: NilClass
+    <unconditional> -> bb20
+
+# backedges
+# - bb21
+# - bb27
+bb24[firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$119: Sorbet::Private::Static::Void, <selfRestore>$120: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
+    # outerLoops: 1
+    <block-call> -> (NilClass ? bb27 : bb25)
+
+# backedges
+# - bb24
+bb25[firstDead=-1](<block-pre-call-temp>$119: Sorbet::Private::Static::Void, <selfRestore>$120: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
+    <statTemp>$116: T.untyped = Solve<<block-pre-call-temp>$119, each>
+    <self>: T.class_of(Main) = <selfRestore>$120
+    <cfgAlias>$187: T.class_of(A) = alias <C A>
+    <block-pre-call-temp>$188: Sorbet::Private::Static::Void = <cfgAlias>$187: T.class_of(A).each()
+    <selfRestore>$189: T.class_of(Main) = <self>
+    <unconditional> -> bb28
+
+# backedges
+# - bb24
+bb27[firstDead=42](<self>: T.class_of(Main), <block-pre-call-temp>$119: Sorbet::Private::Static::Void, <selfRestore>$120: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
+    # outerLoops: 1
+    <self>: T.class_of(Main) = loadSelf(each)
+    <blk>$121: T.untyped = load_yield_params(each)
+    forTemp$10$5: T.untyped = yield_load_arg(0, <blk>$121: T.untyped)
+    <cfgAlias>$127: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$129: Integer(5) = 5
+    <statTemp>$130: Integer(0) = 0
+    <assignTemp>$12$5: T.untyped = <cfgAlias>$127: T.class_of(<Magic>).<expand-splat>(forTemp$10$5: T.untyped, <statTemp>$129: Integer(5), <statTemp>$130: Integer(0))
+    <cfgAlias>$134: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$137: Integer(0) = 0
+    <statTemp>$135: T.untyped = <assignTemp>$12$5: T.untyped.[](<statTemp>$137: Integer(0))
+    <statTemp>$138: String("singleton class instance") = "singleton class instance"
+    <statTemp>$139: String("main") = "main"
+    <statTemp>$140: Symbol(:@a) = :@a
+    @a$132: T.untyped = <cfgAlias>$134: T.class_of(<Magic>).<suggest-field-type>(<statTemp>$135: T.untyped, <statTemp>$138: String("singleton class instance"), <statTemp>$139: String("main"), <statTemp>$140: Symbol(:@a))
+    <cfgAlias>$144: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$147: Integer(1) = 1
+    <statTemp>$145: T.untyped = <assignTemp>$12$5: T.untyped.[](<statTemp>$147: Integer(1))
+    <statTemp>$148: String("class") = "class"
+    <statTemp>$149: String("main") = "main"
+    <statTemp>$150: Symbol(:@@b) = :@@b
+    @@b$142: T.untyped = <cfgAlias>$144: T.class_of(<Magic>).<suggest-field-type>(<statTemp>$145: T.untyped, <statTemp>$148: String("class"), <statTemp>$149: String("main"), <statTemp>$150: Symbol(:@@b))
+    <statTemp>$154: Integer(2) = 2
+    $c$152: T.untyped = <assignTemp>$12$5: T.untyped.[](<statTemp>$154: Integer(2))
+    <statTemp>$157: Integer(3) = 3
+    d$5: T.untyped = <assignTemp>$12$5: T.untyped.[](<statTemp>$157: Integer(3))
+    <cfgAlias>$160: T.class_of(E) = alias <C E>
+    <statTemp>$163: Integer(4) = 4
+    <statTemp>$161: T.untyped = <assignTemp>$12$5: T.untyped.[](<statTemp>$163: Integer(4))
+    <statTemp>$158: T.untyped = <cfgAlias>$160: T.class_of(E).e=(<statTemp>$161: T.untyped)
+    <statTemp>$166: T.untyped = @a$132: T.untyped.inspect()
+    <statTemp>$164: NilClass = <self>: T.class_of(Main).puts(<statTemp>$166: T.untyped)
+    <statTemp>$170: T.untyped = @@b$142: T.untyped.inspect()
+    <statTemp>$168: NilClass = <self>: T.class_of(Main).puts(<statTemp>$170: T.untyped)
+    <statTemp>$174: T.untyped = $c$152: T.untyped.inspect()
+    <statTemp>$172: NilClass = <self>: T.class_of(Main).puts(<statTemp>$174: T.untyped)
+    <statTemp>$178: T.untyped = d$5: T.untyped.inspect()
+    <statTemp>$176: NilClass = <self>: T.class_of(Main).puts(<statTemp>$178: T.untyped)
+    <cfgAlias>$184: T.class_of(E) = alias <C E>
+    <statTemp>$182: T.untyped = <cfgAlias>$184: T.class_of(E).e()
+    <statTemp>$181: T.untyped = <statTemp>$182: T.untyped.inspect()
+    <blockReturnTemp>$122: NilClass = <self>: T.class_of(Main).puts(<statTemp>$181: T.untyped)
+    <blockReturnTemp>$185: T.noreturn = blockreturn<each> <blockReturnTemp>$122: NilClass
+    <unconditional> -> bb24
+
+# backedges
+# - bb25
+# - bb31
+bb28[firstDead=-1](<self>: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped, <block-pre-call-temp>$188: Sorbet::Private::Static::Void, <selfRestore>$189: T.class_of(Main)):
+    # outerLoops: 1
+    <block-call> -> (NilClass ? bb31 : bb29)
+
+# backedges
+# - bb28
+bb29[firstDead=2](<block-pre-call-temp>$188: Sorbet::Private::Static::Void, <selfRestore>$189: T.class_of(Main)):
+    <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$188, each>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb22
-bb25[firstDead=44](<self>: T.class_of(Main), @a$105: T.untyped, @@b$115: T.untyped, $c$125: T.untyped, <block-pre-call-temp>$161: Sorbet::Private::Static::Void, <selfRestore>$162: T.class_of(Main)):
+# - bb28
+bb31[firstDead=44](<self>: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped, <block-pre-call-temp>$188: Sorbet::Private::Static::Void, <selfRestore>$189: T.class_of(Main)):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf(each)
-    <blk>$163: T.untyped = load_yield_params(each)
-    forTemp$6: T.untyped = yield_load_arg(0, <blk>$163: T.untyped)
-    <cfgAlias>$168: T.class_of(<Magic>) = alias <C <Magic>>
-    <assignTemp>$9$6: T.untyped = <cfgAlias>$168: T.class_of(<Magic>).<splat>(forTemp$6: T.untyped)
-    <cfgAlias>$172: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$174: Integer(5) = 5
-    <statTemp>$175: Integer(0) = 0
-    <assignTemp>$10$6: T.untyped = <cfgAlias>$172: T.class_of(<Magic>).<expand-splat>(<assignTemp>$9$6: T.untyped, <statTemp>$174: Integer(5), <statTemp>$175: Integer(0))
-    <cfgAlias>$178: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$181: Integer(0) = 0
-    <statTemp>$179: T.untyped = <assignTemp>$10$6: T.untyped.[](<statTemp>$181: Integer(0))
-    <statTemp>$182: String("singleton class instance") = "singleton class instance"
-    <statTemp>$183: String("main") = "main"
-    <statTemp>$184: Symbol(:@a) = :@a
-    @a$105: T.untyped = <cfgAlias>$178: T.class_of(<Magic>).<suggest-field-type>(<statTemp>$179: T.untyped, <statTemp>$182: String("singleton class instance"), <statTemp>$183: String("main"), <statTemp>$184: Symbol(:@a))
-    <cfgAlias>$187: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$190: Integer(1) = 1
-    <statTemp>$188: T.untyped = <assignTemp>$10$6: T.untyped.[](<statTemp>$190: Integer(1))
-    <statTemp>$191: String("class") = "class"
-    <statTemp>$192: String("main") = "main"
-    <statTemp>$193: Symbol(:@@b) = :@@b
-    @@b$115: T.untyped = <cfgAlias>$187: T.class_of(<Magic>).<suggest-field-type>(<statTemp>$188: T.untyped, <statTemp>$191: String("class"), <statTemp>$192: String("main"), <statTemp>$193: Symbol(:@@b))
-    <statTemp>$196: Integer(2) = 2
-    $c$125: T.untyped = <assignTemp>$10$6: T.untyped.[](<statTemp>$196: Integer(2))
-    <statTemp>$199: Integer(3) = 3
-    d$6: T.untyped = <assignTemp>$10$6: T.untyped.[](<statTemp>$199: Integer(3))
-    <cfgAlias>$202: T.class_of(E) = alias <C E>
-    <statTemp>$205: Integer(4) = 4
-    <statTemp>$203: T.untyped = <assignTemp>$10$6: T.untyped.[](<statTemp>$205: Integer(4))
-    <statTemp>$200: T.untyped = <cfgAlias>$202: T.class_of(E).e=(<statTemp>$203: T.untyped)
-    <statTemp>$208: T.untyped = @a$105: T.untyped.inspect()
-    <statTemp>$206: NilClass = <self>: T.class_of(Main).puts(<statTemp>$208: T.untyped)
-    <statTemp>$212: T.untyped = @@b$115: T.untyped.inspect()
-    <statTemp>$210: NilClass = <self>: T.class_of(Main).puts(<statTemp>$212: T.untyped)
-    <statTemp>$216: T.untyped = $c$125: T.untyped.inspect()
-    <statTemp>$214: NilClass = <self>: T.class_of(Main).puts(<statTemp>$216: T.untyped)
-    <statTemp>$220: T.untyped = d$6: T.untyped.inspect()
-    <statTemp>$218: NilClass = <self>: T.class_of(Main).puts(<statTemp>$220: T.untyped)
-    <cfgAlias>$226: T.class_of(E) = alias <C E>
-    <statTemp>$224: T.untyped = <cfgAlias>$226: T.class_of(E).e()
-    <statTemp>$223: T.untyped = <statTemp>$224: T.untyped.inspect()
-    <blockReturnTemp>$164: NilClass = <self>: T.class_of(Main).puts(<statTemp>$223: T.untyped)
-    <blockReturnTemp>$227: T.noreturn = blockreturn<each> <blockReturnTemp>$164: NilClass
-    <unconditional> -> bb22
+    <blk>$190: T.untyped = load_yield_params(each)
+    forTemp$6: T.untyped = yield_load_arg(0, <blk>$190: T.untyped)
+    <cfgAlias>$195: T.class_of(<Magic>) = alias <C <Magic>>
+    <assignTemp>$13$6: T.untyped = <cfgAlias>$195: T.class_of(<Magic>).<splat>(forTemp$6: T.untyped)
+    <cfgAlias>$199: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$201: Integer(5) = 5
+    <statTemp>$202: Integer(0) = 0
+    <assignTemp>$14$6: T.untyped = <cfgAlias>$199: T.class_of(<Magic>).<expand-splat>(<assignTemp>$13$6: T.untyped, <statTemp>$201: Integer(5), <statTemp>$202: Integer(0))
+    <cfgAlias>$205: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$208: Integer(0) = 0
+    <statTemp>$206: T.untyped = <assignTemp>$14$6: T.untyped.[](<statTemp>$208: Integer(0))
+    <statTemp>$209: String("singleton class instance") = "singleton class instance"
+    <statTemp>$210: String("main") = "main"
+    <statTemp>$211: Symbol(:@a) = :@a
+    @a$132: T.untyped = <cfgAlias>$205: T.class_of(<Magic>).<suggest-field-type>(<statTemp>$206: T.untyped, <statTemp>$209: String("singleton class instance"), <statTemp>$210: String("main"), <statTemp>$211: Symbol(:@a))
+    <cfgAlias>$214: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$217: Integer(1) = 1
+    <statTemp>$215: T.untyped = <assignTemp>$14$6: T.untyped.[](<statTemp>$217: Integer(1))
+    <statTemp>$218: String("class") = "class"
+    <statTemp>$219: String("main") = "main"
+    <statTemp>$220: Symbol(:@@b) = :@@b
+    @@b$142: T.untyped = <cfgAlias>$214: T.class_of(<Magic>).<suggest-field-type>(<statTemp>$215: T.untyped, <statTemp>$218: String("class"), <statTemp>$219: String("main"), <statTemp>$220: Symbol(:@@b))
+    <statTemp>$223: Integer(2) = 2
+    $c$152: T.untyped = <assignTemp>$14$6: T.untyped.[](<statTemp>$223: Integer(2))
+    <statTemp>$226: Integer(3) = 3
+    d$6: T.untyped = <assignTemp>$14$6: T.untyped.[](<statTemp>$226: Integer(3))
+    <cfgAlias>$229: T.class_of(E) = alias <C E>
+    <statTemp>$232: Integer(4) = 4
+    <statTemp>$230: T.untyped = <assignTemp>$14$6: T.untyped.[](<statTemp>$232: Integer(4))
+    <statTemp>$227: T.untyped = <cfgAlias>$229: T.class_of(E).e=(<statTemp>$230: T.untyped)
+    <statTemp>$235: T.untyped = @a$132: T.untyped.inspect()
+    <statTemp>$233: NilClass = <self>: T.class_of(Main).puts(<statTemp>$235: T.untyped)
+    <statTemp>$239: T.untyped = @@b$142: T.untyped.inspect()
+    <statTemp>$237: NilClass = <self>: T.class_of(Main).puts(<statTemp>$239: T.untyped)
+    <statTemp>$243: T.untyped = $c$152: T.untyped.inspect()
+    <statTemp>$241: NilClass = <self>: T.class_of(Main).puts(<statTemp>$243: T.untyped)
+    <statTemp>$247: T.untyped = d$6: T.untyped.inspect()
+    <statTemp>$245: NilClass = <self>: T.class_of(Main).puts(<statTemp>$247: T.untyped)
+    <cfgAlias>$253: T.class_of(E) = alias <C E>
+    <statTemp>$251: T.untyped = <cfgAlias>$253: T.class_of(E).e()
+    <statTemp>$250: T.untyped = <statTemp>$251: T.untyped.inspect()
+    <blockReturnTemp>$191: NilClass = <self>: T.class_of(Main).puts(<statTemp>$250: T.untyped)
+    <blockReturnTemp>$254: T.noreturn = blockreturn<each> <blockReturnTemp>$191: NilClass
+    <unconditional> -> bb28
 
 }
 

--- a/test/testdata/desugar/for.rb.cfg-text.exp
+++ b/test/testdata/desugar/for.rb.cfg-text.exp
@@ -693,327 +693,301 @@ bb1[firstDead=-1]():
 method ::<Class:Main>#main {
 
 bb0[firstDead=-1]():
-    @a$132: T.untyped = alias <C <undeclared-field-stub>> (@a)
-    @@b$142: T.untyped = alias <C <undeclared-field-stub>> (@@b)
-    $c$152: T.untyped = alias <C <undeclared-field-stub>> ($c)
+    @a$128: T.untyped = alias <C <undeclared-field-stub>> (@a)
+    @@b$138: T.untyped = alias <C <undeclared-field-stub>> (@@b)
+    $c$148: T.untyped = alias <C <undeclared-field-stub>> ($c)
     <self>: T.class_of(Main) = cast(<self>: NilClass, T.class_of(Main));
     <cfgAlias>$5: T.class_of(A) = alias <C A>
-    <cfgAlias>$9: T.class_of(T) = alias <C T>
-    <statTemp>$10: NilClass = nil
-    <ifTemp>$7: T.untyped = <cfgAlias>$9: T.class_of(T).unsafe(<statTemp>$10: NilClass)
-    <ifTemp>$7 -> (T.untyped ? bb2 : bb4)
+    <cfgAlias>$8: T.class_of(<Magic>) = alias <C <Magic>>
+    a: T.untyped = <cfgAlias>$8: T.class_of(<Magic>).<element-or-nil>(<cfgAlias>$5: T.class_of(A))
+    <block-pre-call-temp>$11: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(A).each()
+    <selfRestore>$12: T.class_of(Main) = <self>
+    <unconditional> -> bb2
 
 # backedges
-# - bb29
+# - bb23
 bb1[firstDead=-1]():
     <unconditional> -> bb1
 
 # backedges
 # - bb0
-bb2[firstDead=-1](<self>: T.class_of(Main), <cfgAlias>$5: T.class_of(A), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
-    a: T.untyped = <cfgAlias>$5: T.class_of(A).first()
-    <unconditional> -> bb4
-
-# backedges
-# - bb0
-# - bb2
-bb4[firstDead=-1](<self>: T.class_of(Main), <cfgAlias>$5: T.class_of(A), a: T.untyped, @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
-    <block-pre-call-temp>$13: Sorbet::Private::Static::Void = <cfgAlias>$5: T.class_of(A).each()
-    <selfRestore>$14: T.class_of(Main) = <self>
-    <unconditional> -> bb5
-
-# backedges
-# - bb4
-# - bb8
-bb5[firstDead=-1](<self>: T.class_of(Main), a: T.untyped, <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
+# - bb5
+bb2[firstDead=-1](<self>: T.class_of(Main), a: T.untyped, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Main), @a$128: T.untyped, @@b$138: T.untyped, $c$148: T.untyped):
     # outerLoops: 1
-    <block-call> -> (NilClass ? bb8 : bb6)
+    <block-call> -> (NilClass ? bb5 : bb3)
 
 # backedges
-# - bb5
-bb6[firstDead=-1](a: T.untyped, <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
-    <statTemp>$3: T.untyped = Solve<<block-pre-call-temp>$13, each>
-    <self>: T.class_of(Main) = <selfRestore>$14
-    <cfgAlias>$23: T.class_of(A) = alias <C A>
-    <block-pre-call-temp>$24: Sorbet::Private::Static::Void = <cfgAlias>$23: T.class_of(A).each()
-    <selfRestore>$25: T.class_of(Main) = <self>
-    <unconditional> -> bb9
+# - bb2
+bb3[firstDead=-1](a: T.untyped, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Main), @a$128: T.untyped, @@b$138: T.untyped, $c$148: T.untyped):
+    <statTemp>$3: T.untyped = Solve<<block-pre-call-temp>$11, each>
+    <self>: T.class_of(Main) = <selfRestore>$12
+    <cfgAlias>$21: T.class_of(A) = alias <C A>
+    <block-pre-call-temp>$22: Sorbet::Private::Static::Void = <cfgAlias>$21: T.class_of(A).each()
+    <selfRestore>$23: T.class_of(Main) = <self>
+    <unconditional> -> bb6
 
 # backedges
-# - bb5
-bb8[firstDead=6](<self>: T.class_of(Main), a: T.untyped, <block-pre-call-temp>$13: Sorbet::Private::Static::Void, <selfRestore>$14: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
+# - bb2
+bb5[firstDead=6](<self>: T.class_of(Main), a: T.untyped, <block-pre-call-temp>$11: Sorbet::Private::Static::Void, <selfRestore>$12: T.class_of(Main), @a$128: T.untyped, @@b$138: T.untyped, $c$148: T.untyped):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf(each)
-    <blk>$15: T.untyped = load_yield_params(each)
-    a$1: T.untyped = yield_load_arg(0, <blk>$15: T.untyped)
-    <statTemp>$18: T.untyped = a$1: T.untyped.inspect()
-    <blockReturnTemp>$16: NilClass = <self>: T.class_of(Main).puts(<statTemp>$18: T.untyped)
-    <blockReturnTemp>$20: T.noreturn = blockreturn<each> <blockReturnTemp>$16: NilClass
-    <unconditional> -> bb5
+    <blk>$13: T.untyped = load_yield_params(each)
+    a$1: T.untyped = yield_load_arg(0, <blk>$13: T.untyped)
+    <statTemp>$16: T.untyped = a$1: T.untyped.inspect()
+    <blockReturnTemp>$14: NilClass = <self>: T.class_of(Main).puts(<statTemp>$16: T.untyped)
+    <blockReturnTemp>$18: T.noreturn = blockreturn<each> <blockReturnTemp>$14: NilClass
+    <unconditional> -> bb2
+
+# backedges
+# - bb3
+# - bb9
+bb6[firstDead=-1](<self>: T.class_of(Main), a: T.untyped, <block-pre-call-temp>$22: Sorbet::Private::Static::Void, <selfRestore>$23: T.class_of(Main), @a$128: T.untyped, @@b$138: T.untyped, $c$148: T.untyped):
+    # outerLoops: 1
+    <block-call> -> (NilClass ? bb9 : bb7)
 
 # backedges
 # - bb6
-# - bb12
-bb9[firstDead=-1](<self>: T.class_of(Main), a: T.untyped, <block-pre-call-temp>$24: Sorbet::Private::Static::Void, <selfRestore>$25: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
-    # outerLoops: 1
-    <block-call> -> (NilClass ? bb12 : bb10)
+bb7[firstDead=-1](<block-pre-call-temp>$22: Sorbet::Private::Static::Void, <selfRestore>$23: T.class_of(Main), @a$128: T.untyped, @@b$138: T.untyped, $c$148: T.untyped):
+    <statTemp>$19: T.untyped = Solve<<block-pre-call-temp>$22, each>
+    <self>: T.class_of(Main) = <selfRestore>$23
+    <cfgAlias>$46: T.class_of(A) = alias <C A>
+    <cfgAlias>$50: T.class_of(<Magic>) = alias <C <Magic>>
+    <assignTemp>$6: T.untyped = <cfgAlias>$50: T.class_of(<Magic>).<element-or-nil>(<cfgAlias>$46: T.class_of(A))
+    <cfgAlias>$54: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$56: Integer(2) = 2
+    <statTemp>$57: Integer(0) = 0
+    <assignTemp>$7: T.untyped = <cfgAlias>$54: T.class_of(<Magic>).<expand-splat>(<assignTemp>$6: T.untyped, <statTemp>$56: Integer(2), <statTemp>$57: Integer(0))
+    <statTemp>$60: Integer(0) = 0
+    a: T.untyped = <assignTemp>$7: T.untyped.[](<statTemp>$60: Integer(0))
+    <statTemp>$63: Integer(1) = 1
+    b: T.untyped = <assignTemp>$7: T.untyped.[](<statTemp>$63: Integer(1))
+    <block-pre-call-temp>$65: Sorbet::Private::Static::Void = <cfgAlias>$46: T.class_of(A).each()
+    <selfRestore>$66: T.class_of(Main) = <self>
+    <unconditional> -> bb10
 
 # backedges
-# - bb9
-bb10[firstDead=-1](a: T.untyped, <block-pre-call-temp>$24: Sorbet::Private::Static::Void, <selfRestore>$25: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
-    <statTemp>$21: T.untyped = Solve<<block-pre-call-temp>$24, each>
-    <self>: T.class_of(Main) = <selfRestore>$25
-    <cfgAlias>$48: T.class_of(A) = alias <C A>
-    <cfgAlias>$52: T.class_of(T) = alias <C T>
-    <statTemp>$53: NilClass = nil
-    <ifTemp>$50: T.untyped = <cfgAlias>$52: T.class_of(T).unsafe(<statTemp>$53: NilClass)
-    <ifTemp>$50 -> (T.untyped ? bb13 : bb15)
-
-# backedges
-# - bb9
-bb12[firstDead=14](<self>: T.class_of(Main), a: T.untyped, <block-pre-call-temp>$24: Sorbet::Private::Static::Void, <selfRestore>$25: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
+# - bb6
+bb9[firstDead=14](<self>: T.class_of(Main), a: T.untyped, <block-pre-call-temp>$22: Sorbet::Private::Static::Void, <selfRestore>$23: T.class_of(Main), @a$128: T.untyped, @@b$138: T.untyped, $c$148: T.untyped):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf(each)
-    <blk>$26: T.untyped = load_yield_params(each)
-    forTemp$2: T.untyped = yield_load_arg(0, <blk>$26: T.untyped)
-    <cfgAlias>$31: T.class_of(<Magic>) = alias <C <Magic>>
-    <assignTemp>$3$2: T.untyped = <cfgAlias>$31: T.class_of(<Magic>).<splat>(forTemp$2: T.untyped)
-    <cfgAlias>$35: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$37: Integer(1) = 1
-    <statTemp>$38: Integer(0) = 0
-    <assignTemp>$4$2: T.untyped = <cfgAlias>$35: T.class_of(<Magic>).<expand-splat>(<assignTemp>$3$2: T.untyped, <statTemp>$37: Integer(1), <statTemp>$38: Integer(0))
-    <statTemp>$41: Integer(0) = 0
-    a: T.untyped = <assignTemp>$4$2: T.untyped.[](<statTemp>$41: Integer(0))
-    <statTemp>$43: T.untyped = a: T.untyped.inspect()
-    <blockReturnTemp>$27: NilClass = <self>: T.class_of(Main).puts(<statTemp>$43: T.untyped)
-    <blockReturnTemp>$45: T.noreturn = blockreturn<each> <blockReturnTemp>$27: NilClass
-    <unconditional> -> bb9
+    <blk>$24: T.untyped = load_yield_params(each)
+    forTemp$2: T.untyped = yield_load_arg(0, <blk>$24: T.untyped)
+    <cfgAlias>$29: T.class_of(<Magic>) = alias <C <Magic>>
+    <assignTemp>$3$2: T.untyped = <cfgAlias>$29: T.class_of(<Magic>).<splat>(forTemp$2: T.untyped)
+    <cfgAlias>$33: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$35: Integer(1) = 1
+    <statTemp>$36: Integer(0) = 0
+    <assignTemp>$4$2: T.untyped = <cfgAlias>$33: T.class_of(<Magic>).<expand-splat>(<assignTemp>$3$2: T.untyped, <statTemp>$35: Integer(1), <statTemp>$36: Integer(0))
+    <statTemp>$39: Integer(0) = 0
+    a: T.untyped = <assignTemp>$4$2: T.untyped.[](<statTemp>$39: Integer(0))
+    <statTemp>$41: T.untyped = a: T.untyped.inspect()
+    <blockReturnTemp>$25: NilClass = <self>: T.class_of(Main).puts(<statTemp>$41: T.untyped)
+    <blockReturnTemp>$43: T.noreturn = blockreturn<each> <blockReturnTemp>$25: NilClass
+    <unconditional> -> bb6
 
 # backedges
-# - bb10
-bb13[firstDead=-1](<self>: T.class_of(Main), <cfgAlias>$48: T.class_of(A), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
-    <assignTemp>$6: T.untyped = <cfgAlias>$48: T.class_of(A).first()
-    <cfgAlias>$58: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$60: Integer(2) = 2
-    <statTemp>$61: Integer(0) = 0
-    <assignTemp>$7: T.untyped = <cfgAlias>$58: T.class_of(<Magic>).<expand-splat>(<assignTemp>$6: T.untyped, <statTemp>$60: Integer(2), <statTemp>$61: Integer(0))
-    <statTemp>$64: Integer(0) = 0
-    a: T.untyped = <assignTemp>$7: T.untyped.[](<statTemp>$64: Integer(0))
-    <statTemp>$67: Integer(1) = 1
-    b: T.untyped = <assignTemp>$7: T.untyped.[](<statTemp>$67: Integer(1))
-    <unconditional> -> bb15
-
-# backedges
-# - bb10
+# - bb7
 # - bb13
-bb15[firstDead=-1](<self>: T.class_of(Main), a: T.untyped, <cfgAlias>$48: T.class_of(A), b: T.untyped, @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
-    <block-pre-call-temp>$69: Sorbet::Private::Static::Void = <cfgAlias>$48: T.class_of(A).each()
-    <selfRestore>$70: T.class_of(Main) = <self>
-    <unconditional> -> bb16
+bb10[firstDead=-1](<self>: T.class_of(Main), a: T.untyped, b: T.untyped, <block-pre-call-temp>$65: Sorbet::Private::Static::Void, <selfRestore>$66: T.class_of(Main), @a$128: T.untyped, @@b$138: T.untyped, $c$148: T.untyped):
+    # outerLoops: 1
+    <block-call> -> (NilClass ? bb13 : bb11)
+
+# backedges
+# - bb10
+bb11[firstDead=-1](a: T.untyped, b: T.untyped, <block-pre-call-temp>$65: Sorbet::Private::Static::Void, <selfRestore>$66: T.class_of(Main), @a$128: T.untyped, @@b$138: T.untyped, $c$148: T.untyped):
+    <statTemp>$44: T.untyped = Solve<<block-pre-call-temp>$65, each>
+    <self>: T.class_of(Main) = <selfRestore>$66
+    <cfgAlias>$79: T.class_of(A) = alias <C A>
+    <block-pre-call-temp>$80: Sorbet::Private::Static::Void = <cfgAlias>$79: T.class_of(A).each()
+    <selfRestore>$81: T.class_of(Main) = <self>
+    <unconditional> -> bb14
+
+# backedges
+# - bb10
+bb13[firstDead=9](<self>: T.class_of(Main), a: T.untyped, b: T.untyped, <block-pre-call-temp>$65: Sorbet::Private::Static::Void, <selfRestore>$66: T.class_of(Main), @a$128: T.untyped, @@b$138: T.untyped, $c$148: T.untyped):
+    # outerLoops: 1
+    <self>: T.class_of(Main) = loadSelf(each)
+    <blk>$67: T.untyped = load_yield_params(each)
+    a$3: T.untyped = yield_load_arg(0, <blk>$67: T.untyped)
+    b$3: T.untyped = yield_load_arg(1, <blk>$67: T.untyped)
+    <statTemp>$71: T.untyped = a$3: T.untyped.inspect()
+    <statTemp>$69: NilClass = <self>: T.class_of(Main).puts(<statTemp>$71: T.untyped)
+    <statTemp>$74: T.untyped = b$3: T.untyped.inspect()
+    <blockReturnTemp>$68: NilClass = <self>: T.class_of(Main).puts(<statTemp>$74: T.untyped)
+    <blockReturnTemp>$76: T.noreturn = blockreturn<each> <blockReturnTemp>$68: NilClass
+    <unconditional> -> bb10
+
+# backedges
+# - bb11
+# - bb17
+bb14[firstDead=-1](<self>: T.class_of(Main), a: T.untyped, b: T.untyped, <block-pre-call-temp>$80: Sorbet::Private::Static::Void, <selfRestore>$81: T.class_of(Main), @a$128: T.untyped, @@b$138: T.untyped, $c$148: T.untyped):
+    # outerLoops: 1
+    <block-call> -> (NilClass ? bb17 : bb15)
+
+# backedges
+# - bb14
+bb15[firstDead=-1](<block-pre-call-temp>$80: Sorbet::Private::Static::Void, <selfRestore>$81: T.class_of(Main), @a$128: T.untyped, @@b$138: T.untyped, $c$148: T.untyped):
+    <statTemp>$77: T.untyped = Solve<<block-pre-call-temp>$80, each>
+    <self>: T.class_of(Main) = <selfRestore>$81
+    <statTemp>$111: String("main") = "main"
+    <statTemp>$109: NilClass = <self>: T.class_of(Main).puts(<statTemp>$111: String("main"))
+    <cfgAlias>$114: T.class_of(A) = alias <C A>
+    <block-pre-call-temp>$115: Sorbet::Private::Static::Void = <cfgAlias>$114: T.class_of(A).each()
+    <selfRestore>$116: T.class_of(Main) = <self>
+    <unconditional> -> bb18
+
+# backedges
+# - bb14
+bb17[firstDead=18](<self>: T.class_of(Main), a: T.untyped, b: T.untyped, <block-pre-call-temp>$80: Sorbet::Private::Static::Void, <selfRestore>$81: T.class_of(Main), @a$128: T.untyped, @@b$138: T.untyped, $c$148: T.untyped):
+    # outerLoops: 1
+    <self>: T.class_of(Main) = loadSelf(each)
+    <blk>$82: T.untyped = load_yield_params(each)
+    forTemp$4: T.untyped = yield_load_arg(0, <blk>$82: T.untyped)
+    <cfgAlias>$87: T.class_of(<Magic>) = alias <C <Magic>>
+    <assignTemp>$8$4: T.untyped = <cfgAlias>$87: T.class_of(<Magic>).<splat>(forTemp$4: T.untyped)
+    <cfgAlias>$91: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$93: Integer(2) = 2
+    <statTemp>$94: Integer(0) = 0
+    <assignTemp>$9$4: T.untyped = <cfgAlias>$91: T.class_of(<Magic>).<expand-splat>(<assignTemp>$8$4: T.untyped, <statTemp>$93: Integer(2), <statTemp>$94: Integer(0))
+    <statTemp>$97: Integer(0) = 0
+    a: T.untyped = <assignTemp>$9$4: T.untyped.[](<statTemp>$97: Integer(0))
+    <statTemp>$100: Integer(1) = 1
+    b: T.untyped = <assignTemp>$9$4: T.untyped.[](<statTemp>$100: Integer(1))
+    <statTemp>$103: T.untyped = a: T.untyped.inspect()
+    <statTemp>$101: NilClass = <self>: T.class_of(Main).puts(<statTemp>$103: T.untyped)
+    <statTemp>$106: T.untyped = b: T.untyped.inspect()
+    <blockReturnTemp>$83: NilClass = <self>: T.class_of(Main).puts(<statTemp>$106: T.untyped)
+    <blockReturnTemp>$108: T.noreturn = blockreturn<each> <blockReturnTemp>$83: NilClass
+    <unconditional> -> bb14
 
 # backedges
 # - bb15
-# - bb19
-bb16[firstDead=-1](<self>: T.class_of(Main), a: T.untyped, b: T.untyped, <block-pre-call-temp>$69: Sorbet::Private::Static::Void, <selfRestore>$70: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
-    # outerLoops: 1
-    <block-call> -> (NilClass ? bb19 : bb17)
-
-# backedges
-# - bb16
-bb17[firstDead=-1](a: T.untyped, b: T.untyped, <block-pre-call-temp>$69: Sorbet::Private::Static::Void, <selfRestore>$70: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
-    <statTemp>$46: T.untyped = Solve<<block-pre-call-temp>$69, each>
-    <self>: T.class_of(Main) = <selfRestore>$70
-    <cfgAlias>$83: T.class_of(A) = alias <C A>
-    <block-pre-call-temp>$84: Sorbet::Private::Static::Void = <cfgAlias>$83: T.class_of(A).each()
-    <selfRestore>$85: T.class_of(Main) = <self>
-    <unconditional> -> bb20
-
-# backedges
-# - bb16
-bb19[firstDead=9](<self>: T.class_of(Main), a: T.untyped, b: T.untyped, <block-pre-call-temp>$69: Sorbet::Private::Static::Void, <selfRestore>$70: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
-    # outerLoops: 1
-    <self>: T.class_of(Main) = loadSelf(each)
-    <blk>$71: T.untyped = load_yield_params(each)
-    a$3: T.untyped = yield_load_arg(0, <blk>$71: T.untyped)
-    b$3: T.untyped = yield_load_arg(1, <blk>$71: T.untyped)
-    <statTemp>$75: T.untyped = a$3: T.untyped.inspect()
-    <statTemp>$73: NilClass = <self>: T.class_of(Main).puts(<statTemp>$75: T.untyped)
-    <statTemp>$78: T.untyped = b$3: T.untyped.inspect()
-    <blockReturnTemp>$72: NilClass = <self>: T.class_of(Main).puts(<statTemp>$78: T.untyped)
-    <blockReturnTemp>$80: T.noreturn = blockreturn<each> <blockReturnTemp>$72: NilClass
-    <unconditional> -> bb16
-
-# backedges
-# - bb17
-# - bb23
-bb20[firstDead=-1](<self>: T.class_of(Main), a: T.untyped, b: T.untyped, <block-pre-call-temp>$84: Sorbet::Private::Static::Void, <selfRestore>$85: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
-    # outerLoops: 1
-    <block-call> -> (NilClass ? bb23 : bb21)
-
-# backedges
-# - bb20
-bb21[firstDead=-1](<block-pre-call-temp>$84: Sorbet::Private::Static::Void, <selfRestore>$85: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
-    <statTemp>$81: T.untyped = Solve<<block-pre-call-temp>$84, each>
-    <self>: T.class_of(Main) = <selfRestore>$85
-    <statTemp>$115: String("main") = "main"
-    <statTemp>$113: NilClass = <self>: T.class_of(Main).puts(<statTemp>$115: String("main"))
-    <cfgAlias>$118: T.class_of(A) = alias <C A>
-    <block-pre-call-temp>$119: Sorbet::Private::Static::Void = <cfgAlias>$118: T.class_of(A).each()
-    <selfRestore>$120: T.class_of(Main) = <self>
-    <unconditional> -> bb24
-
-# backedges
-# - bb20
-bb23[firstDead=18](<self>: T.class_of(Main), a: T.untyped, b: T.untyped, <block-pre-call-temp>$84: Sorbet::Private::Static::Void, <selfRestore>$85: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
-    # outerLoops: 1
-    <self>: T.class_of(Main) = loadSelf(each)
-    <blk>$86: T.untyped = load_yield_params(each)
-    forTemp$4: T.untyped = yield_load_arg(0, <blk>$86: T.untyped)
-    <cfgAlias>$91: T.class_of(<Magic>) = alias <C <Magic>>
-    <assignTemp>$8$4: T.untyped = <cfgAlias>$91: T.class_of(<Magic>).<splat>(forTemp$4: T.untyped)
-    <cfgAlias>$95: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$97: Integer(2) = 2
-    <statTemp>$98: Integer(0) = 0
-    <assignTemp>$9$4: T.untyped = <cfgAlias>$95: T.class_of(<Magic>).<expand-splat>(<assignTemp>$8$4: T.untyped, <statTemp>$97: Integer(2), <statTemp>$98: Integer(0))
-    <statTemp>$101: Integer(0) = 0
-    a: T.untyped = <assignTemp>$9$4: T.untyped.[](<statTemp>$101: Integer(0))
-    <statTemp>$104: Integer(1) = 1
-    b: T.untyped = <assignTemp>$9$4: T.untyped.[](<statTemp>$104: Integer(1))
-    <statTemp>$107: T.untyped = a: T.untyped.inspect()
-    <statTemp>$105: NilClass = <self>: T.class_of(Main).puts(<statTemp>$107: T.untyped)
-    <statTemp>$110: T.untyped = b: T.untyped.inspect()
-    <blockReturnTemp>$87: NilClass = <self>: T.class_of(Main).puts(<statTemp>$110: T.untyped)
-    <blockReturnTemp>$112: T.noreturn = blockreturn<each> <blockReturnTemp>$87: NilClass
-    <unconditional> -> bb20
-
-# backedges
 # - bb21
-# - bb27
-bb24[firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$119: Sorbet::Private::Static::Void, <selfRestore>$120: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
+bb18[firstDead=-1](<self>: T.class_of(Main), <block-pre-call-temp>$115: Sorbet::Private::Static::Void, <selfRestore>$116: T.class_of(Main), @a$128: T.untyped, @@b$138: T.untyped, $c$148: T.untyped):
     # outerLoops: 1
-    <block-call> -> (NilClass ? bb27 : bb25)
+    <block-call> -> (NilClass ? bb21 : bb19)
 
 # backedges
-# - bb24
-bb25[firstDead=-1](<block-pre-call-temp>$119: Sorbet::Private::Static::Void, <selfRestore>$120: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
-    <statTemp>$116: T.untyped = Solve<<block-pre-call-temp>$119, each>
-    <self>: T.class_of(Main) = <selfRestore>$120
-    <cfgAlias>$187: T.class_of(A) = alias <C A>
-    <block-pre-call-temp>$188: Sorbet::Private::Static::Void = <cfgAlias>$187: T.class_of(A).each()
-    <selfRestore>$189: T.class_of(Main) = <self>
-    <unconditional> -> bb28
+# - bb18
+bb19[firstDead=-1](<block-pre-call-temp>$115: Sorbet::Private::Static::Void, <selfRestore>$116: T.class_of(Main), @a$128: T.untyped, @@b$138: T.untyped, $c$148: T.untyped):
+    <statTemp>$112: T.untyped = Solve<<block-pre-call-temp>$115, each>
+    <self>: T.class_of(Main) = <selfRestore>$116
+    <cfgAlias>$183: T.class_of(A) = alias <C A>
+    <block-pre-call-temp>$184: Sorbet::Private::Static::Void = <cfgAlias>$183: T.class_of(A).each()
+    <selfRestore>$185: T.class_of(Main) = <self>
+    <unconditional> -> bb22
 
 # backedges
-# - bb24
-bb27[firstDead=42](<self>: T.class_of(Main), <block-pre-call-temp>$119: Sorbet::Private::Static::Void, <selfRestore>$120: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped):
+# - bb18
+bb21[firstDead=42](<self>: T.class_of(Main), <block-pre-call-temp>$115: Sorbet::Private::Static::Void, <selfRestore>$116: T.class_of(Main), @a$128: T.untyped, @@b$138: T.untyped, $c$148: T.untyped):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf(each)
-    <blk>$121: T.untyped = load_yield_params(each)
-    forTemp$10$5: T.untyped = yield_load_arg(0, <blk>$121: T.untyped)
-    <cfgAlias>$127: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$129: Integer(5) = 5
-    <statTemp>$130: Integer(0) = 0
-    <assignTemp>$12$5: T.untyped = <cfgAlias>$127: T.class_of(<Magic>).<expand-splat>(forTemp$10$5: T.untyped, <statTemp>$129: Integer(5), <statTemp>$130: Integer(0))
-    <cfgAlias>$134: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$137: Integer(0) = 0
-    <statTemp>$135: T.untyped = <assignTemp>$12$5: T.untyped.[](<statTemp>$137: Integer(0))
-    <statTemp>$138: String("singleton class instance") = "singleton class instance"
-    <statTemp>$139: String("main") = "main"
-    <statTemp>$140: Symbol(:@a) = :@a
-    @a$132: T.untyped = <cfgAlias>$134: T.class_of(<Magic>).<suggest-field-type>(<statTemp>$135: T.untyped, <statTemp>$138: String("singleton class instance"), <statTemp>$139: String("main"), <statTemp>$140: Symbol(:@a))
-    <cfgAlias>$144: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$147: Integer(1) = 1
-    <statTemp>$145: T.untyped = <assignTemp>$12$5: T.untyped.[](<statTemp>$147: Integer(1))
-    <statTemp>$148: String("class") = "class"
-    <statTemp>$149: String("main") = "main"
-    <statTemp>$150: Symbol(:@@b) = :@@b
-    @@b$142: T.untyped = <cfgAlias>$144: T.class_of(<Magic>).<suggest-field-type>(<statTemp>$145: T.untyped, <statTemp>$148: String("class"), <statTemp>$149: String("main"), <statTemp>$150: Symbol(:@@b))
-    <statTemp>$154: Integer(2) = 2
-    $c$152: T.untyped = <assignTemp>$12$5: T.untyped.[](<statTemp>$154: Integer(2))
-    <statTemp>$157: Integer(3) = 3
-    d$5: T.untyped = <assignTemp>$12$5: T.untyped.[](<statTemp>$157: Integer(3))
-    <cfgAlias>$160: T.class_of(E) = alias <C E>
-    <statTemp>$163: Integer(4) = 4
-    <statTemp>$161: T.untyped = <assignTemp>$12$5: T.untyped.[](<statTemp>$163: Integer(4))
-    <statTemp>$158: T.untyped = <cfgAlias>$160: T.class_of(E).e=(<statTemp>$161: T.untyped)
-    <statTemp>$166: T.untyped = @a$132: T.untyped.inspect()
+    <blk>$117: T.untyped = load_yield_params(each)
+    forTemp$10$5: T.untyped = yield_load_arg(0, <blk>$117: T.untyped)
+    <cfgAlias>$123: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$125: Integer(5) = 5
+    <statTemp>$126: Integer(0) = 0
+    <assignTemp>$12$5: T.untyped = <cfgAlias>$123: T.class_of(<Magic>).<expand-splat>(forTemp$10$5: T.untyped, <statTemp>$125: Integer(5), <statTemp>$126: Integer(0))
+    <cfgAlias>$130: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$133: Integer(0) = 0
+    <statTemp>$131: T.untyped = <assignTemp>$12$5: T.untyped.[](<statTemp>$133: Integer(0))
+    <statTemp>$134: String("singleton class instance") = "singleton class instance"
+    <statTemp>$135: String("main") = "main"
+    <statTemp>$136: Symbol(:@a) = :@a
+    @a$128: T.untyped = <cfgAlias>$130: T.class_of(<Magic>).<suggest-field-type>(<statTemp>$131: T.untyped, <statTemp>$134: String("singleton class instance"), <statTemp>$135: String("main"), <statTemp>$136: Symbol(:@a))
+    <cfgAlias>$140: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$143: Integer(1) = 1
+    <statTemp>$141: T.untyped = <assignTemp>$12$5: T.untyped.[](<statTemp>$143: Integer(1))
+    <statTemp>$144: String("class") = "class"
+    <statTemp>$145: String("main") = "main"
+    <statTemp>$146: Symbol(:@@b) = :@@b
+    @@b$138: T.untyped = <cfgAlias>$140: T.class_of(<Magic>).<suggest-field-type>(<statTemp>$141: T.untyped, <statTemp>$144: String("class"), <statTemp>$145: String("main"), <statTemp>$146: Symbol(:@@b))
+    <statTemp>$150: Integer(2) = 2
+    $c$148: T.untyped = <assignTemp>$12$5: T.untyped.[](<statTemp>$150: Integer(2))
+    <statTemp>$153: Integer(3) = 3
+    d$5: T.untyped = <assignTemp>$12$5: T.untyped.[](<statTemp>$153: Integer(3))
+    <cfgAlias>$156: T.class_of(E) = alias <C E>
+    <statTemp>$159: Integer(4) = 4
+    <statTemp>$157: T.untyped = <assignTemp>$12$5: T.untyped.[](<statTemp>$159: Integer(4))
+    <statTemp>$154: T.untyped = <cfgAlias>$156: T.class_of(E).e=(<statTemp>$157: T.untyped)
+    <statTemp>$162: T.untyped = @a$128: T.untyped.inspect()
+    <statTemp>$160: NilClass = <self>: T.class_of(Main).puts(<statTemp>$162: T.untyped)
+    <statTemp>$166: T.untyped = @@b$138: T.untyped.inspect()
     <statTemp>$164: NilClass = <self>: T.class_of(Main).puts(<statTemp>$166: T.untyped)
-    <statTemp>$170: T.untyped = @@b$142: T.untyped.inspect()
+    <statTemp>$170: T.untyped = $c$148: T.untyped.inspect()
     <statTemp>$168: NilClass = <self>: T.class_of(Main).puts(<statTemp>$170: T.untyped)
-    <statTemp>$174: T.untyped = $c$152: T.untyped.inspect()
+    <statTemp>$174: T.untyped = d$5: T.untyped.inspect()
     <statTemp>$172: NilClass = <self>: T.class_of(Main).puts(<statTemp>$174: T.untyped)
-    <statTemp>$178: T.untyped = d$5: T.untyped.inspect()
-    <statTemp>$176: NilClass = <self>: T.class_of(Main).puts(<statTemp>$178: T.untyped)
-    <cfgAlias>$184: T.class_of(E) = alias <C E>
-    <statTemp>$182: T.untyped = <cfgAlias>$184: T.class_of(E).e()
-    <statTemp>$181: T.untyped = <statTemp>$182: T.untyped.inspect()
-    <blockReturnTemp>$122: NilClass = <self>: T.class_of(Main).puts(<statTemp>$181: T.untyped)
-    <blockReturnTemp>$185: T.noreturn = blockreturn<each> <blockReturnTemp>$122: NilClass
-    <unconditional> -> bb24
+    <cfgAlias>$180: T.class_of(E) = alias <C E>
+    <statTemp>$178: T.untyped = <cfgAlias>$180: T.class_of(E).e()
+    <statTemp>$177: T.untyped = <statTemp>$178: T.untyped.inspect()
+    <blockReturnTemp>$118: NilClass = <self>: T.class_of(Main).puts(<statTemp>$177: T.untyped)
+    <blockReturnTemp>$181: T.noreturn = blockreturn<each> <blockReturnTemp>$118: NilClass
+    <unconditional> -> bb18
 
 # backedges
+# - bb19
 # - bb25
-# - bb31
-bb28[firstDead=-1](<self>: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped, <block-pre-call-temp>$188: Sorbet::Private::Static::Void, <selfRestore>$189: T.class_of(Main)):
+bb22[firstDead=-1](<self>: T.class_of(Main), @a$128: T.untyped, @@b$138: T.untyped, $c$148: T.untyped, <block-pre-call-temp>$184: Sorbet::Private::Static::Void, <selfRestore>$185: T.class_of(Main)):
     # outerLoops: 1
-    <block-call> -> (NilClass ? bb31 : bb29)
+    <block-call> -> (NilClass ? bb25 : bb23)
 
 # backedges
-# - bb28
-bb29[firstDead=2](<block-pre-call-temp>$188: Sorbet::Private::Static::Void, <selfRestore>$189: T.class_of(Main)):
-    <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$188, each>
+# - bb22
+bb23[firstDead=2](<block-pre-call-temp>$184: Sorbet::Private::Static::Void, <selfRestore>$185: T.class_of(Main)):
+    <returnMethodTemp>$2: T.untyped = Solve<<block-pre-call-temp>$184, each>
     <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.untyped
     <unconditional> -> bb1
 
 # backedges
-# - bb28
-bb31[firstDead=44](<self>: T.class_of(Main), @a$132: T.untyped, @@b$142: T.untyped, $c$152: T.untyped, <block-pre-call-temp>$188: Sorbet::Private::Static::Void, <selfRestore>$189: T.class_of(Main)):
+# - bb22
+bb25[firstDead=44](<self>: T.class_of(Main), @a$128: T.untyped, @@b$138: T.untyped, $c$148: T.untyped, <block-pre-call-temp>$184: Sorbet::Private::Static::Void, <selfRestore>$185: T.class_of(Main)):
     # outerLoops: 1
     <self>: T.class_of(Main) = loadSelf(each)
-    <blk>$190: T.untyped = load_yield_params(each)
-    forTemp$6: T.untyped = yield_load_arg(0, <blk>$190: T.untyped)
+    <blk>$186: T.untyped = load_yield_params(each)
+    forTemp$6: T.untyped = yield_load_arg(0, <blk>$186: T.untyped)
+    <cfgAlias>$191: T.class_of(<Magic>) = alias <C <Magic>>
+    <assignTemp>$13$6: T.untyped = <cfgAlias>$191: T.class_of(<Magic>).<splat>(forTemp$6: T.untyped)
     <cfgAlias>$195: T.class_of(<Magic>) = alias <C <Magic>>
-    <assignTemp>$13$6: T.untyped = <cfgAlias>$195: T.class_of(<Magic>).<splat>(forTemp$6: T.untyped)
-    <cfgAlias>$199: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$201: Integer(5) = 5
-    <statTemp>$202: Integer(0) = 0
-    <assignTemp>$14$6: T.untyped = <cfgAlias>$199: T.class_of(<Magic>).<expand-splat>(<assignTemp>$13$6: T.untyped, <statTemp>$201: Integer(5), <statTemp>$202: Integer(0))
-    <cfgAlias>$205: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$208: Integer(0) = 0
-    <statTemp>$206: T.untyped = <assignTemp>$14$6: T.untyped.[](<statTemp>$208: Integer(0))
-    <statTemp>$209: String("singleton class instance") = "singleton class instance"
-    <statTemp>$210: String("main") = "main"
-    <statTemp>$211: Symbol(:@a) = :@a
-    @a$132: T.untyped = <cfgAlias>$205: T.class_of(<Magic>).<suggest-field-type>(<statTemp>$206: T.untyped, <statTemp>$209: String("singleton class instance"), <statTemp>$210: String("main"), <statTemp>$211: Symbol(:@a))
-    <cfgAlias>$214: T.class_of(<Magic>) = alias <C <Magic>>
-    <statTemp>$217: Integer(1) = 1
-    <statTemp>$215: T.untyped = <assignTemp>$14$6: T.untyped.[](<statTemp>$217: Integer(1))
-    <statTemp>$218: String("class") = "class"
-    <statTemp>$219: String("main") = "main"
-    <statTemp>$220: Symbol(:@@b) = :@@b
-    @@b$142: T.untyped = <cfgAlias>$214: T.class_of(<Magic>).<suggest-field-type>(<statTemp>$215: T.untyped, <statTemp>$218: String("class"), <statTemp>$219: String("main"), <statTemp>$220: Symbol(:@@b))
-    <statTemp>$223: Integer(2) = 2
-    $c$152: T.untyped = <assignTemp>$14$6: T.untyped.[](<statTemp>$223: Integer(2))
-    <statTemp>$226: Integer(3) = 3
-    d$6: T.untyped = <assignTemp>$14$6: T.untyped.[](<statTemp>$226: Integer(3))
-    <cfgAlias>$229: T.class_of(E) = alias <C E>
-    <statTemp>$232: Integer(4) = 4
-    <statTemp>$230: T.untyped = <assignTemp>$14$6: T.untyped.[](<statTemp>$232: Integer(4))
-    <statTemp>$227: T.untyped = <cfgAlias>$229: T.class_of(E).e=(<statTemp>$230: T.untyped)
-    <statTemp>$235: T.untyped = @a$132: T.untyped.inspect()
+    <statTemp>$197: Integer(5) = 5
+    <statTemp>$198: Integer(0) = 0
+    <assignTemp>$14$6: T.untyped = <cfgAlias>$195: T.class_of(<Magic>).<expand-splat>(<assignTemp>$13$6: T.untyped, <statTemp>$197: Integer(5), <statTemp>$198: Integer(0))
+    <cfgAlias>$201: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$204: Integer(0) = 0
+    <statTemp>$202: T.untyped = <assignTemp>$14$6: T.untyped.[](<statTemp>$204: Integer(0))
+    <statTemp>$205: String("singleton class instance") = "singleton class instance"
+    <statTemp>$206: String("main") = "main"
+    <statTemp>$207: Symbol(:@a) = :@a
+    @a$128: T.untyped = <cfgAlias>$201: T.class_of(<Magic>).<suggest-field-type>(<statTemp>$202: T.untyped, <statTemp>$205: String("singleton class instance"), <statTemp>$206: String("main"), <statTemp>$207: Symbol(:@a))
+    <cfgAlias>$210: T.class_of(<Magic>) = alias <C <Magic>>
+    <statTemp>$213: Integer(1) = 1
+    <statTemp>$211: T.untyped = <assignTemp>$14$6: T.untyped.[](<statTemp>$213: Integer(1))
+    <statTemp>$214: String("class") = "class"
+    <statTemp>$215: String("main") = "main"
+    <statTemp>$216: Symbol(:@@b) = :@@b
+    @@b$138: T.untyped = <cfgAlias>$210: T.class_of(<Magic>).<suggest-field-type>(<statTemp>$211: T.untyped, <statTemp>$214: String("class"), <statTemp>$215: String("main"), <statTemp>$216: Symbol(:@@b))
+    <statTemp>$219: Integer(2) = 2
+    $c$148: T.untyped = <assignTemp>$14$6: T.untyped.[](<statTemp>$219: Integer(2))
+    <statTemp>$222: Integer(3) = 3
+    d$6: T.untyped = <assignTemp>$14$6: T.untyped.[](<statTemp>$222: Integer(3))
+    <cfgAlias>$225: T.class_of(E) = alias <C E>
+    <statTemp>$228: Integer(4) = 4
+    <statTemp>$226: T.untyped = <assignTemp>$14$6: T.untyped.[](<statTemp>$228: Integer(4))
+    <statTemp>$223: T.untyped = <cfgAlias>$225: T.class_of(E).e=(<statTemp>$226: T.untyped)
+    <statTemp>$231: T.untyped = @a$128: T.untyped.inspect()
+    <statTemp>$229: NilClass = <self>: T.class_of(Main).puts(<statTemp>$231: T.untyped)
+    <statTemp>$235: T.untyped = @@b$138: T.untyped.inspect()
     <statTemp>$233: NilClass = <self>: T.class_of(Main).puts(<statTemp>$235: T.untyped)
-    <statTemp>$239: T.untyped = @@b$142: T.untyped.inspect()
+    <statTemp>$239: T.untyped = $c$148: T.untyped.inspect()
     <statTemp>$237: NilClass = <self>: T.class_of(Main).puts(<statTemp>$239: T.untyped)
-    <statTemp>$243: T.untyped = $c$152: T.untyped.inspect()
+    <statTemp>$243: T.untyped = d$6: T.untyped.inspect()
     <statTemp>$241: NilClass = <self>: T.class_of(Main).puts(<statTemp>$243: T.untyped)
-    <statTemp>$247: T.untyped = d$6: T.untyped.inspect()
-    <statTemp>$245: NilClass = <self>: T.class_of(Main).puts(<statTemp>$247: T.untyped)
-    <cfgAlias>$253: T.class_of(E) = alias <C E>
-    <statTemp>$251: T.untyped = <cfgAlias>$253: T.class_of(E).e()
-    <statTemp>$250: T.untyped = <statTemp>$251: T.untyped.inspect()
-    <blockReturnTemp>$191: NilClass = <self>: T.class_of(Main).puts(<statTemp>$250: T.untyped)
-    <blockReturnTemp>$254: T.noreturn = blockreturn<each> <blockReturnTemp>$191: NilClass
-    <unconditional> -> bb28
+    <cfgAlias>$249: T.class_of(E) = alias <C E>
+    <statTemp>$247: T.untyped = <cfgAlias>$249: T.class_of(E).e()
+    <statTemp>$246: T.untyped = <statTemp>$247: T.untyped.inspect()
+    <blockReturnTemp>$187: NilClass = <self>: T.class_of(Main).puts(<statTemp>$246: T.untyped)
+    <blockReturnTemp>$250: T.noreturn = blockreturn<each> <blockReturnTemp>$187: NilClass
+    <unconditional> -> bb22
 
 }
 

--- a/test/testdata/desugar/for.rb.desugar-tree.exp
+++ b/test/testdata/desugar/for.rb.desugar-tree.exp
@@ -25,11 +25,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       begin
         begin
           forTemp$2 = <emptyTree>::<C A>
-          if ::T.unsafe(nil)
-            a = forTemp$2.first()
-          else
-            <emptyTree>
-          end
+          a = ::<Magic>.<element-or-nil>(forTemp$2)
           forTemp$2.each() do |a|
             <self>.puts(a.inspect())
           end
@@ -47,16 +43,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         end
         begin
           forTemp$5 = <emptyTree>::<C A>
-          if ::T.unsafe(nil)
-            begin
-              <assignTemp>$6 = forTemp$5.first()
-              <assignTemp>$7 = ::<Magic>.<expand-splat>(<assignTemp>$6, 2, 0)
-              a = <assignTemp>$7.[](0)
-              b = <assignTemp>$7.[](1)
-              <assignTemp>$6
-            end
-          else
-            <emptyTree>
+          begin
+            <assignTemp>$6 = ::<Magic>.<element-or-nil>(forTemp$5)
+            <assignTemp>$7 = ::<Magic>.<expand-splat>(<assignTemp>$6, 2, 0)
+            a = <assignTemp>$7.[](0)
+            b = <assignTemp>$7.[](1)
+            <assignTemp>$6
           end
           forTemp$5.each() do |a, b|
             begin

--- a/test/testdata/desugar/for.rb.desugar-tree.exp
+++ b/test/testdata/desugar/for.rb.desugar-tree.exp
@@ -23,51 +23,73 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C Main><<C <todo sym>>> < (::<todo sym>)
     def self.main<<todo method>>(&<blk>)
       begin
-        <emptyTree>::<C A>.each() do |a|
-          <self>.puts(a.inspect())
+        begin
+          forTemp$2 = <emptyTree>::<C A>
+          if ::T.unsafe(nil)
+            a = forTemp$2.first()
+          else
+            <emptyTree>
+          end
+          forTemp$2.each() do |a|
+            <self>.puts(a.inspect())
+          end
         end
         <emptyTree>::<C A>.each() do |*forTemp|
           begin
             begin
-              <assignTemp>$2 = ::<Magic>.<splat>(forTemp)
-              <assignTemp>$3 = ::<Magic>.<expand-splat>(<assignTemp>$2, 1, 0)
-              a = <assignTemp>$3.[](0)
-              <assignTemp>$2
+              <assignTemp>$3 = ::<Magic>.<splat>(forTemp)
+              <assignTemp>$4 = ::<Magic>.<expand-splat>(<assignTemp>$3, 1, 0)
+              a = <assignTemp>$4.[](0)
+              <assignTemp>$3
             end
             <self>.puts(a.inspect())
           end
         end
-        <emptyTree>::<C A>.each() do |a, b|
-          begin
-            <self>.puts(a.inspect())
-            <self>.puts(b.inspect())
+        begin
+          forTemp$5 = <emptyTree>::<C A>
+          if ::T.unsafe(nil)
+            begin
+              <assignTemp>$6 = forTemp$5.first()
+              <assignTemp>$7 = ::<Magic>.<expand-splat>(<assignTemp>$6, 2, 0)
+              a = <assignTemp>$7.[](0)
+              b = <assignTemp>$7.[](1)
+              <assignTemp>$6
+            end
+          else
+            <emptyTree>
+          end
+          forTemp$5.each() do |a, b|
+            begin
+              <self>.puts(a.inspect())
+              <self>.puts(b.inspect())
+            end
           end
         end
         <emptyTree>::<C A>.each() do |*forTemp|
           begin
             begin
-              <assignTemp>$4 = ::<Magic>.<splat>(forTemp)
-              <assignTemp>$5 = ::<Magic>.<expand-splat>(<assignTemp>$4, 2, 0)
-              a = <assignTemp>$5.[](0)
-              b = <assignTemp>$5.[](1)
-              <assignTemp>$4
+              <assignTemp>$8 = ::<Magic>.<splat>(forTemp)
+              <assignTemp>$9 = ::<Magic>.<expand-splat>(<assignTemp>$8, 2, 0)
+              a = <assignTemp>$9.[](0)
+              b = <assignTemp>$9.[](1)
+              <assignTemp>$8
             end
             <self>.puts(a.inspect())
             <self>.puts(b.inspect())
           end
         end
         <self>.puts("main")
-        <emptyTree>::<C A>.each() do |forTemp$6|
+        <emptyTree>::<C A>.each() do |forTemp$10|
           begin
             begin
-              <assignTemp>$7 = forTemp$6
-              <assignTemp>$8 = ::<Magic>.<expand-splat>(<assignTemp>$7, 5, 0)
-              @a = <assignTemp>$8.[](0)
-              @@b = <assignTemp>$8.[](1)
-              $c = <assignTemp>$8.[](2)
-              d = <assignTemp>$8.[](3)
-              <emptyTree>::<C E>.e=(<assignTemp>$8.[](4))
-              <assignTemp>$7
+              <assignTemp>$11 = forTemp$10
+              <assignTemp>$12 = ::<Magic>.<expand-splat>(<assignTemp>$11, 5, 0)
+              @a = <assignTemp>$12.[](0)
+              @@b = <assignTemp>$12.[](1)
+              $c = <assignTemp>$12.[](2)
+              d = <assignTemp>$12.[](3)
+              <emptyTree>::<C E>.e=(<assignTemp>$12.[](4))
+              <assignTemp>$11
             end
             begin
               <self>.puts(@a.inspect())
@@ -81,14 +103,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <emptyTree>::<C A>.each() do |*forTemp|
           begin
             begin
-              <assignTemp>$9 = ::<Magic>.<splat>(forTemp)
-              <assignTemp>$10 = ::<Magic>.<expand-splat>(<assignTemp>$9, 5, 0)
-              @a = <assignTemp>$10.[](0)
-              @@b = <assignTemp>$10.[](1)
-              $c = <assignTemp>$10.[](2)
-              d = <assignTemp>$10.[](3)
-              <emptyTree>::<C E>.e=(<assignTemp>$10.[](4))
-              <assignTemp>$9
+              <assignTemp>$13 = ::<Magic>.<splat>(forTemp)
+              <assignTemp>$14 = ::<Magic>.<expand-splat>(<assignTemp>$13, 5, 0)
+              @a = <assignTemp>$14.[](0)
+              @@b = <assignTemp>$14.[](1)
+              $c = <assignTemp>$14.[](2)
+              d = <assignTemp>$14.[](3)
+              <emptyTree>::<C E>.e=(<assignTemp>$14.[](4))
+              <assignTemp>$13
             end
             <self>.puts(@a.inspect())
             <self>.puts(@@b.inspect())

--- a/test/testdata/infer/for_loop_variable_after_loop.rb
+++ b/test/testdata/infer/for_loop_variable_after_loop.rb
@@ -12,13 +12,23 @@ end
 
 T.reveal_type(a) # error: Revealed type: `T.nilable(Integer)`
 
-# Literal arrays are tuple types; `Tuple#first` returns a literal type,
-# which must be widened so that e.g. `b == 3` isn't dead code.
+# Literal arrays are tuple types; literal element types must be widened so
+# that e.g. `b == 3` isn't dead code after the loop.
 for b in [1, 2, 3]
 end
 
 T.reveal_type(b) # error: Revealed type: `T.nilable(Integer)`
 puts("three") if b == 3
+
+# For heterogeneous tuples, the post-loop type is the union of the
+# element types, because the loop can end early via `break`, so the
+# variable may hold any element (or `nil`), not specifically the first
+# or the last one.
+for het in [1, "one"]
+  break if het.is_a?(Integer)
+end
+
+T.reveal_type(het) # error: Revealed type: `T.nilable(T.any(Integer, String))`
 
 h = T.let({x: 1}, T::Hash[Symbol, Integer])
 for k, v in h
@@ -33,3 +43,21 @@ for r in 1..3
 end
 
 T.reveal_type(r) # error: Revealed type: `T.nilable(Integer)`
+
+# Ruby's `for` only requires the collection to respond to `each`. An
+# `each`-only class (no `Enumerable`, no `first`) must not report an error;
+# the loop variable's post-loop type falls back to `T.untyped`.
+class EachOnly
+  extend T::Sig
+
+  sig { params(blk: T.proc.params(arg0: Integer).void).void }
+  def self.each(&blk)
+    yield 1
+  end
+end
+
+for e in EachOnly
+  T.reveal_type(e) # error: Revealed type: `Integer`
+end
+
+T.reveal_type(e) # error: Revealed type: `T.untyped`

--- a/test/testdata/infer/for_loop_variable_after_loop.rb
+++ b/test/testdata/infer/for_loop_variable_after_loop.rb
@@ -1,0 +1,35 @@
+# typed: true
+
+# https://github.com/sorbet/sorbet/issues/10265
+# In Ruby, `for` loops don't define a new scope, so the loop variable
+# continues to exist after the loop, holding `nil` if the collection
+# was empty.
+
+xs = T.let([1, 2, 3], T::Array[Integer])
+for a in xs
+  T.reveal_type(a) # error: Revealed type: `Integer`
+end
+
+T.reveal_type(a) # error: Revealed type: `T.nilable(Integer)`
+
+# Literal arrays are tuple types; `Tuple#first` returns a literal type,
+# which must be widened so that e.g. `b == 3` isn't dead code.
+for b in [1, 2, 3]
+end
+
+T.reveal_type(b) # error: Revealed type: `T.nilable(Integer)`
+puts("three") if b == 3
+
+h = T.let({x: 1}, T::Hash[Symbol, Integer])
+for k, v in h
+  T.reveal_type(k) # error: Revealed type: `Symbol`
+  T.reveal_type(v) # error: Revealed type: `Integer`
+end
+
+T.reveal_type(k) # error: Revealed type: `T.nilable(Symbol)`
+T.reveal_type(v) # error: Revealed type: `T.nilable(Integer)`
+
+for r in 1..3
+end
+
+T.reveal_type(r) # error: Revealed type: `T.nilable(Integer)`

--- a/test/testdata/infer/for_loop_variable_after_loop.rb
+++ b/test/testdata/infer/for_loop_variable_after_loop.rb
@@ -44,9 +44,10 @@ end
 
 T.reveal_type(r) # error: Revealed type: `T.nilable(Integer)`
 
-# Ruby's `for` only requires the collection to respond to `each`. An
-# `each`-only class (no `Enumerable`, no `first`) must not report an error;
-# the loop variable's post-loop type falls back to `T.untyped`.
+# Ruby's `for` only requires the collection to respond to `each`, and the
+# element type comes from the declared block parameter type of `each` --
+# the only method `for` actually calls at runtime. A plain `each`-only
+# class (no `Enumerable`) works as long as `each` has a signature.
 class EachOnly
   extend T::Sig
 
@@ -60,4 +61,36 @@ for e in EachOnly
   T.reveal_type(e) # error: Revealed type: `Integer`
 end
 
-T.reveal_type(e) # error: Revealed type: `T.untyped`
+T.reveal_type(e) # error: Revealed type: `T.nilable(Integer)`
+
+# If `each` has no signature, we know nothing about what it yields, and the
+# loop variable's post-loop type falls back to `T.untyped`.
+class UntypedEach
+  def self.each(&blk)
+    yield 1
+  end
+end
+
+for u in UntypedEach
+end
+
+T.reveal_type(u) # error: Revealed type: `T.untyped`
+
+# An `each` that yields multiple values destructures into the loop
+# variables the same way the block parameters would.
+class PairEach
+  extend T::Sig
+
+  sig { params(blk: T.proc.params(arg0: String, arg1: Integer).void).void }
+  def self.each(&blk)
+    yield "one", 1
+  end
+end
+
+for s, n in PairEach
+  T.reveal_type(s) # error: Revealed type: `String`
+  T.reveal_type(n) # error: Revealed type: `Integer`
+end
+
+T.reveal_type(s) # error: Revealed type: `T.nilable(String)`
+T.reveal_type(n) # error: Revealed type: `T.nilable(Integer)`

--- a/test/testdata/parser/misc.rb.desugar-tree.exp
+++ b/test/testdata/parser/misc.rb.desugar-tree.exp
@@ -76,8 +76,16 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  <self>.arr().each() do |x|
-    <emptyTree>
+  begin
+    forTemp$8 = <self>.arr()
+    if ::T.unsafe(nil)
+      x = forTemp$8.first()
+    else
+      <emptyTree>
+    end
+    forTemp$8.each() do |x|
+      <emptyTree>
+    end
   end
 
   while 0.!=(1)
@@ -107,8 +115,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   begin
-    <hashTemp>$8 = ::<Magic>.<to-hash-dup>(x)
-    <hashTemp>$8
+    <hashTemp>$9 = ::<Magic>.<to-hash-dup>(x)
+    <hashTemp>$9
   end
 
   87
@@ -152,16 +160,16 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   begin
-    <assignTemp>$9 = 1
-    <assignTemp>$10 = ::<Magic>.<expand-splat>(<assignTemp>$9, 2, 0)
-    a = <assignTemp>$10.[](0)
+    <assignTemp>$10 = 1
+    <assignTemp>$11 = ::<Magic>.<expand-splat>(<assignTemp>$10, 2, 0)
+    a = <assignTemp>$11.[](0)
     begin
-      <assignTemp>$11 = <assignTemp>$10.[](1)
-      <assignTemp>$12 = ::<Magic>.<expand-splat>(<assignTemp>$11, 1, 0)
-      x = <assignTemp>$12.[](0)
-      <assignTemp>$11
+      <assignTemp>$12 = <assignTemp>$11.[](1)
+      <assignTemp>$13 = ::<Magic>.<expand-splat>(<assignTemp>$12, 1, 0)
+      x = <assignTemp>$13.[](0)
+      <assignTemp>$12
     end
-    <assignTemp>$9
+    <assignTemp>$10
   end
 
   4
@@ -189,10 +197,10 @@ rescue <emptyTree>::<C E> => x
   nil
 
   begin
-    <assignTemp>$14 = ::<Magic>.<splat>(y)
-    <assignTemp>$15 = ::<Magic>.<expand-splat>(<assignTemp>$14, 0, 0)
-    x = <assignTemp>$15.to_ary()
-    <assignTemp>$14
+    <assignTemp>$15 = ::<Magic>.<splat>(y)
+    <assignTemp>$16 = ::<Magic>.<expand-splat>(<assignTemp>$15, 0, 0)
+    x = <assignTemp>$16.to_ary()
+    <assignTemp>$15
   end
 
   ::<Magic>.<string-interpolate>("foo", <self>.bar()).intern()

--- a/test/testdata/parser/misc.rb.desugar-tree.exp
+++ b/test/testdata/parser/misc.rb.desugar-tree.exp
@@ -78,11 +78,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   begin
     forTemp$8 = <self>.arr()
-    if ::T.unsafe(nil)
-      x = forTemp$8.first()
-    else
-      <emptyTree>
-    end
+    x = ::<Magic>.<element-or-nil>(forTemp$8)
     forTemp$8.each() do |x|
       <emptyTree>
     end

--- a/test/testdata/rbs/assertions_bind.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_bind.rb.rewrite-tree.exp
@@ -94,10 +94,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  ::<Magic>.<build-range>(0, 10, false).each() do |_i|
-    begin
-      <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
-      <emptyTree>::<C T>.reveal_type(<self>)
+  begin
+    forTemp$4 = ::<Magic>.<build-range>(0, 10, false)
+    _i = ::<Magic>.<element-or-nil>(forTemp$4)
+    forTemp$4.each() do |_i|
+      begin
+        <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
+        <emptyTree>::<C T>.reveal_type(<self>)
+      end
     end
   end
 
@@ -168,7 +172,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Foo>)
     <emptyTree>::<C T>.reveal_type(<self>)
   end
-rescue => <rescueTemp>$4
+rescue => <rescueTemp>$5
   begin
     <cast:bind>(<self>, <todo sym>, <emptyTree>::<C Bar>)
     <emptyTree>::<C T>.reveal_type(<self>)

--- a/test/testdata/rbs/assertions_for.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_for.rb.rewrite-tree.exp
@@ -1,24 +1,44 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  <emptyTree>::<C ARGV>.each() do |x|
-    <cast:cast>(x, <todo sym>, <emptyTree>::<C String>)
-  end
-
-  <emptyTree>::<C ARGV>.each() do |x|
-    begin
+  begin
+    forTemp$2 = <emptyTree>::<C ARGV>
+    x = ::<Magic>.<element-or-nil>(forTemp$2)
+    forTemp$2.each() do |x|
       <cast:cast>(x, <todo sym>, <emptyTree>::<C String>)
-      <self>.puts(x)
     end
   end
 
-  <cast:let>(<emptyTree>::<C ARGV>, <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>)).each() do |x|
-    <emptyTree>
+  begin
+    forTemp$3 = <emptyTree>::<C ARGV>
+    x = ::<Magic>.<element-or-nil>(forTemp$3)
+    forTemp$3.each() do |x|
+      begin
+        <cast:cast>(x, <todo sym>, <emptyTree>::<C String>)
+        <self>.puts(x)
+      end
+    end
   end
 
-  <cast:cast>(<emptyTree>::<C ARGV>.each() do |x|
-    <emptyTree>
+  begin
+    forTemp$4 = <cast:let>(<emptyTree>::<C ARGV>, <todo sym>, ::<root>::<C T>::<C Array>.<syntheticSquareBrackets>(<emptyTree>::<C String>))
+    x = ::<Magic>.<element-or-nil>(forTemp$4)
+    forTemp$4.each() do |x|
+      <emptyTree>
+    end
+  end
+
+  <cast:cast>(begin
+    forTemp$5 = <emptyTree>::<C ARGV>
+    x = ::<Magic>.<element-or-nil>(forTemp$5)
+    forTemp$5.each() do |x|
+      <emptyTree>
+    end
   end, <todo sym>, <emptyTree>::<C String>)
 
-  y = <cast:cast>(<emptyTree>::<C ARGV>.each() do |x|
-    <emptyTree>
+  y = <cast:cast>(begin
+    forTemp$6 = <emptyTree>::<C ARGV>
+    x = ::<Magic>.<element-or-nil>(forTemp$6)
+    forTemp$6.each() do |x|
+      <emptyTree>
+    end
   end, <todo sym>, <emptyTree>::<C String>)
 end

--- a/test/testdata/rbs/signatures_blocks.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_blocks.rb.rewrite-tree.exp
@@ -358,14 +358,18 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   <runtime method definition of self.def21>
 
-  ::<Magic>.<build-range>(1, 10, false).each() do |i|
-    <runtime method definition of def23>
+  begin
+    forTemp$2 = ::<Magic>.<build-range>(1, 10, false)
+    i = ::<Magic>.<element-or-nil>(forTemp$2)
+    forTemp$2.each() do |i|
+      <runtime method definition of def23>
+    end
   end
 
   [<runtime method definition of def24>]
 
   <runtime method definition of def25>
-rescue => <rescueTemp>$2
+rescue => <rescueTemp>$3
   <runtime method definition of def26>
 ensure
   <runtime method definition of def27>
@@ -377,16 +381,16 @@ ensure
   end
 
   begin
-    <assignTemp>$3 = <runtime method definition of def30>
-    <assignTemp>$4 = ::<Magic>.<expand-splat>(<assignTemp>$3, 2, 0)
-    var5 = <assignTemp>$4.[](0)
-    var6 = <assignTemp>$4.[](1)
-    <assignTemp>$3
+    <assignTemp>$4 = <runtime method definition of def30>
+    <assignTemp>$5 = ::<Magic>.<expand-splat>(<assignTemp>$4, 2, 0)
+    var5 = <assignTemp>$5.[](0)
+    var6 = <assignTemp>$5.[](1)
+    <assignTemp>$4
   end
 
   begin
-    <assignTemp>$5 = <emptyTree>::<C ARGV>.first()
-    if "foo".===(<assignTemp>$5)
+    <assignTemp>$6 = <emptyTree>::<C ARGV>.first()
+    if "foo".===(<assignTemp>$6)
       <runtime method definition of def31>
     else
       <runtime method definition of def32>


### PR DESCRIPTION
In Ruby, `for` loops don't define a new scope: the loop variable continues to exist after the loop, holding `nil` if the collection was empty. Sorbet desugars `for a in xs` into `xs.each { |a| ... }`, but block parameters are block-local in the LocalVars pass, so the outer `a` was never assigned and its post-loop type was plain `NilClass` instead of `T.nilable(<element type>)`.

This changes the desugaring for `for` loops whose targets are all local variables ("nice desugar") from

    xs.each { |a| ... }

into

    <forTemp>$1 = xs
    a = <forTemp>$1.first() if T.unsafe(nil)
    <forTemp>$1.each { |a| ... }

Notes on the shape of the desugar:

- The collection is evaluated once into a temporary because it's now referenced twice.
- The seed assignment is guarded by an opaque (untyped) condition so that the post-loop type is the lub of "possibly uninitialized" (`NilClass`) and the seed's type. The lub also drops overly-precise literal types (e.g. `Integer(1)` from `Tuple#first` on `[1, 2, 3]`), which would otherwise make code like `a == 3` after the loop appear dead. Since the guard is falsy, the seed never executes at runtime under the Sorbet compiler.
- The mlhs case (`for k, v in hash`) seeds via a `Masgn`, whose `<expand-splat>` distributes `T.nilable([K, V])` into `T.nilable(K)` and `T.nilable(V)`.

Known tradeoff (also present in the desugar proposed in the issue): receivers that implement `each` but not `first` (and don't include `Enumerable`) now report "Method `first` does not exist" on the `for` loop, as seen in test/testdata/desugar/for.rb.

Fixes #10265

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
