### PR TITLE
pass a `string_view` to construct parser literals

### DIFF
--- a/parser/parser/cc/lexer.rl
+++ b/parser/parser/cc/lexer.rl
@@ -1749,7 +1749,7 @@ void lexer::set_state_expr_value() {
       '%s' c_any
       => {
         if (version == ruby_version::RUBY_23) {
-          fgoto *push_literal(literal_type::LOWERS_SYMBOL, std::string(ts + 2, 1), ts);
+          fgoto *push_literal(literal_type::LOWERS_SYMBOL, std::string_view(ts + 2, 1), ts);
         } else {
           p = ts - 1;
           fgoto expr_end;
@@ -2164,13 +2164,13 @@ void lexer::set_state_expr_value() {
       # /=/ (disambiguation with /=)
       '/' c_any
       => {
-        fhold; fgoto *push_literal(literal_type::SLASH_REGEXP, std::string(ts + 0, 1), ts);
+        fhold; fgoto *push_literal(literal_type::SLASH_REGEXP, std::string_view(ts, 1), ts);
       };
 
       # %<string>
       '%' ( any - [A-Za-z] )
       => {
-        fgoto *push_literal(literal_type::PERCENT_STRING, std::string(ts + 1, 1), ts);
+        fgoto *push_literal(literal_type::PERCENT_STRING, std::string_view(ts + 1, 1), ts);
       };
 
       # %w(we are the people)
@@ -2203,7 +2203,7 @@ void lexer::set_state_expr_value() {
           diagnostic_(dlevel::ERROR, dclass::UnexpectedPercentStr, range(ts, te - 1), tok(ts, te-1));
         }
 
-        fgoto *push_literal(type, std::string(te - 1, 1), ts);
+        fgoto *push_literal(type, std::string_view(te - 1, 1), ts);
       };
 
       '%' c_eof
@@ -2268,7 +2268,7 @@ void lexer::set_state_expr_value() {
           p = ts + 1;
           fnext expr_beg; fbreak;
         } else {
-          fnext *push_literal(type, std::string(delim_s, (size_t)(delim_e - delim_s)), ts, heredoc_e, indent, dedent_body);
+          fnext *push_literal(type, std::string_view(delim_s, (size_t)(delim_e - delim_s)), ts, heredoc_e, indent, dedent_body);
 
           if (!herebody_s) {
             herebody_s = new_herebody_s;
@@ -2300,7 +2300,7 @@ void lexer::set_state_expr_value() {
           type = literal_type::DQUOTE_SYMBOL;
         }
 
-        fgoto *push_literal(type, std::string(ts + 1, 1), ts);
+        fgoto *push_literal(type, std::string_view(ts + 1, 1), ts);
       };
 
       # :!@ is :!
@@ -2630,7 +2630,7 @@ void lexer::set_state_expr_value() {
           type = literal_type::DQUOTE_STRING;
         }
 
-        fgoto *push_literal(type, tok(), ts);
+        fgoto *push_literal(type, tok_view(), ts);
       };
 
       w_space_comment;
@@ -2834,7 +2834,7 @@ void lexer::set_state_expr_value() {
           type = literal_type::DQUOTE_STRING;
         }
 
-        fgoto *push_literal(type, std::string(te - 1, 1), ts, nullptr, false, false, true);
+        fgoto *push_literal(type, std::string_view(te - 1, 1), ts, nullptr, false, false, true);
       };
 
       #

--- a/parser/parser/cc/literal.cc
+++ b/parser/parser/cc/literal.cc
@@ -4,7 +4,7 @@
 using namespace ruby_parser;
 using namespace std::literals::string_view_literals;
 
-literal::literal(lexer &lexer, literal_type type, std::string delimiter, const char *str_s, const char *heredoc_e,
+literal::literal(lexer &lexer, literal_type type, std::string_view delimiter, const char *str_s, const char *heredoc_e,
                  bool indent, bool dedent_body, bool label_allowed)
     : _lexer(lexer), _nesting(1), _type(type), indent(indent), dedent_body(dedent_body), label_allowed(label_allowed),
       _interp_braces(0), space_emitted(true), str_s(str_s), saved_herebody_s(nullptr), heredoc_e(heredoc_e) {

--- a/parser/parser/include/ruby_parser/literal.hh
+++ b/parser/parser/include/ruby_parser/literal.hh
@@ -3,6 +3,7 @@
 
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "token.hh"
@@ -57,8 +58,8 @@ public:
     const char *saved_herebody_s;
     const char *heredoc_e;
 
-    literal(lexer &lexer, literal_type type, std::string delimiter, const char *str_s, const char *heredoc_e = nullptr,
-            bool indent = false, bool dedent_body = false, bool label_allowed = false);
+    literal(lexer &lexer, literal_type type, std::string_view delimiter, const char *str_s,
+            const char *heredoc_e = nullptr, bool indent = false, bool dedent_body = false, bool label_allowed = false);
 
     // delete copy constructor to prevent accidental copies. we never
     // legitimately need to copy literal.


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Micro-optimizations.

This is a pretty small win, but fewer `std::string` object constructions has to be good.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.