### PR TITLE
Fix crash in localName2Remote when filePath equals rootPath

### DIFF
--- a/main/lsp/BUILD
+++ b/main/lsp/BUILD
@@ -228,6 +228,24 @@ cc_test(
 )
 
 cc_test(
+    name = "lsp_configuration_test",
+    size = "small",
+    srcs = ["test/lsp_configuration_test.cc"],
+    linkstatic = select({
+        "//tools/config:linkshared": 0,
+        "//conditions:default": 1,
+    }),
+    visibility = ["//tools:__pkg__"],
+    deps = [
+        "lsp",
+        "//payload",
+        "//test/helpers",
+        "@doctest//doctest",
+        "@doctest//doctest:main",
+    ],
+)
+
+cc_test(
     name = "watchman_shutdown_test",
     size = "small",
     srcs = ["test/watchman_shutdown_test.cc"],

--- a/main/lsp/LSPConfiguration.cc
+++ b/main/lsp/LSPConfiguration.cc
@@ -142,7 +142,9 @@ string LSPConfiguration::localName2Remote(string_view filePath) const {
     ENFORCE(absl::StartsWith(filePath, rootPath));
     assertHasClientConfig();
     string_view relativeUri = filePath.substr(rootPath.length());
-    if (relativeUri.at(0) == '/') {
+    // relativeUri is empty when filePath == rootPath (e.g. rootPath is ""); guard against
+    // indexing into an empty string_view before stripping a leading slash.
+    if (absl::StartsWith(relativeUri, "/")) {
         relativeUri = relativeUri.substr(1);
     }
 

--- a/main/lsp/test/lsp_configuration_test.cc
+++ b/main/lsp/test/lsp_configuration_test.cc
@@ -1,0 +1,56 @@
+#include "doctest/doctest.h"
+// has to go first as it violates our requirements
+
+#include "main/lsp/LSPConfiguration.h"
+#include "main/lsp/LSPMessage.h"
+#include "main/lsp/LSPOutput.h"
+#include "main/lsp/json_types.h"
+#include "spdlog/sinks/null_sink.h"
+
+using namespace std;
+
+namespace sorbet::realmain::lsp::test {
+
+namespace {
+
+options::Options makeOptions(string_view rootPath) {
+    options::Options opts;
+    opts.rawInputDirNames.emplace_back(string(rootPath));
+    return opts;
+}
+
+shared_ptr<LSPConfiguration> makeConfig(const options::Options &opts, string_view rootUri) {
+    auto nullSink = make_shared<spdlog::sinks::null_sink_mt>();
+    auto logger = make_shared<spdlog::logger>("console", nullSink);
+    auto config = make_shared<LSPConfiguration>(opts, make_shared<LSPOutputToVector>(), logger, false);
+    InitializeParams initParams(string(rootUri), make_unique<ClientCapabilities>());
+    config->setClientConfig(make_shared<LSPClientConfiguration>(initParams));
+    config->markInitialized();
+    return config;
+}
+
+} // namespace
+
+TEST_CASE("LocalName2RemoteFileAtRoot") {
+    // When filePath == rootPath, the relative path is empty. localName2Remote must not index
+    // into the empty string_view while stripping a leading slash.
+    auto opts = makeOptions("/foo/bar");
+    auto config = makeConfig(opts, "file:///foo/bar");
+    CHECK_EQ(config->localName2Remote("/foo/bar"), "file:///foo/bar/");
+}
+
+TEST_CASE("LocalName2RemoteFileBelowRoot") {
+    auto opts = makeOptions("/foo/bar");
+    auto config = makeConfig(opts, "file:///foo/bar");
+    CHECK_EQ(config->localName2Remote("/foo/bar/baz.rb"), "file:///foo/bar/baz.rb");
+}
+
+TEST_CASE("LocalName2RemoteEmptyRoot") {
+    // Special case: root path is '' (current directory) and root uri is '' (happens in Monaco).
+    // filePath == rootPath == "" yields an empty relative path, which must not throw.
+    auto opts = makeOptions("");
+    auto config = makeConfig(opts, "");
+    CHECK_EQ(config->localName2Remote(""), "");
+}
+
+} // namespace sorbet::realmain::lsp::test

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -72,6 +72,7 @@ compilation_database(
         "//main/lsp:generate_lsp_messages",
         "//main/lsp:generate_lsp_messages_test",
         "//main/lsp:lsp",
+        "//main/lsp:lsp_configuration_test",
         "//main/lsp:lsp_file_updates_test",
         "//main/lsp:lsp_preprocessor_test",
         "//main/lsp:lsp_test",


### PR DESCRIPTION
Extracts a latent-crash fix out of #9935 per [review feedback](https://github.com/sorbet/sorbet/pull/9935#discussion_r2881173468).

`LSPConfiguration::localName2Remote` computes `relativeUri` by stripping `rootPath` off the front of `filePath`, then strips a leading `/`:

```cpp
string_view relativeUri = filePath.substr(rootPath.length());
if (relativeUri.at(0) == '/') { // throws when relativeUri is empty
```

When `filePath == rootPath`, `relativeUri` is empty and `relativeUri.at(0)` throws `std::out_of_range`. This is reachable because `rootPath == ""` is an existing special case (see the "Root uri is '' (happens in Monaco)" branch just below), so a file whose path equals `rootPath` produces an empty `relativeUri`. The `ENFORCE` above only checks `absl::StartsWith(filePath, rootPath)`, which is satisfied by the equal-string case.

The fix guards the leading-slash strip with `absl::StartsWith`, which returns `false` for an empty `string_view` instead of indexing into it. `absl::StartsWith` is already used one line above, so there's no new dependency.

### Motivation

Latent crash in `localName2Remote` when `filePath == rootPath`, surfaced while working on #9935. The maintainer asked to land it as a standalone fix on master.

### Test plan

Adds `main/lsp/test/lsp_configuration_test.cc` (new `//main/lsp:lsp_configuration_test` doctest target) covering `localName2Remote`:

- `LocalName2RemoteFileAtRoot` — `filePath == rootPath` (non-empty root) produces an empty relative path.
- `LocalName2RemoteEmptyRoot` — the `rootPath == ""` / `rootUri == ""` (Monaco) special case.
- `LocalName2RemoteFileBelowRoot` — the normal case, guarding the `absl::StartsWith` equivalence.

Verified the first two cases fail (throw `std::out_of_range`) against the un-patched code and pass with the fix.
