### PR TITLE
Flush critical errors before ending the current epoch

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -236,13 +236,17 @@ bool LSPTypechecker::typecheck(unique_ptr<LSPFileUpdates> updates, WorkerPool &w
             std::tie(committed, startingStratum) =
                 runSlowPath(*updates, kvstore, workers, errorFlusher, SlowPathMode::Cancelable);
         }
-        epoch.committed = committed;
-    }
 
-    if (gs->hadCriticalError()) {
-        gs->errorQueue->flushAllErrors(*gs);
-        // If flushing the critical error didn't crash the entire process, let's reset the bit for the next typecheck.
-        gs->errorQueue->hadCritical = false;
+        // We flush errors while `epoch` is still active, to ensure that we don't accidentally report errors about an
+        // epoch that has ended.
+        if (gs->hadCriticalError()) {
+            gs->errorQueue->flushAllErrors(*gs);
+            // If flushing the critical error didn't crash the entire process, let's reset the bit for the next
+            // typecheck.
+            gs->errorQueue->hadCritical = false;
+        }
+
+        epoch.committed = committed;
     }
 
     sendTypecheckInfo(*config, *gs, committed ? SorbetTypecheckRunStatus::Ended : SorbetTypecheckRunStatus::Cancelled,


### PR DESCRIPTION
Move error flushing to before we end the current epoch in LSP. We currently flush all errors if we see a critical error during typechecking, but do so after we have ended the current epoch. The danger here is that we might end up trying to publish errors for the epoch that we ended, and violate [this enforce](https://github.com/sorbet/sorbet/blob/4b2db33907d3b457d6a16769420fd11442358319/main/lsp/ErrorReporter.cc#L116-L117) at runtime.

Instead, let's do the check and flush while the epoch is still open, ensuring that if the error was relevant to the current epoch, that any state associated is still available.

### Motivation
Attempting to fix a somewhat infrequent crash, whose symptoms are that we see a `nullptr` Timer in the `EpochTimers` vector associated with the current epoch.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No tests included, I'm not sure how to reproduce this.
