### PR TITLE
drop nil before invoking get call arguments on proc to prevent code unreachable

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1390,13 +1390,20 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
                 ENFORCE(link->result);
                 ENFORCE(link->result->main.blockPreType);
 
+                // Drop nil before asking for call arguments. `blockPreType` keeps nilability so
+                // optional blocks type-check correctly at the call site, but once we're inside a
+                // block body the block was definitely provided. Leaving NilClass in the union makes
+                // getCallArguments glb against NilClass#call (often inherited from a polluted
+                // Object#call, e.g. via Class.new), which can produce T.noreturn and mark the block
+                // unreachable. See https://github.com/sorbet/sorbet/issues/8304
                 auto &procType = link->result->main.blockPreType;
-                auto params = procType.getCallArguments(ctx, core::Names::call());
+                auto params = core::Types::dropNil(ctx, procType).getCallArguments(ctx, core::Names::call());
                 auto it = link->result->secondary.get();
                 while (it != nullptr) {
                     auto &secondaryProcType = it->main.blockPreType;
                     if (secondaryProcType != nullptr) {
-                        auto secondaryParams = secondaryProcType.getCallArguments(ctx, core::Names::call());
+                        auto secondaryParams =
+                            core::Types::dropNil(ctx, secondaryProcType).getCallArguments(ctx, core::Names::call());
                         switch (link->result->secondaryKind) {
                             case core::DispatchResult::Combinator::OR:
                                 params = core::Types::any(ctx, params, secondaryParams);

--- a/test/testdata/infer/nilable_block_object_call.rb
+++ b/test/testdata/infer/nilable_block_object_call.rb
@@ -1,0 +1,28 @@
+# typed: true
+# https://github.com/sorbet/sorbet/issues/8304
+#
+# Defining `Object#call` (e.g. via an anonymous `Class.new` in a test) used to
+# make block bodies with nilable block parameters look unreachable, because
+# LoadYieldParams called getCallArguments on the nilable type and glb'd against
+# NilClass's inherited Object#call.
+extend T::Sig
+
+Class.new do
+  # Zero-arity `call` makes NilClass's call args `[]`, which glbs to bottom with
+  # `T.proc.params(a: String)`'s `[String]` when nil is not dropped first.
+  def call
+  end
+end
+
+sig { params(block: T.nilable(T.proc.params(a: String).void)).void }
+def self.foo(&block)
+  if block
+    block.call("a")
+  end
+end
+
+foo do |a|
+  T.reveal_type(a) # error: Revealed type: `String`
+end
+
+foo

--- a/test/testdata/infer/nilable_block_object_call.rb
+++ b/test/testdata/infer/nilable_block_object_call.rb
@@ -39,11 +39,19 @@ untyped_proc do |a|
   T.reveal_type(a) # error: Revealed type: `T.untyped`
 end
 
-module NilableStringParam
+module NilableProcStringParam
   extend T::Sig
   extend T::Helpers
   interface!
   sig { abstract.params(block: T.nilable(T.proc.params(a: String).void)).void }
+  def foo(&block); end
+end
+
+module NilableProcNilableStringParam
+  extend T::Sig
+  extend T::Helpers
+  interface!
+  sig { abstract.params(block: T.nilable(T.proc.params(a: T.nilable(String)).void)).void }
   def foo(&block); end
 end
 
@@ -79,21 +87,21 @@ module IntegerParam
   def foo(&block); end
 end
 
-sig { params(x: T.any(NilableStringParam, IntegerParam)).void }
+sig { params(x: T.any(NilableProcNilableStringParam, IntegerParam)).void }
 def union_different_block_args(x)
   x.foo do |a|
-    T.reveal_type(a) # error: Revealed type: `T.any(T.nilable(String), Integer)`
+    T.reveal_type(a) # error: Revealed type: `T.nilable(T.any(String, Integer))`
   end
 end
 
-sig { params(x: T.any(NilableStringParam, StringParam)).void }
+sig { params(x: T.any(NilableProcNilableStringParam, StringParam)).void }
 def union_same_block_args(x)
   x.foo do |a|
     T.reveal_type(a) # error: Revealed type: `T.nilable(String)`
   end
 end
 
-sig { params(x: T.all(NilableStringParam, StringParam)).void }
+sig { params(x: T.all(NilableProcStringParam, StringParam)).void }
 def intersection_same_block_args(x)
   x.foo do |a|
     T.reveal_type(a) # error: Revealed type: `String`
@@ -108,21 +116,21 @@ def intersection_compatible_block_args(x)
   end
 end
 
-sig { params(x: T.all(T.any(NilableStringParam, StringParam), NilableStringParam)).void }
+sig { params(x: T.all(T.any(NilableProcNilableStringParam, StringParam), NilableProcNilableStringParam)).void }
 def interleaved_all_any(x)
   x.foo do |a|
     T.reveal_type(a) # error: Revealed type: `T.nilable(String)`
   end
 end
 
-sig { params(x: T.any(T.all(NilableStringParam, StringParam), NilableIntegerParam)).void }
+sig { params(x: T.any(T.all(NilableProcStringParam, StringParam), NilableIntegerParam)).void }
 def interleaved_any_all(x)
   x.foo do |a|
     T.reveal_type(a) # error: Revealed type: `T.any(Integer, String)`
   end
 end
 
-sig { params(x: T.all(NilableStringParam, IntegerParam)).void }
+sig { params(x: T.all(NilableProcStringParam, IntegerParam)).void }
 def intersection_incompatible_block_args(x)
   # Even with dropNil, AND of [String] and [Integer] is bottom, so the block
   # body is unreachable. This is independent of Object#call pollution.

--- a/test/testdata/infer/nilable_block_object_call.rb
+++ b/test/testdata/infer/nilable_block_object_call.rb
@@ -5,6 +5,10 @@
 # make block bodies with nilable block parameters look unreachable, because
 # LoadYieldParams called getCallArguments on the nilable type and glb'd against
 # NilClass's inherited Object#call.
+#
+# T.any / T.all cases below exercise dropNil on secondary DispatchResult
+# components. Intersection receivers use interface modules so T.all is
+# inhabitable (unlike T.all of unrelated classes).
 extend T::Sig
 
 Class.new do
@@ -26,3 +30,104 @@ foo do |a|
 end
 
 foo
+
+sig { params(block: T.nilable(Proc)).void }
+def self.untyped_proc(&block)
+end
+
+untyped_proc do |a|
+  T.reveal_type(a) # error: Revealed type: `T.untyped`
+end
+
+module NilableStringParam
+  extend T::Sig
+  extend T::Helpers
+  interface!
+  sig { abstract.params(block: T.nilable(T.proc.params(a: String).void)).void }
+  def foo(&block); end
+end
+
+module NilableIntegerParam
+  extend T::Sig
+  extend T::Helpers
+  interface!
+  sig { abstract.params(block: T.nilable(T.proc.params(a: Integer).void)).void }
+  def foo(&block); end
+end
+
+module NumericParam
+  extend T::Sig
+  extend T::Helpers
+  interface!
+  sig { abstract.params(block: T.proc.params(a: Numeric).void).void }
+  def foo(&block); end
+end
+
+module StringParam
+  extend T::Sig
+  extend T::Helpers
+  interface!
+  sig { abstract.params(block: T.proc.params(a: String).void).void }
+  def foo(&block); end
+end
+
+module IntegerParam
+  extend T::Sig
+  extend T::Helpers
+  interface!
+  sig { abstract.params(block: T.proc.params(a: Integer).void).void }
+  def foo(&block); end
+end
+
+sig { params(x: T.any(NilableStringParam, IntegerParam)).void }
+def union_different_block_args(x)
+  x.foo do |a|
+    T.reveal_type(a) # error: Revealed type: `T.any(T.nilable(String), Integer)`
+  end
+end
+
+sig { params(x: T.any(NilableStringParam, StringParam)).void }
+def union_same_block_args(x)
+  x.foo do |a|
+    T.reveal_type(a) # error: Revealed type: `T.nilable(String)`
+  end
+end
+
+sig { params(x: T.all(NilableStringParam, StringParam)).void }
+def intersection_same_block_args(x)
+  x.foo do |a|
+    T.reveal_type(a) # error: Revealed type: `String`
+  end
+end
+
+sig { params(x: T.all(NumericParam, IntegerParam)).void }
+def intersection_compatible_block_args(x)
+  x.foo do |a|
+    # glb(Numeric, Integer) == Integer
+    T.reveal_type(a) # error: Revealed type: `Integer`
+  end
+end
+
+sig { params(x: T.all(T.any(NilableStringParam, StringParam), NilableStringParam)).void }
+def interleaved_all_any(x)
+  x.foo do |a|
+    T.reveal_type(a) # error: Revealed type: `T.nilable(String)`
+  end
+end
+
+sig { params(x: T.any(T.all(NilableStringParam, StringParam), NilableIntegerParam)).void }
+def interleaved_any_all(x)
+  x.foo do |a|
+    T.reveal_type(a) # error: Revealed type: `T.any(Integer, String)`
+  end
+end
+
+sig { params(x: T.all(NilableStringParam, IntegerParam)).void }
+def intersection_incompatible_block_args(x)
+  # Even with dropNil, AND of [String] and [Integer] is bottom, so the block
+  # body is unreachable. This is independent of Object#call pollution.
+  x.foo do |a|
+          # ^ error: This code is unreachable
+    puts a
+  end
+end


### PR DESCRIPTION
closes https://github.com/sorbet/sorbet/issues/8304#issuecomment-2482289409

Drop nil procs before getting for call arguments. 

### Motivation

I spent an hour trying to tweak my sigs to fix this in my code base, then found the issue linked above. I figured I'd let cursor have a go at fixing it, and the change required to fix it ended up being quite small, so I'm creating this PR. I don't understand this code very deeply, but at a high level the drop nil makes sense with my understanding of the what's causing it (the nilable proc sig). 

### Test plan

Ruby spec added.

