### PR TITLE
Fix error string nit in packager.cc

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -679,7 +679,7 @@ struct PackageSpecBodyWalk {
                 if (info.file.data(ctx).isTestPackage(ctx) && parsedValue != StrictDependenciesLevel::False) {
                     parsedValue = StrictDependenciesLevel::False;
                     if (auto e = ctx.beginError(send.argsLoc(), core::errors::Packager::InvalidStrictDependencies)) {
-                        e.setHeader("Test packages must be be at `{}` level `{}`", "strict_dependencies", "false");
+                        e.setHeader("Test packages must be at `{}` level `{}`", "strict_dependencies", "false");
                         e.replaceWith("Change to false", ctx.locAt(send.getPosArg(0).loc()), "'false'");
                     }
                 }


### PR DESCRIPTION
Replace "Test packages must be be at" with "Test packages must be at"

### Motivation
I noticed this typo come up while working on something.

### Test plan
I didn't add/update any tests since this is a trivial change to a string.