### PR TITLE
Prevent `sorbet.run` crashes for invalid options

### DIFF
--- a/emscripten/main.cc
+++ b/emscripten/main.cc
@@ -1,3 +1,4 @@
+#include "common/EarlyReturnWithCode.h"
 #include "main/lsp/wrapper.h"
 #include "main/realmain.h"
 
@@ -12,9 +13,17 @@ using namespace std;
 
 namespace {
 
+void runSorbet(int argc, char *argv[]) {
+    try {
+        sorbet::realmain::realmain(argc, argv);
+    } catch (sorbet::EarlyReturnWithCode &) {
+        // Prevent handled Sorbet exits from aborting the wasm module and leaving the UI stuck.
+    }
+}
+
 void typecheckString(const char *rubySrc) {
     const char *argv[] = {"sorbet", "--color=always", "--silence-dev-message", "-e", rubySrc};
-    sorbet::realmain::realmain(size(argv), const_cast<char **>(reinterpret_cast<const char **>(argv)));
+    runSorbet(size(argv), const_cast<char **>(reinterpret_cast<const char **>(argv)));
 }
 
 } // namespace
@@ -53,7 +62,7 @@ void EMSCRIPTEN_KEEPALIVE typecheck(const char *optionsJson) {
         argCharStars.push_back(const_cast<char *>(argStrings[i].c_str()));
     }
 
-    sorbet::realmain::realmain(argCharStars.size(), argCharStars.data());
+    runSorbet(argCharStars.size(), argCharStars.data());
 }
 
 void EMSCRIPTEN_KEEPALIVE lsp(void (*respond)(const char *), const char *message) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Prevent crashes when invalid options are used such as https://sorbet.run/?&arg=--enable-experimental-rbs-comments (missing `arg=--parser=prism`)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tested on local server
<img width="908" height="133" alt="Screenshot 2026-07-13 at 10 33 40 AM" src="https://github.com/user-attachments/assets/bc7dbc81-ebb8-48ea-9afc-6a964596e911" />
