### PR TITLE
vscode_extension: Only activate narrowly on sorbet/config

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -4,7 +4,7 @@
   "description": "Ruby IDE features, powered by Sorbet.",
   "author": "Stripe Inc.",
   "license": "Apache-2.0",
-  "version": "0.3.46",
+  "version": "0.3.47",
   "publisher": "sorbet",
   "icon": "icon.png",
   "repository": {
@@ -34,7 +34,7 @@
     "onCommand:sorbet.toggleHighlightUntyped",
     "onCommand:sorbet.toggleTypedFalseCompletionNudges",
     "onLanguage:ruby",
-    "workspaceContains:sorbet/*"
+    "workspaceContains:sorbet/config"
   ],
   "languages": [
     {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This is a quick change to avoid having to attempt to allow this to be
configurable by workspace (e.g. in Stripe's monorepo we want to avoid
opening Sorbet unless a Ruby file was opened, because many developers
won't be using Ruby while developing in the monorepo).

Stripe's codebase happens to not use sorbet/config, while basically
every other Sorbet codebase will, so this is a way to get a
Stripe-specific behavior without having to change the behavior for
existing users or build a big feature.

If other codebases want similar functionality of skipping Sorbet from
starting but do have a `sorbet/config` file, we'll need to revisit this,
but I'm punting on that for a quick fix right now.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Have not tested