### PR TITLE
delete `ParamInfo::operator=(const ParamInfo &)`

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -47,10 +47,11 @@ public:
     std::string toString(const GlobalState &gs) const;
     std::string show(const GlobalState &gs) const;
     std::string_view parameterName(const GlobalState &gs) const;
-    ParamInfo(const ParamInfo &) = delete;
-    ParamInfo() = default;
+    ParamInfo() noexcept = default;
     ParamInfo(ParamInfo &&) noexcept = default;
     ParamInfo &operator=(ParamInfo &&) noexcept = default;
+    ParamInfo(const ParamInfo &) = delete;
+    ParamInfo &operator=(const ParamInfo &) = delete;
     ParamInfo deepCopy() const;
 };
 CheckSize(ParamInfo, 32, 8);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Seems like an oversight that we delete the copy constructor but not the copy assignment operator.

The diff here is a little noisy due to rearranging the order of the declarations and sneaking in a `noexcept` on the default constructor.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

If it compiles, it works.