### PR TITLE
Cache source hash in the file table, switch to XXH128

### DIFF
--- a/core/BUILD
+++ b/core/BUILD
@@ -35,7 +35,6 @@ cc_library(
     deps = [
         "//common",
         "//common/concurrency",
-        "//common/crypto_hashing",
         "//core/hashing",
         "//main/pipeline/semantic_extension:interface",
         "@com_google_absl//absl/strings",

--- a/core/Files.cc
+++ b/core/Files.cc
@@ -1,6 +1,8 @@
+// Must go before xxhash include. Makes a noticeable performance improvement (~10%).
+#define XXH_INLINE_ALL
+
 #include "core/Files.h"
 #include "common/FileOps.h"
-#include "common/crypto_hashing/crypto_hashing.h"
 #include "core/Context.h"
 #include "core/FileHash.h"
 #include "core/GlobalState.h"
@@ -315,9 +317,15 @@ void File::setHasIndexErrors(bool value) {
     flags.hasIndexErrors = value;
 }
 
-std::array<uint8_t, 64> File::sourceHash() const {
+absl::Span<const uint8_t> File::sourceHash() const {
     ENFORCE(this->sourceType != File::Type::NotYetRead);
-    return crypto_hashing::hash64(this->source_);
+    if (!this->sourceHashComputed_) {
+        XXH64_hash_t seed = 0L;
+        this->sourceHash_ = XXH3_128bits_withSeed(this->source_.data(), this->source_.size(), seed);
+        this->sourceHashComputed_ = true;
+    }
+
+    return absl::Span(reinterpret_cast<uint8_t *>(&this->sourceHash_), sizeof(XXH128_hash_t));
 }
 
 } // namespace sorbet::core

--- a/core/Files.h
+++ b/core/Files.h
@@ -5,6 +5,7 @@
 #include "core/LocOffsets.h"
 #include "core/Names.h"
 #include "core/StrictLevel.h"
+#include "xxhash.h"
 #include <array>
 #include <string>
 #include <string_view>
@@ -95,7 +96,7 @@ public:
     static std::string censorFilePathForSnapshotTests(std::string_view orig);
 
     // Returns the hash of the file content. Requires that the file has been read.
-    std::array<uint8_t, 64> sourceHash() const;
+    absl::Span<const uint8_t> sourceHash() const;
 
 private:
     struct Flags {
@@ -128,6 +129,10 @@ private:
     // for that file, and computing lazily allows saving space.
     mutable std::shared_ptr<std::vector<uint32_t>> lineBreaks_;
 
+    // This is the XXH128 hash of the source, lazily computed.
+    mutable XXH128_hash_t sourceHash_;
+
+    mutable bool sourceHashComputed_ = false;
     mutable StrictLevel minErrorLevel_ = StrictLevel::Max;
 
 public:
@@ -138,7 +143,7 @@ private:
     std::shared_ptr<const FileHash> hash_;
 };
 
-CheckSize(File, 96, 8);
+CheckSize(File, 112, 8);
 
 template <typename H> H AbslHashValue(H h, const FileRef &m) {
     return H::combine(std::move(h), m.id());


### PR DESCRIPTION
Switch from using Blake2b to XXH128 for computing file hashes. As XXH128 has a 128-bit output, it's more reasonable to cache it on the `File` object. This will benefit LSP, as we can skip recomputing hashes when re-reading from the session cache, computing it once and reusing that hash while the file hasn't changed in the file table.

This does bloat `File` entries by `16` bytes to `112` total, but I think this tradeoff is worth it for avoiding the on-demand hash computation and enabling faster file content comparison in the future.

### Motivation
Performance, caching the hash instead of recomputing it for each kvstore lookup.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavioral changes expected, existing cache tests should pass
