### PR TITLE
Don't use unique names for anonymous blocks

### DIFF
--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -108,7 +108,6 @@ public:
 
     GlobalState &gs_;
     core::FileRef file_;
-    uint16_t uniqueCounter_ = 1;
     uint32_t maxOff_;
     ruby_parser::base_driver *driver_;
 
@@ -631,12 +630,7 @@ public:
             checkReservedForNumberedParameters(name->view(), loc);
         } else {
             loc = tokLoc(amper);
-            const auto &ctx = driver_->lex.context;
-            nm = ctx.inDef && !ctx.inLambda && !ctx.inBlock
-                     ? core::Names::ampersand()
-                     // We still want a unique name for anonymous block params in block parameter lists (vs
-                     // method def parameter lists) so that they don't shadow the method parameter list.
-                     : gs_.freshNameUnique(core::UniqueNameKind::Parser, core::Names::ampersand(), ++uniqueCounter_);
+            nm = core::Names::ampersand();
         }
 
         return make_unique<BlockParam>(loc, nm);

--- a/test/prism_regression/call_block_with_anonymous_params.rb
+++ b/test/prism_regression/call_block_with_anonymous_params.rb
@@ -1,5 +1,4 @@
 # typed: false
-# disable-parser-comparison: true
 
 foo do |*, **, &|
   "block with anonymous rest, kwrest and block params"

--- a/test/prism_regression/call_block_with_anonymous_params.rb
+++ b/test/prism_regression/call_block_with_anonymous_params.rb
@@ -1,0 +1,6 @@
+# typed: false
+# disable-parser-comparison: true
+
+foo do |*, **, &|
+  "block with anonymous rest, kwrest and block params"
+end

--- a/test/prism_regression/call_block_with_anonymous_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_block_with_anonymous_params.rb.desugar-tree-raw.exp
@@ -1,0 +1,36 @@
+ClassDef{
+  kind = class
+  name = EmptyTree
+  symbol = <C <U <root>>>
+  ancestors = [ConstantLit{
+      symbol = (class ::<todo sym>)
+      orig = nullptr
+    }]
+  rhs = [
+    Send{
+      flags = {privateOk}
+      recv = Self
+      fun = <U foo>
+      block = Block {
+        params = [
+          RestParam{ expr = UnresolvedIdent{
+            kind = Local
+            name = <U *>
+          } }
+          RestParam{ expr = KeywordArg{ expr = UnresolvedIdent{
+            kind = Local
+            name = <U **>
+          } } }
+          BlockParam{ expr = UnresolvedIdent{
+            kind = Local
+            name = <U &>
+          } }
+        ]
+        body = Literal{ value = "block with anonymous rest, kwrest and block params" }
+      }
+      pos_args = 0
+      args = [
+      ]
+    }
+  ]
+}

--- a/test/testdata/desugar/forward_args.rb
+++ b/test/testdata/desugar/forward_args.rb
@@ -39,6 +39,30 @@ class Foo
       T.unsafe(self).p(*)
     end
   end
+
+  def foo8(**)
+    [1,2,3].each do |**|
+      T.unsafe(self).p(**)
+    end
+  end
+
+  def foo9(**kwargs)
+    [1,2,3].each do |**|
+      T.unsafe(self).p(**)
+    end
+  end
+
+  def foo10(&)
+    [1,2,3].each do |&|
+      T.unsafe(self).p(&)
+    end
+  end
+
+  def foo11(&block)
+    [1,2,3].each do |&|
+      T.unsafe(self).p(&)
+    end
+  end
 end
 
 Foo.new.foo

--- a/test/testdata/desugar/forward_args.rb.autocorrects.exp
+++ b/test/testdata/desugar/forward_args.rb.autocorrects.exp
@@ -40,6 +40,30 @@ class Foo
       T.unsafe(self).p(*)
     end
   end
+
+  def foo8(**)
+    [1,2,3].each do |**|
+      T.unsafe(self).p(**)
+    end
+  end
+
+  def foo9(**kwargs)
+    [1,2,3].each do |**|
+      T.unsafe(self).p(**)
+    end
+  end
+
+  def foo10(&)
+    [1,2,3].each do |&|
+      T.unsafe(self).p(&)
+    end
+  end
+
+  def foo11(&block)
+    [1,2,3].each do |&|
+      T.unsafe(self).p(&)
+    end
+  end
 end
 
 Foo.new.foo

--- a/test/testdata/desugar/forward_args.rb.desugar-tree.exp
+++ b/test/testdata/desugar/forward_args.rb.desugar-tree.exp
@@ -63,13 +63,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo10<<todo method>>(&)
-      [1, 2, 3].each() do |&&$2|
+      [1, 2, 3].each() do |&|
         ::<Magic>.<call-with-block-pass>(<emptyTree>::<C T>.unsafe(<self>), :p, &)
       end
     end
 
     def foo11<<todo method>>(&block)
-      [1, 2, 3].each() do |&&$3|
+      [1, 2, 3].each() do |&|
         ::<Magic>.<call-with-block-pass>(<emptyTree>::<C T>.unsafe(<self>), :p, &)
       end
     end

--- a/test/testdata/desugar/forward_args.rb.desugar-tree.exp
+++ b/test/testdata/desugar/forward_args.rb.desugar-tree.exp
@@ -43,6 +43,36 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         ::<Magic>.<call-with-splat>(<emptyTree>::<C T>.unsafe(<self>), :p, [].concat(::T.unsafe(<fwd-args>.to_a())), nil)
       end
     end
+
+    def foo8<<todo method>>(**, &<blk>)
+      [1, 2, 3].each() do |**|
+        <emptyTree>::<C T>.unsafe(<self>).p(begin
+            <hashTemp>$2 = ::<Magic>.<to-hash-dup>(::T.unsafe(<fwd-kwargs>))
+            <hashTemp>$2
+          end)
+      end
+    end
+
+    def foo9<<todo method>>(**kwargs, &<blk>)
+      [1, 2, 3].each() do |**|
+        <emptyTree>::<C T>.unsafe(<self>).p(begin
+            <hashTemp>$2 = ::<Magic>.<to-hash-dup>(::T.unsafe(<fwd-kwargs>))
+            <hashTemp>$2
+          end)
+      end
+    end
+
+    def foo10<<todo method>>(&)
+      [1, 2, 3].each() do |&&$2|
+        ::<Magic>.<call-with-block-pass>(<emptyTree>::<C T>.unsafe(<self>), :p, &)
+      end
+    end
+
+    def foo11<<todo method>>(&block)
+      [1, 2, 3].each() do |&&$3|
+        ::<Magic>.<call-with-block-pass>(<emptyTree>::<C T>.unsafe(<self>), :p, &)
+      end
+    end
   end
 
   <emptyTree>::<C Foo>.new().foo()

--- a/test/whitequark/test_block_arg_combinations_28.rb
+++ b/test/whitequark/test_block_arg_combinations_28.rb
@@ -1,0 +1,3 @@
+# typed: true
+
+f { |&| }

--- a/test/whitequark/test_block_arg_combinations_28.rb.parse-tree-whitequark.exp
+++ b/test/whitequark/test_block_arg_combinations_28.rb.parse-tree-whitequark.exp
@@ -1,0 +1,4 @@
+s(:block,
+  s(:send, nil, :f),
+  s(:params,
+    s(:blockparam, :&)), nil)


### PR DESCRIPTION
### Motivation

#9768 made anonymous block parameters _not_ unique numbered names for methods, but kept it when in a block's parameter list. This isn't really necessary, because it's a Ruby syntax error to try to use both:

```ruby
def f(&)
  tap do |&|
    tap(&)
#       ^ unexpected `&`; anonymous block parameter is also used within block
  end
end
```

This PR changes them to just never be numbered, matching how anonymous positional and keyword parameters work. This is the last usage of the parser's unique counter, which is further cleaned up in #9903.

### Test plan

See included automated tests.
