### PR TITLE
Move sig finder internals out of the header

### DIFF
--- a/core/sig_finder/sig_finder.cc
+++ b/core/sig_finder/sig_finder.cc
@@ -1,7 +1,4 @@
-#include "absl/strings/ascii.h"
-#include "absl/strings/match.h"
 #include "ast/treemap/treemap.h"
-#include "core/core.h"
 
 #include "core/sig_finder/sig_finder.h"
 
@@ -27,114 +24,136 @@ core::SymbolRef getEffectiveOwner(core::Context ctx) {
     }
 }
 
-} // namespace
+struct SigFinderTraversal {
+    const core::Loc queryLoc;
 
-void SigFinder::preTransformClassDef(core::Context ctx, const ast::ClassDef &tree) {
-    auto loc = ctx.locAt(tree.loc);
+    // Track the narrowest location range that still contains the queryLoc.
+    //
+    // If we find a method that's after queryLoc but it's not in this narrowest range,
+    // it means we found a sig that's outside the scope where the queryLoc was.
+    core::Loc narrowestClassDefRange;
 
-    if (!this->narrowestClassDefRange.exists()) {
-        // No narrowestClassDefRange yet, so take the loc of the first ClassDef we see
-        // Usually this is the `<root>` class (whole file), but sometimes the caller might provide
-        // us a specific ClassDef to look in if it has one (not necessarily root)
-        this->narrowestClassDefRange = loc;
-    } else if (loc.contains(this->queryLoc) && this->narrowestClassDefRange.contains(loc)) {
-        // `loc` is contained in the current narrowestClassDefRange, and still contains `queryLoc`
-        this->narrowestClassDefRange = loc;
+    // Track whether the current scope has the queryLoc.
+    std::vector<bool> scopeContainsQueryLoc;
 
-        if (this->result_.has_value() && !loc.contains(ctx.locAt(this->result_->origSend.loc))) {
-            // If there's a result and it's not contained in the new narrowest range, we have to toss it out
-            // (Method defs and class defs are not necessarily sorted by their locs)
-            this->result_ = nullopt;
+    std::optional<SigFinder::Result> result_;
+
+    SigFinderTraversal(core::Loc queryLoc)
+        : queryLoc(queryLoc), narrowestClassDefRange(core::Loc::none()), scopeContainsQueryLoc(std::vector<bool>{}),
+          result_(std::nullopt) {}
+
+    void preTransformClassDef(core::Context ctx, const ast::ClassDef &tree) {
+        auto loc = ctx.locAt(tree.loc);
+
+        if (!this->narrowestClassDefRange.exists()) {
+            // No narrowestClassDefRange yet, so take the loc of the first ClassDef we see
+            // Usually this is the `<root>` class (whole file), but sometimes the caller might provide
+            // us a specific ClassDef to look in if it has one (not necessarily root)
+            this->narrowestClassDefRange = loc;
+        } else if (loc.contains(this->queryLoc) && this->narrowestClassDefRange.contains(loc)) {
+            // `loc` is contained in the current narrowestClassDefRange, and still contains `queryLoc`
+            this->narrowestClassDefRange = loc;
+
+            if (this->result_.has_value() && !loc.contains(ctx.locAt(this->result_->origSend.loc))) {
+                // If there's a result and it's not contained in the new narrowest range, we have to toss it out
+                // (Method defs and class defs are not necessarily sorted by their locs)
+                this->result_ = nullopt;
+            }
+        }
+
+        this->scopeContainsQueryLoc.emplace_back(loc.contains(this->queryLoc));
+    }
+
+    void postTransformClassDef(core::Context ctx, const ast::ClassDef &tree) {
+        ENFORCE(!this->scopeContainsQueryLoc.empty());
+        this->scopeContainsQueryLoc.pop_back();
+    }
+
+    void preTransformMethodDef(core::Context ctx, const ast::MethodDef &tree) {
+        if (this->result_.has_value()) {
+            if (this->result_->origSend.loc.endPos() <= tree.loc.beginPos() &&
+                tree.loc.endPos() <= queryLoc.beginPos()) {
+                // There is a method definition between the current result sig and the queryLoc,
+                // so the sig we found is not for the right method.
+                this->result_ = nullopt;
+            }
         }
     }
 
-    this->scopeContainsQueryLoc.emplace_back(loc.contains(this->queryLoc));
-}
-
-void SigFinder::postTransformClassDef(core::Context ctx, const ast::ClassDef &tree) {
-    ENFORCE(!this->scopeContainsQueryLoc.empty());
-    this->scopeContainsQueryLoc.pop_back();
-}
-
-void SigFinder::preTransformMethodDef(core::Context ctx, const ast::MethodDef &tree) {
-    if (this->result_.has_value()) {
-        if (this->result_->origSend.loc.endPos() <= tree.loc.beginPos() && tree.loc.endPos() <= queryLoc.beginPos()) {
-            // There is a method definition between the current result sig and the queryLoc,
-            // so the sig we found is not for the right method.
-            this->result_ = nullopt;
+    void postTransformRuntimeMethodDefinition(core::Context ctx, const ast::RuntimeMethodDefinition &tree) {
+        if (this->result_.has_value()) {
+            if (this->result_->origSend.loc.endPos() <= tree.loc.beginPos() &&
+                tree.loc.endPos() <= queryLoc.beginPos()) {
+                // There is a method definition between the current result sig and the queryLoc,
+                // so the sig we found is not for the right method.
+                this->result_ = nullopt;
+            }
         }
     }
-}
 
-void SigFinder::postTransformRuntimeMethodDefinition(core::Context ctx, const ast::RuntimeMethodDefinition &tree) {
-    if (this->result_.has_value()) {
-        if (this->result_->origSend.loc.endPos() <= tree.loc.beginPos() && tree.loc.endPos() <= queryLoc.beginPos()) {
-            // There is a method definition between the current result sig and the queryLoc,
-            // so the sig we found is not for the right method.
-            this->result_ = nullopt;
+    void preTransformSend(core::Context ctx, const ast::Send &send) {
+        if (!resolver::TypeSyntax::isSig(ctx, send)) {
+            return;
         }
-    }
-}
 
-void SigFinder::preTransformSend(core::Context ctx, const ast::Send &send) {
-    if (!resolver::TypeSyntax::isSig(ctx, send)) {
-        return;
-    }
+        ENFORCE(!this->scopeContainsQueryLoc.empty());
+        if (!this->scopeContainsQueryLoc.back()) {
+            // Regardless of whether this send is after the queryLoc or inside the narrowestClassDefRange,
+            // we're in a ClassDef whose scope doesn't contain the queryLoc.
+            // (one case where this happens: nested Inner class)
+            return;
+        }
 
-    ENFORCE(!this->scopeContainsQueryLoc.empty());
-    if (!this->scopeContainsQueryLoc.back()) {
-        // Regardless of whether this send is after the queryLoc or inside the narrowestClassDefRange,
-        // we're in a ClassDef whose scope doesn't contain the queryLoc.
-        // (one case where this happens: nested Inner class)
-        return;
-    }
+        auto currentLoc = ctx.locAt(send.loc);
+        if (!currentLoc.exists()) {
+            // Defensive in case location information is disabled (e.g., certain fuzzer modes)
+            return;
+        }
 
-    auto currentLoc = ctx.locAt(send.loc);
-    if (!currentLoc.exists()) {
-        // Defensive in case location information is disabled (e.g., certain fuzzer modes)
-        return;
-    }
+        ENFORCE(this->narrowestClassDefRange.exists());
 
-    ENFORCE(this->narrowestClassDefRange.exists());
+        if (!this->narrowestClassDefRange.contains(currentLoc)) {
+            // This send occurs outside the current narrowest range we know of for a ClassDef that
+            // still contains queryLoc, so even if this Send is after the queryLoc, it would not be
+            // in the right scope.
+            return;
+        } else if (!(currentLoc.endPos() <= this->queryLoc.beginPos())) {
+            // Query loc is not after the send
+            return;
+        }
 
-    if (!this->narrowestClassDefRange.contains(currentLoc)) {
-        // This send occurs outside the current narrowest range we know of for a ClassDef that
-        // still contains queryLoc, so even if this Send is after the queryLoc, it would not be
-        // in the right scope.
-        return;
-    } else if (!(currentLoc.endPos() <= this->queryLoc.beginPos())) {
-        // Query loc is not after the send
-        return;
-    }
-
-    if (this->result_.has_value()) {
-        // Method defs are not guaranteed to be sorted in order by their declLocs
-        auto resultLoc = this->result_->origSend.loc;
-        if (resultLoc.beginPos() < currentLoc.beginPos()) {
-            // Found a method defined before the query but later than previous result: overwrite previous result
+        if (this->result_.has_value()) {
+            // Method defs are not guaranteed to be sorted in order by their declLocs
+            auto resultLoc = this->result_->origSend.loc;
+            if (resultLoc.beginPos() < currentLoc.beginPos()) {
+                // Found a method defined before the query but later than previous result: overwrite previous result
+                auto owner = getEffectiveOwner(ctx);
+                auto parsedSig =
+                    resolver::TypeSyntax::parseSigTop(ctx.withOwner(owner), send, core::Symbols::untyped());
+                this->result_.emplace(move(parsedSig), send);
+            } else {
+                // We've already found an earlier result, so the current is not the first
+            }
+        } else {
+            // Haven't found a result yet, so this one is the best so far.
             auto owner = getEffectiveOwner(ctx);
             auto parsedSig = resolver::TypeSyntax::parseSigTop(ctx.withOwner(owner), send, core::Symbols::untyped());
-            this->result_.emplace(move(parsedSig), send);
-        } else {
-            // We've already found an earlier result, so the current is not the first
-        }
-    } else {
-        // Haven't found a result yet, so this one is the best so far.
-        auto owner = getEffectiveOwner(ctx);
-        auto parsedSig = resolver::TypeSyntax::parseSigTop(ctx.withOwner(owner), send, core::Symbols::untyped());
 
-        this->result_.emplace(move(parsedSig), send);
+            this->result_.emplace(move(parsedSig), send);
+        }
     }
-}
+};
+
+} // namespace
 
 optional<SigFinder::Result> SigFinder::findSignature(core::Context ctx, const ast::ExpressionPtr &tree,
                                                      core::Loc queryLoc) {
-    SigFinder sigFinder(queryLoc);
+    SigFinderTraversal sigFinder(queryLoc);
     ast::ConstTreeWalk::apply(ctx, sigFinder, tree);
     return move(sigFinder.result_);
 }
 optional<SigFinder::Result> SigFinder::findSignature(core::Context ctx, const ast::ClassDef &tree, core::Loc queryLoc) {
-    SigFinder sigFinder(queryLoc);
+    SigFinderTraversal sigFinder(queryLoc);
     ast::ConstTreeWalk::apply(ctx, sigFinder, tree);
     return move(sigFinder.result_);
 }

--- a/core/sig_finder/sig_finder.h
+++ b/core/sig_finder/sig_finder.h
@@ -1,6 +1,6 @@
 #ifndef SORBET_SIG_FINDER
 #define SORBET_SIG_FINDER
-#include "core/core.h"
+
 #include "resolver/type_syntax/type_syntax.h"
 
 namespace sorbet::sig_finder {
@@ -12,31 +12,6 @@ public:
         const ast::Send &origSend;
         Result(resolver::ParsedSig &&sig, const ast::Send &origSend) : sig(std::move(sig)), origSend(origSend) {}
     };
-
-private:
-    const core::Loc queryLoc;
-
-    // Track the narrowest location range that still contains the queryLoc.
-    //
-    // If we find a method that's after queryLoc but it's not in this narrowest range,
-    // it means we found a sig that's outside the scope where the queryLoc was.
-    core::Loc narrowestClassDefRange;
-
-    // Track whether the current scope has the queryLoc.
-    std::vector<bool> scopeContainsQueryLoc;
-
-    std::optional<Result> result_;
-
-public:
-    SigFinder(core::Loc queryLoc)
-        : queryLoc(queryLoc), narrowestClassDefRange(core::Loc::none()), scopeContainsQueryLoc(std::vector<bool>{}),
-          result_(std::nullopt) {}
-
-    void preTransformClassDef(core::Context ctx, const ast::ClassDef &tree);
-    void postTransformClassDef(core::Context ctx, const ast::ClassDef &tree);
-    void preTransformMethodDef(core::Context ctx, const ast::MethodDef &tree);
-    void postTransformRuntimeMethodDefinition(core::Context ctx, const ast::RuntimeMethodDefinition &tree);
-    void preTransformSend(core::Context ctx, const ast::Send &tree);
 
     static std::optional<Result> findSignature(core::Context ctx, const ast::ExpressionPtr &tree, core::Loc queryLoc);
     static std::optional<Result> findSignature(core::Context ctx, const ast::ClassDef &tree, core::Loc queryLoc);


### PR DESCRIPTION
I'd like to refactor the `SigFinder` to use `TreeQuery`, but right now that's an unpleasant refactor because the the internals of its traversal are in the public header. This PR moves the traversal itself to a struct that's private to `sig_finder.cc`, which makes its internals a bit easier to change.

Reviewing with whitespace disabled should show that this is a pretty simple refactor.

### Motivation
Refactoring.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No changes expected, pure refactor.
