### PR TITLE
Bound sig guessing to 10 iterations over the CFG

### DIFF
--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -228,8 +228,12 @@ UnorderedMap<core::NameRef, core::TypePtr> guessArgumentTypes(core::Context ctx,
         }
     }
 
+    // TODO: there's an assumption in the loop below that `core::Types::glb` for a given variable will converge after
+    // enough traversals of the CFG. That appears to be not true, so we bound argument guessing to 10 iterations over
+    // the CFG. The choice of 10 is arbitrary, and a more reasonable bound might be the maximum loop depth of the CFG,
+    // but 10 is probably good enough for most cases.
     bool changed = true;
-    while (changed) {
+    for (int attempt = 0; changed && attempt < 10; ++attempt) {
         changed = false;
         for (auto it = cfg.forwardsTopoSort.rbegin(); it != cfg.forwardsTopoSort.rend(); ++it) {
             cfg::BasicBlock *bb = *it;


### PR DESCRIPTION
In some cases, the loop that iterates over the CFG to guess argument types can fail to terminate. This is an issue with `core::Types::glb` failing to converge, which could just be that we're allocating a new type when we should be returning an existing one. However, it's a nice defensive measure to bound this loop anyway, and this PR does that by allowing at most 10 traversals of the CFG.

I think there's an argument to be made that we should bound by the maximum loop depth, but a loop depth greater than 10 is already a tremendously complicated method, and maybe we should be bailing out early to return a less precise result anyway.

### Motivation
Fixing a potentially infinite loop in signature suggestion.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I haven't had luck boiling down the case that occurred in Stripe's codebase, so I'm going to say that as long as this passes on our existing tests, we're good.
