### PR TITLE
Be careful with type members when reporting a possible crash

### DIFF
--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -71,8 +71,17 @@ private:
                 auto params = app.targs;
 
                 if (members.size() != params.size()) [[unlikely]] {
-                    auto memberNames =
-                        fmt::map_join(members, ", ", [&](auto m) { return m.data(ctx)->name.show(ctx); });
+                    auto memberNames = fmt::map_join(members, ", ", [&](core::TypeMemberRef m) {
+                        if (!m.exists()) {
+                            return "<missing member>"s;
+                        }
+
+                        if (m.id() >= ctx.state.typeMembersUsed()) {
+                            return "<type member from a future stratum>"s;
+                        }
+
+                        return m.data(ctx)->name.show(ctx);
+                    });
                     fatalLogger->error(R"(msg="types should be fully saturated" loc="{}" members="[{}]" app="{}")",
                                        this->loc.showRaw(ctx), memberNames, app.show(ctx));
                     ENFORCE(false);


### PR DESCRIPTION
Avoid dereferencing a type member when reporting crash diagnostics, if it doesn't exist, or would have come from a later package.

### Motivation
Debugging an infrequent crash.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No tests, just diagnostic info
