### PR TITLE
add a `core::RefPtr` type

### DIFF
--- a/core/Refcounting.h
+++ b/core/Refcounting.h
@@ -134,23 +134,12 @@ public:
         return ptr_ != nullptr;
     }
 
-    bool operator==(const RefPtr &other) const noexcept {
-        return ptr_ == other.ptr_;
-    }
-    bool operator!=(const RefPtr &other) const noexcept {
-        return ptr_ != other.ptr_;
-    }
+    bool operator<=>(const RefPtr &other) const noexcept = default;
     bool operator==(std::nullptr_t) const noexcept {
         return ptr_ == nullptr;
     }
     bool operator!=(std::nullptr_t) const noexcept {
         return ptr_ != nullptr;
-    }
-    bool operator==(T *p) const noexcept {
-        return ptr_ == p;
-    }
-    bool operator!=(T *p) const noexcept {
-        return ptr_ != p;
     }
 };
 

--- a/core/Refcounting.h
+++ b/core/Refcounting.h
@@ -143,7 +143,7 @@ public:
     }
 };
 
-template <typename T, typename... Args> RefPtr<T> MakeRefPtr(Args &&...args) {
+template <typename T, typename... Args> RefPtr<T> makeRefPtr(Args &&...args) {
     return RefPtr<T>(new T(std::forward<Args>(args)...));
 }
 

--- a/core/Refcounting.h
+++ b/core/Refcounting.h
@@ -1,0 +1,163 @@
+#ifndef SORBET_REFCOUNTING_H
+#define SORBET_REFCOUNTING_H
+
+#include <atomic>
+#include <cstdint>
+#include <utility>
+
+namespace sorbet::core {
+
+class Refcountable {
+    std::atomic<uint32_t> counter{0};
+
+public:
+    void addref() {
+        this->counter.fetch_add(1);
+    }
+
+    uint32_t release() {
+        // fetch_sub returns value prior to subtract
+        return this->counter.fetch_sub(1) - 1;
+    }
+
+    // You typically should not need to call this; it is mostly for tests to
+    // verify that things manipulating `Refcountable` are getting the counting
+    // logic correct.
+    bool hasMultipleRefs() const {
+        return this->counter.load() > 1;
+    }
+};
+
+// CRTP base for classes that want to be used with RefPtr<T>.
+template <typename T> class RefCounted : public Refcountable {
+public:
+    void addref() {
+        Refcountable::addref();
+    }
+
+    void release() {
+        uint32_t remaining = Refcountable::release();
+        if (remaining == 0) {
+            delete static_cast<T *>(this);
+        }
+    }
+
+protected:
+    ~RefCounted() = default;
+};
+
+// A reference-counting smart pointer.
+//
+// T must inherit from RefCounted<T>.  Instances of T should only be created with
+// `MakeRefPtr`.
+template <typename T> class RefPtr {
+    T *ptr_ = nullptr;
+
+    void assign(T *p) {
+        if (p) {
+            p->addref();
+        }
+        T *old = ptr_;
+        ptr_ = p;
+        if (old) {
+            old->release();
+        }
+    }
+
+public:
+    RefPtr() = default;
+
+    explicit RefPtr(T *p) : ptr_(p) {
+        if (ptr_) {
+            ptr_->addref();
+        }
+    }
+
+    RefPtr(const RefPtr &other) : ptr_(other.ptr_) {
+        if (ptr_) {
+            ptr_->addref();
+        }
+    }
+
+    RefPtr(RefPtr &&other) noexcept : ptr_(other.ptr_) {
+        other.ptr_ = nullptr;
+    }
+
+    ~RefPtr() {
+        if (ptr_) {
+            ptr_->release();
+        }
+    }
+
+    RefPtr &operator=(const RefPtr &other) {
+        if (ptr_ != other.ptr_) {
+            assign(other.ptr_);
+        }
+        return *this;
+    }
+
+    RefPtr &operator=(RefPtr &&other) noexcept {
+        if (ptr_ != other.ptr_) {
+            if (ptr_) {
+                ptr_->release();
+            }
+            ptr_ = other.ptr_;
+            other.ptr_ = nullptr;
+        }
+        return *this;
+    }
+
+    RefPtr &operator=(T *p) {
+        assign(p);
+        return *this;
+    }
+
+    RefPtr &operator=(std::nullptr_t) {
+        if (ptr_) {
+            ptr_->release();
+            ptr_ = nullptr;
+        }
+        return *this;
+    }
+
+    T *get() const noexcept {
+        return ptr_;
+    }
+    T *operator->() const noexcept {
+        return ptr_;
+    }
+    T &operator*() const noexcept {
+        return *ptr_;
+    }
+
+    explicit operator bool() const noexcept {
+        return ptr_ != nullptr;
+    }
+
+    bool operator==(const RefPtr &other) const noexcept {
+        return ptr_ == other.ptr_;
+    }
+    bool operator!=(const RefPtr &other) const noexcept {
+        return ptr_ != other.ptr_;
+    }
+    bool operator==(std::nullptr_t) const noexcept {
+        return ptr_ == nullptr;
+    }
+    bool operator!=(std::nullptr_t) const noexcept {
+        return ptr_ != nullptr;
+    }
+    bool operator==(T *p) const noexcept {
+        return ptr_ == p;
+    }
+    bool operator!=(T *p) const noexcept {
+        return ptr_ != p;
+    }
+};
+
+template <typename T, typename... Args> RefPtr<T> MakeRefPtr(Args &&...args) {
+    return RefPtr<T>(new T(std::forward<Args>(args)...));
+}
+
+} // namespace sorbet::core
+
+#endif

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -4,6 +4,7 @@
 #include "common/common.h"
 #include "core/NameRef.h"
 #include "core/Polarity.h"
+#include "core/Refcounting.h"
 #include "core/ShowOptions.h"
 #include "core/SymbolRef.h"
 #include "core/UntaggedPtr.h"
@@ -13,27 +14,6 @@ namespace sorbet::core {
 class TypeConstraint;
 struct DispatchResult;
 struct DispatchArgs;
-
-class Refcountable {
-    std::atomic<uint32_t> counter{0};
-
-public:
-    void addref() {
-        this->counter.fetch_add(1);
-    }
-
-    uint32_t release() {
-        // fetch_sub returns value prior to subtract
-        return this->counter.fetch_sub(1) - 1;
-    }
-
-    // You typically should not need to call this; it is mostly for tests to
-    // verify that things manipulating `Refcountable` are getting the counting
-    // logic correct.
-    bool hasMultipleRefs() const {
-        return this->counter.load() > 1;
-    }
-};
 
 class TypePtr final {
     template <class To> static To &const_cast_type(const To &what) {

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -364,13 +364,13 @@ TEST_SUITE("RefPtr") {
         int dtor_count = 0;
         {
             auto ptr = sorbet::core::MakeRefPtr<TestRefCounted>(7, dtor_count);
-            CHECK(!ptr.get()->hasMultipleRefs());
+            CHECK(!ptr->hasMultipleRefs());
             {
                 sorbet::core::RefPtr<TestRefCounted> copy(ptr);
-                CHECK(ptr.get()->hasMultipleRefs());
+                CHECK(ptr->hasMultipleRefs());
                 CHECK_EQ(ptr.get(), copy.get());
             }
-            CHECK(!ptr.get()->hasMultipleRefs());
+            CHECK(!ptr->hasMultipleRefs());
             CHECK_EQ(0, dtor_count);
         }
         CHECK_EQ(1, dtor_count);

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -352,7 +352,7 @@ TEST_SUITE("RefPtr") {
     TEST_CASE("Constructs from raw pointer and releases") {
         int dtor_count = 0;
         {
-            auto ptr = sorbet::core::MakeRefPtr<TestRefCounted>(42, dtor_count);
+            auto ptr = sorbet::core::makeRefPtr<TestRefCounted>(42, dtor_count);
             CHECK(ptr != nullptr);
             CHECK_EQ(42, ptr->value);
             CHECK_EQ(42, (*ptr).value);
@@ -363,7 +363,7 @@ TEST_SUITE("RefPtr") {
     TEST_CASE("Copy increments refcount") {
         int dtor_count = 0;
         {
-            auto ptr = sorbet::core::MakeRefPtr<TestRefCounted>(7, dtor_count);
+            auto ptr = sorbet::core::makeRefPtr<TestRefCounted>(7, dtor_count);
             CHECK(!ptr->hasMultipleRefs());
             {
                 sorbet::core::RefPtr<TestRefCounted> copy(ptr);
@@ -379,7 +379,7 @@ TEST_SUITE("RefPtr") {
     TEST_CASE("Move does not increment refcount") {
         int dtor_count = 0;
         {
-            auto ptr = sorbet::core::MakeRefPtr<TestRefCounted>(9, dtor_count);
+            auto ptr = sorbet::core::makeRefPtr<TestRefCounted>(9, dtor_count);
             auto *raw = ptr.get();
             CHECK(!raw->hasMultipleRefs());
 
@@ -395,8 +395,8 @@ TEST_SUITE("RefPtr") {
     TEST_CASE("Copy assignment") {
         int dtor_count = 0;
         {
-            auto a = sorbet::core::MakeRefPtr<TestRefCounted>(1, dtor_count);
-            auto b = sorbet::core::MakeRefPtr<TestRefCounted>(2, dtor_count);
+            auto a = sorbet::core::makeRefPtr<TestRefCounted>(1, dtor_count);
+            auto b = sorbet::core::makeRefPtr<TestRefCounted>(2, dtor_count);
             auto *rawB = b.get();
 
             a = b;
@@ -410,8 +410,8 @@ TEST_SUITE("RefPtr") {
     TEST_CASE("Move assignment") {
         int dtor_count = 0;
         {
-            auto a = sorbet::core::MakeRefPtr<TestRefCounted>(1, dtor_count);
-            auto b = sorbet::core::MakeRefPtr<TestRefCounted>(2, dtor_count);
+            auto a = sorbet::core::makeRefPtr<TestRefCounted>(1, dtor_count);
+            auto b = sorbet::core::makeRefPtr<TestRefCounted>(2, dtor_count);
             auto *rawB = b.get();
 
             a = std::move(b);
@@ -426,7 +426,7 @@ TEST_SUITE("RefPtr") {
     TEST_CASE("Assign nullptr releases") {
         int dtor_count = 0;
         {
-            auto ptr = sorbet::core::MakeRefPtr<TestRefCounted>(5, dtor_count);
+            auto ptr = sorbet::core::makeRefPtr<TestRefCounted>(5, dtor_count);
             ptr = nullptr;
             CHECK(!ptr);
             CHECK_EQ(1, dtor_count);

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -4,6 +4,7 @@
 #include "core/ErrorCollector.h"
 #include "core/ErrorQueue.h"
 #include "core/NameSubstitution.h"
+#include "core/Refcounting.h"
 #include "core/TrailingObjects.h"
 #include "core/TypePtr.h"
 #include "core/Unfreeze.h"
@@ -325,6 +326,112 @@ TEST_SUITE("TrailingObjects") {
         CHECK_EQ(8, TOTestSufficientlyAligned::totalSizeToAlloc<int>(0));
         CHECK_EQ(12, TOTestSufficientlyAligned::totalSizeToAlloc<int>(1));
         CHECK_EQ(16, TOTestSufficientlyAligned::totalSizeToAlloc<int>(2));
+    }
+}
+
+namespace {
+class TestRefCounted final : public sorbet::core::RefCounted<TestRefCounted> {
+public:
+    int value;
+    int *destructor_count;
+    TestRefCounted(int v, int &count) : value(v), destructor_count(&count) {}
+    ~TestRefCounted() {
+        (*destructor_count)++;
+    }
+};
+} // namespace
+
+TEST_SUITE("RefPtr") {
+    TEST_CASE("Default constructs to null") {
+        sorbet::core::RefPtr<TestRefCounted> ptr;
+        CHECK(!ptr);
+        CHECK(ptr == nullptr);
+        CHECK(ptr.get() == nullptr);
+    }
+
+    TEST_CASE("Constructs from raw pointer and releases") {
+        int dtor_count = 0;
+        {
+            auto ptr = sorbet::core::MakeRefPtr<TestRefCounted>(42, dtor_count);
+            CHECK(ptr != nullptr);
+            CHECK_EQ(42, ptr->value);
+            CHECK_EQ(42, (*ptr).value);
+        }
+        CHECK_EQ(1, dtor_count);
+    }
+
+    TEST_CASE("Copy increments refcount") {
+        int dtor_count = 0;
+        {
+            auto ptr = sorbet::core::MakeRefPtr<TestRefCounted>(7, dtor_count);
+            CHECK(!ptr.get()->hasMultipleRefs());
+            {
+                sorbet::core::RefPtr<TestRefCounted> copy(ptr);
+                CHECK(ptr.get()->hasMultipleRefs());
+                CHECK_EQ(ptr.get(), copy.get());
+            }
+            CHECK(!ptr.get()->hasMultipleRefs());
+            CHECK_EQ(0, dtor_count);
+        }
+        CHECK_EQ(1, dtor_count);
+    }
+
+    TEST_CASE("Move does not increment refcount") {
+        int dtor_count = 0;
+        {
+            auto ptr = sorbet::core::MakeRefPtr<TestRefCounted>(9, dtor_count);
+            auto *raw = ptr.get();
+            CHECK(!raw->hasMultipleRefs());
+
+            sorbet::core::RefPtr<TestRefCounted> moved(std::move(ptr));
+            CHECK(!ptr);
+            CHECK(moved);
+            CHECK_EQ(raw, moved.get());
+            CHECK(!raw->hasMultipleRefs());
+        }
+        CHECK_EQ(1, dtor_count);
+    }
+
+    TEST_CASE("Copy assignment") {
+        int dtor_count = 0;
+        {
+            auto a = sorbet::core::MakeRefPtr<TestRefCounted>(1, dtor_count);
+            auto b = sorbet::core::MakeRefPtr<TestRefCounted>(2, dtor_count);
+            auto *rawB = b.get();
+
+            a = b;
+            CHECK_EQ(rawB, a.get());
+            CHECK(rawB->hasMultipleRefs());
+            CHECK_EQ(1, dtor_count); // old 'a' destroyed
+        }
+        CHECK_EQ(2, dtor_count);
+    }
+
+    TEST_CASE("Move assignment") {
+        int dtor_count = 0;
+        {
+            auto a = sorbet::core::MakeRefPtr<TestRefCounted>(1, dtor_count);
+            auto b = sorbet::core::MakeRefPtr<TestRefCounted>(2, dtor_count);
+            auto *rawB = b.get();
+
+            a = std::move(b);
+            CHECK(!b);
+            CHECK_EQ(rawB, a.get());
+            CHECK(!rawB->hasMultipleRefs());
+            CHECK_EQ(1, dtor_count); // old 'a' destroyed
+        }
+        CHECK_EQ(2, dtor_count);
+    }
+
+    TEST_CASE("Assign nullptr releases") {
+        int dtor_count = 0;
+        {
+            auto ptr = sorbet::core::MakeRefPtr<TestRefCounted>(5, dtor_count);
+            ptr = nullptr;
+            CHECK(!ptr);
+            CHECK_EQ(1, dtor_count);
+        }
+        CHECK_EQ(1, dtor_count);
     }
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Following on the plan laid out in #10480, this adds a `RefPtr<T>` type that can be used as a smaller `shared_ptr<T>` replacement, but you have to explicitly opt `T` into refcounting, so the refcount is stored inline with the relevant object, rather than separately as with `shared_ptr`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
