### PR TITLE
make `TestedKnowledge::empty` thread-local to avoid refcount contention

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -1985,5 +1985,5 @@ core::TypeAndOrigins nilTypesWithOriginWithLoc(core::Loc loc) {
 
 Environment::Environment(core::Loc ownerLoc) : uninitialized(nilTypesWithOriginWithLoc(ownerLoc)), ownerLoc(ownerLoc) {}
 
-TestedKnowledge TestedKnowledge::empty;
+thread_local TestedKnowledge TestedKnowledge::empty;
 } // namespace sorbet::infer

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -145,7 +145,7 @@ public:
 
     std::string toString(const core::GlobalState &gs, const cfg::CFG &cfg) const;
 
-    static TestedKnowledge empty; // optimization
+    static thread_local TestedKnowledge empty; // optimization
 
     void removeReferencesToVar(cfg::LocalRef ref);
     void sanityCheck() const;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Turns out having an empty object shared among all threads where the shared object contains mutable refcounts updated by all threads...turns that object into a giant contention point, and is a non-obvious source of shared data between threads.  Let's make this thread-local instead.

This change seems to be good for several hundred milliseconds of just the typechecking/inference time on Stripe's codebase.  What I do not totally understand is that it also seems to be responsible for ~4% of improvement of `scripts/bin/typecheck` on a devbox (!!), as measured by the `wall_time` counter (25 runs and it's pretty consistent across the spectrum of runs).  These two things don't really comport together, but then maybe the `typecheck` counter isn't measuring what I think it's measuring?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.