### PR TITLE
fix condition for `tryApplyDefLocSaver`

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -967,8 +967,8 @@ void tryApplyLocalVarSaver(const core::GlobalState &gs, vector<ast::ParsedFile> 
 }
 
 void tryApplyDefLocSaver(const core::GlobalState &gs, vector<ast::ParsedFile> &indexedCopies) {
-    if (holds_alternative<core::lsp::Query::Loc>(gs.lspQuery.query) &&
-        holds_alternative<core::lsp::Query::Symbol>(gs.lspQuery.query)) {
+    if (!(holds_alternative<core::lsp::Query::Loc>(gs.lspQuery.query) ||
+          holds_alternative<core::lsp::Query::Symbol>(gs.lspQuery.query))) {
         return;
     }
     for (auto &t : indexedCopies) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

#9437 made this condition use `holds_alternative`...but also changed the condition so that it never returns true, so we never take the early exit here.

Assuming I got the de Morgan's law application correct here, this restores things to the original state.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
