### PR TITLE
Add autocorrect to widen an `attr_accessor` sig to `T.nilable`

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3063,11 +3063,23 @@ public:
                 auto title = fmt::format("Initialize as `{}`", suggestType.show(gs));
 
                 if (replaceLoc.adjustLen(gs, -2, 1).source(gs) == "=") {
-                    // Defensive; might be an ivar assignment from `attr_accessor` or `prop`, which
-                    // we don't want an autocorrect for.
+                    // Defensive; might be an ivar assignment from `prop`, which we don't want an
+                    // autocorrect for.
                     auto opts = ShowOptions().withUseValidSyntax();
                     e.replaceWith(title, replaceLoc, "T.let({}, {})", replaceLoc.source(gs).value(),
                                   suggestType.show(gs, opts));
+                } else if (replaceLoc.endPos() < args.callLoc().beginPos()) {
+                    // An `attr_writer` points the RHS of its synthesized `@foo = foo` at the type in
+                    // the sig's `returns(...)`, which always comes before the attr name. Widening
+                    // that type makes the rewriter declare the ivar for us.
+                    //
+                    // Comparing offsets is fine here: both locs are built from `locs.file`.
+                    //
+                    // We wrap the source instead of showing `suggestType`, so that things like type
+                    // aliases keep the spelling the user chose.
+                    auto source = replaceLoc.source(gs).value();
+                    e.replaceWith(fmt::format("Change the type to `T.nilable({})`", source), replaceLoc,
+                                  "T.nilable({})", source);
                 }
             }
         }

--- a/rewriter/AttrReader.cc
+++ b/rewriter/AttrReader.cc
@@ -1,4 +1,5 @@
 #include "rewriter/AttrReader.h"
+#include "absl/strings/match.h"
 #include "ast/Helpers.h"
 #include "core/Context.h"
 #include "core/Names.h"
@@ -63,6 +64,22 @@ ast::ExpressionPtr dupReturnsType(ast::Send *sharedSig) {
         return nullptr;
     }
     return body->getPosArg(0).deepCopy();
+}
+
+// The loc of the type inside the sig's `returns(...)`, so that later phases can suggest widening
+// it to `T.nilable(...)`. See where this is used in the `makeWriter` case below.
+core::LocOffsets returnsTypeLoc(ast::Send *sharedSig) {
+    auto *sig = ASTUtil::castSig(sharedSig);
+
+    ENFORCE(sig != nullptr, "We weren't given a send node that's a valid signature");
+
+    auto *body = findReturnsSend(sig);
+
+    ENFORCE(body->fun == core::Names::returns());
+    if (body->numPosArgs() != 1) {
+        return core::LocOffsets::none();
+    }
+    return body->getPosArg(0).loc();
 }
 
 // This will raise an error if we've given a type that's not what we want
@@ -276,7 +293,27 @@ vector<ast::ExpressionPtr> AttrReader::run(core::MutableContext ctx, ast::Send *
                 body = ast::MK::Assign(loc, ast::MK::Instance(argLoc, varName),
                                        ast::MK::Let(loc, ast::MK::Local(loc, name), dupReturnsType(sig)));
             } else {
-                body = ast::MK::Assign(loc, ast::MK::Instance(argLoc, varName), ast::MK::Local(loc, name));
+                // We're not declaring the ivar, so `# typed: strict` will report an error on this
+                // assignment. Point the RHS at the type in the sig's `returns(...)` so that infer
+                // can suggest widening it to `T.nilable`, which makes the branch above apply.
+                //
+                // Only do this when the type comes before the attr name: that ordering is what lets
+                // infer tell this synthesized assignment apart from one the user wrote. An RBS
+                // comment (`#: Integer`) synthesizes a sig whose locs point inside the comment, and
+                // widening one of those would produce `#: T.nilable(Integer)`, which isn't valid
+                // RBS, so skip a type that lives on a comment line too. Failing either check just
+                // means no autocorrect, so fall back to the loc of the `attr_` send itself.
+                auto rhsLoc = loc;
+                if (sig != nullptr) {
+                    auto typeLoc = returnsTypeLoc(sig);
+                    if (typeLoc.exists() && typeLoc.endPos() < argLoc.beginPos()) {
+                        auto lineStart = ctx.locAt(typeLoc).findStartOfIndentation(ctx).first.adjustLen(ctx, 0, 1);
+                        if (lineStart.exists() && !absl::StartsWith(lineStart.source(ctx).value_or("#"), "#")) {
+                            rhsLoc = typeLoc;
+                        }
+                    }
+                }
+                body = ast::MK::Assign(loc, ast::MK::Instance(argLoc, varName), ast::MK::Local(rhsLoc, name));
             }
             ast::MethodDef::Flags flags;
             flags.isAttrBestEffortUIOnly = true;

--- a/test/testdata/rbs/attr_no_nilable_autocorrect.rb
+++ b/test/testdata/rbs/attr_no_nilable_autocorrect.rb
@@ -1,0 +1,11 @@
+# typed: strict
+# enable-experimental-rbs-comments: true
+
+# The `T.nilable` autocorrect for a non-nilable attr sig widens the type in place. That would
+# produce `#: T.nilable(Integer)` here, which is not valid RBS, so it is not offered.
+class RbsAttr
+  #: Integer
+  attr_accessor :foo
+  #              ^^^ error: Use of undeclared variable `@foo`
+  #              ^^^ error: The instance variable `@foo` must be declared using `T.let` when specifying `# typed: strict`
+end

--- a/test/testdata/rbs/attr_no_nilable_autocorrect.rb.autocorrects.exp
+++ b/test/testdata/rbs/attr_no_nilable_autocorrect.rb.autocorrects.exp
@@ -1,0 +1,13 @@
+# -- test/testdata/rbs/attr_no_nilable_autocorrect.rb --
+# typed: strict
+# enable-experimental-rbs-comments: true
+
+# The `T.nilable` autocorrect for a non-nilable attr sig widens the type in place. That would
+# produce `#: T.nilable(Integer)` here, which is not valid RBS, so it is not offered.
+class RbsAttr
+  #: Integer
+  attr_accessor :foo
+  #              ^^^ error: Use of undeclared variable `@foo`
+  #              ^^^ error: The instance variable `@foo` must be declared using `T.let` when specifying `# typed: strict`
+end
+# ------------------------------

--- a/test/testdata/rewriter/attr_strict.rb
+++ b/test/testdata/rewriter/attr_strict.rb
@@ -25,4 +25,18 @@ class Test
   attr_writer :nilable_writer
   sig {params(untyped_writer: T.untyped).returns(T.untyped)}
   attr_writer :untyped_writer
+
+  # One sig shared by many names only needs widening once.
+  sig {returns(String)}
+  attr_accessor :multi_one, :multi_two
+  #              ^^^^^^^^^ error: Use of undeclared variable `@multi_one`
+  #              ^^^^^^^^^ error: The instance variable `@multi_one` must be declared using `T.let` when specifying `# typed: strict`
+  #                          ^^^^^^^^^ error: Use of undeclared variable `@multi_two`
+  #                          ^^^^^^^^^ error: The instance variable `@multi_two` must be declared using `T.let` when specifying `# typed: strict`
+
+  MyAlias = T.type_alias {Integer}
+  sig {returns(MyAlias)}
+  attr_accessor :aliased
+  #              ^^^^^^^ error: Use of undeclared variable `@aliased`
+  #              ^^^^^^^ error: The instance variable `@aliased` must be declared using `T.let` when specifying `# typed: strict`
 end

--- a/test/testdata/rewriter/attr_strict.rb.autocorrects.exp
+++ b/test/testdata/rewriter/attr_strict.rb.autocorrects.exp
@@ -4,7 +4,7 @@
 class Test
   extend T::Sig
 
-  sig {returns(String)}
+  sig {returns(T.nilable(String))}
   attr_accessor :non_nil_accessor
   #              ^^^^^^^^^^^^^^^^ error: Use of undeclared variable `@non_nil_accessor`
   #              ^^^^^^^^^^^^^^^^ error: The instance variable `@non_nil_accessor` must be declared using `T.let` when specifying `# typed: strict`
@@ -20,11 +20,25 @@ class Test
   sig {returns(T.untyped)}
   attr_reader :untyped_reader # error: Use of undeclared variable `@untyped_reader`
 
-  sig {params(non_nil_writer: String).returns(String)}
+  sig {params(non_nil_writer: String).returns(T.nilable(String))}
   attr_writer :non_nil_writer # error: The instance variable `@non_nil_writer` must be declared using `T.let` when specifying `# typed: strict`
   sig {params(nilable_writer: String).returns(T.nilable(String))}
   attr_writer :nilable_writer
   sig {params(untyped_writer: T.untyped).returns(T.untyped)}
   attr_writer :untyped_writer
+
+  # One sig shared by many names only needs widening once.
+  sig {returns(T.nilable(String))}
+  attr_accessor :multi_one, :multi_two
+  #              ^^^^^^^^^ error: Use of undeclared variable `@multi_one`
+  #              ^^^^^^^^^ error: The instance variable `@multi_one` must be declared using `T.let` when specifying `# typed: strict`
+  #                          ^^^^^^^^^ error: Use of undeclared variable `@multi_two`
+  #                          ^^^^^^^^^ error: The instance variable `@multi_two` must be declared using `T.let` when specifying `# typed: strict`
+
+  MyAlias = T.type_alias {Integer}
+  sig {returns(T.nilable(MyAlias))}
+  attr_accessor :aliased
+  #              ^^^^^^^ error: Use of undeclared variable `@aliased`
+  #              ^^^^^^^ error: The instance variable `@aliased` must be declared using `T.let` when specifying `# typed: strict`
 end
 # ------------------------------


### PR DESCRIPTION
Fixes #6749

Under `# typed: strict`, an `attr_accessor` with a non-nilable sig reports 6002 and 7043 but offers no autocorrect. The same 7043 on a plain `@foo = 0` assignment does offer one.

```ruby
# typed: strict
class A
  extend T::Sig

  sig {returns(Integer)}
  attr_accessor :foo
end
```

Before:

```
repro.rb:6: Use of undeclared variable `@foo` https://srb.help/6002
     6 |  attr_accessor :foo
                         ^^^
repro.rb:6: The instance variable `@foo` must be declared using `T.let` when specifying `# typed: strict` https://srb.help/7043
     6 |  attr_accessor :foo
                         ^^^
Errors: 2
```

After:

```
repro.rb:6: The instance variable `@foo` must be declared using `T.let` when specifying `# typed: strict` https://srb.help/7043
     6 |  attr_accessor :foo
                         ^^^
  Autocorrect: Use `-a` to autocorrect
    repro.rb:5: Replace with `T.nilable(Integer)`
     5 |  sig {returns(Integer)}
                       ^^^^^^^
```

Running `srb tc -a` rewrites the sig to `sig {returns(T.nilable(Integer))}`, and after that the file has no errors. The widened sig makes `AttrReader` emit `@foo = T.let(foo, T.nilable(Integer))`, which clears both 6002 and 7043.

One thing worth calling out: this widens a type the user wrote, so every caller of `foo` now has to handle `nil`. That's a bigger change than the `T.let` autocorrect sitting next to it. It's also the only thing that resolves the error, since `AttrReader` only declares the ivar when the sig is nilable or untyped. It stays opt-in behind `-a` or the editor quick fix.

## What changed

The autocorrect needs the location of the type inside `returns(...)`, and the rewriter is the only phase that sees the sig next to the `attr_accessor`.

* `rewriter/AttrReader.cc`: when the writer isn't declaring the ivar, point the RHS of the synthesized `@foo = foo` at the type inside the sig's `returns(...)` instead of at the `attr_accessor` send.
* `core/types/calls.cc`: in `Magic_suggestUntypedFieldType`, when the RHS location ends before the LHS location begins, offer `T.nilable(<source>)` over that location.

## Tests

* `test/testdata/rewriter/attr_strict.rb` already covered accessor, reader and writer against non-nilable, nilable and untyped. I added two cases: one sig shared by several names, which gets widened once rather than once per error, and a `T.type_alias`, which stays as `T.nilable(MyAlias)` instead of being flattened, because the autocorrect wraps the source text rather than printing the inferred type. The `.autocorrects.exp` records the result, including `attr_reader` getting no autocorrect, since widening wouldn't fix its 6002.
* `test/testdata/rbs/attr_no_nilable_autocorrect.rb` checks that no autocorrect is offered for an RBS comment sig.
* `bazel test test`, `//test:test_prism`, `//test:test_corpus_lsp`, `//test:test_corpus_lsp_prism` and `//test/cli:all` all pass with `--config=dbg`. The LSP corpora matter here because this moves a location that flows into later phases, and they aren't part of `bazel test test`.

## Design notes

**Signal.** The autocorrect fires when the assignment's RHS location ends strictly before its LHS location begins. Ruby syntax means an assignment the user wrote never looks like that, so it only matches a location the rewriter planted on purpose. Comparing raw offsets is safe because `DispatchArgs::callLoc` and `DispatchArgs::argLoc` both build from `locs.file`, so the two locations are always in the same file.

I tried keying off `MethodDef::Flags::isAttrBestEffortUIOnly` first, since `resolver.cc` already uses it to pick an autocorrect. It isn't reachable from `Magic_suggestUntypedFieldType`. A probe build gives three errors: `DispatchArgs` has no `enclosingMethod`, `enclosingMethodForSuper` is a bare `NameRef` with no `data()`, and `core::Method::Flags` has no `isAttrBestEffortUIOnly`. The flag only lives on `ast::MethodDef::Flags` and `core::FoundDefinitions::FoundMethod`, and never reaches the symbol table. Getting it there would mean a new symbol flag plus serialization changes, which seemed like a lot for this fix.

**Stale comment.** The guard in `calls.cc` said "might be an ivar assignment from `attr_accessor` or `prop`, which we don't want an autocorrect for". #6749 asks for an autocorrect in the `attr_accessor` case, so that comment now says `prop` only.

**Why `prop` is excluded.** `Prop.cc` builds both sides of its synthesized assignment from the same `nameLoc` (lines 512 and 621), so its RHS never precedes its LHS and the branch isn't taken. That's incidental rather than guaranteed. Nothing in `Prop.cc` enforces it, and a future change that pointed a prop's RHS earlier in the file would start matching. Only the half about assignments the user wrote is actually guaranteed.

**RBS comments.** An RBS comment sig (`#: Integer`) synthesizes a sig whose locations point inside the comment. Widening one in place gives `#: T.nilable(Integer)`, which isn't valid RBS. The correct widening would be `Integer?`, and emitting that means generating RBS type syntax from a `TypePtr`, which this change doesn't do. So the rewriter suppresses instead: if the type sits on a comment line, no location is planted and no autocorrect is offered.

The trailing form `attr_accessor :foo #: Integer` isn't an attr sig. It parses as an RBS assertion on the expression and reports 7007, so it never reaches this code and doesn't need its own guard.

**Guards, and failing soft.** `returnsTypeLoc` only runs when `sig != nullptr`. A `sig {void}` on an attr already nulls `sig` earlier in `AttrReader::run`, after reporting `VoidAttrReader`, so a void sig never reaches `findReturnsSend`. With no sig at all, or a `returns` without exactly one positional argument, the location is left alone and the `calls.cc` guard is false, so nothing changes.

The ordering invariant is a precondition for planting the location rather than an `ENFORCE`. An assertion there would abort a `--config=dbg` build, and this code runs over every `attr_` in a codebase. If the check ever fails, a missing autocorrect is a better outcome than a crash.
