### PR TITLE
Support serializing uint64_t values

### DIFF
--- a/core/serialize/pickler.h
+++ b/core/serialize/pickler.h
@@ -1,6 +1,7 @@
 #ifndef SORBET_PICKLER_H
 #define SORBET_PICKLER_H
 
+#include "absl/base/casts.h"
 #include "absl/types/span.h"
 #include "common/common.h"
 
@@ -12,7 +13,10 @@ class Pickler {
 public:
     void putU4(uint32_t u);
     void putU1(const uint8_t u);
-    void putS8(const int64_t i);
+    void putU8(const uint64_t i);
+    void putS8(const int64_t i) {
+        this->putU8(absl::bit_cast<uint64_t>(i));
+    }
     void putStr(std::string_view s);
     void putBytes(absl::Span<const uint8_t> bytes);
     std::vector<uint8_t> result();
@@ -27,7 +31,10 @@ class UnPickler {
 public:
     uint32_t getU4();
     uint8_t getU1();
-    int64_t getS8();
+    uint64_t getU8();
+    int64_t getS8() {
+        return absl::bit_cast<int64_t>(this->getU8());
+    }
     std::string_view getStr();
     absl::Span<const uint8_t> getBytes();
     explicit UnPickler(const uint8_t *const compressed, spdlog::logger &tracer);

--- a/core/serialize/serialize.cc
+++ b/core/serialize/serialize.cc
@@ -248,8 +248,8 @@ uint32_t UnPickler::getU4() {
     }
 }
 
-void Pickler::putS8(const int64_t i) {
-    auto u = absl::bit_cast<uint64_t>(i);
+void Pickler::putU8(const uint64_t i) {
+    auto u = i;
     while (u > 127) {
         putU1((u & 127) | 128);
         u = u >> 7;
@@ -257,7 +257,7 @@ void Pickler::putS8(const int64_t i) {
     putU1(u & 127);
 }
 
-int64_t UnPickler::getS8() {
+uint64_t UnPickler::getU8() {
     uint64_t res = 0;
     uint64_t vle = 128;
     int i = 0;
@@ -266,7 +266,7 @@ int64_t UnPickler::getS8() {
         res |= (vle & 127) << (i * 7);
         i++;
     }
-    return absl::bit_cast<int64_t>(res);
+    return res;
 }
 
 void SerializerImpl::pickle(Pickler &p, shared_ptr<const FileHash> fh) {


### PR DESCRIPTION
`Pickler::putS8` and `UnPickler::getS8` serialize unsigned values internally. It's helpful to have the unsigned variants available as well, so let's expose them directly and define the signed ones in terms of them.

### Motivation
I'd like to switch to using `xxHash` for file hashes, and being able to serialize `uint64_t` values directly would be nice.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Pure refactoring, no changes in behavior expected.
