### PR TITLE
Revert "Make sorbet-runtime tolerant of method redefinitions"

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -42,16 +42,13 @@ module T::Private::Methods
   end
   # rubocop:enable Naming/ClassAndModuleCamelCase
 
-  # sig_state:
+  # blk_or_decl:
   # - It's a `Proc` if we haven't forced the thunk yet.
   # - It's a `Declaration` if we have, but we haven't finished building the sig
   #   (This can matter for circular load-time behavior, where a method is
   #   called while its Signature is being built)
-  # - It's a `Signature` if we've finished building the sig. This allows
-  #   the first-call wrapper to find its own signature even if it was
-  #   evaluated externally (e.g., by run_all_sig_blocks) and
-  #   @signatures_by_method[key] was overwritten by a redefinition.
-  DeclarationBlock = Struct.new(:mod, :method_name, :loc, :sig_state, :final, :abstract, :override, :overridable)
+  # - It's `nil` if we've finished building the sig
+  DeclarationBlock = Struct.new(:mod, :method_name, :loc, :blk_or_decl, :final, :abstract, :override, :overridable)
 
   def self.declare_sig(mod, loc, arg, &blk)
     if T::Private::DeclState.current.active_declaration
@@ -79,7 +76,7 @@ module T::Private::Methods
       raise DeclBuilder::BuilderError.new("You must declare a `sig` before using `#{dsl_name}` on the method `#{method_name}`")
     end
 
-    if !previous_declaration.sig_state.is_a?(Proc)
+    if !previous_declaration.blk_or_decl.is_a?(Proc)
       raise DeclBuilder::BuilderError.new("Cannot call `#{dsl_name} #{method_name.inspect}`, because the sig block has already run")
     end
 
@@ -323,26 +320,6 @@ module T::Private::Methods
     end
 
     if current_declaration.nil?
-      key = method_owner_and_name_to_key(mod, method_name)
-      # Drop any existing sig, because the `sig_block` closes over the
-      # `original_method` at the time that the sig wrapper was registered, and
-      # forcing the sig would thus redefine the the redefined method back to
-      # the original method.
-      old_sig = @sig_wrappers.delete(key)
-
-      # Ruby only reports method redefinitions if `$VERBOSE` is truthy. Let's
-      # do the same for sigs.
-      if old_sig && $VERBOSE
-        # We can probably get away with not printing any location information
-        # (like the Ruby VM would for method redefinition warnings) because the
-        # Ruby VM itself will have printed the location information in its
-        # method redefinition warning (and it does that faster, using functions
-        # that constult the CFP directly).
-        Warning.warn(
-          "sorbet-runtime: warning: Dropping unevaluated signature for #{mod}##{method_name} because it was redefined\n"
-        )
-      end
-
       return
     end
 
@@ -371,7 +348,7 @@ module T::Private::Methods
 
     original_method = mod.instance_method(method_name)
     sig_block = lambda do
-      T::Private::Methods.run_sig(method_name, original_method, current_declaration, unwrap: true)
+      T::Private::Methods.run_sig(method_name, original_method, current_declaration)
     end
 
     # Always replace the original method with this wrapper,
@@ -379,56 +356,23 @@ module T::Private::Methods
     # This wrapper is very slow, so it will subsequently re-wrap with a much faster wrapper
     # (or unwrap back to the original method).
     key = method_owner_and_name_to_key(mod, method_name)
-    built_sig = nil
-    if T::Private::IS_TYPECHECKING
-      built_sig = T.let(nil, T.nilable(Signature))
-    end
     T::Private::ClassUtils.replace_method(original_method, mod, method_name) do |*args, &blk|
-      callee = Kernel.__callee__ || raise("Unknown __callee__ for method without a signature")
-      method_sig = built_sig
+      method_sig = T::Private::Methods.maybe_run_sig_block_for_key(key)
       if !method_sig
-        # Check if this wrapper's sig_block is still the active one for this key
-        #
-        # If not, the method was redefined and this wrapper is being called via
-        # a captured method object from reflection (e.g., `instance_method` or
-        # `method` from before the redefinition).
-        #
-        # We can only use maybe_run_sig_block_for_key if there was no
-        # redefinition, because it would otherwise call unwrap_method,
-        # overwriting the redefinition.
-        method_sig =
-          if T::Private::Methods._sig_block_is_current?(key, sig_block)
-            T::Private::Methods.maybe_run_sig_block_for_key(key)
-          elsif !(method_sig = current_declaration.sig_state).is_a?(Signature)
-            # This is essentially a permanent slow path: since the method was
-            # redefined before the sig block had a chance to run, we can't unwrap
-            # the method, as that would overwrite the redefinition, effectively
-            # putting the method back to its original definition. (Note that
-            # `run_sig` is what we call in the `sig_block`, but this one just
-            # doesn't unwrap.)
-            T::Private::Methods.run_sig(method_name, original_method, current_declaration, unwrap: false)
-          else
-            # The declaration was already consumed (e.g., module_function copies
-            # the first-call wrapper to the singleton class, sharing the same
-            # DeclarationBlock; if the instance method's sig is evaluated first,
-            # sig_state is a Signature when the singleton copy runs).
-            method_sig
-          end
+        callee = __callee__ || raise("Unknown __callee__ for method without a signature")
+        method_sig = T::Private::Methods.signature_for_method(original_method)
         if !method_sig
-          method_sig = T::Private::Methods.signature_for_method(original_method)
-          if !method_sig
-            raise "`sig` not present for method `#{callee}` on #{self.inspect} but you're trying to run it anyways. " \
-              "This should only be executed if you used `alias_method` to grab a handle to a method after `sig`ing it, but that clearly isn't what you are doing. " \
-              "Maybe look to see if an exception was thrown in your `sig` lambda or somehow else your `sig` wasn't actually applied to the method."
-          end
+          raise "`sig` not present for method `#{callee}` on #{self.inspect} but you're trying to run it anyways. " \
+            "This should only be executed if you used `alias_method` to grab a handle to a method after `sig`ing it, but that clearly isn't what you are doing. " \
+            "Maybe look to see if an exception was thrown in your `sig` lambda or somehow else your `sig` wasn't actually applied to the method."
         end
-        built_sig = method_sig
-      end
 
-      # If this wrapper is being called via an alias, unwrap the alias so
-      # subsequent calls bypass the wrapper entirely.
-      if callee != method_name
-        T::Private::Methods._unwrap_alias(method_sig, self, original_method, callee)
+        method_sig = T::Private::Methods._unwrap_alias(
+          method_sig,
+          self,
+          original_method,
+          callee,
+        )
       end
 
       # Should be the same logic as CallValidation.wrap_method_if_needed but we
@@ -488,7 +432,7 @@ module T::Private::Methods
 
   # Executes the `sig` block, and converts the resulting Declaration
   # to a Signature.
-  def self.run_sig(method_name, original_method, declaration_block, unwrap:)
+  def self.run_sig(method_name, original_method, declaration_block)
     current_declaration =
       begin
         run_builder(declaration_block)
@@ -507,29 +451,21 @@ module T::Private::Methods
         Signature.new_untyped(method: original_method)
       end
 
-    if unwrap
-      unwrap_method(signature.method.owner, signature, original_method)
-    end
+    unwrap_method(signature.method.owner, signature, original_method)
 
-    # Store the finished signature (dropping the Declaration in the process).
-    # Only do this after we've actually wrapped the method and recorded the
-    # signature, because that might raise an exception, leaving the
-    # declaration in a weird state if the program rescues that exception and
-    # continues.
-    #
-    # Storing the signature here allows the first-call wrapper to find its
-    # own signature even if it was evaluated externally (e.g., by
-    # run_all_sig_blocks) and @signatures_by_method[key] was later overwritten
-    # by a redefinition.
-    declaration_block.sig_state = signature
+    # Drop this declaration. Only drop it after we've actually wrapped the
+    # method and recorded the signature, because that might raise an exception,
+    # leaving the declaration in a weird state if the program rescues that
+    # exception and continues.
+    declaration_block.blk_or_decl = nil
 
     signature
   end
 
   def self.run_builder(declaration_block)
-    sig_state = declaration_block.sig_state
-    return sig_state if sig_state.is_a?(Declaration)
-    if !sig_state.is_a?(Proc)
+    blk_or_decl = declaration_block.blk_or_decl
+    return blk_or_decl if blk_or_decl.is_a?(Declaration)
+    if blk_or_decl.nil?
       raise "DeclarationBlock for #{declaration_block.mod} at #{declaration_block.loc} should have already been unwrapped"
     end
 
@@ -539,9 +475,9 @@ module T::Private::Methods
       declaration_block.override,
       declaration_block.overridable
     )
-    decl = builder.instance_exec(&sig_state).finalize!.decl
+    decl = builder.instance_exec(&blk_or_decl).finalize!.decl
     # Record that we've already run `blk` once and constructed a `Declaration`
-    declaration_block.sig_state = decl
+    declaration_block.blk_or_decl = decl
     decl
   end
 
@@ -598,11 +534,6 @@ module T::Private::Methods
 
   def self.has_sig_block_for_method(method)
     has_sig_block_for_key(method_to_key(method))
-  end
-
-  # Only public because it needs to get called inside the first-call wrapper closure.
-  def self._sig_block_is_current?(key, sig_block)
-    @sig_wrappers[key].equal?(sig_block)
   end
 
   private_class_method def self.has_sig_block_for_key(key)

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
@@ -11,8 +11,8 @@ module T::Private::Methods
     sig {returns(T.nilable(Thread::Backtrace::Location))}
     attr_accessor :loc
 
-    sig {returns(T.any(T.proc.returns(DeclBuilder), Declaration, Signature))}
-    attr_accessor :sig_state
+    sig {returns(T.nilable(T.any(T.proc.returns(DeclBuilder), Declaration)))}
+    attr_accessor :blk_or_decl
 
     sig {returns(T::Boolean)}
     attr_accessor :final
@@ -31,7 +31,7 @@ module T::Private::Methods
         mod: Module,
         method_name: T.nilable(Symbol),
         loc: T.nilable(Thread::Backtrace::Location),
-        sig_state: Proc,
+        blk: Proc,
         final: T::Boolean,
         abstract: T.nilable(T::Boolean),
         override: T.nilable({allow_incompatible: T.any(T::Boolean, Symbol)}),
@@ -39,7 +39,7 @@ module T::Private::Methods
       )
         .void
     end
-    def initialize(mod, method_name, loc, sig_state, final, abstract, override, overridable); end
+    def initialize(mod, method_name, loc, blk, final, abstract, override, overridable); end
   end
 
   @installed_hooks = T.let({}, T::Hash[Module, TrueClass])
@@ -96,11 +96,8 @@ module T::Private::Methods
   sig {params(method_sig: Signature, receiver: Object, original_method: UnboundMethod, callee: Symbol).returns(T::Private::Methods::Signature)}
   def self._unwrap_alias(method_sig, receiver, original_method, callee); end
 
-  sig {params(method_name: Symbol, original_method: UnboundMethod, declaration_block: DeclarationBlock, unwrap: T::Boolean).returns(T::Private::Methods::Signature)}
-  def self.run_sig(method_name, original_method, declaration_block, unwrap:); end
-
-  sig {params(key: String, sig_block: T.proc.returns(Signature)).returns(T::Boolean)}
-  def self._sig_block_is_current?(key, sig_block); end
+  sig {params(method_name: Symbol, original_method: UnboundMethod, declaration_block: DeclarationBlock).returns(T::Private::Methods::Signature)}
+  def self.run_sig(method_name, original_method, declaration_block); end
 
   sig {params(declaration_block: DeclarationBlock).returns(T::Private::Methods::Declaration)}
   def self.run_builder(declaration_block); end

--- a/gems/sorbet-runtime/test/types/edge_cases.rb
+++ b/gems/sorbet-runtime/test/types/edge_cases.rb
@@ -331,7 +331,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Shouldn't add overhead
         klass.bar # Need extra call since first one came before `foo` unwrap
         allocs = counting_allocations { klass.bar }
-        assert_equal(0, allocs)
+        assert_equal(1, allocs)
         allocs = counting_allocations { klass.bar }
         assert_equal(0, allocs)
       end
@@ -379,7 +379,7 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
         # Shouldn't add overhead
         klass.bar # Need extra call since first one came before `foo` unwrap
         allocs = counting_allocations { klass.bar }
-        assert_equal(0, allocs)
+        assert_equal(1, allocs)
         allocs = counting_allocations { klass.bar }
         assert_equal(0, allocs)
       end
@@ -1014,263 +1014,12 @@ class Opus::Types::Test::EdgeCasesTest < Critic::Unit::UnitTest
     ], unique_method_redefinitions.sort)
   end
 
-  it 'drops an un-evaluated sig if the method is redefined' do
-    klass = Class.new do
-      extend T::Sig
-      sig { returns(Integer) }
-      def foo; 0; end
-
-      define_method(:foo) { "not an int" }
-    end
-
-    assert_equal("not an int", klass.new.foo)
-    assert_nil(T::Utils.signature_for_method(klass.instance_method(:foo)))
-  end
-
-  it 'does not validate a captured old method against a new sig' do
-    orig_foo = nil
-    klass = Class.new do
-      extend T::Sig
-
-      sig { params(bad: T::Boolean).returns(Integer) }
-      def self.foo(bad)
-        bad ? "not an int" : 0
-      end
-
-      orig_foo = method(:foo)
-
-      sig { params(bad: T::Boolean).returns(Float) }
-      def self.foo(bad)
-        bad ? "not a float" : 0.0
-      end
-    end
-
-    # Call new method first, to be sure that the new method doesn't overwrite
-    # the old method.
-
-    # New method validates against Float sig
-    assert_equal(0.0, klass.foo(false))
-    err = assert_raises(TypeError) { klass.foo(true) }
-    assert_match(/Expected type Float/, err.message)
-
-    # Old captured method validates against Integer sig (its own), not Float
-    assert_equal(0, orig_foo.call(false))
-    err = assert_raises(TypeError) { orig_foo.call(true) }
-    assert_match(/Expected type Integer/, err.message)
-  end
-
-  it 'preserves define_method wrapper when sig is evaluated via bind_call' do
-    klass = Class.new do
-      extend T::Sig
-
-      sig { returns(String) }
-      def foo
-        "original"
-      end
-
-      orig_foo = instance_method(:foo)
-
-      define_method(:foo) do
-        "wrapped(#{orig_foo.bind_call(self)})"
-      end
-    end
-
-    obj = klass.new
-    assert_equal("wrapped(original)", obj.foo)
-    assert_equal("wrapped(original)", obj.foo)
-  end
-
-  it 'handles module_function when instance sig is evaluated before singleton call' do
-    mod = Module.new do
-      extend T::Sig
-
-      sig { params(x: Integer).returns(Integer) }
-      module_function def foo(x)
-        x
-      end
-    end
-
-    # Evaluate the instance method's sig first, but don't actually call the
-    # method. This just touches the `sig_block`, but doesn't actually update
-    # the built sig in the wrapper method's closure.
-    T::Utils.signature_for_method(mod.instance_method(:foo))
-
-    # Call the singleton method version. Its first-call wrapper shares the same
-    # DeclarationBlock, which has already been consumed.
-    assert_equal(42, mod.foo(42))
-  end
-
-  it 'does not validate module_function singleton call against a redefined sig' do
-    mod = Module.new do
-      extend T::Sig
-
-      sig { params(x: Integer).returns(Integer) }
-      module_function def foo(x)
-        x
-      end
-
-      T::Utils.signature_for_method(instance_method(:foo))
-
-      # Redefine foo with a new sig that has a different return type.
-      sig { params(x: String).returns(String) }
-      def foo(x)
-        x
-      end
-    end
-
-    T::Utils.signature_for_method(mod.instance_method(:foo))
-
-    # Call the original module_function singleton copy. It should validate
-    # against the Integer sig not the String sig, because we only redefined the
-    # instance method.
-    assert_equal(42, mod.foo(42))
-    err = assert_raises(TypeError) { mod.foo("hello") }
-    assert_match(/Expected type Integer/, err.message)
-  end
-
-  it 'works with BasicObject subclass' do
-    mod = Module.new do
-      extend T::Sig
-      sig { returns(Integer) }
-      def foo
-        42
-      end
-    end
-
-    klass = Class.new(BasicObject) do
-      include mod
-    end
-
-    obj = klass.new
-    assert_equal(42, obj.foo)
-    assert_equal(42, obj.foo)
-  end
-
   it "can mark a class abstract! even if it defines a method called method" do
     Class.new do
       extend T::Helpers
       # bad override of Object#method
       def self.method; end
       abstract!
-    end
-  end
-
-  it 'handles alias_method + redefinition: call patched first' do
-    klass = Class.new do
-      extend T::Sig
-
-      sig { returns(T::Array[Symbol]) }
-      def test_alias_method
-        [:unpatch]
-      end
-
-      alias_method :test_alias_method_old, :test_alias_method
-      def test_alias_method
-        [:patch] + test_alias_method_old
-      end
-    end
-
-    obj = klass.new
-    3.times do
-      assert_equal(%i[patch unpatch], obj.test_alias_method)
-    end
-  end
-
-  it 'handles alias_method + redefinition: call old directly first' do
-    klass = Class.new do
-      extend T::Sig
-
-      sig { returns(T::Array[Symbol]) }
-      def test_alias_method
-        [:unpatch]
-      end
-
-      alias_method :test_alias_method_old, :test_alias_method
-      def test_alias_method
-        [:patch] + test_alias_method_old
-      end
-    end
-
-    obj = klass.new
-    # Calling _old directly triggers the wrapper with __callee__ != method_name.
-    # Must not overwrite _old with the redefined (patched) method.
-    3.times do
-      assert_equal([:unpatch], obj.test_alias_method_old)
-    end
-  end
-
-  it 'handles alias_method + redefinition that calls old method' do
-    klass = Class.new do
-      extend T::Sig
-
-      sig { returns(T::Array[Symbol]) }
-      def test_alias_method
-        [:unpatch]
-      end
-
-      alias_method :test_alias_method_old, :test_alias_method
-      def test_alias_method
-        [:patch] + test_alias_method_old
-      end
-    end
-
-    obj = klass.new
-    # Unwrap _old via direct call first
-    assert_equal([:unpatch], obj.test_alias_method_old)
-    # Then the patched method must still work (calling through _old)
-    3.times do
-      assert_equal(%i[patch unpatch], obj.test_alias_method)
-    end
-  end
-
-  it 'handles alias_method + redefinition: call patched then old directly' do
-    klass = Class.new do
-      extend T::Sig
-
-      sig { returns(T::Array[Symbol]) }
-      def test_alias_method
-        [:unpatch]
-      end
-
-      alias_method :test_alias_method_old, :test_alias_method
-      def test_alias_method
-        [:patch] + test_alias_method_old
-      end
-    end
-
-    obj = klass.new
-    # Patched calls through _old (triggers wrapper on _old via that path)
-    assert_equal(%i[patch unpatch], obj.test_alias_method)
-    # Then calling _old directly must still return the original behavior
-    3.times do
-      assert_equal([:unpatch], obj.test_alias_method_old)
-    end
-  end
-
-  it 'handles define_method redefinition: call via original UnboundMethod' do
-    original_um = nil
-    klass = Class.new do
-      extend T::Sig
-
-      sig { returns(T::Array[Symbol]) }
-      def test_patch_method
-        [:unpatch]
-      end
-
-      original_um = instance_method(:test_patch_method)
-      define_method(:test_patch_method) do
-        [:patch] + original_um.bind_call(self)
-      end
-    end
-
-    obj = klass.new
-    # Calling via the captured UnboundMethod triggers the wrapper directly
-    3.times do
-      assert_equal([:unpatch], original_um.bind_call(obj))
-    end
-    # The patched method still works
-    3.times do
-      assert_equal(%i[patch unpatch], obj.test_patch_method)
     end
   end
 end


### PR DESCRIPTION
Reverts sorbet/sorbet#10397

This caused some test failures when we attempted to upgrade Stripe's codebase to it, which somehow weren't caught by the test runs on the original Sorbet PR.

Stripe employees can see the failing build here:

http://go/builds/bui_V0aZHw8B0NB5DG

I'll have to make a repro and revisit the strategy.