### PR TITLE
Generate `NameRef` for methods with the same name as classes.

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1944,25 +1944,24 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 if (absl::EndsWith(complex->value, "r")) {
                     auto rationalValue = complex->value.substr(0, complex->value.size() - "r"sv.size());
                     auto kernel = MK::Constant(loc, core::Symbols::Kernel());
-                    core::NameRef rationalName = core::Names::KernelRational();
                     core::NameRef value = dctx.ctx.state.enterNameUTF8(rationalValue);
-                    imaginaryPart = MK::Send1(loc, move(kernel), rationalName, locZeroLen, MK::String(loc, value));
+                    imaginaryPart =
+                        MK::Send1(loc, move(kernel), core::Names::KernelRational(), locZeroLen, MK::String(loc, value));
                 } else {
                     core::NameRef value = dctx.ctx.state.enterNameUTF8(complex->value);
                     imaginaryPart = MK::String(loc, value);
                 }
 
                 auto kernel = MK::Constant(loc, core::Symbols::Kernel());
-                core::NameRef complex_name = core::Names::KernelComplex();
-                auto send =
-                    MK::Send2(loc, move(kernel), complex_name, locZeroLen, MK::Int(loc, 0), move(imaginaryPart));
+                auto send = MK::Send2(loc, move(kernel), core::Names::KernelComplex(), locZeroLen, MK::Int(loc, 0),
+                                      move(imaginaryPart));
                 result = move(send);
             },
             [&](parser::Rational *complex) {
                 auto kernel = MK::Constant(loc, core::Symbols::Kernel());
-                core::NameRef complex_name = core::Names::KernelRational();
                 core::NameRef value = dctx.ctx.state.enterNameUTF8(complex->val);
-                auto send = MK::Send1(loc, move(kernel), complex_name, locZeroLen, MK::String(loc, value));
+                auto send =
+                    MK::Send1(loc, move(kernel), core::Names::KernelRational(), locZeroLen, MK::String(loc, value));
                 result = move(send);
             },
             [&](parser::Array *array) {

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -1944,7 +1944,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 if (absl::EndsWith(complex->value, "r")) {
                     auto rationalValue = complex->value.substr(0, complex->value.size() - "r"sv.size());
                     auto kernel = MK::Constant(loc, core::Symbols::Kernel());
-                    core::NameRef rationalName = core::Names::Constants::Rational().dataCnst(dctx.ctx)->original;
+                    core::NameRef rationalName = core::Names::KernelRational();
                     core::NameRef value = dctx.ctx.state.enterNameUTF8(rationalValue);
                     imaginaryPart = MK::Send1(loc, move(kernel), rationalName, locZeroLen, MK::String(loc, value));
                 } else {
@@ -1953,14 +1953,14 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                 }
 
                 auto kernel = MK::Constant(loc, core::Symbols::Kernel());
-                core::NameRef complex_name = core::Names::Constants::Complex().dataCnst(dctx.ctx)->original;
+                core::NameRef complex_name = core::Names::KernelComplex();
                 auto send =
                     MK::Send2(loc, move(kernel), complex_name, locZeroLen, MK::Int(loc, 0), move(imaginaryPart));
                 result = move(send);
             },
             [&](parser::Rational *complex) {
                 auto kernel = MK::Constant(loc, core::Symbols::Kernel());
-                core::NameRef complex_name = core::Names::Constants::Rational().dataCnst(dctx.ctx)->original;
+                core::NameRef complex_name = core::Names::KernelRational();
                 core::NameRef value = dctx.ctx.state.enterNameUTF8(complex->val);
                 auto send = MK::Send1(loc, move(kernel), complex_name, locZeroLen, MK::String(loc, value));
                 result = move(send);

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -2724,10 +2724,9 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                 // The `i` is already stripped out of `value`, but there is still an `r`, so strip that off too.
                 auto rationalValue = value.substr(0, value.size() - "r"sv.size());
                 auto kernel = MK::Constant(numberLoc, core::Symbols::Kernel());
-                core::NameRef rationalName = core::Names::KernelRational();
                 core::NameRef valueName = ctx.state.enterNameUTF8(rationalValue);
-                imaginaryPart = MK::Send1(numberLoc, move(kernel), rationalName, numberLoc.copyWithZeroLength(),
-                                          MK::String(numberLoc, valueName));
+                imaginaryPart = MK::Send1(numberLoc, move(kernel), core::Names::KernelRational(),
+                                          numberLoc.copyWithZeroLength(), MK::String(numberLoc, valueName));
             } else {
                 core::NameRef valueName = ctx.state.enterNameUTF8(value);
                 imaginaryPart = MK::String(numberLoc, valueName);
@@ -2735,9 +2734,8 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
 
             // Create the desugared Complex call: `Kernel.Complex(0, imaginary_part)`
             auto kernel = MK::Constant(numberLoc, core::Symbols::Kernel());
-            core::NameRef complexName = core::Names::KernelComplex();
-            auto complexCall = MK::Send2(numberLoc, move(kernel), complexName, numberLoc.copyWithZeroLength(),
-                                         MK::Int(numberLoc, 0), move(imaginaryPart));
+            auto complexCall = MK::Send2(numberLoc, move(kernel), core::Names::KernelComplex(),
+                                         numberLoc.copyWithZeroLength(), MK::Int(numberLoc, 0), move(imaginaryPart));
 
             // If there was a sign, wrap in unary operation
             // E.g. desugar `+42` to `42.+()`
@@ -3186,11 +3184,10 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             value = value.substr(0, value.size() - "r"sv.size()); // drop the `r` suffix
 
             auto kernel = MK::Constant(location, core::Symbols::Kernel());
-            core::NameRef rationalName = core::Names::KernelRational();
             core::NameRef valueName = ctx.state.enterNameUTF8(value);
 
             // Desugar to `123r` to `::Kernel.Rational("123")`
-            return MK::Send1(location, move(kernel), rationalName, location.copyWithZeroLength(),
+            return MK::Send1(location, move(kernel), core::Names::KernelRational(), location.copyWithZeroLength(),
                              MK::String(location, valueName));
         }
         case PM_REDO_NODE: { // The `redo` keyword

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -2724,7 +2724,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
                 // The `i` is already stripped out of `value`, but there is still an `r`, so strip that off too.
                 auto rationalValue = value.substr(0, value.size() - "r"sv.size());
                 auto kernel = MK::Constant(numberLoc, core::Symbols::Kernel());
-                core::NameRef rationalName = core::Names::Constants::Rational().dataCnst(ctx)->original;
+                core::NameRef rationalName = core::Names::KernelRational();
                 core::NameRef valueName = ctx.state.enterNameUTF8(rationalValue);
                 imaginaryPart = MK::Send1(numberLoc, move(kernel), rationalName, numberLoc.copyWithZeroLength(),
                                           MK::String(numberLoc, valueName));
@@ -2735,7 +2735,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
 
             // Create the desugared Complex call: `Kernel.Complex(0, imaginary_part)`
             auto kernel = MK::Constant(numberLoc, core::Symbols::Kernel());
-            core::NameRef complexName = core::Names::Constants::Complex().dataCnst(ctx)->original;
+            core::NameRef complexName = core::Names::KernelComplex();
             auto complexCall = MK::Send2(numberLoc, move(kernel), complexName, numberLoc.copyWithZeroLength(),
                                          MK::Int(numberLoc, 0), move(imaginaryPart));
 
@@ -3186,7 +3186,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             value = value.substr(0, value.size() - "r"sv.size()); // drop the `r` suffix
 
             auto kernel = MK::Constant(location, core::Symbols::Kernel());
-            core::NameRef rationalName = core::Names::Constants::Rational().dataCnst(ctx)->original;
+            core::NameRef rationalName = core::Names::KernelRational();
             core::NameRef valueName = ctx.state.enterNameUTF8(value);
 
             // Desugar to `123r` to `::Kernel.Rational("123")`

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -549,8 +549,10 @@ NameDef names[] = {
     {"Regexp", "Regexp", true},
     {"Exception", "Exception", true},
     {"StandardError", "StandardError", true},
-    {"Complex", "Complex", true},
-    {"Rational", "Rational", true},
+    {"Complex", "Complex", true},   // The `::Complex` class
+    {"KernelComplex", "Complex"},   // The `Kernel.Complex` method
+    {"Rational", "Rational", true}, // The `::Rational` class
+    {"KernelRational", "Rational"}, // The `Kernel.Rational` method
     // A magic non user-creatable class with methods to keep state between passes
     {"Magic", "<Magic>", true},
     // A magic non user-creatable class to attach symbols for blaming untyped to
@@ -669,14 +671,25 @@ void emit_register(ostream &out) {
 }
 
 int main(int argc, char **argv) {
-    int constantI = 0;
     int utf8I = 0;
+    sorbet::UnorderedMap<string, int> utf8Ids;
+    // Deduplicates the given name, so a constant and non-constant entry
+    // with the same string will reuse the same id.
+    auto enterUTF8Name = [&utf8Ids, &utf8I](NameDef &name) {
+        auto [it, inserted] = utf8Ids.emplace(name.val, utf8I);
+        if (inserted) {
+            utf8I++;
+        }
+        return it->second;
+    };
+
+    int constantI = 0;
     for (auto &name : names) {
         if (name.isConstant) {
-            utf8I++;
+            enterUTF8Name(name);
             name.id = constantI++;
         } else {
-            name.id = utf8I++;
+            name.id = enterUTF8Name(name);
         }
     }
     int lastConstantId = constantI;


### PR DESCRIPTION
### Motivation

`.dataCnst(dctx.ctx)->original` is clunky. It's also not a constexpr, so it can't be used as a `case` label.

### Test plan

Pure refactor.