### PR TITLE
Skip vscode extension jobs on branches if no changes

### DIFF
--- a/.buildkite/build-vscode-extension.sh
+++ b/.buildkite/build-vscode-extension.sh
@@ -2,6 +2,13 @@
 
 set -euo pipefail
 
+if [ "${BUILDKITE_BRANCH:-}" != "master" ]; then
+  if ! git diff --name-only "origin/master...HEAD" | grep -q '^vscode_extension/'; then
+    echo "Skipping because there are no changes to vscode_extension/"
+    exit 0
+  fi
+fi
+
 # shellcheck source-path=SCRIPTDIR/..
 source .buildkite/tools/with_backoff.sh
 

--- a/.buildkite/test-vscode-extension.sh
+++ b/.buildkite/test-vscode-extension.sh
@@ -2,6 +2,13 @@
 
 set -euo pipefail
 
+if [ "${BUILDKITE_BRANCH:-}" != "master" ]; then
+  if ! git diff --name-only "origin/master...HEAD" | grep -q '^vscode_extension/'; then
+    echo "Skipping because there are no changes to vscode_extension/"
+    exit 0
+  fi
+fi
+
 # shellcheck source-path=SCRIPTDIR/..
 source .buildkite/tools/with_backoff.sh
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We get periodic flakiness on the VS Code job when the yarn registry is having problems. It's not clear the best way to prevent that from affecting master builds, but we can trivially make it not affect branch builds.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The log line where this shows up:

https://buildkite.com/sorbet/sorbet/builds/43705#019faf6a-e358-4c47-bf89-d0d712758372/L111
