### PR TITLE
Support RBS assertions inside interpolations

### DIFF
--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -596,6 +596,35 @@ pm_node_t *AssertionsRewriter::rewriteNode(pm_node_t *node) {
             return node;
         }
 
+        case PM_INTERPOLATED_STRING_NODE: {
+            auto *string = down_cast_nonnull<pm_interpolated_string_node_t>(node);
+            node = maybeInsertCast(node);
+            rewriteNodes(string->parts);
+            return node;
+        }
+        case PM_INTERPOLATED_SYMBOL_NODE: {
+            auto *symbol = down_cast_nonnull<pm_interpolated_symbol_node_t>(node);
+            node = maybeInsertCast(node);
+            rewriteNodes(symbol->parts);
+            return node;
+        }
+        case PM_INTERPOLATED_REGULAR_EXPRESSION_NODE: {
+            auto *regexp = down_cast_nonnull<pm_interpolated_regular_expression_node_t>(node);
+            node = maybeInsertCast(node);
+            rewriteNodes(regexp->parts);
+            return node;
+        }
+        case PM_INTERPOLATED_X_STRING_NODE: {
+            auto *string = down_cast_nonnull<pm_interpolated_x_string_node_t>(node);
+            node = maybeInsertCast(node);
+            rewriteNodes(string->parts);
+            return node;
+        }
+        case PM_EMBEDDED_STATEMENTS_NODE: {
+            auto *embedded = down_cast_nonnull<pm_embedded_statements_node_t>(node);
+            rewriteNullableNode(up_cast(embedded->statements));
+            return node;
+        }
         // Simple write assignments
         case PM_LOCAL_VARIABLE_WRITE_NODE: {
             auto *write = down_cast_nonnull<pm_local_variable_write_node_t>(node);

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -589,6 +589,34 @@ void CommentsAssociator::walkNode(pm_node_t *node) {
             consumeCommentsInsideNode(node, "array");
             break;
         }
+        case PM_INTERPOLATED_STRING_NODE: {
+            auto *string = down_cast_nonnull<pm_interpolated_string_node_t>(node);
+            associateAssertionCommentsToNode(node);
+            walkNodes(string->parts);
+            consumeCommentsInsideNode(node, "string");
+            break;
+        }
+        case PM_INTERPOLATED_SYMBOL_NODE: {
+            auto *symbol = down_cast_nonnull<pm_interpolated_symbol_node_t>(node);
+            associateAssertionCommentsToNode(node);
+            walkNodes(symbol->parts);
+            consumeCommentsInsideNode(node, "symbol");
+            break;
+        }
+        case PM_INTERPOLATED_REGULAR_EXPRESSION_NODE: {
+            auto *regexp = down_cast_nonnull<pm_interpolated_regular_expression_node_t>(node);
+            associateAssertionCommentsToNode(node);
+            walkNodes(regexp->parts);
+            consumeCommentsInsideNode(node, "regexp");
+            break;
+        }
+        case PM_INTERPOLATED_X_STRING_NODE: {
+            auto *string = down_cast_nonnull<pm_interpolated_x_string_node_t>(node);
+            associateAssertionCommentsToNode(node);
+            walkNodes(string->parts);
+            consumeCommentsInsideNode(node, "xstring");
+            break;
+        }
         case PM_BEGIN_NODE: {
             auto *begin = down_cast_nonnull<pm_begin_node_t>(node);
 
@@ -623,6 +651,12 @@ void CommentsAssociator::walkNode(pm_node_t *node) {
             auto nodeLoc = translateLocation(node->location);
             lastLine = posToLine(nodeLoc.endPos());
             consumeCommentsInsideNode(node, "begin");
+            break;
+        }
+        case PM_EMBEDDED_STATEMENTS_NODE: {
+            auto *embedded = down_cast_nonnull<pm_embedded_statements_node_t>(node);
+            walkNode(up_cast(embedded->statements));
+            consumeCommentsInsideNode(node, "interpolation");
             break;
         }
         case PM_BLOCK_NODE: {

--- a/test/testdata/rbs/assertions_interpolation.rb
+++ b/test/testdata/rbs/assertions_interpolation.rb
@@ -1,0 +1,52 @@
+# typed: strict
+# enable-experimental-rbs-comments: true
+
+integer = T.let(nil, T.nilable(String))
+
+result = "#{(
+  integer #: as String
+).upcase}"
+T.reveal_type(result) # error: Revealed type: `String`
+
+percent_string = %Q[
+  #{(
+    integer #: as String
+  ).upcase}
+]
+T.reveal_type(percent_string) # error: Revealed type: `String`
+
+heredoc = <<~STRING
+  #{(
+    integer #: as String
+  ).upcase}
+STRING
+T.reveal_type(heredoc) # error: Revealed type: `String`
+
+symbol = :"#{(
+  integer #: as String
+).upcase}"
+T.reveal_type(symbol) # error: Revealed type: `Symbol`
+
+regexp = /#{(
+  integer #: as String
+).upcase}/
+T.reveal_type(regexp) # error: Revealed type: `Regexp`
+
+xstring = `echo #{(
+  integer #: as String
+).upcase}`
+T.reveal_type(xstring) # error: Revealed type: `String`
+
+words = %W[
+  #{(
+    integer #: as String
+  ).upcase}
+]
+T.reveal_type(words) # error: Revealed type: `[String] (1-tuple)`
+
+symbols = %I[
+  #{(
+    integer #: as String
+  ).upcase}
+]
+T.reveal_type(symbols) # error: Revealed type: `[Symbol] (1-tuple)`


### PR DESCRIPTION
### Motivation

 ```markdown
   RBS assertion comments inside interpolations were not associated with the interpolated expression. For example:

   ```ruby
   integer = T.let(nil, T.nilable(String))

   "#{(
     integer #: as String
   ).upcase}"
 ```

Sorbet treated the assertion as unused and reported that upcase could be called on nil.

This change makes the RBS comment associators and assertion rewriters descend into interpolated literal contents. It supports both the legacy and Prism pipelines for:

 - interpolated strings, including `%Q` and heredocs
 - dynamic symbols
 - regular expressions
 - command strings
 - `%W` word arrays
 - `%I` symbol arrays

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
