### PR TITLE
Bump xxHash to 0.8.3

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -163,10 +163,10 @@ def register_sorbet_dependencies():
 
     http_archive(
         name = "xxhash",
-        url = "https://github.com/Cyan4973/xxHash/archive/v0.8.0.zip",
-        sha256 = "064333c754f166837bbefefa497642a60b3f8035e54bae52eb304d3cb3ceb655",
+        url = "https://github.com/Cyan4973/xxHash/archive/v0.8.3.zip",
+        sha256 = "db2c12e6f05d45546d3581b6881b25090fd65ab5194891da0b2a1a9c49beda66",
         build_file = "@com_stripe_ruby_typer//third_party:xxhash.BUILD",
-        strip_prefix = "xxHash-0.8.0",
+        strip_prefix = "xxHash-0.8.3",
     )
 
     http_archive(


### PR DESCRIPTION
There have been some small changes in the 3 years since 0.8.0 was released.

### Motivation
I'm planning to use XXH64 to replace our use of blake2b for file hashing, and figured that updating would be a good first step.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavioral changes expected
