### PR TITLE
Fix bogus T.attached_class error when reporting final method errors

### DIFF
--- a/core/sig_finder/sig_finder.cc
+++ b/core/sig_finder/sig_finder.cc
@@ -41,10 +41,10 @@ void SigFinder::preTransformClassDef(core::Context ctx, const ast::ClassDef &tre
         // `loc` is contained in the current narrowestClassDefRange, and still contains `queryLoc`
         this->narrowestClassDefRange = loc;
 
-        if (this->result_.has_value() && !loc.contains(ctx.locAt(this->result_->origSend.loc))) {
+        if (this->bestSend_ != nullptr && !loc.contains(ctx.locAt(this->bestSend_->loc))) {
             // If there's a result and it's not contained in the new narrowest range, we have to toss it out
             // (Method defs and class defs are not necessarily sorted by their locs)
-            this->result_ = nullopt;
+            this->bestSend_ = nullptr;
         }
     }
 
@@ -57,21 +57,21 @@ void SigFinder::postTransformClassDef(core::Context ctx, const ast::ClassDef &tr
 }
 
 void SigFinder::preTransformMethodDef(core::Context ctx, const ast::MethodDef &tree) {
-    if (this->result_.has_value()) {
-        if (this->result_->origSend.loc.endPos() <= tree.loc.beginPos() && tree.loc.endPos() <= queryLoc.beginPos()) {
+    if (this->bestSend_ != nullptr) {
+        if (this->bestSend_->loc.endPos() <= tree.loc.beginPos() && tree.loc.endPos() <= queryLoc.beginPos()) {
             // There is a method definition between the current result sig and the queryLoc,
             // so the sig we found is not for the right method.
-            this->result_ = nullopt;
+            this->bestSend_ = nullptr;
         }
     }
 }
 
 void SigFinder::postTransformRuntimeMethodDefinition(core::Context ctx, const ast::RuntimeMethodDefinition &tree) {
-    if (this->result_.has_value()) {
-        if (this->result_->origSend.loc.endPos() <= tree.loc.beginPos() && tree.loc.endPos() <= queryLoc.beginPos()) {
+    if (this->bestSend_ != nullptr) {
+        if (this->bestSend_->loc.endPos() <= tree.loc.beginPos() && tree.loc.endPos() <= queryLoc.beginPos()) {
             // There is a method definition between the current result sig and the queryLoc,
             // so the sig we found is not for the right method.
-            this->result_ = nullopt;
+            this->bestSend_ = nullptr;
         }
     }
 }
@@ -107,36 +107,51 @@ void SigFinder::preTransformSend(core::Context ctx, const ast::Send &send) {
         return;
     }
 
-    if (this->result_.has_value()) {
-        // Method defs are not guaranteed to be sorted in order by their declLocs
-        auto resultLoc = this->result_->origSend.loc;
-        if (resultLoc.beginPos() < currentLoc.beginPos()) {
-            // Found a method defined before the query but later than previous result: overwrite previous result
-            auto owner = getEffectiveOwner(ctx);
-            auto parsedSig = resolver::TypeSyntax::parseSigTop(ctx.withOwner(owner), send, core::Symbols::untyped());
-            this->result_.emplace(move(parsedSig), send);
-        } else {
-            // We've already found an earlier result, so the current is not the first
-        }
+    // Note: we deliberately do not parse `send` here. Parsing a `sig` has the side effect of
+    // reporting type errors on it, and this loop may pass over the same `sig` (or an unrelated,
+    // syntactically-invalid one) many times while searching for the best candidate. We only ever
+    // want to parse the single, final winning candidate, and only when the caller actually asked
+    // for the parsed result--see parseBestSend, findSignature, and findSignatureSend below.
+    if (this->bestSend_ == nullptr || this->bestSend_->loc.beginPos() < currentLoc.beginPos()) {
+        // Either we haven't found a candidate yet, or this send is a method defined before the
+        // query but later than the previous candidate: replace the previous candidate.
+        this->bestSend_ = &send;
+        this->bestOwner_ = getEffectiveOwner(ctx);
     } else {
-        // Haven't found a result yet, so this one is the best so far.
-        auto owner = getEffectiveOwner(ctx);
-        auto parsedSig = resolver::TypeSyntax::parseSigTop(ctx.withOwner(owner), send, core::Symbols::untyped());
-
-        this->result_.emplace(move(parsedSig), send);
+        // We've already found a later candidate, so the current send is not the best one.
     }
+}
+
+optional<SigFinder::Result> SigFinder::parseBestSend(core::Context ctx) const {
+    if (this->bestSend_ == nullptr) {
+        return nullopt;
+    }
+    auto parsedSig =
+        resolver::TypeSyntax::parseSigTop(ctx.withOwner(this->bestOwner_), *this->bestSend_, core::Symbols::untyped());
+    return Result(move(parsedSig), *this->bestSend_);
 }
 
 optional<SigFinder::Result> SigFinder::findSignature(core::Context ctx, const ast::ExpressionPtr &tree,
                                                      core::Loc queryLoc) {
     SigFinder sigFinder(queryLoc);
     ast::ConstTreeWalk::apply(ctx, sigFinder, tree);
-    return move(sigFinder.result_);
+    return sigFinder.parseBestSend(ctx);
 }
 optional<SigFinder::Result> SigFinder::findSignature(core::Context ctx, const ast::ClassDef &tree, core::Loc queryLoc) {
     SigFinder sigFinder(queryLoc);
     ast::ConstTreeWalk::apply(ctx, sigFinder, tree);
-    return move(sigFinder.result_);
+    return sigFinder.parseBestSend(ctx);
+}
+
+const ast::Send *SigFinder::findSignatureSend(core::Context ctx, const ast::ExpressionPtr &tree, core::Loc queryLoc) {
+    SigFinder sigFinder(queryLoc);
+    ast::ConstTreeWalk::apply(ctx, sigFinder, tree);
+    return sigFinder.bestSend_;
+}
+const ast::Send *SigFinder::findSignatureSend(core::Context ctx, const ast::ClassDef &tree, core::Loc queryLoc) {
+    SigFinder sigFinder(queryLoc);
+    ast::ConstTreeWalk::apply(ctx, sigFinder, tree);
+    return sigFinder.bestSend_;
 }
 
 } // namespace sorbet::sig_finder

--- a/core/sig_finder/sig_finder.cc
+++ b/core/sig_finder/sig_finder.cc
@@ -145,8 +145,9 @@ struct SigFinderTraversal {
         if (this->bestSend_ == nullptr) {
             return nullopt;
         }
+        ENFORCE(this->bestOwner_.exists());
         auto parsedSig = resolver::TypeSyntax::parseSigTop(ctx.withOwner(this->bestOwner_), *this->bestSend_,
-                                                            core::Symbols::untyped());
+                                                           core::Symbols::untyped());
         return SigFinder::Result(move(parsedSig), *this->bestSend_);
     }
 };

--- a/core/sig_finder/sig_finder.h
+++ b/core/sig_finder/sig_finder.h
@@ -25,12 +25,20 @@ private:
     // Track whether the current scope has the queryLoc.
     std::vector<bool> scopeContainsQueryLoc;
 
-    std::optional<Result> result_;
+    // The best `sig` send found so far, and the owner it should be parsed in (i.e., a singleton
+    // class, for a `sig` on a `self.` method). We deliberately do NOT parse this send as we find
+    // it: parsing a `sig` has the side effect of reporting type errors on it, so it must only
+    // ever be parsed once, for the single winning candidate, and only if the caller actually asked
+    // for the parsed result (see findSignature vs. findSignatureSend below).
+    const ast::Send *bestSend_;
+    core::SymbolRef bestOwner_;
+
+    std::optional<Result> parseBestSend(core::Context ctx) const;
 
 public:
     SigFinder(core::Loc queryLoc)
         : queryLoc(queryLoc), narrowestClassDefRange(core::Loc::none()), scopeContainsQueryLoc(std::vector<bool>{}),
-          result_(std::nullopt) {}
+          bestSend_(nullptr) {}
 
     void preTransformClassDef(core::Context ctx, const ast::ClassDef &tree);
     void postTransformClassDef(core::Context ctx, const ast::ClassDef &tree);
@@ -38,8 +46,17 @@ public:
     void postTransformRuntimeMethodDefinition(core::Context ctx, const ast::RuntimeMethodDefinition &tree);
     void preTransformSend(core::Context ctx, const ast::Send &tree);
 
+    // Finds the `sig` (if any) belonging to the method at queryLoc, and parses it, reporting any
+    // type errors found in the sig. Use this when the caller needs the parsed type information
+    // (e.g., a method's argument types).
     static std::optional<Result> findSignature(core::Context ctx, const ast::ExpressionPtr &tree, core::Loc queryLoc);
     static std::optional<Result> findSignature(core::Context ctx, const ast::ClassDef &tree, core::Loc queryLoc);
+
+    // Finds the `sig` (if any) belonging to the method at queryLoc, without parsing it. Use this
+    // when the caller only needs syntactic information about the `sig` (e.g., its location, or
+    // whether it has a block), so that we avoid the redundant, error-reporting parse entirely.
+    static const ast::Send *findSignatureSend(core::Context ctx, const ast::ExpressionPtr &tree, core::Loc queryLoc);
+    static const ast::Send *findSignatureSend(core::Context ctx, const ast::ClassDef &tree, core::Loc queryLoc);
 };
 
 } // namespace sorbet::sig_finder

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -601,12 +601,15 @@ optional<core::AutocorrectSuggestion>
 constructOverrideAutocorrect(const core::Context ctx, const ast::ExpressionPtr &tree, const ast::MethodDef &methodDef) {
     auto methodLoc = ctx.locAt(methodDef.declLoc);
 
-    auto parsedSig = sig_finder::SigFinder::findSignature(ctx, tree, methodLoc.copyWithZeroLength());
-    if (!parsedSig.has_value()) {
+    // Only the send's syntax is needed here (its location, flags, and block), so look it up
+    // without parsing it: parsing has the side effect of reporting type errors on it, which we
+    // don't want to trigger just to find where it is.
+    auto *origSendPtr = sig_finder::SigFinder::findSignatureSend(ctx, tree, methodLoc.copyWithZeroLength());
+    if (origSendPtr == nullptr) {
         return nullopt;
     }
 
-    auto &origSend = parsedSig->origSend;
+    auto &origSend = *origSendPtr;
 
     // If the sig itself is generated, it doesn't make much sense to suggest an autocorrect for it.
     if (origSend.flags.isRewriterSynthesized) {
@@ -794,10 +797,15 @@ void validateFinalMethodHelper(core::Context ctx, const core::ClassOrModuleRef k
             e.setHeader("`{}` was declared as final but its method `{}` was not declared as final",
                         errMsgClass.show(ctx), sym.name(ctx).show(ctx));
             auto queryLoc = defLoc.copyWithZeroLength();
-            auto parsedSig = sig_finder::SigFinder::findSignature(ctx, classDef, queryLoc);
+            // Only the send's location is needed here, so look it up without parsing it: parsing
+            // has the side effect of reporting type errors on it (e.g. `T.attached_class` errors
+            // based on the wrong owner, since this helper doesn't know about `self.` methods),
+            // which we don't want to trigger just to find where the `sig` is.
+            // See https://github.com/sorbet/sorbet/issues/9460
+            auto *origSend = sig_finder::SigFinder::findSignatureSend(ctx, classDef, queryLoc);
 
-            if (parsedSig.has_value() && parsedSig->origSend.funLoc.exists()) {
-                auto funLoc = ctx.locAt(parsedSig->origSend.funLoc);
+            if (origSend != nullptr && origSend->funLoc.exists()) {
+                auto funLoc = ctx.locAt(origSend->funLoc);
                 e.replaceWith("Mark it as `sig(:final)`", funLoc, "sig(:final)");
             }
         }

--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -798,10 +798,8 @@ void validateFinalMethodHelper(core::Context ctx, const core::ClassOrModuleRef k
                         errMsgClass.show(ctx), sym.name(ctx).show(ctx));
             auto queryLoc = defLoc.copyWithZeroLength();
             // Only the send's location is needed here, so look it up without parsing it: parsing
-            // has the side effect of reporting type errors on it (e.g. `T.attached_class` errors
-            // based on the wrong owner, since this helper doesn't know about `self.` methods),
-            // which we don't want to trigger just to find where the `sig` is.
-            // See https://github.com/sorbet/sorbet/issues/9460
+            // has the side effect of reporting type errors on it, which we don't want to trigger
+            // just to find where it is.
             auto *origSend = sig_finder::SigFinder::findSignatureSend(ctx, classDef, queryLoc);
 
             if (origSend != nullptr && origSend->funLoc.exists()) {

--- a/test/testdata/resolver/final_attached_class.rb
+++ b/test/testdata/resolver/final_attached_class.rb
@@ -1,0 +1,35 @@
+# typed: true
+
+# Regression test for https://github.com/sorbet/sorbet/issues/9460
+#
+# `T.attached_class` is legal here: `make` is a singleton method. The only
+# real problem is the missing `sig(:final)`. Fixing that error should not
+# require also fixing a `T.attached_class` error that shouldn't exist.
+
+class Parent
+  extend T::Sig, T::Helpers
+  final!
+
+  sig { returns(T.attached_class) }
+  def self.make # error: `Parent` was declared as final but its method `make` was not declared as final
+    raise
+  end
+end
+
+# Same bug, but with two non-final methods in the class. The final-method
+# validator visits each offending method and re-parses the preceding `sig`
+# to build the "Replace with `sig(:final)`" autocorrect. Before the fix,
+# each visit re-parsed the `sig { returns(T.attached_class) }` above `make`,
+# so the bogus error was emitted once per non-final method in the class.
+class MultipleNonFinalMethods
+  extend T::Sig, T::Helpers
+  final!
+
+  sig { returns(T.attached_class) }
+  def self.make # error: `MultipleNonFinalMethods` was declared as final but its method `make` was not declared as final
+    raise
+  end
+
+  sig { void }
+  def other; end # error: `MultipleNonFinalMethods` was declared as final but its method `other` was not declared as final
+end

--- a/test/testdata/resolver/final_attached_class.rb
+++ b/test/testdata/resolver/final_attached_class.rb
@@ -33,3 +33,23 @@ class MultipleNonFinalMethods
   sig { void }
   def other; end # error: `MultipleNonFinalMethods` was declared as final but its method `other` was not declared as final
 end
+
+# With several `sig` blocks in the same class, the search for "which `sig` belongs to this
+# method" has to walk past earlier, unrelated `sig`s to find the right one. Make sure each
+# non-final method's autocorrect still points at its own `sig`, and not at an earlier one
+# (which, before the fix, could also mean re-parsing--and re-erroring on--that earlier `sig`).
+class MultipleSigBlocks
+  extend T::Sig, T::Helpers
+  final!
+
+  sig { void }
+  def self.first; end # error: `MultipleSigBlocks` was declared as final but its method `first` was not declared as final
+
+  sig { returns(T.attached_class) }
+  def self.second # error: `MultipleSigBlocks` was declared as final but its method `second` was not declared as final
+    raise
+  end
+
+  sig(:final) { void }
+  def self.third; end
+end


### PR DESCRIPTION
When a `final!` class has a non-final `self.` method, the "was not declared as final" autocorrect looks up the preceding sig via `SigFinder::findSignature`, which re-parses the sig to locate it. That reparse ran with the wrong owner (the instance class rather than its singleton class), so a legitimate `T.attached_class` usage was flagged as invalid, and the reparse happened once per non-final method, duplicating the error.

Add `SigFinder::findSignatureSend`, a syntax-only lookup that returns the `ast::Send` without parsing it, and use it at the two definition_validator call sites that only need the send's location, not its parsed type. `findSignature` also now parses only the single winning candidate, once, instead of every candidate it walks past.

Fixes https://github.com/sorbet/sorbet/issues/9460

### Motivation

```ruby
class Parent
  extend T::Sig, T::Helpers
  final!

  sig { returns(T.attached_class) }
  def self.make
    raise
  end
end
```

This reports two errors, but only one is real:

- `Parent was declared as final but its method make was not declared as final` — correct, `make` should be `sig(:final)`.
- `T.attached_class may only be used in singleton methods on classes...` — wrong. `make` **is** a singleton method; `T.attached_class` is used correctly here. Sorbet is reporting an error against code that isn't there.

The bogus error only appears because fixing the *real* error (adding the missing `sig(:final)`) requires locating the `sig` to build the autocorrect edit, and that lookup happens to run the sig back through the full type-checker as a side effect. Removing `final!` removes the (correct) trigger for that lookup, and the bogus error disappears along with it — which is what made this confusing to diagnose from the user's side, since the two errors look unrelated but one causes the other.

### Test plan

Added `test/testdata/resolver/final_attached_class.rb`, a test_corpus regression test covering:

- A `final!` class with one non-final `self.` method whose sig uses `T.attached_class` — asserts only the legitimate "was not declared as final" error fires, and the bogus `T.attached_class` error does not.
- The same setup with two non-final methods, to cover the duplicate-error variant (previously the bogus error fired once per non-final method in the class).

Confirmed the test fails on `master` (reproduces both bugs) and passes with this fix, via:

```
bazel test //test:test_PosTests/testdata/resolver/final_attached_class
```

Also ran the full `resolver/` and `definition_validator/` test-corpus suites, plus the `move_method` and `convert_to_singleton_method` LSP code-action tests (the two callers that rely on `SigFinder`'s parsed-sig output, to confirm they're unaffected by the only-parse-the-winner change) — 295/295 pass, no regressions.
