### PR TITLE
Use source hashes to detect edits

### DIFF
--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -119,7 +119,7 @@ LSPIndexer::getTypecheckingPathInternal(const vector<shared_ptr<core::File>> &ch
         // working in `__package.rb` since every edit causes a slow path.
         // Note: We don't use File::isPackage because we have not necessarily set the packager options on initialGS yet
         if (this->config->opts.cacheSensitiveOptions.sorbetPackages && oldFile.hasPackageRbPath() &&
-            oldFile.source() != f->source()) {
+            oldFile.sourceHash() != f->sourceHash()) {
             logger.debug("Taking slow path because {} is a package file", f->path());
             prodCategoryCounterInc("lsp.slow_path_reason", "package_file");
             timeit.setTag("path_chosen", "slow");

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -298,6 +298,7 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
         ENFORCE(fref.exists(), "New files are not supported in the fast path");
         ENFORCE(fref == gs->findFileByPath(file->path()));
 
+        auto newHash = file->sourceHash();
         auto oldFile = gs->replaceFile(fref, std::move(file));
 
         if (shouldRunIncrementalNamer) {
@@ -318,10 +319,12 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
             oldFoundHashesForFiles.emplace(fref, oldFile->getFileHash());
         }
 
-        // We track the edit stratum for all files that were updated by the edit. Unfortunately this
-        // will include files that were opened, but not changed. In the future, if we can tell if the
-        // file was changed by the edit, we should make this update to `editStratum` conditional.
-        editStratum = std::min(this->fileToStratum[fref.id()], editStratum);
+        // We track the edit stratum for all files that were updated by the edit, if their source hashes differ. This
+        // will avoid bumping the fastPathEditStratum down when the file was opened by a query like go-to-definition,
+        // but is still fairly coarse grained, as any change will mark the package as needing to be re-typechecked.
+        if (oldFile->sourceHash() != newHash) {
+            editStratum = std::min(this->fileToStratum[fref.id()], editStratum);
+        }
 
         // If file doesn't have a typed: sigil, then we need to ensure it's typechecked using typed: false.
         fref.data(*gs).strictLevel = pipeline::decideStrictLevel(*gs, fref, config->opts);
@@ -471,7 +474,7 @@ core::packages::Stratum determineStartingStratum(const core::GlobalState &gs,
             // We can't keep any part of the symbol table if the package file has changed. The byte-for-byte comparison
             // is a little expensive here, but we could refactor LSPIndexer::getTypecheckingPathInternal to cache the
             // results of this check on the LSPFileUpdates so that we could avoid the additional check here.
-            if (file->hasPackageRbPath() && fref.data(gs).source() != file->source()) {
+            if (file->hasPackageRbPath() && fref.data(gs).sourceHash() != file->sourceHash()) {
                 return core::packages::Stratum(0);
             }
 

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -1594,4 +1594,94 @@ TEST_CASE_FIXTURE(ProtocolTest, "ErrorsRemainAfterSlowPathRestart") {
     }
 }
 
+// Tests that no-op fast path edits don't push the fastPathEditStratum down, affecting where we can start the next slow
+// path from.
+TEST_CASE_FIXTURE(ProtocolTest, "ViewingFilesDoesntAffectFastPathEditStratum") {
+    auto initOpts = make_shared<realmain::options::Options>();
+    initOpts->cacheSensitiveOptions.sorbetPackages = true;
+    initOpts->packageDirected = true;
+    resetState(initOpts);
+
+    vector<pair<string, string>> files = {
+        {"__package.rb", PackageTextBuilder().withName("Root").withExports({"Root::A"}).build()},
+        {"a.rb", "# typed: true\n"
+                 "module Root\n"
+                 "  class A\n"
+                 "    def fun\n"
+                 "    end\n"
+                 "  end\n"
+                 "end\n"},
+        {"foo/__package.rb",
+         PackageTextBuilder().withName("Root::Foo").withExports({"Root::Foo::A"}).withImports({"Root"}).build()},
+        {"foo/a.rb", "# typed: true\n"
+                     "module Root::Foo\n"
+                     "  class A\n"
+                     "    def foo\n"
+                     "      Root::A.new()\n"
+                     "    end\n"
+                     "  end\n"
+                     "end\n"},
+    };
+
+    writeFilesToFS(files);
+
+    for (auto &[path, _] : files) {
+        this->lspWrapper->opts->inputFileNames.emplace_back(fmt::format("{}/{}", this->rootPath, path));
+    }
+
+    auto supportsMarkdown = true;
+    auto supportsCodeActionResolve = true;
+    auto opts = make_unique<SorbetInitializationOptions>();
+    opts->enableTypecheckInfo = true;
+
+    // The initial slow path.
+    assertErrorDiagnostics(initializeLSP(supportsMarkdown, supportsCodeActionResolve, move(opts)), {});
+
+    // Only open a.rb, to test that we skip this stratum on the next slow path
+    assertErrorDiagnostics(send(*openFile(files[1].first, files[1].second)), {});
+
+    // Make a slow path edit to Root::Foo::A
+    {
+        assertErrorDiagnostics(send(*openFile(files[3].first, files[3].second)), {});
+
+        // Make a slow path modification to an existing file.
+        auto resps = send(*changeFile(files[3].first,
+                                      "# typed: true\n"
+                                      "module Root::Foo\n"
+                                      "  class A\n"
+                                      "    module Foo\n"
+                                      "    end\n"
+                                      "\n"
+                                      "    def foo\n"
+                                      "      Root::A.new() + :type_error\n"
+                                      "    end\n"
+                                      "  end\n"
+                                      "end\n",
+                                      2));
+
+        // We should see at a minimum the start/end typechecking messages.
+        REQUIRE(resps.size() >= 2);
+
+        // We should see a starting and ending slow path message, with errors between. The error message between is the
+        // error on `Root::Foo::A`.
+        CHECK_EQ(resps.size(), 3);
+        {
+            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps.front()->asNotification().params);
+            CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
+            CHECK_EQ(params->status, SorbetTypecheckRunStatus::Started);
+        }
+
+        {
+            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps.back()->asNotification().params);
+            CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
+            CHECK_EQ(params->status, SorbetTypecheckRunStatus::Ended);
+
+            // We're modifying package `Root::Foo`, after a no-op edit to `Root`. As a result, we should restart at
+            // stratum 1.
+            CHECK_EQ(params->startingStratum, 1);
+        }
+
+        assertErrorDiagnostics(move(resps), {{files[3].first, 7, "Method `+` does not exist"}});
+    }
+}
 } // namespace sorbet::test::lsp


### PR DESCRIPTION
Avoid unnecessarily lowering the `LSPTypechecker::fastPathEditStratum` when file edits don't change the source. This will stop us from pessimistically bounding the next copy of symbol table by the package of the last file opened, and will instead bound by the package of the last file changed.

This still isn't perfect, as we would ideally compare the locs of the file hashes. However, we need this information computed anyway for working with the kvstore cache, so we might as well use it to stop penalizing folks from using features like go-to-definition.

### Motivation
Performance of Sorbet in package-directed mode.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
