### PR TITLE
rename `Refcounted` to `Refcountable`

### DIFF
--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -14,7 +14,7 @@ class TypeConstraint;
 struct DispatchResult;
 struct DispatchArgs;
 
-class Refcounted {
+class Refcountable {
     friend class TypePtrTestHelper;
     std::atomic<uint32_t> counter{0};
 
@@ -124,7 +124,7 @@ private:
         return val;
     }
 
-    static tagged_storage tagPtr(Tag tag, Refcounted *expr) {
+    static tagged_storage tagPtr(Tag tag, Refcountable *expr) {
         auto val = tagToMask(tag);
 
         auto maskedPtr = reinterpret_cast<tagged_storage>(expr) << 16;
@@ -170,9 +170,9 @@ private:
         return val;
     }
 
-    Refcounted *get() const {
+    Refcountable *get() const {
         auto val = store & PTR_MASK;
-        return reinterpret_cast<Refcounted *>(val >> 16);
+        return reinterpret_cast<Refcountable *>(val >> 16);
     }
 
 public:
@@ -217,7 +217,7 @@ public:
         return *this;
     };
 
-    explicit TypePtr(Tag tag, Refcounted *expr) noexcept : store(tagPtr(tag, expr)) {
+    explicit TypePtr(Tag tag, Refcountable *expr) noexcept : store(tagPtr(tag, expr)) {
         expr->addref();
     }
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -439,7 +439,7 @@ template <> inline ClassType cast_type_nonnull<ClassType>(const TypePtr &what) {
  * this variable has been bound by "something" but we don't know exactly what (see the SelfTypeParam
  * docs below).
  */
-TYPE(LambdaParam) final : public Refcounted {
+TYPE(LambdaParam) final : public Refcountable {
 public:
     TypeMemberRef definition;
 
@@ -678,7 +678,7 @@ template <> inline NamedLiteralType cast_type_nonnull<NamedLiteralType>(const Ty
     }
 }
 
-TYPE(IntegerLiteralType) final : public Refcounted {
+TYPE(IntegerLiteralType) final : public Refcountable {
 public:
     const int64_t value;
 
@@ -712,7 +712,7 @@ template <> inline TypePtr make_type<IntegerLiteralType, long long &>(long long 
     return make_type<IntegerLiteralType>(static_cast<int64_t>(val));
 }
 
-TYPE(FloatLiteralType) final : public Refcounted {
+TYPE(FloatLiteralType) final : public Refcountable {
 public:
     const double value;
 
@@ -746,7 +746,7 @@ template <> inline TypePtr make_type<FloatLiteralType, float &&>(float &&val) {
  * TypeVars are the used for the type parameters of generic methods, e.g. T.type_parameter(:U)
  * Note: These are mutated post-construction and cannot be inlined.
  */
-TYPE(TypeVar) final : public Refcounted {
+TYPE(TypeVar) final : public Refcountable {
 public:
     TypeParameterRef sym;
     TypeVar(TypeParameterRef sym);
@@ -767,7 +767,7 @@ public:
 };
 CheckSize(TypeVar, 8, 8);
 
-TYPE(OrType) final : public Refcounted {
+TYPE(OrType) final : public Refcountable {
 public:
     TypePtr left;
     TypePtr right;
@@ -825,7 +825,7 @@ private:
 };
 CheckSize(OrType, 24, 8);
 
-TYPE(AndType) final : public Refcounted {
+TYPE(AndType) final : public Refcountable {
 public:
     TypePtr left;
     TypePtr right;
@@ -874,7 +874,7 @@ private:
 };
 CheckSize(AndType, 24, 8);
 
-TYPE(ShapeType) final : public Refcounted {
+TYPE(ShapeType) final : public Refcountable {
 public:
     std::vector<TypePtr> keys; // TODO: store sorted by whatever
     std::vector<TypePtr> values;
@@ -911,7 +911,7 @@ public:
 };
 CheckSize(ShapeType, 56, 8);
 
-TYPE(TupleType) final : public Refcounted {
+TYPE(TupleType) final : public Refcountable {
 private:
     TupleType() = delete;
 
@@ -942,7 +942,7 @@ public:
 };
 CheckSize(TupleType, 32, 8);
 
-TYPE(AppliedType) final : public Refcounted {
+TYPE(AppliedType) final : public Refcountable {
 public:
     ClassOrModuleRef klass;
     std::vector<TypePtr> targs;
@@ -976,7 +976,7 @@ CheckSize(AppliedType, 32, 8);
 //
 // These are used within the inferencer in places where we need to track
 // user-written types in the source code.
-TYPE(MetaType) final : public Refcounted {
+TYPE(MetaType) final : public Refcountable {
 public:
     TypePtr wrapped;
 
@@ -1188,7 +1188,7 @@ template <> inline BlamedUntyped cast_type_nonnull<BlamedUntyped>(const TypePtr 
     return BlamedUntyped(core::SymbolRef::fromRaw(what.inlinedValue()));
 }
 
-TYPE(UnresolvedClassType) final : public Refcounted, public ClassType {
+TYPE(UnresolvedClassType) final : public Refcountable, public ClassType {
 public:
     const core::SymbolRef scope;
     const std::vector<core::NameRef> names;
@@ -1204,7 +1204,7 @@ public:
     uint32_t hash(const GlobalState &gs) const;
 };
 
-TYPE(UnresolvedAppliedType) final : public Refcounted, public ClassType {
+TYPE(UnresolvedAppliedType) final : public Refcountable, public ClassType {
 public:
     const core::ClassOrModuleRef klass;
     const std::vector<TypePtr> targs;

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -221,12 +221,12 @@ public:
         return ptr.store;
     }
 
-    static Refcounted *get(const TypePtr &ptr) {
+    static Refcountable *get(const TypePtr &ptr) {
         CHECK(ptr.containsPtr());
         return ptr.get();
     }
 
-    static TypePtr create(TypePtr::Tag tag, Refcounted *type) {
+    static TypePtr create(TypePtr::Tag tag, Refcountable *type) {
         return TypePtr(tag, type);
     }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Like the subject says.

The motivation behind this: I'd like to introduce a superclass for a generic refcounted sort of thing, modeled on Firefox's `RefCounted<T>`:

https://searchfox.org/firefox-main/source/mfbt/RefCounted.h#28-47

With accompanying `RefPtr<T>` support, which will be smaller than a `shared_ptr<T>`.

https://searchfox.org/firefox-main/source/mfbt/RefPtr.h#54

I want to do this to try to make `KnowledgeRef`s in the infer machinery smaller and possibly even support non-atomic refcounting, since they are entirely thread-local.

I don't think `TypePtr` can be subsumed into that machinery, so I need a separation between "this thing has a refcount" vs. "this thing's lifetime is entirely managed through refcounting".  Hence this PR as a starting point; bikeshedding welcome on the particular names.  (Thinking about `RefcountManaged<T>` or something for the Sorbet equivalent of Firefox's `RefCounted<T>`...)

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

If it compiles, it works.