### PR TITLE
Only track the edit stratum for files that are part of the update set

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -312,11 +312,12 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
             // errors (because no-op edits will not run incremental namer), but that's fine because
             // GlobalState doesn't change for no-op edits, and retypecheck already drops all errors.
             oldFoundHashesForFiles.emplace(fref, oldFile->getFileHash());
-
-            // Since this is a real edit, update the edit stratum to reflect the stratum of this file's
-            // package.
-            editStratum = std::min(this->fileToStratum[fref.id()], editStratum);
         }
+
+        // We track the edit stratum for all files that were updated by the edit. Unfortunately this
+        // will include files that were opened, but not changed. In the future, if we can tell if the
+        // file was changed by the edit, we should make this update to `editStratum` conditional.
+        editStratum = std::min(this->fileToStratum[fref.id()], editStratum);
 
         // If file doesn't have a typed: sigil, then we need to ensure it's typechecked using typed: false.
         fref.data(*gs).strictLevel = pipeline::decideStrictLevel(*gs, fref, config->opts);

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -221,8 +221,7 @@ bool LSPTypechecker::typecheck(unique_ptr<LSPFileUpdates> updates, WorkerPool &w
 
             // Remember where in the package graph we're making this change, as that will determine how much we can
             // copy on the next slow path.
-            this->fastPathEditStratum =
-                std::min(this->fastPathEditStratum, this->getFileStratumMapping().getStratumForFiles(filesTypechecked));
+            this->fastPathEditStratum = std::min(this->fastPathEditStratum, result.editStratum);
 
             ENFORCE(updates->updatedFiles.empty());
             ENFORCE(updates->updatedFileRefs.empty());
@@ -286,6 +285,7 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
     }
 
     config->logger->debug("Added {} files that were not part of the edit to the update set", toTypecheck.size());
+    auto editStratum = this->lastStratum;
     UnorderedMap<core::FileRef, shared_ptr<const core::FileHash>> oldFoundHashesForFiles;
     auto ix = -1;
     for (auto &file : updates.updatedFiles) {
@@ -312,6 +312,10 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
             // errors (because no-op edits will not run incremental namer), but that's fine because
             // GlobalState doesn't change for no-op edits, and retypecheck already drops all errors.
             oldFoundHashesForFiles.emplace(fref, oldFile->getFileHash());
+
+            // Since this is a real edit, update the edit stratum to reflect the stratum of this file's
+            // package.
+            editStratum = std::min(this->fileToStratum[fref.id()], editStratum);
         }
 
         // If file doesn't have a typed: sigil, then we need to ensure it's typechecked using typed: false.
@@ -417,7 +421,7 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
         "Running fast path over num_files={} incrementalNamer={} preemption={} duration={} files=[{}]",
         toTypecheck.size(), shouldRunIncrementalNamer, isPreemption, duration.usec, files);
 
-    return FastPathResult{move(toTypecheck), move(toCache)};
+    return FastPathResult{move(toTypecheck), move(toCache), editStratum};
 }
 
 namespace {

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -130,6 +130,9 @@ class LSPTypechecker final {
 
         // Copies of the indexed trees that were updated during the fast path, for updating the cache of open files.
         std::vector<ast::ParsedFile> indexedTrees;
+
+        // The stratum that the edit took place, or lastStratum if it didn't affect anything.
+        core::packages::Stratum editStratum;
     };
 
     /** Runs incremental typechecking on the provided updates. Returns the final list of files typechecked. */

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -1565,24 +1565,25 @@ TEST_CASE_FIXTURE(ProtocolTest, "ErrorsRemainAfterSlowPathRestart") {
                                       "end\n",
                                       2));
 
+        // We should see at a minimum the start/end typechecking messages.
+        REQUIRE(resps.size() >= 2);
+
         // We should see a starting and ending slow path message, with the end message indicating that the slow path
-        // started from stratum 0. The messages inbetween are errors on both `Root::A` and `Root::Foo::A`
-        REQUIRE_EQ(resps.size(), 4);
+        // started from stratum 0. The message inbetween is the error on `Root::Foo::A`.
+        CHECK_EQ(resps.size(), 3);
         {
-            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps[0]->asNotification().params);
+            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps.front()->asNotification().params);
             CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
             CHECK_EQ(params->status, SorbetTypecheckRunStatus::Started);
         }
 
         {
-            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps[3]->asNotification().params);
+            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps.back()->asNotification().params);
             CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
             CHECK_EQ(params->status, SorbetTypecheckRunStatus::Ended);
 
-            // We're modifying package `Root::Foo`, which means that idealy we don't need to typecheck `Root` again.
-            // However, we made a fast-path edit to `Root::A` but don't have enough information to know that it's not an
-            // additive edit, and as a result need to check its package again.
-            CHECK_EQ(params->startingStratum, 0);
+            // We're modifying package `Root::Foo`, which means that we don't need to typecheck `Root` again.
+            CHECK_EQ(params->startingStratum, 1);
         }
 
         assertErrorDiagnostics(move(resps), {

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -1568,9 +1568,9 @@ TEST_CASE_FIXTURE(ProtocolTest, "ErrorsRemainAfterSlowPathRestart") {
         // We should see at a minimum the start/end typechecking messages.
         REQUIRE(resps.size() >= 2);
 
-        // We should see a starting and ending slow path message, with the end message indicating that the slow path
-        // started from stratum 0. The message inbetween is the error on `Root::Foo::A`.
-        CHECK_EQ(resps.size(), 3);
+        // We should see a starting and ending slow path message, with errors between. The error messages between are
+        // the error on `Root::Foo::A` and the fast-path error from `Root::A`.
+        CHECK_EQ(resps.size(), 4);
         {
             auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps.front()->asNotification().params);
             CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
@@ -1582,8 +1582,9 @@ TEST_CASE_FIXTURE(ProtocolTest, "ErrorsRemainAfterSlowPathRestart") {
             CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
             CHECK_EQ(params->status, SorbetTypecheckRunStatus::Ended);
 
-            // We're modifying package `Root::Foo`, which means that we don't need to typecheck `Root` again.
-            CHECK_EQ(params->startingStratum, 1);
+            // We're modifying package `Root::Foo`, but we had made a fast-path edit that changed a file in `Root`. As a
+            // result, we start back in stratum `0`.
+            CHECK_EQ(params->startingStratum, 0);
         }
 
         assertErrorDiagnostics(move(resps), {


### PR DESCRIPTION
Currently we set `LSPTypechecker::fastPathEditStratum` to the lowest stratum for all the files involved in the edit (including those pulled in as part of an incremental edit). This means that modifying a file with a method that has a semi-common name might push the edit stratum down further than it should.

This PR fixes the issue by only tracking the edit stratum for files that are part of `updatedFiles` list, and ignoring the extra files in the `fastPathExtraFiles` list.

This PR doesn't address the issue where opening a file will push the edit stratum down, as we currently can't tell the difference between opening a file and modifying a file.

### Motivation
Enable more symbol table reuse in the slow path.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
