### PR TITLE
sorbet-runtime: Re-enable allocation counting in edge_cases.rb

### DIFF
--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -61,10 +61,6 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     GC.stat[:total_allocated_objects] - before - 1 # Subtract one for the allocation by GC.stat itself
   end
 
-  private def check_alloc_counts
-    @check_alloc_counts = Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0')
-  end
-
   describe 'aliasing' do
     describe 'instance method' do
       it 'handles alias_method with runtime checking' do
@@ -88,7 +84,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Should use fast path
         obj = klass.new
         allocs = counting_allocations { obj.bar }
-        assert_operator(allocs, :<, 5) if check_alloc_counts
+        assert_operator(allocs, :<, 5)
       end
 
       it 'handles alias_method without runtime checking' do
@@ -107,7 +103,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Shouldn't add overhead
         obj = klass.new
         allocs = counting_allocations { obj.bar }
-        assert_equal(0, allocs) if check_alloc_counts
+        assert_equal(0, allocs)
       end
 
       it 'handles alias with runtime checking' do
@@ -131,7 +127,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Should use fast path
         obj = klass.new
         allocs = counting_allocations { obj.bar }
-        assert_operator(allocs, :<, 5) if check_alloc_counts
+        assert_operator(allocs, :<, 5)
       end
 
       it 'handles alias without runtime checking' do
@@ -150,7 +146,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Shouldn't add overhead
         obj = klass.new
         allocs = counting_allocations { obj.bar }
-        assert_equal(0, allocs) if check_alloc_counts
+        assert_equal(0, allocs)
       end
 
       it 'handles alias to superclass method with runtime checking' do
@@ -179,7 +175,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Should use fast path
         obj = subclass.new
         allocs = counting_allocations { obj.bar }
-        assert_operator(allocs, :<, 5) if check_alloc_counts
+        assert_operator(allocs, :<, 5)
       end
 
       it 'handles alias to superclass method without runtime checking' do
@@ -203,7 +199,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Shouldn't add overhead
         obj = subclass.new
         allocs = counting_allocations { obj.bar }
-        assert_equal(0, allocs) if check_alloc_counts
+        assert_equal(0, allocs)
       end
 
       it 'handles alias_method to included method with runtime checking' do
@@ -232,7 +228,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Should use fast path
         obj = klass.new
         allocs = counting_allocations { obj.bar }
-        assert_operator(allocs, :<, 5) if check_alloc_counts
+        assert_operator(allocs, :<, 5)
       end
 
       it 'handles alias_method to included method without runtime checking' do
@@ -256,7 +252,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Shouldn't add overhead
         obj = klass.new
         allocs = counting_allocations { obj.bar }
-        assert_equal(0, allocs) if check_alloc_counts
+        assert_equal(0, allocs)
       end
     end
 
@@ -283,7 +279,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         # Should use fast path
         allocs = counting_allocations { klass.bar }
-        assert_operator(allocs, :<, 5) if check_alloc_counts
+        assert_operator(allocs, :<, 5)
       end
 
       it 'handles alias_method without runtime checking' do
@@ -304,7 +300,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Shouldn't add overhead
         klass.bar # Need extra call since first one came before `foo` unwrap
         allocs = counting_allocations { klass.bar }
-        assert_equal(0, allocs) if check_alloc_counts
+        assert_equal(0, allocs)
       end
 
       it 'handles alias with runtime checking' do
@@ -329,7 +325,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         # Should use fast path
         allocs = counting_allocations { klass.bar }
-        assert_operator(allocs, :<, 5) if check_alloc_counts
+        assert_operator(allocs, :<, 5)
       end
 
       it 'handles alias without runtime checking' do
@@ -350,7 +346,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Shouldn't add overhead
         klass.bar # Need extra call since first one came before `foo` unwrap
         allocs = counting_allocations { klass.bar }
-        assert_equal(0, allocs) if check_alloc_counts
+        assert_equal(0, allocs)
       end
 
       it 'handles alias_method to superclass method with runtime checking' do
@@ -380,7 +376,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         # Should use fast path
         allocs = counting_allocations { subclass.bar }
-        assert_operator(allocs, :<, 5) if check_alloc_counts
+        assert_operator(allocs, :<, 5)
       end
 
       it 'handles alias_method to superclass method without runtime checking' do
@@ -405,7 +401,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         # Shouldn't add overhead
         allocs = counting_allocations { subclass.bar }
-        assert_equal(0, allocs) if check_alloc_counts
+        assert_equal(0, allocs)
       end
 
       it 'handles alias_method to extended method with runtime checking' do
@@ -436,7 +432,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         # Should use fast path
         allocs = counting_allocations { klass.bar }
-        assert_operator(allocs, :<, 5) if check_alloc_counts
+        assert_operator(allocs, :<, 5)
       end
 
       it 'handles alias_method to extended method without runtime checking' do
@@ -462,7 +458,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         # Shouldn't add overhead
         allocs = counting_allocations { klass.bar }
-        assert_equal(0, allocs) if check_alloc_counts
+        assert_equal(0, allocs)
       end
 
       it 'handles method reference without sig' do

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -126,6 +126,8 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Shouldn't add overhead
         obj = klass.new
         allocs = counting_allocations { obj.bar }
+        assert_equal(1, allocs)
+        allocs = counting_allocations { obj.bar }
         assert_equal(0, allocs)
       end
 
@@ -168,6 +170,8 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         # Shouldn't add overhead
         obj = klass.new
+        allocs = counting_allocations { obj.bar }
+        assert_equal(1, allocs)
         allocs = counting_allocations { obj.bar }
         assert_equal(0, allocs)
       end
@@ -222,6 +226,8 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Shouldn't add overhead
         obj = subclass.new
         allocs = counting_allocations { obj.bar }
+        assert_equal(1, allocs)
+        allocs = counting_allocations { obj.bar }
         assert_equal(0, allocs)
       end
 
@@ -275,6 +281,8 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Shouldn't add overhead
         obj = klass.new
         allocs = counting_allocations { obj.bar }
+        assert_equal(1, allocs)
+        allocs = counting_allocations { obj.bar }
         assert_equal(0, allocs)
       end
     end
@@ -323,6 +331,8 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Shouldn't add overhead
         klass.bar # Need extra call since first one came before `foo` unwrap
         allocs = counting_allocations { klass.bar }
+        assert_equal(1, allocs)
+        allocs = counting_allocations { klass.bar }
         assert_equal(0, allocs)
       end
 
@@ -368,6 +378,8 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         # Shouldn't add overhead
         klass.bar # Need extra call since first one came before `foo` unwrap
+        allocs = counting_allocations { klass.bar }
+        assert_equal(1, allocs)
         allocs = counting_allocations { klass.bar }
         assert_equal(0, allocs)
       end
@@ -423,6 +435,8 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         assert_equal(:foo, superclass.foo)
 
         # Shouldn't add overhead
+        allocs = counting_allocations { subclass.bar }
+        assert_equal(1, allocs)
         allocs = counting_allocations { subclass.bar }
         assert_equal(0, allocs)
       end
@@ -480,6 +494,8 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         assert_equal(:foo, klass.bar)
 
         # Shouldn't add overhead
+        allocs = counting_allocations { klass.bar }
+        assert_equal(1, allocs)
         allocs = counting_allocations { klass.bar }
         assert_equal(0, allocs)
       end

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -66,6 +66,24 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     gc.stat(:total_allocated_objects) - before
   end
 
+  def trace_counting_allocations(&blk)
+    require 'objspace'
+    gc = GC
+    object_space = ObjectSpace
+    gc.start
+    generation = gc.count
+    allocs = 0
+    object_space.trace_object_allocations do
+      before = gc.stat(:total_allocated_objects)
+      yield
+      allocs = gc.stat(:total_allocated_objects) - before
+    end
+    puts
+    object_space.dump_all(output: :stdout, since: generation)
+    puts "------------------------------------------------------------"
+    allocs
+  end
+
   describe 'aliasing' do
     describe 'instance method' do
       it 'handles alias_method with runtime checking' do

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -257,7 +257,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Should use fast path
         obj = klass.new
         allocs = counting_allocations { obj.bar }
-        assert_operator(allocs, :<, 5)
+        assert_operator(allocs, :<=, 5)
       end
 
       it 'handles alias_method to included method without runtime checking' do
@@ -469,7 +469,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
 
         # Should use fast path
         allocs = counting_allocations { klass.bar }
-        assert_operator(allocs, :<, 5)
+        assert_operator(allocs, :<=, 5)
       end
 
       it 'handles alias_method to extended method without runtime checking' do

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -55,10 +55,15 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     assert_equal('bar', mod.foo('bar'))
   end
 
-  private def counting_allocations
-    before = GC.stat[:total_allocated_objects]
+  def counting_allocations(&blk)
+    # This might trigger a constcache object to get allocated, depending on
+    # whether any intervening methods/classes have been defined.
+    # We don't want to include allocations from the instrumentation itself.
+    gc = GC
+
+    before = gc.stat(:total_allocated_objects)
     yield
-    GC.stat[:total_allocated_objects] - before - 1 # Subtract one for the allocation by GC.stat itself
+    gc.stat(:total_allocated_objects) - before
   end
 
   describe 'aliasing' do


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm working on #10397. There's one failure on pay-server as a result of that
change, and when I went to write a test for it, I realized that we already have
the test that would have caught the regression I introduced, except that it's
been disabled whenever we're testing on something past Ruby 3.0 (i.e., always,
since we run on 3.1 and 3.3).

I think that we might have disabled these allocation tracking tests when we
upgraded just because the counts weren't stable enough, but I think we should
add them back because they're real tests.




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Once I turn on allocation counting again, most of the alias_method related tests
fail. It seems that to _fully_ warm up the alias_method-defined methods, we have
to call the method an additional time, because the second call allocates a
`callcache` object:

```json
{
  "address": "0xe515a61c6e60",
  "type": "IMEMO",
  "class": "0xe515a6244068",
  "imemo_type": "callcache",
  "references": [
    "0xe515a624a4b8"
  ],
  "file": "test/types/edge_cases.rb",
  "line": 128,
  "method": "test_0002_handles alias_method without runtime checking",
  "generation": 27,
  "memsize": 40,
  "flags": {
    "wb_protected": true
  }
}
```

Given the history of the test, it seems like that was not always the case, and
we should probably strive to fix that. However, at least the final call does
eventually get to no new allocations (which #10397 regressed).

I'm working on fixing the regression in #10397, which may end up fixing this
"additional required warm-up call" problem too, but I have no promises. For now,
I just want the tests committed.