### PR TITLE
Update mimalloc to 3.4.4

### DIFF
--- a/third_party/externals.bzl
+++ b/third_party/externals.bzl
@@ -123,10 +123,10 @@ def register_sorbet_dependencies():
 
     http_archive(
         name = "mimalloc",
-        url = "https://github.com/microsoft/mimalloc/archive/refs/tags/v3.3.2.zip",  # 3.3.2
-        sha256 = "66539a07c48eb868a7186b03db3fd8b56dd97453b7eab8aef8695ac93a5a743f",
+        url = "https://github.com/microsoft/mimalloc/archive/refs/tags/v3.4.4.zip",  # 3.4.4
+        sha256 = "586e2fbe471057e9a395c7ba1e81867be162ec3d1b39e87f530e59e40ccc08d6",
         build_file = "@com_stripe_ruby_typer//third_party:mimalloc.BUILD",
-        strip_prefix = "mimalloc-3.3.2",
+        strip_prefix = "mimalloc-3.4.4",
     )
 
     http_archive(


### PR DESCRIPTION
Updates mimalloc to 3.4.4, which includes the fix for calling `free(NULL)` before mimalloc's page map has been initialized.

Closes #10524.

### Motivation

On glibc 2.44, `newlocale()` calls `free(NULL)` during C++ locale initialization. Sorbet's Linux release binary interposes mimalloc's `free`, and mimalloc 3.3.2 dereferences its uninitialized page map before Sorbet reaches `main`.

This is tracked upstream in [microsoft/mimalloc#1341](https://github.com/microsoft/mimalloc/issues/1341) and fixed by [microsoft/mimalloc@b2226c1](https://github.com/microsoft/mimalloc/commit/b2226c195fe884223f6d6f68ea52df476e57e5c2), which is included in mimalloc 3.4.4.

### Test plan

No automated test is included because the crash depends on the final Linux release link and glibc 2.44, which the current CI images do not provide.

- `./bazel build @mimalloc//:mimalloc --config=release-linux`
- `./bazel build //main:sorbet --strip=always --config=release-linux` in `stripe/sorbet-build-image:latest`
- `tools/scripts/format_build_files.sh -t`
- Ran the old and rebuilt binaries with the same cached Arch glibc loaders:

  | mimalloc | glibc 2.43 | glibc 2.44 |
  | --- | --- | --- |
  | 3.3.2 | exits successfully | segfaults with status 139 |
  | 3.4.4 | exits successfully | exits successfully |

- Ran `sorbet --no-config -e 'puts 1'` with mimalloc 3.4.4 and glibc 2.44: `No errors! Great job.`
