### PR TITLE
Perf: share one immutable empty KnowledgeFact singleton

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -246,7 +246,16 @@ string KnowledgeFact::toString(const core::GlobalState &gs, const cfg::CFG &cfg)
     return fmt::format("{}{}", fmt::join(buf1, ""), fmt::join(buf2, ""));
 }
 
-KnowledgeRef::KnowledgeRef() : knowledge(make_shared<KnowledgeFact>()) {}
+namespace {
+const shared_ptr<KnowledgeFact> &emptyKnowledgeFact() {
+    // Shared, never-mutated empty fact. Because its use_count is always > 1, KnowledgeRef::mutate()
+    // will always copy-on-write before any modification, so aliasing it is safe.
+    static const shared_ptr<KnowledgeFact> empty = make_shared<KnowledgeFact>();
+    return empty;
+}
+} // namespace
+
+KnowledgeRef::KnowledgeRef() : knowledge(emptyKnowledgeFact()) {}
 
 const KnowledgeFact &KnowledgeRef::operator*() const {
     return *knowledge.get();


### PR DESCRIPTION
KnowledgeRef's default ctor called make_shared<KnowledgeFact>(), so every default-constructed VariableState heap-allocated two empty KnowledgeFacts (_truthy and _falsy) per block per live variable. In the dominant single-parent path populateFrom overwrites both immediately, freeing the just-allocated empties.

Point the default ctor at a shared, function-local-static empty KnowledgeFact instead. Its use_count is always > 1, so KnowledgeRef::mutate()'s existing copy-on-write (use_count() > 1) always copies before any write, making the alias observationally identical to owning a fresh empty fact; the singleton itself is never mutated.

### Test plan
Outcome: infer.knowledgefact.allocated on the pinned 730-file corpus (https://github.com/alexander-stripe/sorbet/commit/0daffeaf4a917fec68ccd27e308b5e3e9cd61912) drops 117996 -> 2236 (-115760, -98.11%). test_corpus is green in both opt and dbg (the dbg ENFORCE(use_count()==1) in mutate() proves the singleton is never written in place) with zero .exp diffs.