### PR TITLE
Update ractor.rbi to match current Ractor API

### DIFF
--- a/rbi/stdlib/ractor.rbi
+++ b/rbi/stdlib/ractor.rbi
@@ -19,8 +19,8 @@ class Ractor
   sig { params(blk: T.proc.params(message: T.untyped).returns(T.nilable(T::Boolean))).returns(T.untyped) }
   def self.receive_if(&blk); end
 
-  sig { params(rest: T.untyped, blk: T.proc.params(arg: T.untyped).returns(T.untyped)).void }
-  def self.initialize(**rest, &blk); end
+  sig { params(args: T.untyped, name: T.nilable(String), blk: T.proc.params(arg: T.untyped).returns(T.untyped)).void }
+  def initialize(*args, name: nil, &blk); end
 
   sig { returns(Integer) }
   def self.count; end

--- a/test/testdata/rbi/ractor.rb
+++ b/test/testdata/rbi/ractor.rb
@@ -1,0 +1,21 @@
+# typed: true
+
+r = Ractor.new("hello") do |msg|
+  msg
+end
+T.reveal_type(r) # error: Revealed type: `Ractor`
+
+r2 = Ractor.new do
+  42
+end
+T.reveal_type(r2) # error: Revealed type: `Ractor`
+
+r3 = Ractor.new("a", "b") do |a, b|
+  a + b
+end
+T.reveal_type(r3) # error: Revealed type: `Ractor`
+
+r4 = Ractor.new(name: "test") do
+  42
+end
+T.reveal_type(r4) # error: Revealed type: `Ractor`


### PR DESCRIPTION
The stdlib RBI for Ractor was incorrect. `initialize` was declared as a class method, which caused `new` to fall back to BasicObject on typecheck.

Added regression test at test/testdata/rbi/ractor.rb.
