### PR TITLE
delete extraneous `todoAttachedClassItems` transfers

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -3124,9 +3124,6 @@ public:
                     combinedTodoUntypedResultTypes.emplace_back(move(threadResult.todoUntypedResultTypes));
                     combinedTodoResolveCastItems.emplace_back(move(threadResult.todoResolveCastItems));
                     combinedTodoResolveFieldItems.emplace_back(move(threadResult.todoResolveFieldItems));
-                    combinedTodoAttachedClassItems.emplace_back(move(threadResult.todoAttachedClassItems));
-                    combinedTodoAttachedClassItems.emplace_back(move(threadResult.todoAttachedClassItems));
-                    combinedTodoAttachedClassItems.emplace_back(move(threadResult.todoAttachedClassItems));
                     combinedTodoResolveStaticFieldItems.emplace_back(move(threadResult.todoResolveStaticFieldItems));
                     combinedTodoResolveSimpleStaticFieldItems.emplace_back(
                         move(threadResult.todoResolveSimpleStaticFieldItems));


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Somehow we already did this a couple lines above, so these are just useless no-ops.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.