### PR TITLE
avoid redundant `rfind` call

### DIFF
--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -401,7 +401,7 @@ optional<ParsedSig> parseSigWithSelfTypeParams(core::Context ctx, const ast::Sen
                         core::Loc loc{ctx.file, send->loc};
                         if (auto orig = loc.source(ctx)) {
                             auto dot = orig->rfind(".");
-                            if (orig->rfind(".") == string::npos) {
+                            if (dot == string::npos) {
                                 e.replaceWith("Remove this use of `params`", loc, "");
                             } else {
                                 e.replaceWith("Remove this use of `params`", loc, "{}", orig->substr(0, dot));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is an error case, so the performance doesn't really matter, but the code is a bit clearer.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
