### PR TITLE
Narrow types for `case`/`when` against a literal value

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -674,6 +674,14 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
             whoKnows.truthy().addYesTypeTest(local, typeTestsWithVar, ref, klassType);
             whoKnows.falsy().addNoTypeTest(local, typeTestsWithVar, ref, klassType);
         }
+
+        if(
+            core::isa_type<core::NamedLiteralType>(klassType) ||
+            core::isa_type<core::IntegerLiteralType>(klassType) ||
+            core::isa_type<core::FloatLiteralType>(klassType)
+          ) {
+            whoKnows.truthy().addYesTypeTest(local, typeTestsWithVar, ref, klassType);
+        }
         whoKnows.sanityCheck();
         return;
     }

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -675,6 +675,7 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
             whoKnows.falsy().addNoTypeTest(local, typeTestsWithVar, ref, klassType);
         }
 
+        // `when` against a literal
         if (core::isa_type<core::NamedLiteralType>(klassType) || core::isa_type<core::IntegerLiteralType>(klassType) ||
             core::isa_type<core::FloatLiteralType>(klassType)) {
             whoKnows.truthy().addYesTypeTest(local, typeTestsWithVar, ref, klassType);

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -675,11 +675,8 @@ void Environment::updateKnowledge(core::Context ctx, cfg::LocalRef local, core::
             whoKnows.falsy().addNoTypeTest(local, typeTestsWithVar, ref, klassType);
         }
 
-        if(
-            core::isa_type<core::NamedLiteralType>(klassType) ||
-            core::isa_type<core::IntegerLiteralType>(klassType) ||
-            core::isa_type<core::FloatLiteralType>(klassType)
-          ) {
+        if (core::isa_type<core::NamedLiteralType>(klassType) || core::isa_type<core::IntegerLiteralType>(klassType) ||
+            core::isa_type<core::FloatLiteralType>(klassType)) {
             whoKnows.truthy().addYesTypeTest(local, typeTestsWithVar, ref, klassType);
         }
         whoKnows.sanityCheck();

--- a/test/testdata/infer/case_when_literal.rb
+++ b/test/testdata/infer/case_when_literal.rb
@@ -1,0 +1,54 @@
+# typed: true
+
+extend T::Sig
+
+sig {params(x: T.any(Integer, String)).returns(T.any(Integer, String))}
+def foo(x)
+  case x
+  when 5
+    T.reveal_type(x) # error: Revealed type: `Integer(5)`
+    x
+  when "hello"
+    T.reveal_type(x) # error: Revealed type: `String("hello")`
+  when String
+    T.reveal_type(x) # error: Revealed type: `String`
+    x
+  else
+    T.reveal_type(x) # error: Revealed type: `Integer`
+    x
+  end
+end
+
+sig {params(x: T.any(Symbol, Float)).void}
+def symbol_and_float(x)
+  case x
+  when :foo
+    T.reveal_type(x) # error: Revealed type: `Symbol(:foo)`
+  when 3.14
+    T.reveal_type(x) # error: Revealed type: `Float(3.140000)`
+  else
+    T.reveal_type(x) # error: Revealed type: `T.any(Symbol, Float)`
+  end
+end
+
+sig {params(x: Integer).void}
+def literal_narrows_within_same_type(x)
+  case x
+  when 1
+    T.reveal_type(x) # error: Revealed type: `Integer(1)`
+  else
+    T.reveal_type(x) # error: Revealed type: `Integer`
+  end
+end
+
+sig {params(x: T.any(Integer, String)).void}
+def multiple_literals(x)
+  case x
+  when 5, 6
+    T.reveal_type(x) # error: Revealed type: `Integer`
+  when "a", "b"
+    T.reveal_type(x) # error: Revealed type: `String`
+  else
+    T.reveal_type(x) # error: Revealed type: `T.any(Integer, String)`
+  end
+end

--- a/test/testdata/infer/case_when_nilable.rb
+++ b/test/testdata/infer/case_when_nilable.rb
@@ -1,0 +1,13 @@
+# typed: strong
+
+x = ["blah", nil].sample
+T.reveal_type(x) # error: Revealed type: `T.nilable(String)`
+
+case x
+when 'blah'
+  T.reveal_type(x) # error: Revealed type: `String("blah")`
+when String
+  T.reveal_type(x) # error: Revealed type: `String`
+else
+  T.reveal_type(x) # error: Revealed type: `NilClass`
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
This PR implements type narrowing for `when` blocks comparing against a literal type. This ensures nilable types are handled correctly, while also providing more specific type information in the `when` block when the target variable is known to be a literal. 

The implementation checks the type tag against the three literal variants `NamedLiteralType` (String and Symbol), `IntegerLiteralType`, `FloatLiteralType` and adds the corresponding yes type test when the condition is truthy. We know literal types' `===` is the same as equality, so if the comparison is truthy then the target variable must be that literal. 

Example:

```ruby
# typed: strong

x = ["blah", nil].sample # local variable
T.reveal_type(x)

case x
when 'blah'
  T.reveal_type(x)
else
  T.reveal_type(x)
end
```
New output (correctly narrowed):
```
example.rb:7: Revealed type: T.nilable(String) https://srb.help/7014
     7 |T.reveal_type(x)
        ^^^^^^^^^^^^^^^^
  Got T.nilable(String) originating from:
    example.rb:3:
     3 |x = ["blah", nil].sample # local variable
            ^^^^^^^^^^^^^^^^^^^^

example.rb:13: Revealed type: String("blah") https://srb.help/7014
    13 |  T.reveal_type(x)
          ^^^^^^^^^^^^^^^^
  Got String("blah") originating from:
    example.rb:3:
     3 |x = ["blah", nil].sample # local variable
            ^^^^^^^^^^^^^^^^^^^^
    example.rb:10:
    10 |when 'blah'
             ^^^^^^

example.rb:17: Revealed type: T.nilable(String) https://srb.help/7014
    17 |  T.reveal_type(x)
          ^^^^^^^^^^^^^^^^
  Got T.nilable(String) originating from:
    example.rb:3:
     3 |x = ["blah", nil].sample # local variable
            ^^^^^^^^^^^^^^^^^^^^
Errors: 3
```
**Note:** the else case has `T.nilable(String)` type. AFAIK it's not possible to further narrow this down to `NilClass` by negating the literal type. We only know `x != "blah"` and since `x` is `T.nilable(String)` that is not enough information to conclude it is `NilClass` (it could still be any other string or nil)


Previous observed output (did not narrow):
```
editor.rb:7: Revealed type: T.nilable(String) https://srb.help/7014
     7 |T.reveal_type(x)
        ^^^^^^^^^^^^^^^^
  Got T.nilable(String) originating from:
    editor.rb:3:
     3 |x = ["blah", nil].sample # local variable
            ^^^^^^^^^^^^^^^^^^^^

editor.rb:13: Revealed type: T.nilable(String) https://srb.help/7014
    13 |  T.reveal_type(x)
          ^^^^^^^^^^^^^^^^
  Got T.nilable(String) originating from:
    editor.rb:3:
     3 |x = ["blah", nil].sample # local variable
            ^^^^^^^^^^^^^^^^^^^^

editor.rb:17: Revealed type: T.nilable(String) https://srb.help/7014
    17 |  T.reveal_type(x)
          ^^^^^^^^^^^^^^^^
  Got T.nilable(String) originating from:
    editor.rb:3:
     3 |x = ["blah", nil].sample # local variable
            ^^^^^^^^^^^^^^^^^^^^
Errors: 3
```


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Closes #9446 . Previously, `when` against a literal type did not narrow the target variable. This resulted in a nilable variable still being nilable even inside a `when` block that confirmed it is not nil.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Added the following test files:
* `test/testdata/infer/case_when_literal.rb` - Literal narrowing test cases
* `test/testdata/infer/case_when_nilable.rb` - Nilable narrowing test case

Existing test suite passes locally.
