### PR TITLE
make `KnowledgeFact` refcounting non-atomic

### DIFF
--- a/core/Refcounting.h
+++ b/core/Refcounting.h
@@ -18,6 +18,10 @@ template <> class Refcountable<RefCountAtomicity::NonAtomic> {
     uint32_t counter{0};
 
 public:
+    Refcountable() noexcept = default;
+    Refcountable(const Refcountable&) = delete;
+    Refcountable& operator=(const Refcountable&) = delete;
+
     void addref() {
         this->counter++;
     }

--- a/core/Refcounting.h
+++ b/core/Refcounting.h
@@ -7,7 +7,34 @@
 
 namespace sorbet::core {
 
-class Refcountable {
+enum class RefCountAtomicity {
+    Atomic,
+    NonAtomic,
+};
+
+template <RefCountAtomicity Atomic> class Refcountable;
+
+template <> class Refcountable<RefCountAtomicity::NonAtomic> {
+    uint32_t counter{0};
+
+public:
+    void addref() {
+        this->counter++;
+    }
+
+    uint32_t release() {
+        return --this->counter;
+    }
+
+    // You typically should not need to call this; it is mostly for tests to
+    // verify that things manipulating `Refcountable` are getting the counting
+    // logic correct.
+    bool hasMultipleRefs() const {
+        return this->counter > 1;
+    }
+};
+
+template <> class Refcountable<RefCountAtomicity::Atomic> {
     std::atomic<uint32_t> counter{0};
 
 public:
@@ -29,14 +56,14 @@ public:
 };
 
 // CRTP base for classes that want to be used with RefPtr<T>.
-template <typename T> class RefCounted : public Refcountable {
+template <typename T, RefCountAtomicity Atomic> class RefCounted : public Refcountable<Atomic> {
 public:
     void addref() {
-        Refcountable::addref();
+        Refcountable<Atomic>::addref();
     }
 
     void release() {
-        uint32_t remaining = Refcountable::release();
+        uint32_t remaining = Refcountable<Atomic>::release();
         if (remaining == 0) {
             delete static_cast<T *>(this);
         }

--- a/core/TypePtr.h
+++ b/core/TypePtr.h
@@ -15,6 +15,8 @@ class TypeConstraint;
 struct DispatchResult;
 struct DispatchArgs;
 
+typedef core::Refcountable<RefCountAtomicity::Atomic> TypePtrRefcountable;
+
 class TypePtr final {
     template <class To> static To &const_cast_type(const To &what) {
         return const_cast<To &>(what);
@@ -110,7 +112,7 @@ private:
         return val;
     }
 
-    static tagged_storage tagPtr(Tag tag, Refcountable *expr) {
+    static tagged_storage tagPtr(Tag tag, TypePtrRefcountable *expr) {
         auto val = tagToMask(tag);
 
         auto maskedPtr = reinterpret_cast<tagged_storage>(expr) << 16;
@@ -156,9 +158,9 @@ private:
         return val;
     }
 
-    Refcountable *get() const {
+    TypePtrRefcountable *get() const {
         auto val = store & PTR_MASK;
-        return reinterpret_cast<Refcountable *>(val >> 16);
+        return reinterpret_cast<TypePtrRefcountable *>(val >> 16);
     }
 
 public:
@@ -203,7 +205,7 @@ public:
         return *this;
     };
 
-    explicit TypePtr(Tag tag, Refcountable *expr) noexcept : store(tagPtr(tag, expr)) {
+    explicit TypePtr(Tag tag, TypePtrRefcountable *expr) noexcept : store(tagPtr(tag, expr)) {
         expr->addref();
     }
 

--- a/core/Types.h
+++ b/core/Types.h
@@ -439,7 +439,7 @@ template <> inline ClassType cast_type_nonnull<ClassType>(const TypePtr &what) {
  * this variable has been bound by "something" but we don't know exactly what (see the SelfTypeParam
  * docs below).
  */
-TYPE(LambdaParam) final : public Refcountable {
+TYPE(LambdaParam) final : public TypePtrRefcountable {
 public:
     TypeMemberRef definition;
 
@@ -678,7 +678,7 @@ template <> inline NamedLiteralType cast_type_nonnull<NamedLiteralType>(const Ty
     }
 }
 
-TYPE(IntegerLiteralType) final : public Refcountable {
+TYPE(IntegerLiteralType) final : public TypePtrRefcountable {
 public:
     const int64_t value;
 
@@ -712,7 +712,7 @@ template <> inline TypePtr make_type<IntegerLiteralType, long long &>(long long 
     return make_type<IntegerLiteralType>(static_cast<int64_t>(val));
 }
 
-TYPE(FloatLiteralType) final : public Refcountable {
+TYPE(FloatLiteralType) final : public TypePtrRefcountable {
 public:
     const double value;
 
@@ -746,7 +746,7 @@ template <> inline TypePtr make_type<FloatLiteralType, float &&>(float &&val) {
  * TypeVars are the used for the type parameters of generic methods, e.g. T.type_parameter(:U)
  * Note: These are mutated post-construction and cannot be inlined.
  */
-TYPE(TypeVar) final : public Refcountable {
+TYPE(TypeVar) final : public TypePtrRefcountable {
 public:
     TypeParameterRef sym;
     TypeVar(TypeParameterRef sym);
@@ -767,7 +767,7 @@ public:
 };
 CheckSize(TypeVar, 8, 8);
 
-TYPE(OrType) final : public Refcountable {
+TYPE(OrType) final : public TypePtrRefcountable {
 public:
     TypePtr left;
     TypePtr right;
@@ -825,7 +825,7 @@ private:
 };
 CheckSize(OrType, 24, 8);
 
-TYPE(AndType) final : public Refcountable {
+TYPE(AndType) final : public TypePtrRefcountable {
 public:
     TypePtr left;
     TypePtr right;
@@ -874,7 +874,7 @@ private:
 };
 CheckSize(AndType, 24, 8);
 
-TYPE(ShapeType) final : public Refcountable {
+TYPE(ShapeType) final : public TypePtrRefcountable {
 public:
     std::vector<TypePtr> keys; // TODO: store sorted by whatever
     std::vector<TypePtr> values;
@@ -911,7 +911,7 @@ public:
 };
 CheckSize(ShapeType, 56, 8);
 
-TYPE(TupleType) final : public Refcountable {
+TYPE(TupleType) final : public TypePtrRefcountable {
 private:
     TupleType() = delete;
 
@@ -942,7 +942,7 @@ public:
 };
 CheckSize(TupleType, 32, 8);
 
-TYPE(AppliedType) final : public Refcountable {
+TYPE(AppliedType) final : public TypePtrRefcountable {
 public:
     ClassOrModuleRef klass;
     std::vector<TypePtr> targs;
@@ -976,7 +976,7 @@ CheckSize(AppliedType, 32, 8);
 //
 // These are used within the inferencer in places where we need to track
 // user-written types in the source code.
-TYPE(MetaType) final : public Refcountable {
+TYPE(MetaType) final : public TypePtrRefcountable {
 public:
     TypePtr wrapped;
 
@@ -1188,7 +1188,7 @@ template <> inline BlamedUntyped cast_type_nonnull<BlamedUntyped>(const TypePtr 
     return BlamedUntyped(core::SymbolRef::fromRaw(what.inlinedValue()));
 }
 
-TYPE(UnresolvedClassType) final : public Refcountable, public ClassType {
+TYPE(UnresolvedClassType) final : public TypePtrRefcountable, public ClassType {
 public:
     const core::SymbolRef scope;
     const std::vector<core::NameRef> names;
@@ -1204,7 +1204,7 @@ public:
     uint32_t hash(const GlobalState &gs) const;
 };
 
-TYPE(UnresolvedAppliedType) final : public Refcountable, public ClassType {
+TYPE(UnresolvedAppliedType) final : public TypePtrRefcountable, public ClassType {
 public:
     const core::ClassOrModuleRef klass;
     const std::vector<TypePtr> targs;

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -217,12 +217,12 @@ public:
         return ptr.store;
     }
 
-    static Refcountable *get(const TypePtr &ptr) {
+    static TypePtrRefcountable *get(const TypePtr &ptr) {
         CHECK(ptr.containsPtr());
         return ptr.get();
     }
 
-    static TypePtr create(TypePtr::Tag tag, Refcountable *type) {
+    static TypePtr create(TypePtr::Tag tag, TypePtrRefcountable *type) {
         return TypePtr(tag, type);
     }
 
@@ -330,7 +330,7 @@ TEST_SUITE("TrailingObjects") {
 }
 
 namespace {
-class TestRefCounted final : public sorbet::core::RefCounted<TestRefCounted> {
+class TestRefCounted final : public sorbet::core::RefCounted<TestRefCounted, sorbet::core::RefCountAtomicity::Atomic> {
 public:
     int value;
     int *destructor_count;

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1985,5 +1985,5 @@ core::TypeAndOrigins nilTypesWithOriginWithLoc(core::Loc loc) {
 
 Environment::Environment(core::Loc ownerLoc) : uninitialized(nilTypesWithOriginWithLoc(ownerLoc)), ownerLoc(ownerLoc) {}
 
-TestedKnowledge TestedKnowledge::empty;
+thread_local TestedKnowledge TestedKnowledge::empty;
 } // namespace sorbet::infer

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -145,7 +145,7 @@ public:
 
     std::string toString(const core::GlobalState &gs, const cfg::CFG &cfg) const;
 
-    static TestedKnowledge empty; // optimization
+    static thread_local TestedKnowledge empty; // optimization
 
     void removeReferencesToVar(cfg::LocalRef ref);
     void sanityCheck() const;

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -42,7 +42,7 @@ class Environment;
 /**
  * Encode things that we know hold and don't hold.
  */
-struct KnowledgeFact : public core::RefCounted<KnowledgeFact> {
+struct KnowledgeFact : public core::RefCounted<KnowledgeFact, core::RefCountAtomicity::Atomic> {
     KnowledgeFact() = default;
 
     bool isDead = false;

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -42,7 +42,7 @@ class Environment;
 /**
  * Encode things that we know hold and don't hold.
  */
-struct KnowledgeFact : public core::RefCounted<KnowledgeFact, core::RefCountAtomicity::Atomic> {
+struct KnowledgeFact : public core::RefCounted<KnowledgeFact, core::RefCountAtomicity::NonAtomic> {
     KnowledgeFact() = default;
 
     bool isDead = false;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We never pass these things across threads, so there's no reason to have them use atomic refcounting.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
