### PR TITLE
website: Add a note about `include`/`extend` circularity

### DIFF
--- a/website/docs/unsupported.md
+++ b/website/docs/unsupported.md
@@ -326,6 +326,7 @@ Sorbet does not track `require`, `require_relative`, or `autoload` declarations.
 This means that Sorbet does not report errors for these errors or warnings from the Ruby VM:
 
 - Accessing constants that are defined somewhere in the project but haven't been loaded yet when the code runs.
+  - This includes constants that appear to resolve statically, but which rely on an assumption that all `include` and `extend` lines will have run by the time a constant is accessed.
 - Reassigning a constant (`X = 1; X = 2`), which are warnings in the Ruby VM, so long as the declared type of the constant is the same in both definitions.
 - Redefining a method (`def f; end; def f; end`), so long as the arity of the method is the same in both definitions
 - Accessing an instance variable before it's been initialized.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is not a bug:

```ruby
# typed: true

module M
  X = 1
end

class A
  X # 💥 NameError, because `include M` has not run yet
  include M
end
```

[→ View on sorbet.run](https://sorbet.run/#%23%20typed%3A%20true%0A%0Amodule%20M%0A%20%20X%20%3D%201%0Aend%0A%0Aclass%20A%0A%20%20X%20%23%20%F0%9F%92%A5%20NameError%2C%20because%20%60include%20M%60%20has%20not%20run%20yet%0A%20%20include%20M%0Aend)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Docs-only change