### PR TITLE
don't overwrite an entire `VariableUseSite` during dealiasing

### DIFF
--- a/cfg/Instructions.h
+++ b/cfg/Instructions.h
@@ -20,7 +20,7 @@ public:
     LocalRef variable;
     core::TypePtr type;
     VariableUseSite() = default;
-    VariableUseSite(LocalRef local) : variable(local){};
+    explicit VariableUseSite(LocalRef local) : variable(local){};
     VariableUseSite(LocalRef local, core::TypePtr type) : variable(local), type(std::move(type)){};
     VariableUseSite(const VariableUseSite &) = delete;
     const VariableUseSite &operator=(const VariableUseSite &rhs) = delete;

--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -46,7 +46,7 @@ void CFGBuilder::simplify(core::Context ctx, CFG &cfg) {
 
             if (thenb == elseb) {
                 // Remove condition from unconditional jumps
-                bb->bexit.cond = LocalRef::unconditional();
+                bb->bexit.cond.variable = LocalRef::unconditional();
 
                 // These two simplifications only apply on unconditional jumps that:
                 //

--- a/cfg/builder/builder_finalize.cc
+++ b/cfg/builder/builder_finalize.cc
@@ -247,14 +247,14 @@ void CFGBuilder::dealias(core::Context ctx, CFG &cfg) {
                 if (auto v = cast_instruction<Ident>(bind.value)) {
                     v->what = maybeDealias(ctx, cfg, v->what, current);
                 } else if (auto v = cast_instruction<Send>(bind.value)) {
-                    v->recv = maybeDealias(ctx, cfg, v->recv.variable, current);
+                    v->recv.variable = maybeDealias(ctx, cfg, v->recv.variable, current);
                     for (auto &arg : v->argRefs()) {
                         arg = maybeDealias(ctx, cfg, arg, current);
                     }
                 } else if (auto v = cast_instruction<TAbsurd>(bind.value)) {
-                    v->what = maybeDealias(ctx, cfg, v->what.variable, current);
+                    v->what.variable = maybeDealias(ctx, cfg, v->what.variable, current);
                 } else if (auto v = cast_instruction<Return>(bind.value)) {
-                    v->what = maybeDealias(ctx, cfg, v->what.variable, current);
+                    v->what.variable = maybeDealias(ctx, cfg, v->what.variable, current);
                 }
             }
 
@@ -265,7 +265,7 @@ void CFGBuilder::dealias(core::Context ctx, CFG &cfg) {
             }
         }
         if (bb->bexit.cond.variable != LocalRef::unconditional()) {
-            bb->bexit.cond = maybeDealias(ctx, cfg, bb->bexit.cond.variable, current);
+            bb->bexit.cond.variable = maybeDealias(ctx, cfg, bb->bexit.cond.variable, current);
         }
     }
 }

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -18,7 +18,7 @@ void CFGBuilder::conditionalJump(BasicBlock *from, LocalRef cond, BasicBlock *th
         ENFORCE(!from->bexit.isCondSet(), "condition for block already set");
         ENFORCE(from->bexit.thenb == nullptr, "thenb already set");
         ENFORCE(from->bexit.elseb == nullptr, "elseb already set");
-        from->bexit.cond = cond;
+        from->bexit.cond.variable = cond;
         from->bexit.thenb = thenb;
         from->bexit.elseb = elseb;
         from->bexit.loc = loc;
@@ -33,7 +33,7 @@ void CFGBuilder::unconditionalJump(BasicBlock *from, BasicBlock *to, CFG &inWhat
         ENFORCE(!from->bexit.isCondSet(), "condition for block already set");
         ENFORCE(from->bexit.thenb == nullptr, "thenb already set");
         ENFORCE(from->bexit.elseb == nullptr, "elseb already set");
-        from->bexit.cond = LocalRef::unconditional();
+        from->bexit.cond.variable = LocalRef::unconditional();
         from->bexit.elseb = to;
         from->bexit.thenb = to;
         from->bexit.loc = loc;
@@ -201,7 +201,7 @@ void CFGBuilder::jumpToDead(BasicBlock *from, CFG &inWhat, core::LocOffsets loc)
         ENFORCE(!from->bexit.isCondSet(), "condition for block already set");
         ENFORCE(from->bexit.thenb == nullptr, "thenb already set");
         ENFORCE(from->bexit.elseb == nullptr, "elseb already set");
-        from->bexit.cond = LocalRef::unconditional();
+        from->bexit.cond.variable = LocalRef::unconditional();
         from->bexit.elseb = db;
         from->bexit.thenb = db;
         from->bexit.loc = loc;
@@ -930,8 +930,6 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::ExpressionPtr &what, Ba
                     auto magic = cctx.newTemporary(core::Names::magic());
                     synthesizeExpr(current, magic, core::LocOffsets::none(), make_insn<Alias>(core::Symbols::Magic()));
                     auto retryTemp = cctx.newTemporary(core::Names::retryTemp());
-                    InlinedVector<cfg::LocalRef, 2> args{};
-                    InlinedVector<core::LocOffsets, 2> argLocs{};
                     const size_t numArgs = 0;
                     auto isPrivateOk = false;
                     auto snd = Send::make(magic, what.loc(), core::Names::retry(), core::LocOffsets::none(), numArgs,


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Trying to write a `LocalRef` into a `VariableUseSite` winds up constructing an entirely new `VariableUseSite`.  But that is useless work at this point because there are no types (and if there were, we are overwriting them anyway).  So we can just overwrite the variable we were dealiasing with the new value.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.