### PR TITLE
Move file hash generation to File::sourceHash

### DIFF
--- a/core/BUILD
+++ b/core/BUILD
@@ -35,6 +35,7 @@ cc_library(
     deps = [
         "//common",
         "//common/concurrency",
+        "//common/crypto_hashing",
         "//core/hashing",
         "//main/pipeline/semantic_extension:interface",
         "@com_google_absl//absl/strings",

--- a/core/Files.cc
+++ b/core/Files.cc
@@ -1,5 +1,6 @@
 #include "core/Files.h"
 #include "common/FileOps.h"
+#include "common/crypto_hashing/crypto_hashing.h"
 #include "core/Context.h"
 #include "core/FileHash.h"
 #include "core/GlobalState.h"
@@ -312,6 +313,11 @@ bool File::hasIndexErrors() const {
 
 void File::setHasIndexErrors(bool value) {
     flags.hasIndexErrors = value;
+}
+
+std::array<uint8_t, 64> File::sourceHash() const {
+    ENFORCE(this->sourceType != File::Type::NotYetRead);
+    return crypto_hashing::hash64(this->source_);
 }
 
 } // namespace sorbet::core

--- a/core/Files.h
+++ b/core/Files.h
@@ -5,6 +5,7 @@
 #include "core/LocOffsets.h"
 #include "core/Names.h"
 #include "core/StrictLevel.h"
+#include <array>
 #include <string>
 #include <string_view>
 
@@ -92,6 +93,9 @@ public:
 
     static constexpr std::string_view URL_PREFIX = "https://github.com/sorbet/sorbet/tree/master/";
     static std::string censorFilePathForSnapshotTests(std::string_view orig);
+
+    // Returns the hash of the file content. Requires that the file has been read.
+    std::array<uint8_t, 64> sourceHash() const;
 
 private:
     struct Flags {

--- a/core/serialize/BUILD
+++ b/core/serialize/BUILD
@@ -16,7 +16,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//ast",
-        "//common/crypto_hashing",
         "//core",
         "@com_google_absl//absl/types:span",
         "@lz4",

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -3,7 +3,6 @@
 #include "absl/strings/escaping.h" // BytesToHexString
 #include "absl/types/span.h"
 #include "ast/Helpers.h"
-#include "common/crypto_hashing/crypto_hashing.h"
 #include "common/sort/sort.h"
 #include "common/timers/Timer.h"
 #include "core/Error.h"
@@ -1234,7 +1233,7 @@ vector<uint8_t> Serializer::storeTree(const core::File &file, const ast::ParsedF
 
     // See comment in `serialize.h` above `loadTree`.
     p.putU4(file.source().size());
-    p.putBytes(crypto_hashing::hash64(file.source()));
+    p.putBytes(file.sourceHash());
 
     SerializerImpl::pickle(p, file.getFileHash());
     SerializerImpl::pickle(p, file, tree.tree);
@@ -1251,7 +1250,7 @@ ast::ExpressionPtr Serializer::loadTree(const core::GlobalState &gs, core::File 
         return nullptr;
     }
 
-    auto expectedHash = crypto_hashing::hash64(file.source());
+    auto expectedHash = file.sourceHash();
     auto hashBytes = p.getBytes();
     if (hashBytes != expectedHash) {
         return nullptr;


### PR DESCRIPTION
This is a no-op change that switches from calling `crypto_hashing::hash64` directly on `File::source_` to instead calling a new `File::sourceHash` method.

### Motivation
Incrementally moving towards being able to cache the hash on the `File` itself, instead of recomputing it every time.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavior changes expected, existing tests should pass.
