### PR TITLE
use a more efficient algorithm to find files for symbol queries

### DIFF
--- a/core/FileHash.cc
+++ b/core/FileHash.cc
@@ -1,4 +1,5 @@
 #include "core/FileHash.h"
+#include "absl/algorithm/container.h"
 #include "common/sort/sort.h"
 #include "core/FoundDefinitions.h"
 #include "core/GlobalState.h"
@@ -86,6 +87,47 @@ void WithoutUniqueNameHash::sortAndDedupe(vector<core::WithoutUniqueNameHash> &h
     fast_sort(hashes);
     hashes.resize(std::distance(hashes.begin(), std::unique(hashes.begin(), hashes.end())));
     hashes.shrink_to_fit();
+}
+
+// This is adapted from
+// https://github.com/llvm/llvm-project/blob/b89e774672678ef26baf8f94c616f43551d29428/libcxx/include/__algorithm/set_intersection.h#L47-L123
+bool WithoutUniqueNameHash::sortedIntersects(const vector<WithoutUniqueNameHash> &a,
+                                             const vector<WithoutUniqueNameHash> &b) {
+    ENFORCE_NO_TIMER(absl::c_is_sorted(a));
+    ENFORCE_NO_TIMER(absl::c_is_sorted(b));
+
+    auto aIt = a.begin();
+    auto aEnd = a.end();
+    auto bIt = b.begin();
+    auto bEnd = b.end();
+
+    bool prevEqual = false;
+
+    while (bIt != bEnd) {
+        auto aNext = std::lower_bound(aIt, aEnd, *bIt);
+        std::swap(aNext, aIt);
+        bool aEqual = aNext == aIt;
+
+        if (aEqual && prevEqual) {
+            return true;
+        }
+        prevEqual = aEqual;
+
+        if (aIt == aEnd) {
+            break;
+        }
+
+        auto bNext = std::lower_bound(bIt, bEnd, *aIt);
+        std::swap(bNext, bIt);
+        bool bEqual = bNext == bIt;
+
+        if (bEqual && prevEqual) {
+            return true;
+        }
+        prevEqual = bEqual;
+    }
+
+    return false;
 }
 
 FullNameHash::FullNameHash(const GlobalState &gs, NameRef nm) : _hashValue(incZero(hashFullNameRef(gs, nm))) {}

--- a/core/FileHash.h
+++ b/core/FileHash.h
@@ -14,6 +14,11 @@ class SerializerImpl;
 class WithoutUniqueNameHash {
 public:
     static void sortAndDedupe(std::vector<core::WithoutUniqueNameHash> &hashes);
+    // Returns `true` if the two vectors share a value, and `false` otherwise. This requires that the two vectors are
+    // sorted, which is also a requirement of using `absl::c_set_intersetion`, so this is a drop-in replacement when the
+    // resulting set isn't needed.
+    static bool sortedIntersects(const std::vector<WithoutUniqueNameHash> &a,
+                                 const std::vector<WithoutUniqueNameHash> &b);
 
     WithoutUniqueNameHash(const GlobalState &gs, NameRef nm);
     inline bool isDefined() const {

--- a/main/lsp/LSPFileUpdates.cc
+++ b/main/lsp/LSPFileUpdates.cc
@@ -47,52 +47,6 @@ LSPFileUpdates LSPFileUpdates::copy() const {
 
 namespace {
 
-// Returns `true` if the two containers share a value, and `false` otherwise. This requires that the two containers are
-// sorted, which is also a requirement of using `absl::c_set_intersetion`, so this is a drop-in replacement when the
-// resulting set isn't needed.
-//
-// This is adapted from
-// https://github.com/llvm/llvm-project/blob/b89e774672678ef26baf8f94c616f43551d29428/libcxx/include/__algorithm/set_intersection.h#L47-L123
-// and modified to return early when any intersection is found.
-bool intersects(const vector<core::WithoutUniqueNameHash> &changed, const vector<core::WithoutUniqueNameHash> &used) {
-    auto changedIt = changed.begin();
-    auto changedEnd = changed.end();
-    auto usedIt = used.begin();
-    auto usedEnd = used.end();
-
-    bool prevEqual = false;
-
-    while (usedIt != usedEnd) {
-        auto changedNext = std::lower_bound(changedIt, changedEnd, *usedIt);
-        std::swap(changedNext, changedIt);
-        bool changedEqual = changedNext == changedIt;
-
-        // If we didn't advance `changedIt`, and the previous lower_bound call for `used` also didn't advance `usedIt`,
-        // we've found a match.
-        if (changedEqual && prevEqual) {
-            return true;
-        }
-        prevEqual = changedEqual;
-
-        if (changedIt == changedEnd) {
-            break;
-        }
-
-        auto usedNext = std::lower_bound(usedIt, usedEnd, *changedIt);
-        std::swap(usedNext, usedIt);
-        bool usedEqual = usedNext == usedIt;
-
-        // If we didn't advance `usedIt`, and the previous lower_bound call for `changed` also didn't advance
-        // `changedIt`, we've found a match.
-        if (usedEqual && prevEqual) {
-            return true;
-        }
-        prevEqual = usedEqual;
-    }
-
-    return false;
-}
-
 // An output iterator that only writes out the `nameHash` component of a `SymbolHash`. This allows us to avoid
 // materializing a vector of `WithoutUniqueNameHash` when we're only interested in the `nameHash` components.
 class NameHashOutputIterator final {
@@ -207,7 +161,8 @@ LSPFileUpdates::fastPathFilesToTypecheck(const core::GlobalState &gs, const LSPC
         }
 
         ENFORCE(oldFile->getFileHash() != nullptr);
-        if (!intersects(changedSymbolNameHashes, oldFile->getFileHash()->usages.nameHashes)) {
+        if (!core::WithoutUniqueNameHash::sortedIntersects(changedSymbolNameHashes,
+                                                           oldFile->getFileHash()->usages.nameHashes)) {
             continue;
         }
 

--- a/main/lsp/LSPQuery.cc
+++ b/main/lsp/LSPQuery.cc
@@ -110,6 +110,7 @@ LSPQueryResult LSPQuery::bySymbol(const LSPConfiguration &config, LSPTypechecker
     absl::c_transform(symbols, back_inserter(symShortNameHashes), [&gs](auto symbol) {
         return core::WithoutUniqueNameHash{gs, symbol.name(gs)};
     });
+    fast_sort(symShortNameHashes);
     // Locate files that contain the same Name as the symbol. Is an overapproximation, but a good first filter.
     size_t i = 0;
     // skip idx 0 (corresponds to File that does not exist, so it contains nullptr)
@@ -129,9 +130,7 @@ LSPQueryResult LSPQuery::bySymbol(const LSPConfiguration &config, LSPTypechecker
         const auto &hash = *file->getFileHash();
         const auto &usedSymbolNameHashes = hash.usages.nameHashes;
 
-        if (absl::c_any_of(symShortNameHashes, [&](const auto &symShortNameHash) {
-                return absl::c_contains(usedSymbolNameHashes, symShortNameHash);
-            })) {
+        if (core::WithoutUniqueNameHash::sortedIntersects(symShortNameHashes, usedSymbolNameHashes)) {
             frefs.emplace_back(ref);
         }
     }


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We currently use a pretty inefficient algorithm for finding files matching particular symbols in LSP queries: loop over all symbols we're looking for, and linearly check if the file defines any of them.

I think that we don't really look for multiple symbols at a time (?), so the time complexity of the above doesn't really bite us, but we should be able to do better.

Fortunately, we have basically the exact same computation required when computing which files need typechecking elsewhere in LSP, so we can reuse the efficient set intersection algorithm we developed there.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
