### PR TITLE
compute field types a little more succinctly

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1267,10 +1267,10 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                             }
                         } else if (symbol.isField(ctx)) {
                             auto field = symbol.asFieldRef();
-                            tp.type = core::Types::resultTypeAsSeenFrom(
-                                ctx, field.data(ctx)->resultType, symbol.owner(ctx).asClassOrModuleRef(),
-                                ctx.owner.enclosingClass(ctx),
-                                ctx.owner.enclosingClass(ctx).data(ctx)->selfTypeArgs(ctx));
+                            auto enclosingClass = ctx.owner.enclosingClass(ctx);
+                            tp.type = core::Types::resultTypeAsSeenFrom(ctx, field.data(ctx)->resultType,
+                                                                        field.data(ctx)->owner, enclosingClass,
+                                                                        enclosingClass.data(ctx)->selfTypeArgs(ctx));
                         } else {
                             tp.type = resultType;
                         }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Just some easy cleanups spotted here:

1. We don't need to call `SymbolRef#enclosingClass` twice on the same thing.
2. We can get the owner directly through `field`, rather than indirecting (and switching!) on `symbol`.  And this way the compiler should be able to see that we're accessing `.data()` once and reuse it.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.