### PR TITLE
Perf: gate intrinsic-dispatch substitution loop on send.fun

### DIFF
--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -125,15 +125,17 @@ public:
             [[maybe_unused]] auto _substituted = subst.substituteSymbolName(name);
         }
 
-        send.fun = subst.substituteSymbolName(send.fun);
-
-        // Some intrinsic method dispatch to other methods. Defensively assume that any method that
-        // shares a name with an intrinsic might be an intrinsic method.
-        for (const auto &[source, targets] : core::intrinsicMethodsDispatchMap()) {
-            for (const auto target : targets) {
+        // Some intrinsic methods dispatch to other methods. Defensively assume that any method that
+        // shares a name with an intrinsic might be an intrinsic method, and substitute its dispatch
+        // targets so their names survive into the merged GlobalState.
+        const auto &dispatchMap = core::intrinsicMethodsDispatchMap();
+        if (auto it = dispatchMap.find(send.fun); it != dispatchMap.end()) {
+            for (const auto target : it->second) {
                 [[maybe_unused]] auto _substituted = subst.substituteSymbolName(target);
             }
         }
+
+        send.fun = subst.substituteSymbolName(send.fun);
     }
 
     void postTransformLiteral(core::Context ctx, ExpressionPtr &tree) {

--- a/ast/substitute/Substitute.cc
+++ b/ast/substitute/Substitute.cc
@@ -52,6 +52,17 @@ private:
         return literal->asName();
     }
 
+    core::NameRef substituteDispatchedName(core::NameRef name) {
+        const auto &dispatchMap = core::intrinsicMethodsDispatchMap();
+        if (auto it = dispatchMap.find(name); it != dispatchMap.end()) {
+            for (const auto target : it->second) {
+                [[maybe_unused]] auto _substituted = subst.substituteSymbolName(target);
+            }
+        }
+
+        return subst.substituteSymbolName(name);
+    }
+
 public:
     SubstWalk(T &subst) : subst(subst) {}
 
@@ -105,13 +116,13 @@ public:
             if (send.numPosArgs() > 0) {
                 auto name = unwrapLiteralToName(send.getPosArg(0));
                 if (name.exists()) {
-                    [[maybe_unused]] auto _substituted = subst.substituteSymbolName(name);
+                    [[maybe_unused]] auto _substituted = substituteDispatchedName(name);
                 }
             }
             if (send.numPosArgs() > 1) {
                 auto name = unwrapLiteralToName(send.getPosArg(1));
                 if (name.exists()) {
-                    [[maybe_unused]] auto _substituted = subst.substituteSymbolName(name);
+                    [[maybe_unused]] auto _substituted = substituteDispatchedName(name);
                 }
             }
         } else if (send.fun == core::Names::callWithSplat() || send.fun == core::Names::callWithBlockPass() ||
@@ -122,20 +133,10 @@ public:
             // positional arg at index 1.
             auto name = unwrapLiteralToName(send.getPosArg(1));
             ENFORCE(name.exists(), "Name should exist because this arg should be a Literal");
-            [[maybe_unused]] auto _substituted = subst.substituteSymbolName(name);
+            [[maybe_unused]] auto _substituted = substituteDispatchedName(name);
         }
 
-        // Some intrinsic methods dispatch to other methods. Defensively assume that any method that
-        // shares a name with an intrinsic might be an intrinsic method, and substitute its dispatch
-        // targets so their names survive into the merged GlobalState.
-        const auto &dispatchMap = core::intrinsicMethodsDispatchMap();
-        if (auto it = dispatchMap.find(send.fun); it != dispatchMap.end()) {
-            for (const auto target : it->second) {
-                [[maybe_unused]] auto _substituted = subst.substituteSymbolName(target);
-            }
-        }
-
-        send.fun = subst.substituteSymbolName(send.fun);
+        send.fun = substituteDispatchedName(send.fun);
     }
 
     void postTransformLiteral(core::Context ctx, ExpressionPtr &tree) {

--- a/test/testdata/lsp/fast_path/call_with_splat_new__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/call_with_splat_new__1.1.rbupdate
@@ -1,0 +1,10 @@
+# typed: strict
+# assert-fast-path: call_with_splat_new__1.rb,call_with_splat_new__2.rb
+
+class A
+  extend T::Sig
+
+  sig {params(x: String).void}
+  def initialize(x)
+  end
+end

--- a/test/testdata/lsp/fast_path/call_with_splat_new__1.rb
+++ b/test/testdata/lsp/fast_path/call_with_splat_new__1.rb
@@ -1,0 +1,9 @@
+# typed: strict
+
+class A
+  extend T::Sig
+
+  sig {params(x: Integer).void}
+  def initialize(x)
+  end
+end

--- a/test/testdata/lsp/fast_path/call_with_splat_new__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/call_with_splat_new__2.1.rbupdate
@@ -1,0 +1,9 @@
+# typed: strict
+# exclude-from-file-update: true
+
+int_arg = [1]
+str_arg = ['']
+  A.new(*int_arg)
+# ^ error: Expected `String` but found `Integer(1)` for argument `x`
+  A.new(*str_arg)
+# spacer

--- a/test/testdata/lsp/fast_path/call_with_splat_new__2.rb
+++ b/test/testdata/lsp/fast_path/call_with_splat_new__2.rb
@@ -1,0 +1,9 @@
+# typed: strict
+# spacer for exclude-from-file-update
+
+int_arg = [1]
+str_arg = ['']
+  A.new(*int_arg)
+# spacer
+  A.new(*str_arg)
+# ^ error: Expected `Integer` but found `String("")` for argument `x`


### PR DESCRIPTION
_Agent note: Stack currently being worked on in code-789._

### Motivation

`SubstWalk::preTransformSend` runs once per `Send`. Before this PR, every send walked the full `intrinsicMethodsDispatchMap()` and substituted every intrinsic dispatch target, even when the send could not dispatch to that target. The gate replaces that full-map walk with a lookup for the dispatched-to name, retaining the performance benefit while preserving the names required by the LSP fast path.

### The change

`preTransformSend` now uses `substituteDispatchedName` for every name that a send can dispatch to:

```
send.fun
magic-send symbol literal (`<call-with-splat>`, `<call-with-block-pass>`,
  `<call-with-splat-and-block-pass>`, and `<check-and-and>`)
`alias_method` symbol literals
```

The helper probes `intrinsicMethodsDispatchMap()` using the pre-substitution name, substitutes all dispatch targets, then substitutes the name itself. The map is keyed in the source `GlobalState` name space, so this ordering is required.

### Behavior preservation follow-up

The original gate as reviewed was not behavior-preserving; the reviewer correctly identified an observable gap. The magic sends dispatch to the method named by their symbol-literal argument. When that method is itself an intrinsic, its targets were dropped from the `UsageHash`: for example, `A.new(*args)` desugars through `<call-with-splat>` with `:new`, and the `Class_new` intrinsic dispatches to `initialize`. A fast-path signature edit to `A#initialize` then skipped files calling `A.new(*args)`, leaving stale diagnostics.

The follow-up commit fixes this by probing the dispatch map through the shared helper for every dispatched-to name: `send.fun`, the magic sends' symbol-literal argument, and `alias_method`'s arguments. The new `test/testdata/lsp/fast_path/call_with_splat_new__*` regression fails without the symbol-literal probe and passes with it; it also passes on `master`.

One residual divergence from the old blanket loop remains intentionally. A caller of an alias to an intrinsic (`alias_method :make, :new`, then `A.make(1)` in another file) no longer receives the old loop's incidental `initialize` coverage. This matches existing fast-path behavior for aliases to non-intrinsic methods: their callers are not retypechecked when the aliased method's signature changes.

### Performance evidence

The 828,001 to 113,978 (−86.2%) `substituteSymbolName` call-count reduction was measured for the pre-fix gate. This follow-up adds one dispatch-map probe per special-cased send and substitutes targets only for literal dispatch-map hits. That work is negligible next to removing the prior full dispatch-map walk for every send.

### Implementation plan

[Implementation plan and Lean UsageHash proof](https://gist.github.com/alexander-stripe/d00ada341e466366bc17fc8c0c98a078)

### Test plan

- `//test:test_LSPTests/testdata/lsp/fast_path/call_with_splat_new` verifies fast-path rechecking and changed diagnostics for `A.new(*args)` after an `A#initialize` signature edit.
- `//test:test_corpus_lsp` passes 2,254/2,254 targets and exercises `LazyNameSubstitution`/`UsageHash` behavior.
- `//test:test_corpus` passes 2,254/2,254 targets with no pipeline output diffs.
