### PR TITLE
More logging for variance crash

### DIFF
--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -1,3 +1,4 @@
+#include "common/strings/formatting.h"
 #include "common/typecase.h"
 #include "core/Polarity.h"
 #include "core/Symbols.h"
@@ -70,8 +71,10 @@ private:
                 auto params = app.targs;
 
                 if (members.size() != params.size()) [[unlikely]] {
-                    fatalLogger->error(R"(msg="types should be fully saturated" loc="{}" members={} params={})",
-                                       this->loc.showRaw(ctx), members.size(), params.size());
+                    auto memberNames =
+                        fmt::map_join(members, ", ", [&](auto m) { return m.data(ctx)->name.show(ctx); });
+                    fatalLogger->error(R"(msg="types should be fully saturated" loc="{}" members="[{}]" app="{}")",
+                                       this->loc.showRaw(ctx), memberNames, app.show(ctx));
                     ENFORCE(false);
                 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I considered adding the stratum to the log line as well, but opted against it
because we don't have a public helper for getting the stratum off of
`GlobalState` (we could add one, but it felt weird to add it for debugging
only). If I didn't look hard enough and there's actually a way to get at that
information from `GlobalState`, let me know.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Testing on Stripe engineers