### PR TITLE
Fix flaky 7027 for constants annotated in RBI files (realworld issue)

### DIFF
--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -2301,6 +2301,19 @@ class ResolveTypeMembersAndFieldsWalk {
         return result;
     }
 
+    // Whether the type of this static field is given by an explicit annotation (`X = T.let(..., Type)`),
+    // instead of being inferred from the right hand side of the assignment.
+    //
+    // Looks through `InsSeq`s, like `resolveConstantType` does.
+    static bool isExplicitlyAnnotatedStaticField(const ast::ExpressionPtr &rhs) {
+        const ast::ExpressionPtr *expr = &rhs;
+        while (auto insSeq = ast::cast_tree<ast::InsSeq>(*expr)) {
+            expr = &insSeq->expr;
+        }
+
+        return ast::isa_tree<ast::Cast>(*expr);
+    }
+
     // Tries to resolve the given static field. Returns Types::todo() if it is unable to resolve the field.
     [[nodiscard]] static core::TypePtr tryResolveStaticField(core::Context ctx, ResolveStaticFieldItem &job) {
         ENFORCE(job.sym.data(ctx)->flags.isStaticField);
@@ -3229,11 +3242,34 @@ public:
                 resolveField(ctx, job);
             }
         }
-        for (auto &threadTodos : combinedTodoResolveStaticFieldItems) {
-            for (auto &job : threadTodos) {
-                core::Context ctx(gs, job.sym, job.file);
-                if (auto resultType = resolveStaticField(ctx, job)) {
-                    job.sym.data(gs)->resultType = resultType;
+        // Resolve explicitly annotated static fields before the ones whose type has to be inferred from
+        // the right hand side of the assignment.
+        //
+        // A constant can be assigned in one file and annotated in another one, which is how an RBI file
+        // declares the type of a constant defined in a `.rb` file:
+        //
+        //     # foo.rb
+        //     X = {"a" => "b"}.freeze
+        //
+        //     # foo.rbi
+        //     X = T.let(T.unsafe(nil), T::Hash[String, String])
+        //
+        // `resolveStaticField` asks for a type annotation (error 7027) when the symbol's `resultType` is
+        // still unset by the time its job runs, so resolving the annotation last would report that the
+        // constant needs an annotation, even though it has one. These jobs are grouped by the worker
+        // thread that produced them, so which one runs first would otherwise depend on how the files
+        // were distributed across threads.
+        for (auto annotatedPass : {true, false}) {
+            for (auto &threadTodos : combinedTodoResolveStaticFieldItems) {
+                for (auto &job : threadTodos) {
+                    if (isExplicitlyAnnotatedStaticField(job.asgn->rhs) != annotatedPass) {
+                        continue;
+                    }
+
+                    core::Context ctx(gs, job.sym, job.file);
+                    if (auto resultType = resolveStaticField(ctx, job)) {
+                        job.sym.data(gs)->resultType = resultType;
+                    }
                 }
             }
         }

--- a/test/testdata/resolver/constant_annotated_in_rbi__1.rb
+++ b/test/testdata/resolver/constant_annotated_in_rbi__1.rb
@@ -1,0 +1,16 @@
+# typed: strict
+
+class ConstantAnnotatedInRbi
+  # The type annotations for these constants are in the `.rbi` file. Hash literals have no inferred
+  # type, so without an annotation, a `T.let` would be requested here.
+  MY_HASH = {
+    "a" => "b",
+  }.freeze
+
+  UNCHECKED_HASH = {
+    "c" => "d",
+  }.freeze
+end
+
+T.reveal_type(ConstantAnnotatedInRbi::MY_HASH) # error: Revealed type: `T::Hash[String, String]`
+T.reveal_type(ConstantAnnotatedInRbi::UNCHECKED_HASH) # error: Revealed type: `T::Hash[String, String]`

--- a/test/testdata/resolver/constant_annotated_in_rbi__2.rbi
+++ b/test/testdata/resolver/constant_annotated_in_rbi__2.rbi
@@ -1,0 +1,6 @@
+# typed: strict
+
+class ConstantAnnotatedInRbi
+  MY_HASH = T.let(T.unsafe(nil), T::Hash[String, String])
+  UNCHECKED_HASH = T.let(T.unsafe(nil), T::Hash[String, String], checked: false)
+end


### PR DESCRIPTION
Hi!

A constant annotated in an RBI file still gets 7027 ("Constants must have type annotations with `T.let`")
when its value is a hash literal:

```ruby
# foo.rb
# typed: strict
class Foo
  MY_HASH = {"a" => "b"}.freeze # 7027
end

# foo.rbi
# typed: strict
class Foo
  MY_HASH = T.let(T.unsafe(nil), T::Hash[String, String])
end
```

It's also unstable — ten runs over an unmodified tree gave me 2, 0, 2, 1, 2, 1, 2, 1, 2, 1 errors.

This isn't a reduced case: I hit it in a production repo, on constants in AWS Lambda handlers that run
without `sorbet-runtime`, so the `.rb` can't carry a `T.let` and the RBI file is the only place to annotate
them. The effect is CI that goes red or green at random on an unchanged commit, and the only workaround I
found is duplicating the annotation in the `.rb` behind an `if defined?(T::Sig)` guard, so that it resolves
earlier in the same file.

`resolveStaticField` asks for an annotation when the symbol's `resultType` is still unset by the time its job
runs, and hash literals have no inferred type, so the `.rb` job needs the RBI's `T.let` job to have run
first. Both are deferred, since the annotated type isn't a simple class type, and the deferred bucket is
grouped by worker thread, so the order varies.

This drains the deferred static fields in two passes, annotated ones first. Test added; it fails before the
change.
