### PR TITLE
avoid copying a newly-allocated string for inference's timer

### DIFF
--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -43,7 +43,7 @@ bool silenceDeadCodeError(const cfg::InstructionPtr &value) {
 }
 
 unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg) {
-    Timer timeit(ctx.state.tracer(), "Inference::run", {{"func", string(cfg->symbol.toStringFullName(ctx))}});
+    Timer timeit(ctx.state.tracer(), "Inference::run", {{"func", cfg->symbol.toStringFullName(ctx)}});
     ENFORCE(cfg->symbol == ctx.owner.asMethodRef());
     auto methodLoc = ctx.locAt(cfg->declLoc);
     prodCounterInc("types.input.methods.typechecked");


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This function already returns a string, no need to construct another one.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.