### PR TITLE
Clarify desugar tree formatting for keyword rest and anonymous parameters

### DIFF
--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1295,7 +1295,11 @@ string Block::showRaw(const core::GlobalState &gs, int tabs) const {
 }
 
 string RestParam::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
-    return "*" + this->expr.toStringWithTabs(gs, tabs);
+    if (auto kwargSplat = cast_tree<KeywordArg>(this->expr)) { // Handle keyword arg splat, like `def foo(**kwargs)`
+        return "**" + kwargSplat->expr.toStringWithTabs(gs, tabs);
+    } else { // Handle rest arg splat, like `def foo(*args)`
+        return "*" + this->expr.toStringWithTabs(gs, tabs);
+    }
 }
 
 string KeywordArg::toStringWithTabs(const core::GlobalState &gs, int tabs) const {

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1294,11 +1294,31 @@ string Block::showRaw(const core::GlobalState &gs, int tabs) const {
     return fmt::to_string(buf);
 }
 
+namespace {
+core::NameRef extractIdentName(const ExpressionPtr &expr) {
+    if (auto unresolvedIdent = cast_tree<UnresolvedIdent>(expr)) {
+        return unresolvedIdent->name;
+    } else {
+        return core::NameRef::noName();
+    }
+}
+} // namespace
+
 string RestParam::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
     if (auto kwargSplat = cast_tree<KeywordArg>(this->expr)) { // Handle keyword arg splat, like `def foo(**kwargs)`
-        return "**" + kwargSplat->expr.toStringWithTabs(gs, tabs);
+        auto name = extractIdentName(kwargSplat->expr);
+        if (name == core::Names::starStar()) {
+            return "**";
+        } else {
+            return "**" + kwargSplat->expr.toStringWithTabs(gs, tabs);
+        }
     } else { // Handle rest arg splat, like `def foo(*args)`
-        return "*" + this->expr.toStringWithTabs(gs, tabs);
+        auto name = extractIdentName(this->expr);
+        if (name == core::Names::star()) {
+            return "*";
+        } else {
+            return "*" + this->expr.toStringWithTabs(gs, tabs);
+        }
     }
 }
 
@@ -1323,7 +1343,11 @@ string ShadowArg::toStringWithTabs(const core::GlobalState &gs, int tabs) const 
 }
 
 string BlockParam::toStringWithTabs(const core::GlobalState &gs, int tabs) const {
-    return "&" + this->expr.toStringWithTabs(gs, tabs);
+    if (extractIdentName(this->expr) == core::Names::ampersand()) { // Anonymous block param, like `def foo(&)`
+        return "&";
+    } else {
+        return "&" + this->expr.toStringWithTabs(gs, tabs);
+    }
 }
 
 string_view RescueCase::nodeName() const {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -840,10 +840,10 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 if (!send->args.empty() && parser::isa_node<parser::BlockPass>(send->args.back().get())) {
                     auto *bp = parser::cast_node<parser::BlockPass>(send->args.back().get());
                     blockPassLoc = bp->loc;
-                    if (bp->block == nullptr) {
-                        // Replace an anonymous block pass like `f(&)` with a local variable reference, like `f(&&)`.
+                    if (bp->block == nullptr) { // Anonymous block pass, like `f(&)`
+                        // Treat it as a block pass of a local variable literally named `&`.
                         blockPassArg = MK::Local(bp->loc.copyEndWithZeroLength(), core::Names::ampersand());
-                    } else {
+                    } else { // Block pass with an explicit expression, like `f(&block)`
                         blockPassArg = node2TreeImpl(dctx, bp->block);
                     }
 

--- a/test/testdata/desugar/anonymous_blockarg.rb.desugar-tree.exp
+++ b/test/testdata/desugar/anonymous_blockarg.rb.desugar-tree.exp
@@ -1,9 +1,9 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def foo<<todo method>>(args, &&)
+  def foo<<todo method>>(args, &)
     ::<Magic>.<call-with-splat-and-block-pass>(<self>, :bar, ::<Magic>.<splat>(args), nil, &)
   end
 
-  def bar<<todo method>>(args, &&)
+  def bar<<todo method>>(args, &)
     ::<Magic>.<call-with-block-pass>(<self>, :baz, &)
   end
 

--- a/test/testdata/desugar/bad_block_pass.rb.desugar-tree.exp
+++ b/test/testdata/desugar/bad_block_pass.rb.desugar-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def a<<todo method>>(*<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
+  def a<<todo method>>(*<fwd-args>, **<fwd-kwargs>, &<fwd-block>)
     <emptyTree>
   end
 

--- a/test/testdata/desugar/block_given.rb.desugar-tree.exp
+++ b/test/testdata/desugar/block_given.rb.desugar-tree.exp
@@ -32,7 +32,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  def method_with_anonymous_block_param<<todo method>>(&&)
+  def method_with_anonymous_block_param<<todo method>>(&)
     begin
       if &
         <self>.block_given?()

--- a/test/testdata/desugar/forward_args.rb.desugar-tree.exp
+++ b/test/testdata/desugar/forward_args.rb.desugar-tree.exp
@@ -4,22 +4,22 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    def foo<<todo method>>(*<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
+    def foo<<todo method>>(*<fwd-args>, **<fwd-kwargs>, &<fwd-block>)
       ::<Magic>.<call-with-splat-and-block-pass>(<emptyTree>::<C T>.unsafe(<self>), :bar, ::<Magic>.<splat>(<fwd-args>).concat([::<Magic>.<to-hash-dup>(<fwd-kwargs>)]), nil, <fwd-block>)
     end
 
-    def foo2<<todo method>>(*args, *kwargs:, &block)
+    def foo2<<todo method>>(*args, **kwargs, &block)
       ::<Magic>.<call-with-splat-and-block-pass>(<emptyTree>::<C T>.unsafe(<self>), :bar, ::<Magic>.<splat>(args), [begin
             <hashTemp>$2 = ::<Magic>.<to-hash-dup>(kwargs)
             <hashTemp>$2
           end], block)
     end
 
-    def foo3<<todo method>>(*<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
+    def foo3<<todo method>>(*<fwd-args>, **<fwd-kwargs>, &<fwd-block>)
       ::<Magic>.<call-with-splat-and-block-pass>(<emptyTree>::<C T>.unsafe(<self>), :bar, ::<Magic>.<splat>([1, 2, 3]).concat(::<Magic>.<splat>(<fwd-args>)).concat([::<Magic>.<to-hash-dup>(<fwd-kwargs>)]), nil, <fwd-block>)
     end
 
-    def foo4<<todo method>>(*args, *kwargs:, &block)
+    def foo4<<todo method>>(*args, **kwargs, &block)
       ::<Magic>.<call-with-splat-and-block-pass>(<emptyTree>::<C T>.unsafe(<self>), :bar, ::<Magic>.<splat>([1, 2, 3]).concat(::<Magic>.<splat>(args)), [begin
             <hashTemp>$2 = ::<Magic>.<to-hash-dup>(kwargs)
             <hashTemp>$2

--- a/test/testdata/desugar/forward_args.rb.desugar-tree.exp
+++ b/test/testdata/desugar/forward_args.rb.desugar-tree.exp
@@ -26,19 +26,19 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
           end], block)
     end
 
-    def foo5<<todo method>>(**, &<blk>)
-      [1, 2, 3].each() do |**|
+    def foo5<<todo method>>(*, &<blk>)
+      [1, 2, 3].each() do |*|
         ::<Magic>.<call-with-splat>(<emptyTree>::<C T>.unsafe(<self>), :p, [].concat(::T.unsafe(<fwd-args>.to_a())), nil)
       end
     end
 
     def foo6<<todo method>>(*args, &<blk>)
-      [1, 2, 3].each() do |**|
+      [1, 2, 3].each() do |*|
         ::<Magic>.<call-with-splat>(<emptyTree>::<C T>.unsafe(<self>), :p, [].concat(::T.unsafe(<fwd-args>.to_a())), nil)
       end
     end
 
-    def foo7<<todo method>>(**, &<blk>)
+    def foo7<<todo method>>(*, &<blk>)
       [1, 2, 3].each() do |*args|
         ::<Magic>.<call-with-splat>(<emptyTree>::<C T>.unsafe(<self>), :p, [].concat(::T.unsafe(<fwd-args>.to_a())), nil)
       end

--- a/test/testdata/desugar/forwarded_rest_args_array.rb.desugar-tree.exp
+++ b/test/testdata/desugar/forwarded_rest_args_array.rb.desugar-tree.exp
@@ -6,7 +6,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  def start_dotdotdot<<todo method>>(**, *<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
+  def start_dotdotdot<<todo method>>(**, *<fwd-args>, **<fwd-kwargs>, &<fwd-block>)
     <emptyTree>
   end
 end

--- a/test/testdata/desugar/forwarded_rest_args_array.rb.desugar-tree.exp
+++ b/test/testdata/desugar/forwarded_rest_args_array.rb.desugar-tree.exp
@@ -1,12 +1,12 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def forwarded_rest_args<<todo method>>(**, &<blk>)
+  def forwarded_rest_args<<todo method>>(*, &<blk>)
     begin
       xs = [:before].concat(::<Magic>.<splat>(*)).concat([:after])
       <emptyTree>::<C T>.reveal_type(xs)
     end
   end
 
-  def start_dotdotdot<<todo method>>(**, *<fwd-args>, **<fwd-kwargs>, &<fwd-block>)
+  def start_dotdotdot<<todo method>>(*, *<fwd-args>, **<fwd-kwargs>, &<fwd-block>)
     <emptyTree>
   end
 end

--- a/test/testdata/desugar/forwarded_restarg_and_kwrestarg.rb.rewrite-tree.exp
+++ b/test/testdata/desugar/forwarded_restarg_and_kwrestarg.rb.rewrite-tree.exp
@@ -19,7 +19,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <emptyTree>
   end
 
-  def foo<<todo method>>(**, &<blk>)
+  def foo<<todo method>>(*, &<blk>)
     begin
       res = ::<Magic>.<call-with-splat>(<self>, :pos_args, [].concat(::T.unsafe(<fwd-args>.to_a())), nil)
       <emptyTree>::<C T>.reveal_type(res)
@@ -29,7 +29,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  def bar<<todo method>>(***:, &<blk>)
+  def bar<<todo method>>(**, &<blk>)
     begin
       <self>.req_kwargs(begin
           <hashTemp>$2 = ::<Magic>.<to-hash-dup>(::T.unsafe(<fwd-kwargs>))
@@ -62,7 +62,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  def baz<<todo method>>(**, ***:, &&)
+  def baz<<todo method>>(*, **, &)
     begin
       ::<Magic>.<call-with-splat-and-block-pass>(<self>, :all_the_args, [].concat(::T.unsafe(<fwd-args>.to_a())), [begin
             <hashTemp>$2 = ::<Magic>.<to-hash-dup>(::T.unsafe(<fwd-kwargs>))
@@ -84,7 +84,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.params(:**, <emptyTree>::<C Integer>).void()
   end
 
-  def buzz<<todo method>>(***:, &<blk>)
+  def buzz<<todo method>>(**, &<blk>)
     <emptyTree>
   end
 

--- a/test/testdata/desugar/op_asgn_kw_block.rb.desugar-tree.exp
+++ b/test/testdata/desugar/op_asgn_kw_block.rb.desugar-tree.exp
@@ -9,14 +9,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
-    def []<<todo method>>(*args, *kwargs:, &blk)
+    def []<<todo method>>(*args, **kwargs, &blk)
       begin
         <self>.p([args, kwargs, blk])
         0
       end
     end
 
-    def []=<<todo method>>(*args, *kwargs:, &blk)
+    def []=<<todo method>>(*args, **kwargs, &blk)
       begin
         <self>.p([args, kwargs, blk])
         0

--- a/test/testdata/lsp/completion/bad_arguments.rb.desugar-tree.exp
+++ b/test/testdata/lsp/completion/bad_arguments.rb.desugar-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def foo<<todo method>>(*args, *kwargs:, &<blk>)
+  def foo<<todo method>>(*args, **kwargs, &<blk>)
     <emptyTree>
   end
 

--- a/test/testdata/namer/arguments.rb.desugar-tree.exp
+++ b/test/testdata/namer/arguments.rb.desugar-tree.exp
@@ -1,10 +1,10 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
   class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
-    def take_arguments<<todo method>>(a, b = 1, *c, d:, e: = 2, *f:, &g)
+    def take_arguments<<todo method>>(a, b = 1, *c, d:, e: = 2, **f, &g)
       begin
         [a, b, c, d, e, f, g]
         h = 1
-        <self>.proc() do |a, b = 1, *c, d:, e: = 2, *f:, &g; h|
+        <self>.proc() do |a, b = 1, *c, d:, e: = 2, **f, &g; h|
           [a, b, c, d, e, f, g, h]
         end
       end

--- a/test/testdata/namer/arguments.rb.flatten-tree.exp
+++ b/test/testdata/namer/arguments.rb.flatten-tree.exp
@@ -4,7 +4,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       begin
         [a, b, c, d, e, f, g]
         h = 1
-        <self>.proc() do |a$1, b$1 = 1, *c$1, d$1:, e$1: = 2, *f$1:, &g$1; h$1|
+        <self>.proc() do |a$1, b$1 = 1, *c$1, d$1:, e$1: = 2, **f$1, &g$1; h$1|
           [a$1, b$1, c$1, d$1, e$1, f$1, g$1, h$1]
         end
       end

--- a/test/testdata/parser/block_forwarding_permutations.rb.desugar-tree.exp
+++ b/test/testdata/parser/block_forwarding_permutations.rb.desugar-tree.exp
@@ -11,7 +11,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     ::<Magic>.<call-with-block-pass>(<self>, :bar, &)
   end
 
-  def case4_forwarding<<todo method>>(*<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
+  def case4_forwarding<<todo method>>(*<fwd-args>, **<fwd-kwargs>, &<fwd-block>)
     ::<Magic>.<call-with-splat-and-block-pass>(<self>, :bar, ::<Magic>.<splat>(<fwd-args>).concat([::<Magic>.<to-hash-dup>(<fwd-kwargs>)]), nil, <fwd-block>)
   end
 
@@ -21,7 +21,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  def case6_forwarding_and_literal<<todo method>>(*<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
+  def case6_forwarding_and_literal<<todo method>>(*<fwd-args>, **<fwd-kwargs>, &<fwd-block>)
     ::<Magic>.<call-with-splat-and-block-pass>(<self>, :foo, ::<Magic>.<splat>(<fwd-args>).concat([::<Magic>.<to-hash-dup>(<fwd-kwargs>)]), nil, <fwd-block>) do ||
       "literal block"
     end

--- a/test/testdata/parser/block_forwarding_permutations.rb.desugar-tree.exp
+++ b/test/testdata/parser/block_forwarding_permutations.rb.desugar-tree.exp
@@ -7,7 +7,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     ::<Magic>.<call-with-block-pass>(<self>, :bar, block)
   end
 
-  def case3_anonymous_block_param<<todo method>>(&&)
+  def case3_anonymous_block_param<<todo method>>(&)
     ::<Magic>.<call-with-block-pass>(<self>, :bar, &)
   end
 
@@ -33,7 +33,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  def case8_anonymous_block_pass_and_literal<<todo method>>(&&)
+  def case8_anonymous_block_pass_and_literal<<todo method>>(&)
     ::<Magic>.<call-with-block-pass>(<self>, :foo, &) do ||
       "literal block"
     end

--- a/test/testdata/parser/error_recovery/forward_args.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/forward_args.rb.desugar-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def foo<<todo method>>(**, *<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
+  def foo<<todo method>>(**, *<fwd-args>, **<fwd-kwargs>, &<fwd-block>)
     [1, 2, 3].each() do |_1|
       _1
     end

--- a/test/testdata/parser/error_recovery/forward_args.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/forward_args.rb.desugar-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def foo<<todo method>>(**, *<fwd-args>, **<fwd-kwargs>, &<fwd-block>)
+  def foo<<todo method>>(*, *<fwd-args>, **<fwd-kwargs>, &<fwd-block>)
     [1, 2, 3].each() do |_1|
       _1
     end

--- a/test/testdata/parser/error_recovery/forward_args_with_block.rb.desugar-tree.exp
+++ b/test/testdata/parser/error_recovery/forward_args_with_block.rb.desugar-tree.exp
@@ -1,5 +1,5 @@
 class <emptyTree><<C <root>>> < (::<todo sym>)
-  def test<<todo method>>(*<fwd-args>, *<fwd-kwargs>:, &<fwd-block>)
+  def test<<todo method>>(*<fwd-args>, **<fwd-kwargs>, &<fwd-block>)
     [1, 2, 3].each() do ||
       ::<Magic>.<call-with-splat-and-block-pass>(<self>, :foo, ::<Magic>.<splat>(<fwd-args>).concat([::<Magic>.<to-hash-dup>(<fwd-kwargs>)]), nil, <fwd-block>) do ||
         <emptyTree>

--- a/test/testdata/parser/misc.rb.desugar-tree.exp
+++ b/test/testdata/parser/misc.rb.desugar-tree.exp
@@ -102,7 +102,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
   <self>.<super>(ZSuperArgs)
 
-  def kwfoo<<todo method>>(x:, y: = 1, *z:, &<blk>)
+  def kwfoo<<todo method>>(x:, y: = 1, **z, &<blk>)
     <emptyTree>
   end
 
@@ -221,7 +221,7 @@ rescue <emptyTree>::<C E> => x
     <emptyTree>
   end
 
-  def ssfoo<<todo method>>(***:, &<blk>)
+  def ssfoo<<todo method>>(****, &<blk>)
     <emptyTree>
   end
 

--- a/test/testdata/parser/misc.rb.desugar-tree.exp
+++ b/test/testdata/parser/misc.rb.desugar-tree.exp
@@ -217,11 +217,11 @@ rescue <emptyTree>::<C E> => x
       <emptyTree>
     end)
 
-  def sfoo<<todo method>>(**, &<blk>)
+  def sfoo<<todo method>>(*, &<blk>)
     <emptyTree>
   end
 
-  def ssfoo<<todo method>>(****, &<blk>)
+  def ssfoo<<todo method>>(**, &<blk>)
     <emptyTree>
   end
 

--- a/test/testdata/rbs/assertions_block.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_block.rb.rewrite-tree.exp
@@ -3,7 +3,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.params(:args, ::<root>::<C T>.untyped(), :&, ::<root>::<C T>.proc().params(:arg0, ::<root>::<C T>.nilable(<emptyTree>::<C String>)).returns(<emptyTree>::<C String>)).returns(::<root>::<C T>.untyped())
   end
 
-  def take_block<<todo method>>(*args, &&)
+  def take_block<<todo method>>(*args, &)
     <emptyTree>
   end
 

--- a/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_defs.rb.rewrite-tree.exp
@@ -87,7 +87,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.params(:p, <emptyTree>::<C Integer>).void()
   end
 
-  def sig_mismatch10<<todo method>>(*p:, &<blk>)
+  def sig_mismatch10<<todo method>>(**p, &<blk>)
     <emptyTree>
   end
 
@@ -253,7 +253,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.params(:p1, <emptyTree>::<C P1>, :p2, ::<root>::<C T>.nilable(<emptyTree>::<C P2>), :p3, <emptyTree>::<C P3>, :p4, <emptyTree>::<C P4>, :p5, ::<root>::<C T>.nilable(<emptyTree>::<C P5>), :p6, <emptyTree>::<C P6>, :block, ::<root>::<C T>.proc().void()).void()
   end
 
-  def method17<<todo method>>(p1, p2 = nil, *p3, p4:, p5: = nil, *p6:, &block)
+  def method17<<todo method>>(p1, p2 = nil, *p3, p4:, p5: = nil, **p6, &block)
     begin
       <emptyTree>::<C T>.reveal_type(p1)
       <emptyTree>::<C T>.reveal_type(p2)

--- a/test/testdata/resolver/sig_anon_block.rb.desugar-tree.exp
+++ b/test/testdata/resolver/sig_anon_block.rb.desugar-tree.exp
@@ -13,7 +13,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <self>.params(:&, <emptyTree>::<C T>.proc().returns(<emptyTree>::<C Integer>)).void()
   end
 
-  def foo<<todo method>>(&&)
+  def foo<<todo method>>(&)
     begin
       res = ::<Magic>.<call-with-block-pass>(<self>, :takes_block, &)
       <emptyTree>::<C T>.reveal_type(res)

--- a/test/testdata/rewriter/prop.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree.exp
@@ -644,7 +644,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   end
 
   class <emptyTree>::<C EncryptedProp><<C <todo sym>>> < (::<todo sym>)
-    def self.encrypted_prop<<todo method>>(name, kind: = nil, *opts:, &<blk>)
+    def self.encrypted_prop<<todo method>>(name, kind: = nil, **opts, &<blk>)
       <emptyTree>
     end
 


### PR DESCRIPTION
### Motivation

Makes it match Ruby's syntax:

```diff
# Desugar of `def foo(*rest, **kwargs, &block)`
-def foo(*rest, *kwargs:, &block)
+def foo(*rest, **kwargs, &block)
```

Also makes it more clear when using anonymous rest parameters:

```diff
# Desugar of `def foo(*, **, &)`
-def foo(**, ***:, &&)
+def foo(*, **, &)
```

Supersedes #9760, #9762, and #9767, fixing the output format without changing any of the internal representation.

### Test plan

Updated tests.
