### PR TITLE
decrease the size of `KnowledgeRef` and friends

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -59,25 +59,6 @@ void TypeTestReverseIndex::cloneFrom(const TypeTestReverseIndex &index) {
 
 const InlinedVector<cfg::LocalRef, 1> TypeTestReverseIndex::empty;
 
-/**
- * Encode things that we know hold and don't hold.
- */
-struct KnowledgeFact {
-    bool isDead = false;
-    /* the following type tests are known to be true */
-    InlinedVector<pair<cfg::LocalRef, core::TypePtr>, 1> yesTypeTests;
-    /* the following type tests are known to be false */
-    InlinedVector<pair<cfg::LocalRef, core::TypePtr>, 1> noTypeTests;
-
-    /* this is a "merge" of two knowledges - computes a "lub" of knowledges */
-    void min(core::Context ctx, const KnowledgeFact &other);
-
-    void sanityCheck() const;
-
-    string toString(const core::GlobalState &gs, const cfg::CFG &cfg) const;
-};
-CheckSize(KnowledgeFact, 56, 8);
-
 KnowledgeFilter::KnowledgeFilter(core::Context ctx, cfg::CFG &cfg) {
     used_vars.resize(cfg.numLocalVariables());
     for (auto &bb : cfg.basicBlocks) {

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -238,9 +238,17 @@ const KnowledgeFact *KnowledgeRef::operator->() const {
     return knowledge.get();
 }
 
+KnowledgeFact::KnowledgeFact(bool isDead, const InlinedVector<std::pair<cfg::LocalRef, core::TypePtr>, 1> &yesTypeTests,
+                             const InlinedVector<std::pair<cfg::LocalRef, core::TypePtr>, 1> &noTypeTests)
+    : isDead(isDead), yesTypeTests(yesTypeTests), noTypeTests(noTypeTests) {}
+
+core::RefPtr<KnowledgeFact> KnowledgeFact::freshCopy() {
+    return core::makeRefPtr<KnowledgeFact>(isDead, yesTypeTests, noTypeTests);
+}
+
 KnowledgeFact &KnowledgeRef::mutate() {
     if (knowledge->hasMultipleRefs()) {
-        knowledge = core::makeRefPtr<KnowledgeFact>(*knowledge);
+        knowledge = knowledge->freshCopy();
     }
     ENFORCE(!knowledge->hasMultipleRefs());
     return *knowledge.get();

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -228,7 +228,7 @@ string KnowledgeFact::toString(const core::GlobalState &gs, const cfg::CFG &cfg)
     return fmt::format("{}{}", fmt::join(buf1, ""), fmt::join(buf2, ""));
 }
 
-KnowledgeRef::KnowledgeRef() : knowledge(make_shared<KnowledgeFact>()) {}
+KnowledgeRef::KnowledgeRef() : knowledge(core::makeRefPtr<KnowledgeFact>()) {}
 
 const KnowledgeFact &KnowledgeRef::operator*() const {
     return *knowledge.get();
@@ -239,10 +239,10 @@ const KnowledgeFact *KnowledgeRef::operator->() const {
 }
 
 KnowledgeFact &KnowledgeRef::mutate() {
-    if (knowledge.use_count() > 1) {
-        knowledge = make_shared<KnowledgeFact>(*knowledge);
+    if (knowledge->hasMultipleRefs()) {
+        knowledge = core::makeRefPtr<KnowledgeFact>(*knowledge);
     }
-    ENFORCE(knowledge.use_count() == 1);
+    ENFORCE(!knowledge->hasMultipleRefs());
     return *knowledge.get();
 }
 

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -37,7 +37,25 @@ public:
 };
 
 class Environment;
-struct KnowledgeFact;
+
+/**
+ * Encode things that we know hold and don't hold.
+ */
+struct KnowledgeFact {
+    bool isDead = false;
+    /* the following type tests are known to be true */
+    InlinedVector<pair<cfg::LocalRef, core::TypePtr>, 1> yesTypeTests;
+    /* the following type tests are known to be false */
+    InlinedVector<pair<cfg::LocalRef, core::TypePtr>, 1> noTypeTests;
+
+    /* this is a "merge" of two knowledges - computes a "lub" of knowledges */
+    void min(core::Context ctx, const KnowledgeFact &other);
+
+    void sanityCheck() const;
+
+    string toString(const core::GlobalState &gs, const cfg::CFG &cfg) const;
+};
+CheckSize(KnowledgeFact, 56, 8);
 
 // storing all the knowledge is slow
 // it only makes sense for us to store it if we are going to use it

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -43,6 +43,8 @@ class Environment;
  * Encode things that we know hold and don't hold.
  */
 struct KnowledgeFact : public core::RefCounted<KnowledgeFact> {
+    KnowledgeFact() = default;
+
     bool isDead = false;
     /* the following type tests are known to be true */
     InlinedVector<std::pair<cfg::LocalRef, core::TypePtr>, 1> yesTypeTests;
@@ -55,6 +57,12 @@ struct KnowledgeFact : public core::RefCounted<KnowledgeFact> {
     void sanityCheck() const;
 
     std::string toString(const core::GlobalState &gs, const cfg::CFG &cfg) const;
+
+    // Can't use the regular copy constructor because `core::RefCounted` isn't copyable.
+    core::RefPtr<KnowledgeFact> freshCopy();
+
+    KnowledgeFact(bool isDead, const InlinedVector<std::pair<cfg::LocalRef, core::TypePtr>, 1> &yesTypeTests,
+                  const InlinedVector<std::pair<cfg::LocalRef, core::TypePtr>, 1> &noTypeTests);
 };
 CheckSize(KnowledgeFact, 56, 8);
 

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -44,16 +44,16 @@ class Environment;
 struct KnowledgeFact {
     bool isDead = false;
     /* the following type tests are known to be true */
-    InlinedVector<pair<cfg::LocalRef, core::TypePtr>, 1> yesTypeTests;
+    InlinedVector<std::pair<cfg::LocalRef, core::TypePtr>, 1> yesTypeTests;
     /* the following type tests are known to be false */
-    InlinedVector<pair<cfg::LocalRef, core::TypePtr>, 1> noTypeTests;
+    InlinedVector<std::pair<cfg::LocalRef, core::TypePtr>, 1> noTypeTests;
 
     /* this is a "merge" of two knowledges - computes a "lub" of knowledges */
     void min(core::Context ctx, const KnowledgeFact &other);
 
     void sanityCheck() const;
 
-    string toString(const core::GlobalState &gs, const cfg::CFG &cfg) const;
+    std::string toString(const core::GlobalState &gs, const cfg::CFG &cfg) const;
 };
 CheckSize(KnowledgeFact, 56, 8);
 

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -111,7 +111,7 @@ public:
 
     void removeReferencesToVar(cfg::LocalRef ref);
 };
-CheckSize(KnowledgeRef, 16, 8);
+CheckSize(KnowledgeRef, 8, 8);
 
 /** Almost a named pair of two KnowledgeFact-s. One holds knowledge that is true when a variable is falsy,
  * the other holds knowledge which is true if the same variable is falsy->
@@ -151,7 +151,7 @@ public:
     void sanityCheck() const;
     void emitKnowledgeSizeMetric() const;
 };
-CheckSize(TestedKnowledge, 40, 8);
+CheckSize(TestedKnowledge, 24, 8);
 
 class Environment {
     const core::TypeAndOrigins uninitialized;

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -6,6 +6,7 @@
 #include "core/Context.h"
 #include "core/Error.h"
 #include "core/Names.h"
+#include "core/Refcounting.h"
 #include "core/Symbols.h"
 #include "core/errors/infer.h"
 #include "core/errors/internal.h"
@@ -41,7 +42,7 @@ class Environment;
 /**
  * Encode things that we know hold and don't hold.
  */
-struct KnowledgeFact {
+struct KnowledgeFact : public core::RefCounted<KnowledgeFact> {
     bool isDead = false;
     /* the following type tests are known to be true */
     InlinedVector<std::pair<cfg::LocalRef, core::TypePtr>, 1> yesTypeTests;
@@ -77,7 +78,7 @@ class KnowledgeRef {
     // Is private to ensure that yes/no type test updates go through trusted paths that keep TypeTestReverseIndex
     // updated.
     KnowledgeFact &mutate();
-    std::shared_ptr<KnowledgeFact> knowledge;
+    core::RefPtr<KnowledgeFact> knowledge;
 
 public:
     KnowledgeRef();


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We can finally make the changes to shrink `KnowledgeRef` after the last several PRs.

The only wrinkle is that `KnowledgeFact` has to be fully declared in `environment.h`.  This is...non-optimal?  I think we could get around this by redoing a bit of `RefPtr` to not define all its methods inline, so that the compiler would delay their template expansion until they are needed.  But I'm not _overly_ concerned about this given that `infer` doesn't really sit in the middle of the dependency graph, but at the leaves, so misuse here seems unlikely.  Happy to hear pushback otherwise.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.