### PR TITLE
Show UTF-8 in string/symbol literal types instead of octal escapes

### DIFF
--- a/core/Names.cc
+++ b/core/Names.cc
@@ -158,7 +158,7 @@ string NameRef::show(const GlobalState &gs) const {
 string NameRef::showAsSymbolLiteral(const GlobalState &gs) const {
     auto shown = this->show(gs);
     if (absl::StrContains(shown, " ")) {
-        return fmt::format(":\"{}\"", absl::CEscape(shown));
+        return fmt::format(":\"{}\"", absl::Utf8SafeCEscape(shown));
     } else {
         return fmt::format(":{}", shown);
     }

--- a/core/types/printing.cc
+++ b/core/types/printing.cc
@@ -81,7 +81,7 @@ string NamedLiteralType::show(const GlobalState &gs, ShowOptions options) const 
 string NamedLiteralType::showValue(const GlobalState &gs) const {
     switch (kind) {
         case NamedLiteralType::Kind::String:
-            return fmt::format("\"{}\"", absl::CEscape(name.show(gs)));
+            return fmt::format("\"{}\"", absl::Utf8SafeCEscape(name.show(gs)));
         case NamedLiteralType::Kind::Symbol: {
             return name.showAsSymbolLiteral(gs);
         }

--- a/test/testdata/lsp/utf8_safe_string_literal_display.rb
+++ b/test/testdata/lsp/utf8_safe_string_literal_display.rb
@@ -1,0 +1,24 @@
+# typed: true
+extend T::Sig
+
+accented = "café"
+# ^ hover: String("café")
+
+emoji = "😀"
+# ^ hover: String("😀")
+
+sym = :café
+# ^ hover: Symbol(:café)
+
+spaced = :"hello café"
+# ^ hover: Symbol(:"hello café")
+
+sig { params(x: Integer).void }
+def foo(x)
+  puts(x)
+end
+
+foo("café") # error: Expected `Integer` but found `String("café")`
+foo("😀") # error: Expected `Integer` but found `String("😀")`
+foo(:café) # error: Expected `Integer` but found `Symbol(:café)`
+foo(:"hello café") # error: Expected `Integer` but found `Symbol(:"hello café")`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Hover and error messages currently render non-ASCII string/symbol literal types with `absl::CEscape`, so e.g. `"café"` shows up as `String("caf\303\251")`.

Switch to `absl::Utf8SafeCEscape` so UTF-8 stays readable while controls and quotes are still escaped.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Literal types with non-ASCII UTF-8 are hard to read in hover and diagnostics because every non-ASCII byte is octal-escaped.

CEscape was added in #1579 to escape newlines/quotes in diagnostic text (see test/cli/escaping). Octal-escaping UTF-8 was a side effect, not the goal. Utf8SafeCEscape keeps that intent.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
