### PR TITLE
Add RBI signature for `Array#rfind`

### DIFF
--- a/rbi/core/array.rbi
+++ b/rbi/core/array.rbi
@@ -2165,6 +2165,53 @@ class Array < Object
   sig {returns(T::Enumerator[Elem])}
   def reverse_each(&blk); end
 
+  # Returns the last element for which the block returns a truthy value.
+  #
+  # With a block given, calls the block with successive elements of the array
+  # in reverse order; returns the first element for which the block returns a
+  # truthy value:
+  #
+  # ```ruby
+  # [1, 2, 3, 4, 5, 6].rfind {|element| element < 5}       # => 4
+  # ```
+  #
+  # If no such element is found, calls `if_none_proc` and returns its return
+  # value:
+  #
+  # ```ruby
+  # [1, 2, 3, 4].rfind(proc {0}) {|element| element < -2}  # => 0
+  # ```
+  #
+  # With no block given, returns an Enumerator.
+  #
+  # See also
+  # [`Array#find`](https://docs.ruby-lang.org/en/4.0/Array.html#method-i-find).
+  sig do
+    type_parameters(:U)
+      .params(
+        ifnone: T.proc.returns(T.type_parameter(:U)),
+        blk: T.proc.params(arg0: Elem).returns(BasicObject),
+      )
+      .returns(T.any(T.type_parameter(:U), Elem))
+  end
+  sig do
+    type_parameters(:U)
+      .params(
+        ifnone: T.proc.returns(T.type_parameter(:U)),
+      )
+      .returns(T::Enumerator[T.any(T.type_parameter(:U), Elem)])
+  end
+  sig do
+    params(
+      blk: T.proc.params(arg0: Elem).returns(BasicObject),
+    )
+    .returns(T.nilable(Elem))
+  end
+  sig do
+    returns(T::Enumerator[Elem])
+  end
+  def rfind(ifnone=T.unsafe(nil), &blk); end
+
   # Returns the *index* of the last object in `self` `==` to `obj`.
   #
   # If a block is given instead of an argument, returns the *index* of the first

--- a/test/testdata/rbi/array.rb
+++ b/test/testdata/rbi/array.rb
@@ -79,3 +79,13 @@ x = [[3.4], [1, "a"]]
 T.reveal_type(x.transpose) # error: Revealed type: `T::Array[T::Array[T.untyped]]`
 x = [[3.4, "a"], [:a, 5]]
 T.reveal_type(x.transpose) # error: Revealed type: `[T::Array[T.any(Float, Symbol)], T::Array[T.any(Integer, String)]] (2-tuple)`
+
+# rfind
+# block only -> T.nilable(Elem)
+T.reveal_type([1, 2, 3].rfind { |x| x > 1 }) # error: Revealed type: `T.nilable(Integer)`
+# no block -> Enumerator
+T.reveal_type([1, 2, 3].rfind) # error: Revealed type: `T::Enumerator[Integer]`
+# ifnone proc + block -> T.any(U, Elem)
+T.reveal_type([1, 2, 3].rfind(proc { 'none' }) { |x| x > 5 }) # error: Revealed type: `T.any(Integer, String)`
+# ifnone proc, no block -> Enumerator with union
+T.reveal_type([1, 2, 3].rfind(proc { 'none' })) # error: Revealed type: `T::Enumerator[T.any(Integer, String)]`


### PR DESCRIPTION
`Array#rfind` is a new method introduced in Ruby 4.0 ([Feature #21678](https://bugs.ruby-lang.org/issues/21678)) that iterates elements in reverse order, returning the first element for which the block returns a truthy value. It is the reverse analog of `Enumerable#find`, with the same four overload forms:

```
- ifnone proc + block -> T.any(U, Elem)
- ifnone proc only    -> T::Enumerator[T.any(U, Elem)]
- block only          -> T.nilable(Elem)
- neither             -> T::Enumerator[Elem]
```

The signature mirrors `Enumerable#find exactly`, using `type_parameters(:U)` for the `ifnone` fallback return type. Placed alphabetically between `reverse_each` and `rindex` in `rbi/core/array.rbi`.

Added four `T.reveal_type` test cases in `test/testdata/rbi/array.rb` covering all four overload forms with verified expected types.