### PR TITLE
eliminate the `TypePtrTestHelper` dependency from `Refcountable`

### DIFF
--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -15,7 +15,6 @@ struct DispatchResult;
 struct DispatchArgs;
 
 class Refcountable {
-    friend class TypePtrTestHelper;
     std::atomic<uint32_t> counter{0};
 
 public:
@@ -26,6 +25,13 @@ public:
     uint32_t release() {
         // fetch_sub returns value prior to subtract
         return this->counter.fetch_sub(1) - 1;
+    }
+
+    // You typically should not need to call this; it is mostly for tests to
+    // verify that things manipulating `Refcountable` are getting the counting
+    // logic correct.
+    bool hasMultipleRefs() const {
+        return this->counter.load() > 1;
     }
 };
 

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -207,11 +207,6 @@ TEST_CASE("Substitute") {
 // Privileged class that is friends with TypePtr
 class TypePtrTestHelper {
 public:
-    static std::atomic<uint32_t> *counter(const TypePtr &ptr) {
-        CHECK(ptr.containsPtr());
-        return &ptr.get()->counter;
-    }
-
     static uint64_t inlinedValue(const TypePtr &ptr) {
         CHECK(!ptr.containsPtr());
         return ptr.inlinedValue();
@@ -243,29 +238,30 @@ TEST_SUITE("TypePtr") {
 
     TEST_CASE("Properly manages counter") {
         auto ptr = make_type<UnresolvedClassType>(Symbols::untyped(), vector<NameRef>{});
-        auto counter = TypePtrTestHelper::counter(ptr);
-        REQUIRE_NE(nullptr, counter);
-        CHECK_EQ(1, counter->load());
+        auto refptr = TypePtrTestHelper::get(ptr);
+        REQUIRE_NE(nullptr, refptr);
+        REQUIRE(!refptr->hasMultipleRefs());
 
         {
             // Copy should increment counter
             TypePtr ptrCopy(ptr);
-            REQUIRE_EQ(counter, TypePtrTestHelper::counter(ptrCopy));
-            CHECK_EQ(2, counter->load());
+            auto refptrCopy = TypePtrTestHelper::get(ptrCopy);
+            REQUIRE_EQ(refptr, refptrCopy);
+            REQUIRE(refptr->hasMultipleRefs());
         }
 
         // Destruction of copy should decrement counter
-        CHECK_EQ(1, counter->load());
+        REQUIRE(!refptr->hasMultipleRefs());
 
         {
             TypePtr ptrCopy(ptr);
             // Assigning/overwriting should decrement counter
             ptr = TypePtr();
-            CHECK_EQ(1, counter->load());
+            REQUIRE(!refptr->hasMultipleRefs());
 
             // Moving should keep counter the same
             ptr = move(ptrCopy);
-            CHECK_EQ(1, counter->load());
+            REQUIRE(!refptr->hasMultipleRefs());
 
             // Moving should clear counter from ptrCopy and make it an empty TypePtr
             CHECK_EQ(0, TypePtrTestHelper::store(ptrCopy));
@@ -274,9 +270,9 @@ TEST_SUITE("TypePtr") {
             // Assigning to nullptr should increment counter (and not try to increment the null counter field in
             // ptrCopy)
             ptrCopy = ptr;
-            CHECK_EQ(2, counter->load());
+            REQUIRE(refptr->hasMultipleRefs());
         }
-        CHECK_EQ(1, counter->load());
+        REQUIRE(!refptr->hasMultipleRefs());
     }
 
     TEST_CASE("Tagging works as expected") {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

`Refcountable` currently declares that `TypePtrTestHelper` is its `friend`; this introduces a dependency that's not desirable, and I would like to remove it.  To do that, we need a public API that tests can access.

I don't love that we're exposing something like `hasMultipleRefs`, but if we want to use `Refcountable` or similar for `KnowledgeRef` in infer, we need something like it, and I think `hasMultipleRefs` is a better API design than `std::shared_ptr::use_count`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
