### PR TITLE
Add some more info to a variance.cc enforce

### DIFF
--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -69,9 +69,11 @@ private:
                 auto members = app.klass.data(ctx)->typeMembers();
                 auto params = app.targs;
 
-                ENFORCE(members.size() == params.size(),
-                        "types should be fully saturated, but there are {} members and {} params", members.size(),
-                        params.size());
+                if (members.size() != params.size()) [[unlikely]] {
+                    fatalLogger->error(R"(msg="types should be fully saturated" loc="{}" members={} params={})",
+                                       this->loc.showRaw(ctx), members.size(), params.size());
+                    ENFORCE(false);
+                }
 
                 for (int i = 0; i < members.size(); ++i) {
                     auto memberVariance = members[i].data(ctx)->variance();


### PR DESCRIPTION
We're seeing occasional crashes at this point in variance.cc when running in package-directed mode, and I'd like to log some more information about the crash so that we can start tracking it down.

### Motivation
Debugging.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Not applicable.
