### PR TITLE
Preserve type literals across (most) least upper bound calculations

### DIFF
--- a/core/Types.h
+++ b/core/Types.h
@@ -67,6 +67,12 @@ enum class UntypedMode {
     AlwaysIncompatible = 2,
 };
 
+// How literal types should be handled in least-upper-bound calculations.
+enum class LiteralTypesMode {
+    broaden,  // lub(123, 456) = Integer
+    preserve, // lub(123, 456) = 123 | 456
+};
+
 class Types final {
 public:
     /** Greater lower bound: the widest type that is subtype of both t1 and t2 */
@@ -170,11 +176,14 @@ public:
      */
     static TypePtr approximateTypeVars(const GlobalState &gs, const TypePtr &what, const TypeConstraint &tc);
     static TypePtr dropLiteral(const GlobalState &gs, const TypePtr &tp);
+    /** Drops literal types, recursively processing union components. */
+    static TypePtr dropLiteralRecursive(const GlobalState &gs, const TypePtr &tp);
 
     /** Internal implementation. You should probably use all(). */
     static TypePtr glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     /** Internal implementation. You should probably use any(). */
-    static TypePtr lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
+    static TypePtr lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2,
+                       LiteralTypesMode literalTypesMode = LiteralTypesMode::preserve);
 
     static TypePtr lubAll(const GlobalState &gs, const std::vector<TypePtr> &elements);
     static TypePtr arrayOf(const GlobalState &gs, const TypePtr &elem);
@@ -299,6 +308,34 @@ inline bool is_proxy_type(const TypePtr &what) {
         case TypePtr::Tag::ShapeType:
         case TypePtr::Tag::TupleType:
             return true;
+        case TypePtr::Tag::ClassType:
+        case TypePtr::Tag::BlamedUntyped:
+        case TypePtr::Tag::UnresolvedClassType:
+        case TypePtr::Tag::UnresolvedAppliedType:
+        case TypePtr::Tag::OrType:
+        case TypePtr::Tag::AndType:
+        case TypePtr::Tag::LambdaParam:
+        case TypePtr::Tag::SelfTypeParam:
+        case TypePtr::Tag::SelfType:
+        case TypePtr::Tag::AliasType:
+        case TypePtr::Tag::AppliedType:
+        case TypePtr::Tag::TypeVar:
+        case TypePtr::Tag::MetaType:
+            return false;
+    }
+}
+
+inline bool is_literal_type(const TypePtr &what) {
+    if (what == nullptr) {
+        return false;
+    }
+    switch (what.tag()) {
+        case TypePtr::Tag::NamedLiteralType:
+        case TypePtr::Tag::IntegerLiteralType:
+        case TypePtr::Tag::FloatLiteralType:
+            return true;
+        case TypePtr::Tag::ShapeType:
+        case TypePtr::Tag::TupleType:
         case TypePtr::Tag::ClassType:
         case TypePtr::Tag::BlamedUntyped:
         case TypePtr::Tag::UnresolvedClassType:
@@ -810,9 +847,11 @@ private:
     template <class T>
     friend bool Types::isSubTypeUnderConstraint(const GlobalState &gs, TypeConstraint &constr, const TypePtr &t1,
                                                 const TypePtr &t2, UntypedMode mode, T &errorDetailsCollector);
-    friend TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
+    friend TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2,
+                                   LiteralTypesMode literalTypesMode);
     friend TypePtr lubGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
-    friend TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
+    friend TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2,
+                              LiteralTypesMode literalTypesMode);
     friend TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr filterOrComponents(const TypePtr &originalType, absl::Span<const TypePtr> typeFilter);
     friend TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from,
@@ -864,7 +903,8 @@ private:
     friend TypePtr lubGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr glbDistributeAnd(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr glbGround(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
-    friend TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
+    friend TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2,
+                              LiteralTypesMode literalTypesMode);
     friend TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2);
     friend TypePtr Types::unwrapSelfTypeParam(Context ctx, const TypePtr &t1);
     friend TypePtr Types::dropSubtypesOf(const GlobalState &gs, const TypePtr &from,

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3559,11 +3559,11 @@ public:
             auto valueType = shape.values[*idx];
             auto expectedType = valueType;
             auto actualType = *args.args[1];
-            // This check (with the dropLiteral's) mimics what we do for pinning errors in environment.cc
+            // The literal broadening here mimics what we do for pinning errors in environment.cc.
             // TODO(jez) How should this interact with highlight untyped?
             core::ErrorSection::Collector errorDetailsCollector;
-            if (!Types::isSubType(gs, Types::dropLiteral(gs, actualType.type), Types::dropLiteral(gs, expectedType),
-                                  errorDetailsCollector)) {
+            if (!Types::isSubType(gs, Types::dropLiteralRecursive(gs, actualType.type),
+                                  Types::dropLiteralRecursive(gs, expectedType), errorDetailsCollector)) {
                 auto argLoc = args.argLoc(1);
 
                 if (auto e = gs.beginError(argLoc, errors::Infer::MethodArgumentMismatch)) {

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -70,7 +70,7 @@ TypePtr Types::any(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
 
 const TypePtr underlying(const GlobalState &gs, const TypePtr &t1) {
     if (is_proxy_type(t1)) {
-        return t1.underlying(gs);
+        return t1.underlying(gs); // Broaden e.g. `:abc` to `Symbol`
     }
     return t1;
 }
@@ -434,39 +434,40 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         auto class2 = cast_type_nonnull<ClassType>(underlyingL2);
                         if (class1.symbol == class2.symbol) {
                             if (l1.equals(l2)) {
-                                result = t1;
+                                result = t1; // lub(:abc, :abc) = :abc
                             } else {
-                                result = l1.underlying(gs);
+                                result = l1.underlying(gs); // broadening lub(:abc, :def) = Symbol
                             }
                         } else {
+                            // broadening lub(:abc, "def") = lub(Symbol, String)
                             result = lubGround(gs, l1.underlying(gs), l2.underlying(gs));
                         }
                     } else {
-                        result = lub(gs, l1.underlying(gs), t2.underlying(gs));
+                        result = lub(gs, l1.underlying(gs), t2.underlying(gs)); // broadening lub(:abc, _) = Symbol | _
                     }
                 },
                 [&](const IntegerLiteralType &l1) {
                     if (isa_type<IntegerLiteralType>(t2)) {
                         auto &l2 = cast_type_nonnull<IntegerLiteralType>(t2);
                         if (l1.equals(l2)) {
-                            result = t1;
+                            result = t1; // lub(123, 123) = 123
                         } else {
-                            result = l1.underlying(gs);
+                            result = l1.underlying(gs); // broadening lub(1, 2) = Integer
                         }
                     } else {
-                        result = lub(gs, l1.underlying(gs), t2.underlying(gs));
+                        result = lub(gs, l1.underlying(gs), t2.underlying(gs)); // broadening lub(1, _) = Integer | _
                     }
                 },
                 [&](const FloatLiteralType &l1) {
                     if (isa_type<FloatLiteralType>(t2)) {
                         auto &l2 = cast_type_nonnull<FloatLiteralType>(t2);
                         if (l1.equals(l2)) {
-                            result = t1;
+                            result = t1; // lub(1.23, 1.23) = 1.23
                         } else {
-                            result = l1.underlying(gs);
+                            result = l1.underlying(gs); // broadening lub(1.23, 4.56) = Float
                         }
                     } else {
-                        result = lub(gs, l1.underlying(gs), t2.underlying(gs));
+                        result = lub(gs, l1.underlying(gs), t2.underlying(gs)); // broadening lub(1.23, t2) = Float | t2
                     }
                 });
             ENFORCE(result != nullptr);
@@ -476,11 +477,11 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
 
             TypePtr und = t1.underlying(gs);
             if (isSubType(gs, und, t2)) {
-                return t2;
+                return t2; // lub(:abc, Symbol) = Symbol, lub([Foo], Array) = Array, etc.
             } else if (allowProxyInLub) {
-                return OrType::make_shared(t1, t2);
+                return OrType::make_shared(t1, t2); // lub(:abc, Unrelated) = :abc | Unrelated
             } else {
-                return lub(gs, t2, und);
+                return lub(gs, t2, und); // broadening lub(:abc, Foo) = Symbol | Foo
             }
         }
     } else if (is_proxy_type(t2)) { // only t2 is proxy
@@ -488,11 +489,11 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
 
         TypePtr und = t2.underlying(gs);
         if (isSubType(gs, und, t1)) {
-            return t1;
+            return t1; // lub(Symbol, :abc) = Symbol, lub(Array, [Foo]) = Array, etc.
         } else if (allowProxyInLub) {
-            return OrType::make_shared(t1, t2);
+            return OrType::make_shared(t1, t2); // lub(Unrelated, :abc) =  Unrelated | :abc
         } else {
-            return lub(gs, t1, und);
+            return lub(gs, t1, und); // broadening lub(Foo, :abc) = Foo | Symbol
         }
     }
 

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -486,7 +486,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
     } else if (is_proxy_type(t2)) {
         // only 2nd is proxy
         bool allowProxyInLub = isa_type<TupleType>(t2) || isa_type<ShapeType>(t2);
-        // only 1st is proxy
+
         TypePtr und = t2.underlying(gs);
         if (isSubType(gs, und, t1)) {
             return t1;

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -68,7 +68,10 @@ TypePtr Types::any(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
     return ret;
 }
 
-const TypePtr underlying(const GlobalState &gs, const TypePtr &t1) {
+const TypePtr underlying(const GlobalState &gs, const TypePtr &t1, LiteralTypesMode literalTypesMode) {
+    if (literalTypesMode == LiteralTypesMode::preserve && is_literal_type(t1)) {
+        return t1; // Preserve the literal type, e.g. keep `:abc` as `:abc`
+    }
     if (is_proxy_type(t1)) {
         return t1.underlying(gs); // Broaden e.g. `:abc` to `Symbol`
     }
@@ -108,7 +111,8 @@ TypePtr filterOrComponents(const TypePtr &originalType, absl::Span<const TypePtr
     }
 }
 
-TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
+TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2,
+                        LiteralTypesMode literalTypesMode) {
     InlinedVector<TypePtr, 4> originalOrComponents;
     InlinedVector<TypePtr, 4> typesConsumed;
     auto o1 = cast_type<OrType>(t1);
@@ -117,7 +121,7 @@ TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr 
     fillInOrComponents(originalOrComponents, o1->right);
 
     for (auto &component : originalOrComponents) {
-        auto lubbed = Types::any(gs, component, t2);
+        auto lubbed = Types::lub(gs, component, t2, literalTypesMode);
         if (lubbed == component) {
             // lubbed == component, so t2 <: component and t2 <: t1
             categoryCounterInc("lubDistributeOr.outcome", "t1");
@@ -131,7 +135,7 @@ TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr 
     if (typesConsumed.empty()) {
         // t1 has no components that overlap with t2
         categoryCounterInc("lubDistributeOr.outcome", "worst");
-        return OrType::make_shared(t1, underlying(gs, t2));
+        return OrType::make_shared(t1, underlying(gs, t2, literalTypesMode));
     }
     // lub back everything except typesConsumed
     auto remainingTypes = filterOrComponents(t1, typesConsumed);
@@ -141,7 +145,7 @@ TypePtr lubDistributeOr(const GlobalState &gs, const TypePtr &t1, const TypePtr 
         return t2;
     }
     categoryCounterInc("lubDistributeOr.outcome", "consumedComponent");
-    return OrType::make_shared(move(remainingTypes), underlying(gs, t2));
+    return OrType::make_shared(move(remainingTypes), underlying(gs, t2, literalTypesMode));
 }
 
 TypePtr glbDistributeAnd(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
@@ -210,14 +214,16 @@ TypePtr dropLubComponents(const GlobalState &gs, const TypePtr &t1, const TypePt
     return t1;
 }
 
-TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) {
+TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2, LiteralTypesMode literalTypesMode) {
+    const bool preserveLiteralTypes = literalTypesMode == LiteralTypesMode::preserve;
+
     if (t1 == t2) {
         categoryCounterInc("lub", "ref-eq");
         return t1;
     }
 
     if (t1.kind() > t2.kind()) { // force the relation to be symmentric and half the implementation
-        return lub(gs, t2, t1);
+        return lub(gs, t2, t1, literalTypesMode);
     }
 
     if (isa_type<ClassType>(t1)) {
@@ -254,7 +260,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
 
     if (isa_type<OrType>(t2)) { // 3, 5, 6
         categoryCounterInc("lub", "or>");
-        return lubDistributeOr(gs, t2, t1);
+        return lubDistributeOr(gs, t2, t1, literalTypesMode);
     } else if (auto a2 = cast_type<AndType>(t2)) { // 2, 4
         if (auto a1 = cast_type<AndType>(t1)) {
             // Check if the members of a1 and a2 are referentially equivalent. This helps simplify T.all types created
@@ -266,18 +272,18 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         }
 
         categoryCounterInc("lub", "and>");
-        auto t1d = underlying(gs, t1);
+        auto t1d = underlying(gs, t1, literalTypesMode);
         auto t2filtered = dropLubComponents(gs, t2, t1d);
         if (t2filtered != t2) {
-            return lub(gs, t1d, t2filtered);
+            return lub(gs, t1d, t2filtered, literalTypesMode);
         }
         if (isa_type<OrType>(t1)) {
-            return lubDistributeOr(gs, t1, t2);
+            return lubDistributeOr(gs, t1, t2, literalTypesMode);
         }
         return OrType::make_shared(t1, t2filtered);
     } else if (isa_type<OrType>(t1)) {
         categoryCounterInc("lub", "<or");
-        return lubDistributeOr(gs, t1, t2);
+        return lubDistributeOr(gs, t1, t2, literalTypesMode);
     }
 
     if (auto a1 = cast_type<AppliedType>(t1)) {
@@ -320,7 +326,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             }
             ENFORCE(i < a1->klass.data(gs)->typeMembers().size());
             if (idxTypeMember.data(gs)->flags.isCovariant) {
-                newTargs.emplace_back(Types::any(gs, a1->targs[i], a2->targs[j]));
+                newTargs.emplace_back(lub(gs, a1->targs[i], a2->targs[j], literalTypesMode));
             } else if (idxTypeMember.data(gs)->flags.isInvariant) {
                 if (!Types::equiv(gs, a1->targs[i], a2->targs[j])) {
                     return OrType::make_shared(t1s, t2s);
@@ -367,7 +373,8 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                             bool differ2 = false;
                             for (auto &el2 : a2->elems) {
                                 ++i;
-                                auto &inserted = elemLubs.emplace_back(lub(gs, a1.elems[i], el2));
+                                auto &inserted =
+                                    elemLubs.emplace_back(lub(gs, a1.elems[i], el2, LiteralTypesMode::broaden));
                                 differ1 = differ1 || inserted != a1.elems[i];
                                 differ2 = differ2 || inserted != el2;
                             }
@@ -382,7 +389,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                             result = Types::arrayOfUntyped(Symbols::Magic_UntypedSource_tupleLub());
                         }
                     } else {
-                        result = lub(gs, a1.underlying(gs), t2.underlying(gs));
+                        result = lub(gs, a1.underlying(gs), t2.underlying(gs), literalTypesMode);
                     }
                 },
                 [&](const ShapeType &h1) { // Warning: this implements COVARIANT hashes
@@ -401,8 +408,8 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                                     result = Types::hashOfUntyped(Symbols::Magic_UntypedSource_shapeLub());
                                     return;
                                 }
-                                auto &inserted =
-                                    valueLubs.emplace_back(lub(gs, h1.values[optind.value()], h2->values[i]));
+                                auto &inserted = valueLubs.emplace_back(
+                                    lub(gs, h1.values[optind.value()], h2->values[i], LiteralTypesMode::broaden));
                                 differ1 = differ1 || inserted != h1.values[optind.value()];
                                 differ2 = differ2 || inserted != h2->values[i];
                             }
@@ -421,7 +428,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         if (allowProxyInLub) {
                             result = OrType::make_shared(t1, t2);
                         } else {
-                            result = lub(gs, h1.underlying(gs), t2.underlying(gs));
+                            result = lub(gs, h1.underlying(gs), t2.underlying(gs), literalTypesMode);
                         }
                     }
                 },
@@ -435,15 +442,22 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         if (class1.symbol == class2.symbol) {
                             if (l1.equals(l2)) {
                                 result = t1; // lub(:abc, :abc) = :abc
+                            } else if (preserveLiteralTypes) {
+                                result = OrType::make_shared(t1, t2); // preserving lub(:abc, :def) = :abc | :def
                             } else {
                                 result = l1.underlying(gs); // broadening lub(:abc, :def) = Symbol
                             }
+                        } else if (preserveLiteralTypes) {
+                            result = OrType::make_shared(t1, t2); // preserving lub(:abc, "def") = :abc | "def"
                         } else {
                             // broadening lub(:abc, "def") = lub(Symbol, String)
                             result = lubGround(gs, l1.underlying(gs), l2.underlying(gs));
                         }
+                    } else if (preserveLiteralTypes) {
+                        result = OrType::make_shared(t1, t2); // preserving lub(:abc, _) = :abc | _
                     } else {
-                        result = lub(gs, l1.underlying(gs), t2.underlying(gs)); // broadening lub(:abc, _) = Symbol | _
+                        result = lub(gs, l1.underlying(gs), t2.underlying(gs), literalTypesMode);
+                        // broadening lub(:abc, _) = Symbol | _
                     }
                 },
                 [&](const IntegerLiteralType &l1) {
@@ -451,11 +465,16 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         auto &l2 = cast_type_nonnull<IntegerLiteralType>(t2);
                         if (l1.equals(l2)) {
                             result = t1; // lub(123, 123) = 123
+                        } else if (preserveLiteralTypes) {
+                            result = OrType::make_shared(t1, t2); // preserving lub(1, 2) = 1 | 2
                         } else {
                             result = l1.underlying(gs); // broadening lub(1, 2) = Integer
                         }
+                    } else if (preserveLiteralTypes) {
+                        result = OrType::make_shared(t1, t2); // preserving lub(1, _) = 1 | _
                     } else {
-                        result = lub(gs, l1.underlying(gs), t2.underlying(gs)); // broadening lub(1, _) = Integer | _
+                        result = lub(gs, l1.underlying(gs), t2.underlying(gs), literalTypesMode);
+                        // broadening lub(1, _) = Integer | _
                     }
                 },
                 [&](const FloatLiteralType &l1) {
@@ -463,17 +482,22 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         auto &l2 = cast_type_nonnull<FloatLiteralType>(t2);
                         if (l1.equals(l2)) {
                             result = t1; // lub(1.23, 1.23) = 1.23
+                        } else if (preserveLiteralTypes) {
+                            result = OrType::make_shared(t1, t2); // lub(1.23, 4.56) = 1.23 | 4.56
                         } else {
                             result = l1.underlying(gs); // broadening lub(1.23, 4.56) = Float
                         }
+                    } else if (preserveLiteralTypes) {
+                        result = OrType::make_shared(t1, t2); // preserving lub(1.23, t2) = 1.23 | t2
                     } else {
-                        result = lub(gs, l1.underlying(gs), t2.underlying(gs)); // broadening lub(1.23, t2) = Float | t2
+                        result = lub(gs, l1.underlying(gs), t2.underlying(gs), literalTypesMode);
+                        // broadening lub(1.23, t2) = Float | t2
                     }
                 });
             ENFORCE(result != nullptr);
             return result;
         } else { // only t1 is proxy
-            bool allowProxyInLub = isa_type<TupleType>(t1) || isa_type<ShapeType>(t1);
+            bool allowProxyInLub = isa_type<TupleType>(t1) || isa_type<ShapeType>(t1) || preserveLiteralTypes;
 
             TypePtr und = t1.underlying(gs);
             if (isSubType(gs, und, t2)) {
@@ -481,11 +505,11 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             } else if (allowProxyInLub) {
                 return OrType::make_shared(t1, t2); // lub(:abc, Unrelated) = :abc | Unrelated
             } else {
-                return lub(gs, t2, und); // broadening lub(:abc, Foo) = Symbol | Foo
+                return lub(gs, t2, und, literalTypesMode); // broadening lub(:abc, Foo) = Symbol | Foo
             }
         }
     } else if (is_proxy_type(t2)) { // only t2 is proxy
-        bool allowProxyInLub = isa_type<TupleType>(t2) || isa_type<ShapeType>(t2);
+        bool allowProxyInLub = isa_type<TupleType>(t2) || isa_type<ShapeType>(t2) || preserveLiteralTypes;
 
         TypePtr und = t2.underlying(gs);
         if (isSubType(gs, und, t1)) {
@@ -493,7 +517,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         } else if (allowProxyInLub) {
             return OrType::make_shared(t1, t2); // lub(Unrelated, :abc) =  Unrelated | :abc
         } else {
-            return lub(gs, t1, und); // broadening lub(Foo, :abc) = Foo | Symbol
+            return lub(gs, t1, und, literalTypesMode); // broadening lub(Foo, :abc) = Foo | Symbol
         }
     }
 
@@ -511,7 +535,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             // We should at least treat it like T::Types::Base, not Object, but again: another day.
             auto m1underlying = m1 == nullptr ? t1 : Types::Object();
             auto m2underlying = m2 == nullptr ? t2 : Types::Object();
-            return lub(gs, m1underlying, m2underlying);
+            return lub(gs, m1underlying, m2underlying, literalTypesMode);
         }
     }
 

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -352,9 +352,9 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
 
     if (is_proxy_type(t1)) {
         categoryCounterInc("lub", "<proxy");
-        if (is_proxy_type(t2)) {
+        if (is_proxy_type(t2)) { // t1 and t2 are both proxy types
             categoryCounterInc("lub", "proxy>");
-            // both are proxy
+
             TypePtr result;
             typecase(
                 t1,
@@ -471,9 +471,9 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                 });
             ENFORCE(result != nullptr);
             return result;
-        } else {
+        } else { // only t1 is proxy
             bool allowProxyInLub = isa_type<TupleType>(t1) || isa_type<ShapeType>(t1);
-            // only 1st is proxy
+
             TypePtr und = t1.underlying(gs);
             if (isSubType(gs, und, t2)) {
                 return t2;
@@ -483,8 +483,7 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                 return lub(gs, t2, und);
             }
         }
-    } else if (is_proxy_type(t2)) {
-        // only 2nd is proxy
+    } else if (is_proxy_type(t2)) { // only t2 is proxy
         bool allowProxyInLub = isa_type<TupleType>(t2) || isa_type<ShapeType>(t2);
 
         TypePtr und = t2.underlying(gs);
@@ -742,7 +741,7 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
     }
 
     if (is_proxy_type(t1)) {
-        if (is_proxy_type(t2)) {
+        if (is_proxy_type(t2)) { // t1 and t2 are both proxy types
             if (t1.tag() != t2.tag()) {
                 return Types::bottom();
             }
@@ -850,16 +849,14 @@ TypePtr Types::glb(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                 });
             ENFORCE(result != nullptr);
             return result;
-        } else {
-            // only 1st is proxy
+        } else { // only t1 is proxy
             if (Types::isSubType(gs, t1, t2)) {
                 return t1;
             } else {
                 return Types::bottom();
             }
         }
-    } else if (is_proxy_type(t2)) {
-        // only 1st is proxy
+    } else if (is_proxy_type(t2)) { // only t2 is proxy
         if (Types::isSubType(gs, t2, t1)) {
             return t2;
         } else {
@@ -1434,8 +1431,7 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
     }
 
     if (is_proxy_type(t1)) {
-        if (is_proxy_type(t2)) {
-            // both are proxy
+        if (is_proxy_type(t2)) { // t1 and t2 are both proxy types
             bool result;
             // TODO: simply compare as memory regions
             typecase(
@@ -1537,16 +1533,14 @@ bool isSubTypeUnderConstraintSingle(const GlobalState &gs, TypeConstraint &const
                     result = l1.equals(l2);
                 });
             return result;
-        } else {
-            // only 1st is proxy
+        } else { // only t1 is proxy
             TypePtr und = t1.underlying(gs);
             return isSubTypeUnderConstraintSingle(gs, constr, mode, und, t2, errorDetailsCollector);
         }
-    } else if (is_proxy_type(t2)) {
-        // only 2nd is proxy
+    } else if (is_proxy_type(t2)) { // only t2 is proxy
         // non-proxies are never subtypes of proxies.
         return false;
-    } else {
+    } else { // neither are proxies
         if (isa_type<ClassType>(t1)) {
             if (isa_type<ClassType>(t2)) {
                 auto c1 = cast_type_nonnull<ClassType>(t1);

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -351,6 +351,18 @@ TypePtr Types::dropLiteral(const GlobalState &gs, const TypePtr &tp) {
     return tp;
 }
 
+TypePtr Types::dropLiteralRecursive(const GlobalState &gs, const TypePtr &tp) {
+    if (auto orType = cast_type<OrType>(tp)) {
+        auto left = dropLiteralRecursive(gs, orType->left);
+        auto right = dropLiteralRecursive(gs, orType->right);
+        if (left == orType->left && right == orType->right) {
+            return tp;
+        }
+        return Types::lub(gs, left, right, LiteralTypesMode::broaden);
+    }
+    return Types::dropLiteral(gs, tp);
+}
+
 TypePtr Types::lubAll(const GlobalState &gs, const vector<TypePtr> &elements) {
     TypePtr acc = Types::bottom();
     for (auto &el : elements) {
@@ -360,7 +372,7 @@ TypePtr Types::lubAll(const GlobalState &gs, const vector<TypePtr> &elements) {
         //
         // Which means that to remove all literals, it's sufficient to do a single `dropLiteral`
         // at the call `lubAll` call site.
-        acc = Types::lub(gs, acc, el);
+        acc = Types::lub(gs, acc, el, LiteralTypesMode::broaden);
     }
     return acc;
 }
@@ -590,7 +602,7 @@ TypePtr TupleType::underlying(const GlobalState &gs) const {
     if (this->elems.empty()) {
         return Types::arrayOfUntyped(Symbols::Magic_UntypedSource_tupleUnderlying());
     } else {
-        return Types::arrayOf(gs, Types::dropLiteral(gs, Types::lubAll(gs, this->elems)));
+        return Types::arrayOf(gs, Types::dropLiteralRecursive(gs, Types::lubAll(gs, this->elems)));
     }
 }
 

--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -854,7 +854,9 @@ void Environment::mergeWith(core::Context ctx, const Environment &other, cfg::CF
         const auto &otherTO = other.getTypeAndOrigin(var);
         auto &thisTO = pair.second.typeAndOrigins;
         if (thisTO.type != nullptr) {
-            thisTO.type = core::Types::any(ctx, thisTO.type, otherTO.type);
+            auto literalTypesMode =
+                var.isSyntheticTemporary(inWhat) ? core::LiteralTypesMode::preserve : core::LiteralTypesMode::broaden;
+            thisTO.type = core::Types::lub(ctx, thisTO.type, otherTO.type, literalTypesMode);
             thisTO.type.sanityCheck(ctx);
             for (auto origin : otherTO.origins) {
                 if (!absl::c_linear_search(thisTO.origins, origin)) {
@@ -1765,8 +1767,11 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
 
             // TODO(jez) What should we do about untyped code and pinning?
             core::ErrorSection::Collector errorDetailsCollector;
-            bool asGoodAs = core::Types::isSubType(ctx, core::Types::dropLiteral(ctx, tp.type),
-                                                   core::Types::dropLiteral(ctx, cur.type), errorDetailsCollector);
+            // Flow-sensitive joins retain literal facts, but inferred loop pins use their broader assignment type.
+            auto expectedType = pin != pinnedTypes.end() ? core::Types::dropLiteral(ctx, cur.type)
+                                                         : core::Types::dropLiteralRecursive(ctx, cur.type);
+            bool asGoodAs = core::Types::isSubType(ctx, core::Types::dropLiteral(ctx, tp.type), expectedType,
+                                                   errorDetailsCollector);
 
             {
                 switch (bindMinLoops) {

--- a/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
+++ b/test/testdata/cfg/rescue_else_block.rb.cfg-text.exp
@@ -32,7 +32,7 @@ bb1[firstDead=-1]():
 # backedges
 # - bb0
 # - bb4
-bb3[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: Exception):
+bb3[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer(1)), <exceptionValue>$3: Exception):
     <cfgAlias>$7: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$8: T::Boolean = <cfgAlias>$7: T.class_of(StandardError).===(<exceptionValue>$3: Exception)
     <isaCheckTemp>$8 -> (T::Boolean ? bb10 : bb11)
@@ -64,14 +64,14 @@ bb7[firstDead=0]():
 
 # backedges
 # - bb3
-bb10[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer), <exceptionValue>$3: StandardError):
+bb10[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer(1)), <exceptionValue>$3: StandardError):
     <exceptionValue>$3: NilClass = nil
     <keepForCfgTemp>$5: T.untyped = <keep-alive> <exceptionValue>$3
     <gotoDeadTemp>$9 -> (NilClass ? bb1 : bb12)
 
 # backedges
 # - bb3
-bb11[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer)):
+bb11[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer(1))):
     <gotoDeadTemp>$9: TrueClass = true
     <gotoDeadTemp>$9 -> (TrueClass ? bb1 : bb12)
 
@@ -80,8 +80,8 @@ bb11[firstDead=-1](<returnMethodTemp>$2: T.nilable(Integer)):
 # - bb7
 # - bb10
 # - bb11
-bb12[firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)
+bb12[firstDead=1](<returnMethodTemp>$2: T.nilable(T.any(Integer(1), Integer(3)))):
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(T.any(Integer(1), Integer(3)))
     <unconditional> -> bb1
 
 }

--- a/test/testdata/cfg/uaf1.rb.cfg-text.exp
+++ b/test/testdata/cfg/uaf1.rb.cfg-text.exp
@@ -69,7 +69,7 @@ bb5[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::V
 # backedges
 # - bb5
 # - bb8
-bb7[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer), <exceptionValue>$8: Exception, <gotoDeadTemp>$13: NilClass):
+bb7[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer(1)), <exceptionValue>$8: Exception, <gotoDeadTemp>$13: NilClass):
     # outerLoops: 1
     <cfgAlias>$11: T.class_of(StandardError) = alias <C StandardError>
     <isaCheckTemp>$12: T::Boolean = <cfgAlias>$11: T.class_of(StandardError).===(<exceptionValue>$8: Exception)
@@ -100,7 +100,7 @@ bb11[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::
 
 # backedges
 # - bb7
-bb12[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer)):
+bb12[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.nilable(Integer(1))):
     # outerLoops: 1
     <gotoDeadTemp>$13: TrueClass = true
     <gotoDeadTemp>$13 -> (TrueClass ? bb1 : bb13)
@@ -109,9 +109,9 @@ bb12[firstDead=-1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::
 # - bb10
 # - bb11
 # - bb12
-bb13[firstDead=1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: Integer, <gotoDeadTemp>$13: NilClass):
+bb13[firstDead=1](<self>: A, <block-pre-call-temp>$5: Sorbet::Private::Static::Void, <selfRestore>$6: A, <blockReturnTemp>$7: T.any(Integer(1), Integer(2)), <gotoDeadTemp>$13: NilClass):
     # outerLoops: 1
-    <blockReturnTemp>$15: T.noreturn = blockreturn<map> <blockReturnTemp>$7: Integer
+    <blockReturnTemp>$15: T.noreturn = blockreturn<map> <blockReturnTemp>$7: T.any(Integer(1), Integer(2))
     <unconditional> -> bb2
 
 }

--- a/test/testdata/infer/compact.rb
+++ b/test/testdata/infer/compact.rb
@@ -14,3 +14,19 @@ T.assert_type!(
   [[1], nil].compact,
   T::Array[[Integer]],
 )
+
+extend T::Sig
+
+sig {returns(T.nilable([String, String]))}
+def maybe_row
+  T.unsafe(nil)
+end
+
+sig {returns(T::Array[[String, String]])}
+def compact_tuple_unions
+  [
+    T.unsafe(nil) ? ["Payment method", T.unsafe(nil)] : nil,
+    maybe_row,
+    T.unsafe(nil) ? ["Card verification", T.unsafe(nil)] : nil,
+  ].compact
+end

--- a/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/complex_implication_1.rb.cfg-text.exp
@@ -155,8 +155,8 @@ bb22[firstDead=-1]():
 # - bb20
 # - bb21
 # - bb22
-bb24[firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)
+bb24[firstDead=1](<returnMethodTemp>$2: T.nilable(Integer(1))):
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer(1))
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/control_flow/complex_implications_2.rb.cfg-text.exp
+++ b/test/testdata/infer/control_flow/complex_implications_2.rb.cfg-text.exp
@@ -62,8 +62,8 @@ bb9[firstDead=-1]():
 # backedges
 # - bb8
 # - bb9
-bb10[firstDead=1](<returnMethodTemp>$2: T.nilable(Integer)):
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer)
+bb10[firstDead=1](<returnMethodTemp>$2: T.nilable(Integer(1))):
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Integer(1))
     <unconditional> -> bb1
 
 }

--- a/test/testdata/infer/exception_knowledge.rb
+++ b/test/testdata/infer/exception_knowledge.rb
@@ -43,3 +43,24 @@ def example3(x:)
   # effectively uninitialized
   T.reveal_type(e) # error: `NilClass`
 end
+
+sig { params(success: T::Boolean).void }
+def assignment_before_reraise(success)
+  status = "default"
+  begin
+    if success
+      status = "ok"
+    else
+      begin
+        raise
+      rescue
+        status = "special"
+        raise
+      end
+    end
+  rescue
+    T.reveal_type(status) # error: Revealed type: `String`
+    raise unless status == "special"
+    puts("handled")
+  end
+end

--- a/test/testdata/infer/flatten.rb
+++ b/test/testdata/infer/flatten.rb
@@ -173,7 +173,7 @@ or_type_collection = [
   end
 ]
 
-T.reveal_type(or_type_collection) # error: Revealed type: `[T.any(T::Array[String], Integer)] (1-tuple)`
-T.reveal_type(or_type_collection.flatten(1)) # error: Revealed type: `T::Array[T.any(String, Integer)]`
-T.reveal_type(or_type_collection.flatten(2)) # error: Revealed type: `T::Array[T.any(String, Integer)]`
-T.reveal_type(or_type_collection.flatten) # error: Revealed type: `T::Array[T.any(String, Integer)]`
+T.reveal_type(or_type_collection) # error: Revealed type: `[T.any(Integer(1), [String("2")])] (1-tuple)`
+T.reveal_type(or_type_collection.flatten(1)) # error: Revealed type: `T::Array[T.any(Integer, String)]
+T.reveal_type(or_type_collection.flatten(2)) # error: Revealed type: `T::Array[T.any(Integer, String)]`
+T.reveal_type(or_type_collection.flatten) # error: Revealed type: `T::Array[T.any(Integer, String)]`

--- a/test/testdata/infer/infer1.rb
+++ b/test/testdata/infer/infer1.rb
@@ -48,4 +48,3 @@ def baz8
    b = 1
  end
 end
-

--- a/test/testdata/infer/pinned_control_flow.rb
+++ b/test/testdata/infer/pinned_control_flow.rb
@@ -68,4 +68,11 @@ class Main
           a = 2
       end
   end
+
+  def unify_literals(cond)
+      a = cond ? :heads : :tails
+      while cond
+          a = :something_else
+      end
+  end
 end

--- a/test/testdata/infer/shape_square_brackets.rb
+++ b/test/testdata/infer/shape_square_brackets.rb
@@ -21,6 +21,11 @@ def test2(x)
   # This type is wrong, because the key `foo:` is now `String("world")`, but that's no worse than normal pinned variables
   T.reveal_type(opts) # error: Revealed type: `{foo: String("hello")} (shape of T::Hash[T.untyped, T.untyped])`
 
+  status = T.unsafe(nil) ? 'ok' : 'remove'
+  record = {status: status}
+  record[:status] = 'failure'
+  record[:status] = 1 # error: Expected `String` but found `Integer(1)` for key `Symbol(:status)`
+
   # Non-literal type for key
   opts[String.new] = 0
 end

--- a/test/testdata/infer/symbol_literal_lub.rb
+++ b/test/testdata/infer/symbol_literal_lub.rb
@@ -1,0 +1,233 @@
+# typed: true
+
+any_symbol = T.let(:abc, Symbol)
+
+T.reveal_type(
+  if T.unsafe(nil)
+    :abc
+  else
+    :def
+  end
+) # error: Revealed type: `T.any(Symbol(:abc), Symbol(:def))`
+
+T.reveal_type(
+  if T.unsafe(nil)
+    :abc
+  else
+    any_symbol
+  end
+) # error: Revealed type: `Symbol`
+
+T.reveal_type(
+  if T.unsafe(nil)
+    any_symbol
+  else
+    :abc
+  end
+) # error: Revealed type: `Symbol`
+
+T.reveal_type(
+  if T.unsafe(nil)
+    :abc
+  else
+    "def"
+  end
+) # error: Revealed type: `T.any(Symbol(:abc), String("def"))`
+
+T.reveal_type(
+  if T.unsafe(nil)
+    "abc"
+  else
+    "def"
+  end
+) # error: Revealed type: `T.any(String("abc"), String("def"))`
+
+T.reveal_type(
+  if T.unsafe(nil)
+    1
+  else
+    2
+  end
+) # error: Revealed type: `T.any(Integer(1), Integer(2))`
+
+T.reveal_type(
+  if T.unsafe(nil)
+    1.0
+  else
+    2.0
+  end
+) # error: Revealed type: `T.any(Float(1.000000), Float(2.000000))`
+
+any_string = T.let("", String)
+
+T.reveal_type(
+  if T.unsafe(nil)
+    :abc
+  else
+    any_string
+  end
+) # error: Revealed type: `T.any(String, Symbol(:abc))`
+
+T.reveal_type(
+  if T.unsafe(nil)
+    any_string
+  else
+    :abc
+  end
+) # error: Revealed type: `T.any(String, Symbol(:abc))`
+
+any_object = T.let(Object.new, Object)
+
+T.reveal_type(
+  if T.unsafe(nil)
+    :abc
+  else
+    any_object
+  end
+) # error: Revealed type: `Object`
+
+T.reveal_type(
+  if T.unsafe(nil)
+    any_object
+  else
+    :abc
+  end
+) # error: Revealed type: `Object`
+
+class Unrelated; end
+unrelated = T.let(Unrelated.new, Unrelated)
+
+T.reveal_type(
+  if T.unsafe(nil)
+    :abc
+  else
+    unrelated
+  end
+) # error: Revealed type: `T.any(Unrelated, Symbol(:abc))`
+
+T.reveal_type(
+  if T.unsafe(nil)
+    unrelated
+  else
+    :abc
+  end
+) # error: Revealed type: `T.any(Unrelated, Symbol(:abc))`
+
+tuple = [nil]
+
+T.reveal_type(
+  if T.unsafe(nil)
+    :abc
+  else
+    tuple
+  end
+) # error: Revealed type: `T.any(Symbol(:abc), [NilClass])`
+
+T.reveal_type(
+  if T.unsafe(nil)
+    tuple
+  else
+    :abc
+  end
+) # error: Revealed type: `T.any(Symbol(:abc), [NilClass])`
+
+T.reveal_type(
+  if T.unsafe(nil)
+    if T.unsafe(nil)
+      :abc
+    else
+      :def
+    end
+  else
+    :ghi
+  end
+) # error: Revealed type: `T.any(Symbol(:ghi), Symbol(:abc), Symbol(:def))`
+
+T.reveal_type(
+  if T.unsafe(nil)
+    if T.unsafe(nil)
+      :abc
+    else
+      :def
+    end
+  else
+    any_symbol
+  end
+) # error: Revealed type: `Symbol`
+
+T.reveal_type(
+  if T.unsafe(nil)
+    if T.unsafe(nil)
+      :abc
+    else
+      :def
+    end
+  else
+    1
+  end
+) # error: Revealed type: `T.any(Integer(1), Symbol(:abc), Symbol(:def))`
+
+T.reveal_type([:abc, :def].sample) # error: Revealed type: `Symbol`
+T.reveal_type(["abc", "def"].sample) # error: Revealed type: `String`
+T.reveal_type([1, 2].sample) # error: Revealed type: `Integer`
+T.reveal_type([1.0, 2.0].sample) # error: Revealed type: `Float`
+T.reveal_type([[:abc, 1], [:def, 2]].sample) # error: Revealed type: `[Symbol, Integer] (2-tuple)`
+
+strings = [T.unsafe(nil) ? "abc" : "def"]
+strings << "ghi"
+T.reveal_type(strings.first) # error: Revealed type: `T.any(String("abc"), String("def"))`
+
+T.reveal_type(
+  if T.unsafe(nil)
+    [:abc, 1]
+  else
+    [:def, 2]
+  end
+) # error: Revealed type: `[Symbol, Integer] (2-tuple)`
+
+T.reveal_type(
+  if T.unsafe(nil)
+    {key: "abc"}
+  else
+    {key: "def"}
+  end
+) # error: Revealed type: `{key: String} (shape of T::Hash[T.untyped, T.untyped])`
+
+T.reveal_type(
+  if T.unsafe(nil)
+    [1]
+  else
+    [2]
+  end
+) # error: Revealed type: `[Integer] (1-tuple)`
+
+T.reveal_type(
+  if T.unsafe(nil)
+    {key: 1}
+  else
+    {key: 2}
+  end
+) # error: Revealed type: `{key: Integer} (shape of T::Hash[T.untyped, T.untyped])`
+
+local_array = [1, 2]
+T.reveal_type(local_array) # error: Revealed type: `[Integer(1), Integer(2)] (2-tuple)`
+
+LITERAL_ARRAY = [1, 2]
+T.reveal_type(LITERAL_ARRAY) # error: Revealed type: `T::Array[Integer]`
+
+# TODO: Explicit annotations should not broaden literal types when assigning to a local.
+# x = T.let(:heads, T.any(:heads, :tails))
+# T.reveal_type(x) # expected type: `T.any(Symbol(:heads), Symbol(:tails))`
+
+# TODO: add this case back in and fix it later
+# extend T::Sig
+# sig do
+#   type_parameters(:U)
+#     .params(left: T.type_parameter(:U), right: T.type_parameter(:U))
+#     .returns(T.type_parameter(:U))
+# end
+# def pick(left, right)
+#   left
+# end
+#
+# T.reveal_type(pick(:abc, :def)) # expected type: `T.any(Symbol(:abc), Symbol(:def))`

--- a/test/testdata/lsp/fast_path/static_init_method_locs.rb
+++ b/test/testdata/lsp/fast_path/static_init_method_locs.rb
@@ -14,5 +14,5 @@ class A
   if T.unsafe(nil)
     x = 1
   end
-  T.reveal_type(x) # error: `T.nilable(Integer)`
+  T.reveal_type(x) # error: Revealed type: `T.nilable(Integer)`
 end


### PR DESCRIPTION
### Motivation

This PR changes the way the LUB calculations handle literal types.

Today, literals are widened to their underlying type, e.g.

```ruby
T.reveal_type(
  if T.unsafe(true) # Revealed type: Symbol
    :heads
  else
    :tails
  end
)
```

This makes Symbol literal types ([PR](https://github.com/sorbet/sorbet/pull/10582)) clunky to work with, requiring a cast in cases like this:

```ruby
#: -> (:heads | :tails)
def flip_coin
  if T.unsafe(true)
    :heads
  else
    :tails
  end
# ^^^
# Expected `T.any(Symbol(:heads), Symbol(:tails))` but found `Symbol` for method result type
end
```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
