### PR TITLE
no-op: Shuffle some sorbet-runtime code for aliases

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -361,12 +361,12 @@ module T::Private::Methods
       if !method_sig
         receiver = self
         callee = __callee__ || raise("Unknown __callee__ for method without a signature")
-    method_sig = T::Private::Methods.signature_for_method(original_method)
-    if !method_sig
-      raise "`sig` not present for method `#{callee}` on #{receiver.inspect} but you're trying to run it anyways. " \
-        "This should only be executed if you used `alias_method` to grab a handle to a method after `sig`ing it, but that clearly isn't what you are doing. " \
-        "Maybe look to see if an exception was thrown in your `sig` lambda or somehow else your `sig` wasn't actually applied to the method."
-    end
+        method_sig = T::Private::Methods.signature_for_method(original_method)
+        if !method_sig
+          raise "`sig` not present for method `#{callee}` on #{receiver.inspect} but you're trying to run it anyways. " \
+            "This should only be executed if you used `alias_method` to grab a handle to a method after `sig`ing it, but that clearly isn't what you are doing. " \
+            "Maybe look to see if an exception was thrown in your `sig` lambda or somehow else your `sig` wasn't actually applied to the method."
+        end
 
         method_sig = T::Private::Methods._handle_missing_method_signature(
           method_sig,

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -359,11 +359,11 @@ module T::Private::Methods
     T::Private::ClassUtils.replace_method(original_method, mod, method_name) do |*args, &blk|
       method_sig = T::Private::Methods.maybe_run_sig_block_for_key(key)
       if !method_sig
-      method_sig = T::Private::Methods._handle_missing_method_signature(
-        self,
-        original_method,
-        __callee__ || raise("Unknown __callee__ for method without a signature"),
-      )
+        method_sig = T::Private::Methods._handle_missing_method_signature(
+          self,
+          original_method,
+          __callee__ || raise("Unknown __callee__ for method without a signature"),
+        )
       end
 
       # Should be the same logic as CallValidation.wrap_method_if_needed but we

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -368,7 +368,7 @@ module T::Private::Methods
             "Maybe look to see if an exception was thrown in your `sig` lambda or somehow else your `sig` wasn't actually applied to the method."
         end
 
-        method_sig = T::Private::Methods._handle_missing_method_signature(
+        method_sig = T::Private::Methods._unwrap_alias(
           method_sig,
           receiver,
           original_method,
@@ -400,7 +400,8 @@ module T::Private::Methods
     end
   end
 
-  def self._handle_missing_method_signature(method_sig, receiver, original_method, callee)
+  # Only public so that it can be accessed in the closure for _on_method_added
+  def self._unwrap_alias(method_sig, receiver, original_method, callee)
     if receiver.class <= original_method.owner
       receiving_class = receiver.class
     elsif receiver.singleton_class <= original_method.owner

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -359,10 +359,12 @@ module T::Private::Methods
     T::Private::ClassUtils.replace_method(original_method, mod, method_name) do |*args, &blk|
       method_sig = T::Private::Methods.maybe_run_sig_block_for_key(key)
       if !method_sig
+        receiver = self
+        callee = __callee__ || raise("Unknown __callee__ for method without a signature")
         method_sig = T::Private::Methods._handle_missing_method_signature(
-          self,
+          receiver,
           original_method,
-          __callee__ || raise("Unknown __callee__ for method without a signature"),
+          callee,
         )
       end
 

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -359,18 +359,17 @@ module T::Private::Methods
     T::Private::ClassUtils.replace_method(original_method, mod, method_name) do |*args, &blk|
       method_sig = T::Private::Methods.maybe_run_sig_block_for_key(key)
       if !method_sig
-        receiver = self
         callee = __callee__ || raise("Unknown __callee__ for method without a signature")
         method_sig = T::Private::Methods.signature_for_method(original_method)
         if !method_sig
-          raise "`sig` not present for method `#{callee}` on #{receiver.inspect} but you're trying to run it anyways. " \
+          raise "`sig` not present for method `#{callee}` on #{self.inspect} but you're trying to run it anyways. " \
             "This should only be executed if you used `alias_method` to grab a handle to a method after `sig`ing it, but that clearly isn't what you are doing. " \
             "Maybe look to see if an exception was thrown in your `sig` lambda or somehow else your `sig` wasn't actually applied to the method."
         end
 
         method_sig = T::Private::Methods._unwrap_alias(
           method_sig,
-          receiver,
+          self,
           original_method,
           callee,
         )

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -361,7 +361,15 @@ module T::Private::Methods
       if !method_sig
         receiver = self
         callee = __callee__ || raise("Unknown __callee__ for method without a signature")
+    method_sig = T::Private::Methods.signature_for_method(original_method)
+    if !method_sig
+      raise "`sig` not present for method `#{callee}` on #{receiver.inspect} but you're trying to run it anyways. " \
+        "This should only be executed if you used `alias_method` to grab a handle to a method after `sig`ing it, but that clearly isn't what you are doing. " \
+        "Maybe look to see if an exception was thrown in your `sig` lambda or somehow else your `sig` wasn't actually applied to the method."
+    end
+
         method_sig = T::Private::Methods._handle_missing_method_signature(
+          method_sig,
           receiver,
           original_method,
           callee,
@@ -392,14 +400,7 @@ module T::Private::Methods
     end
   end
 
-  def self._handle_missing_method_signature(receiver, original_method, callee)
-    method_sig = T::Private::Methods.signature_for_method(original_method)
-    if !method_sig
-      raise "`sig` not present for method `#{callee}` on #{receiver.inspect} but you're trying to run it anyways. " \
-        "This should only be executed if you used `alias_method` to grab a handle to a method after `sig`ing it, but that clearly isn't what you are doing. " \
-        "Maybe look to see if an exception was thrown in your `sig` lambda or somehow else your `sig` wasn't actually applied to the method."
-    end
-
+  def self._handle_missing_method_signature(method_sig, receiver, original_method, callee)
     if receiver.class <= original_method.owner
       receiving_class = receiver.class
     elsif receiver.singleton_class <= original_method.owner

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -358,11 +358,13 @@ module T::Private::Methods
     key = method_owner_and_name_to_key(mod, method_name)
     T::Private::ClassUtils.replace_method(original_method, mod, method_name) do |*args, &blk|
       method_sig = T::Private::Methods.maybe_run_sig_block_for_key(key)
-      method_sig ||= T::Private::Methods._handle_missing_method_signature(
+      if !method_sig
+      method_sig = T::Private::Methods._handle_missing_method_signature(
         self,
         original_method,
         __callee__ || raise("Unknown __callee__ for method without a signature"),
       )
+      end
 
       # Should be the same logic as CallValidation.wrap_method_if_needed but we
       # don't want that extra layer of indirection in the callstack

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
@@ -94,7 +94,7 @@ module T::Private::Methods
   def self._on_method_added(hook_mod, mod, method_name); end
 
   sig {params(method_sig: Signature, receiver: Object, original_method: UnboundMethod, callee: Symbol).returns(T::Private::Methods::Signature)}
-  def self._handle_missing_method_signature(method_sig, receiver, original_method, callee); end
+  def self._unwrap_alias(method_sig, receiver, original_method, callee); end
 
   sig {params(method_name: Symbol, original_method: UnboundMethod, declaration_block: DeclarationBlock).returns(T::Private::Methods::Signature)}
   def self.run_sig(method_name, original_method, declaration_block); end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
@@ -93,8 +93,8 @@ module T::Private::Methods
   sig {params(hook_mod: Module, mod: Module, method_name: Symbol).void}
   def self._on_method_added(hook_mod, mod, method_name); end
 
-  sig {params(receiver: Object, original_method: UnboundMethod, callee: Symbol).returns(T::Private::Methods::Signature)}
-  def self._handle_missing_method_signature(receiver, original_method, callee); end
+  sig {params(method_sig: Signature, receiver: Object, original_method: UnboundMethod, callee: Symbol).returns(T::Private::Methods::Signature)}
+  def self._handle_missing_method_signature(method_sig, receiver, original_method, callee); end
 
   sig {params(method_name: Symbol, original_method: UnboundMethod, declaration_block: DeclarationBlock).returns(T::Private::Methods::Signature)}
   def self.run_sig(method_name, original_method, declaration_block); end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm working on #10397, which is proving to have some hairy parts when it comes
to aliases. It will help to make that change smaller if I have shuffled the
implementation of `_on_method_added` like this.

Every commit is a no-op, so you should be able to see that reviewing by commit.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests