### PR TITLE
Only report "was not exported" if it was imported

### DIFF
--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -606,16 +606,16 @@ public:
                     return;
                 }
 
-                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
-                        e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
-                        e.addErrorLine(pkg.declLoc(), "Exported from package here");
-                        if (auto importAutocorrect = this->package.addImport(ctx, pkg)) {
-                            e.maybeAddAutocorrect(move(importAutocorrect));
-                            if (!db.errorHint().empty()) {
-                                e.addErrorNote("{}", db.errorHint());
-                            }
+                if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
+                    e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
+                    e.addErrorLine(pkg.declLoc(), "Exported from package here");
+                    if (auto importAutocorrect = this->package.addImport(ctx, pkg)) {
+                        e.maybeAddAutocorrect(move(importAutocorrect));
+                        if (!db.errorHint().empty()) {
+                            e.addErrorNote("{}", db.errorHint());
                         }
                     }
+                }
             }
 
             // We should only report a visibility error if we're not going to add a visible_to to the package
@@ -694,44 +694,44 @@ public:
                         ENFORCE(false, "At most three reasons should be present");
                     }
                     e.setHeader("`{}` cannot be referenced here because {}", lit.symbol().show(ctx), reason);
-                        e.addErrorNote("`{}`'s package is not imported", lit.symbol().show(ctx));
+                    e.addErrorNote("`{}`'s package is not imported", lit.symbol().show(ctx));
                 }
             }
         } else if (!isExported) {
-                if (db.genPackagesMode() != core::packages::GenPackagesMode::Disabled) {
-                    return;
+            if (db.genPackagesMode() != core::packages::GenPackagesMode::Disabled) {
+                return;
+            }
+            std::optional<core::AutocorrectSuggestion> exportAutocorrect;
+            auto symToExport = litSymbol;
+            auto enumClass = getEnumClassForEnumValue(ctx.state, symToExport);
+            if (enumClass.exists()) {
+                symToExport = enumClass;
+            }
+            bool definesBehavior =
+                !litSymbol.isClassOrModule() || litSymbol.asClassOrModuleRef().data(ctx)->flags.isBehaviorDefining;
+            if (definesBehavior) {
+                // For compatibility with gen-packages, we do _not_ add an export if it doesn't define
+                // behavior. This is mostly because it's easier to get Sorbet to behave like gen-packages
+                // than the other way around.
+                //
+                // If we move to a world where all __package.rb edits are done via Sorbet autocorrects,
+                // we could make this addExport call unconditional.
+                if (auto exp = pkg.addExport(ctx, symToExport)) {
+                    exportAutocorrect.emplace(exp.value());
                 }
-                    std::optional<core::AutocorrectSuggestion> exportAutocorrect;
-                    auto symToExport = litSymbol;
-                    auto enumClass = getEnumClassForEnumValue(ctx.state, symToExport);
-                    if (enumClass.exists()) {
-                        symToExport = enumClass;
-                    }
-                    bool definesBehavior = !litSymbol.isClassOrModule() ||
-                                           litSymbol.asClassOrModuleRef().data(ctx)->flags.isBehaviorDefining;
-                    if (definesBehavior) {
-                        // For compatibility with gen-packages, we do _not_ add an export if it doesn't define
-                        // behavior. This is mostly because it's easier to get Sorbet to behave like gen-packages
-                        // than the other way around.
-                        //
-                        // If we move to a world where all __package.rb edits are done via Sorbet autocorrects,
-                        // we could make this addExport call unconditional.
-                        if (auto exp = pkg.addExport(ctx, symToExport)) {
-                            exportAutocorrect.emplace(exp.value());
-                        }
-                    }
+            }
 
-                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedPackagePrivateName)) {
-                        e.setHeader("`{}` resolves but is not exported from `{}`", litSymbol.show(ctx), pkg.show(ctx));
-                        addExportInfo(ctx, e, litSymbol, definesBehavior);
+            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedPackagePrivateName)) {
+                e.setHeader("`{}` resolves but is not exported from `{}`", litSymbol.show(ctx), pkg.show(ctx));
+                addExportInfo(ctx, e, litSymbol, definesBehavior);
 
-                        if (exportAutocorrect.has_value()) {
-                            e.maybeAddAutocorrect(move(exportAutocorrect));
-                            if (!db.errorHint().empty()) {
-                                e.addErrorNote("{}", db.errorHint());
-                            }
-                        }
+                if (exportAutocorrect.has_value()) {
+                    e.maybeAddAutocorrect(move(exportAutocorrect));
+                    if (!db.errorHint().empty()) {
+                        e.addErrorNote("{}", db.errorHint());
                     }
+                }
+            }
         }
     }
 

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -527,142 +527,138 @@ public:
     }
 
     static void reportImportError(core::Context ctx) {
-            auto strictDepsLevel = this->package.strictDependenciesLevel;
-            auto importStrictDepsLevel = pkg.strictDependenciesLevel;
-            bool layeringViolation = false;
-            bool strictDependenciesTooLow = false;
-            bool causesCycle = false;
-            bool causesVisibilityError = !pkg.isVisibleTo(ctx, this->package);
-            bool badTestReference = pkg.testPackage() && !this->package.testPackage();
-            optional<string> path;
-            if (db.enforceLayering()) {
-                layeringViolation = strictDepsLevel > core::packages::StrictDependenciesLevel::False &&
-                                    this->package.causesLayeringViolation(db, pkg);
-                strictDependenciesTooLow = importStrictDepsLevel != core::packages::StrictDependenciesLevel::None &&
-                                           importStrictDepsLevel < this->package.minimumStrictDependenciesLevel();
-                // If there's a path from the imported packaged to this package, then adding the import will close
-                // the loop and cause a cycle.
-                path = pkg.pathTo(ctx, this->package.mangledName());
-                causesCycle =
-                    strictDepsLevel >= core::packages::StrictDependenciesLevel::LayeredDag && path.has_value();
+        auto strictDepsLevel = this->package.strictDependenciesLevel;
+        auto importStrictDepsLevel = pkg.strictDependenciesLevel;
+        bool layeringViolation = false;
+        bool strictDependenciesTooLow = false;
+        bool causesCycle = false;
+        bool causesVisibilityError = !pkg.isVisibleTo(ctx, this->package);
+        bool badTestReference = pkg.testPackage() && !this->package.testPackage();
+        optional<string> path;
+        if (db.enforceLayering()) {
+            layeringViolation = strictDepsLevel > core::packages::StrictDependenciesLevel::False &&
+                                this->package.causesLayeringViolation(db, pkg);
+            strictDependenciesTooLow = importStrictDepsLevel != core::packages::StrictDependenciesLevel::None &&
+                                       importStrictDepsLevel < this->package.minimumStrictDependenciesLevel();
+            // If there's a path from the imported packaged to this package, then adding the import will close
+            // the loop and cause a cycle.
+            path = pkg.pathTo(ctx, this->package.mangledName());
+            causesCycle = strictDepsLevel >= core::packages::StrictDependenciesLevel::LayeredDag && path.has_value();
+        }
+        bool hasModularityError =
+            layeringViolation || strictDependenciesTooLow || causesCycle || badTestReference || causesVisibilityError;
+        // visible_to errors are handled separately (by `updateVisibilityFor`),
+        // so they're not included in this causesModularityError field of referencedPackages
+        referencedPackages[otherPackage].causesModularityError = hasModularityError && !causesVisibilityError;
+        if (!hasModularityError) {
+            if (db.genPackagesMode() != core::packages::GenPackagesMode::Disabled) {
+                return;
             }
-            bool hasModularityError = layeringViolation || strictDependenciesTooLow || causesCycle ||
-                                      badTestReference || causesVisibilityError;
-            // visible_to errors are handled separately (by `updateVisibilityFor`),
-            // so they're not included in this causesModularityError field of referencedPackages
-            referencedPackages[otherPackage].causesModularityError = hasModularityError && !causesVisibilityError;
-            if (!hasModularityError) {
-                if (db.genPackagesMode() != core::packages::GenPackagesMode::Disabled) {
+
+            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
+                e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
+                e.addErrorLine(pkg.declLoc(), "Exported from package here");
+                if (auto importAutocorrect = this->package.addImport(ctx, pkg)) {
+                    e.maybeAddAutocorrect(move(importAutocorrect));
+                    if (!db.errorHint().empty()) {
+                        e.addErrorNote("{}", db.errorHint());
+                    }
+                }
+            }
+        } else {
+            // TODO(neil): Provide actionable advice and/or link to a doc that would help the user resolve these
+            // layering/strict_dependencies issues.
+            auto error = causesCycle         ? core::errors::Packager::StrictDependenciesViolation
+                         : layeringViolation ? core::errors::Packager::LayeringViolation
+                         : badTestReference  ? core::errors::Packager::TestImportMismatch
+                                             : core::errors::Packager::StrictDependenciesViolation;
+            if (auto e = ctx.beginError(lit.loc(), error)) {
+                vector<string> reasons;
+                e.addErrorLine(this->package.declLoc(), "Enclosing package declared here");
+
+                // We should only report a visibility error if we're not going to add a visible_to to the package
+                // Otherwise the error is pointless since it'll go away after the new visible_to is added
+                if (causesVisibilityError && !ctx.state.packageDB().updateVisibilityFor(otherPackage)) {
+                    reasons.emplace_back(core::ErrorColors::format(
+                        "Package `{}` includes explicit visibility modifiers and cannot be imported from `{}`",
+                        pkg.show(ctx), this->package.show(ctx)));
+                    e.addErrorNote("Please consult with the owning team before adding a `{}` line to the package `{}`",
+                                   "visible_to", pkg.show(ctx));
+                }
+
+                if (badTestReference) {
+                    reasons.emplace_back(core::ErrorColors::format("`{}` may not reference `{}` packages",
+                                                                   this->package.show(ctx), "test!"));
+                    e.addErrorLine(pkg.declLoc(), "Referenced `{}` package defined here", "test!");
+                }
+                if (causesCycle) {
+                    reasons.emplace_back(core::ErrorColors::format("importing its package would put `{}` into a cycle",
+                                                                   this->package.show(ctx)));
+                    auto currentStrictDepsLevel = fmt::format(
+                        "strict_dependencies '{}'", core::packages::strictDependenciesLevelToString(strictDepsLevel));
+                    e.addErrorLine(core::Loc(this->package.file, this->package.locs.strictDependenciesLevel),
+                                   "`{}` is `{}`, which disallows cycles", this->package.show(ctx),
+                                   currentStrictDepsLevel);
+                    ENFORCE(path.has_value(),
+                            "Path from pkg to this->package should always exist if causesCycle is true");
+                    e.addErrorNote("Path from `{}` to `{}`:\n{}", pkg.show(ctx), this->package.show(ctx), path.value());
+                }
+
+                if (layeringViolation) {
+                    reasons.emplace_back("importing its package would cause a layering violation");
+                    ENFORCE(pkg.layer.exists(), "causesLayeringViolation should return false if layer is not set");
+                    ENFORCE(this->package.layer.exists(),
+                            "causesLayeringViolation should return false if layer is not set");
+                    e.addErrorLine(core::Loc(pkg.file, pkg.locs.layer),
+                                   "Package `{}` must be at most layer `{}` (to match package `{}`) but is "
+                                   "currently layer `{}`",
+                                   pkg.show(ctx), this->package.layer.show(ctx), this->package.show(ctx),
+                                   pkg.layer.show(ctx));
+                }
+
+                if (strictDependenciesTooLow) {
+                    reasons.emplace_back(
+                        core::ErrorColors::format("its `{}` is not strict enough", "strict_dependencies"));
+                    ENFORCE(importStrictDepsLevel != core::packages::StrictDependenciesLevel::None,
+                            "strictDependenciesTooLow should be false if strict_dependencies level is not set");
+                    auto requiredStrictDepsLevel =
+                        fmt::format("strict_dependencies '{}'", core::packages::strictDependenciesLevelToString(
+                                                                    this->package.minimumStrictDependenciesLevel()));
+                    auto currentStrictDepsLevel =
+                        fmt::format("strict_dependencies '{}'",
+                                    core::packages::strictDependenciesLevelToString(importStrictDepsLevel));
+                    e.addErrorLine(core::Loc(pkg.file, pkg.locs.strictDependenciesLevel),
+                                   "`{}` must be at least `{}` but is currently `{}`", pkg.show(ctx),
+                                   requiredStrictDepsLevel, currentStrictDepsLevel);
+                }
+
+                if (reasons.empty() && causesVisibilityError &&
+                    ctx.state.packageDB().updateVisibilityFor(otherPackage)) {
+                    // Force the error to build here, so that we don't report an error
+                    e.build();
                     return;
                 }
 
-                if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
-                    e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
-                    e.addErrorLine(pkg.declLoc(), "Exported from package here");
-                    if (auto importAutocorrect = this->package.addImport(ctx, pkg)) {
-                        e.maybeAddAutocorrect(move(importAutocorrect));
-                        if (!db.errorHint().empty()) {
-                            e.addErrorNote("{}", db.errorHint());
-                        }
-                    }
+                ENFORCE(!reasons.empty(), "At least one reason should be present");
+                string reason;
+                if (reasons.size() == 1) {
+                    reason = reasons[0];
+                } else if (reasons.size() == 2) {
+                    reason = fmt::format("{}, and {}", reasons[0], reasons[1]);
+                } else if (reasons.size() == 3) {
+                    reason = fmt::format("{}, {}, and {}", reasons[0], reasons[1], reasons[2]);
+                } else if (reasons.size() == 4) {
+                    reason = fmt::format("{}, {}, {}, and {}", reasons[0], reasons[1], reasons[2], reasons[3]);
+                } else if (reasons.size() == 5) {
+                    reason = fmt::format("{}, {}, {}, {}, and {}", reasons[0], reasons[1], reasons[2], reasons[3],
+                                         reasons[4]);
+                } else {
+                    ENFORCE(false, "At most five reasons should be present");
                 }
-            } else {
-                // TODO(neil): Provide actionable advice and/or link to a doc that would help the user resolve these
-                // layering/strict_dependencies issues.
-                auto error = causesCycle         ? core::errors::Packager::StrictDependenciesViolation
-                             : layeringViolation ? core::errors::Packager::LayeringViolation
-                             : badTestReference  ? core::errors::Packager::TestImportMismatch
-                                                 : core::errors::Packager::StrictDependenciesViolation;
-                if (auto e = ctx.beginError(lit.loc(), error)) {
-                    vector<string> reasons;
-                    e.addErrorLine(this->package.declLoc(), "Enclosing package declared here");
-
-                    // We should only report a visibility error if we're not going to add a visible_to to the package
-                    // Otherwise the error is pointless since it'll go away after the new visible_to is added
-                    if (causesVisibilityError && !ctx.state.packageDB().updateVisibilityFor(otherPackage)) {
-                        reasons.emplace_back(core::ErrorColors::format(
-                            "Package `{}` includes explicit visibility modifiers and cannot be imported from `{}`",
-                            pkg.show(ctx), this->package.show(ctx)));
-                        e.addErrorNote(
-                            "Please consult with the owning team before adding a `{}` line to the package `{}`",
-                            "visible_to", pkg.show(ctx));
-                    }
-
-                    if (badTestReference) {
-                        reasons.emplace_back(core::ErrorColors::format("`{}` may not reference `{}` packages",
-                                                                       this->package.show(ctx), "test!"));
-                        e.addErrorLine(pkg.declLoc(), "Referenced `{}` package defined here", "test!");
-                    }
-                    if (causesCycle) {
-                        reasons.emplace_back(core::ErrorColors::format(
-                            "importing its package would put `{}` into a cycle", this->package.show(ctx)));
-                        auto currentStrictDepsLevel =
-                            fmt::format("strict_dependencies '{}'",
-                                        core::packages::strictDependenciesLevelToString(strictDepsLevel));
-                        e.addErrorLine(core::Loc(this->package.file, this->package.locs.strictDependenciesLevel),
-                                       "`{}` is `{}`, which disallows cycles", this->package.show(ctx),
-                                       currentStrictDepsLevel);
-                        ENFORCE(path.has_value(),
-                                "Path from pkg to this->package should always exist if causesCycle is true");
-                        e.addErrorNote("Path from `{}` to `{}`:\n{}", pkg.show(ctx), this->package.show(ctx),
-                                       path.value());
-                    }
-
-                    if (layeringViolation) {
-                        reasons.emplace_back("importing its package would cause a layering violation");
-                        ENFORCE(pkg.layer.exists(), "causesLayeringViolation should return false if layer is not set");
-                        ENFORCE(this->package.layer.exists(),
-                                "causesLayeringViolation should return false if layer is not set");
-                        e.addErrorLine(core::Loc(pkg.file, pkg.locs.layer),
-                                       "Package `{}` must be at most layer `{}` (to match package `{}`) but is "
-                                       "currently layer `{}`",
-                                       pkg.show(ctx), this->package.layer.show(ctx), this->package.show(ctx),
-                                       pkg.layer.show(ctx));
-                    }
-
-                    if (strictDependenciesTooLow) {
-                        reasons.emplace_back(
-                            core::ErrorColors::format("its `{}` is not strict enough", "strict_dependencies"));
-                        ENFORCE(importStrictDepsLevel != core::packages::StrictDependenciesLevel::None,
-                                "strictDependenciesTooLow should be false if strict_dependencies level is not set");
-                        auto requiredStrictDepsLevel = fmt::format("strict_dependencies '{}'",
-                                                                   core::packages::strictDependenciesLevelToString(
-                                                                       this->package.minimumStrictDependenciesLevel()));
-                        auto currentStrictDepsLevel =
-                            fmt::format("strict_dependencies '{}'",
-                                        core::packages::strictDependenciesLevelToString(importStrictDepsLevel));
-                        e.addErrorLine(core::Loc(pkg.file, pkg.locs.strictDependenciesLevel),
-                                       "`{}` must be at least `{}` but is currently `{}`", pkg.show(ctx),
-                                       requiredStrictDepsLevel, currentStrictDepsLevel);
-                    }
-
-                    if (reasons.empty() && causesVisibilityError &&
-                        ctx.state.packageDB().updateVisibilityFor(otherPackage)) {
-                        // Force the error to build here, so that we don't report an error
-                        e.build();
-                        return;
-                    }
-
-                    ENFORCE(!reasons.empty(), "At least one reason should be present");
-                    string reason;
-                    if (reasons.size() == 1) {
-                        reason = reasons[0];
-                    } else if (reasons.size() == 2) {
-                        reason = fmt::format("{}, and {}", reasons[0], reasons[1]);
-                    } else if (reasons.size() == 3) {
-                        reason = fmt::format("{}, {}, and {}", reasons[0], reasons[1], reasons[2]);
-                    } else if (reasons.size() == 4) {
-                        reason = fmt::format("{}, {}, {}, and {}", reasons[0], reasons[1], reasons[2], reasons[3]);
-                    } else if (reasons.size() == 5) {
-                        reason = fmt::format("{}, {}, {}, {}, and {}", reasons[0], reasons[1], reasons[2], reasons[3],
-                                             reasons[4]);
-                    } else {
-                        ENFORCE(false, "At most five reasons should be present");
-                    }
-                    e.setHeader("`{}` cannot be referenced here because {}", lit.symbol().show(ctx), reason);
-                    e.addErrorNote("`{}`'s package is not imported", lit.symbol().show(ctx));
-                }
+                e.setHeader("`{}` cannot be referenced here because {}", lit.symbol().show(ctx), reason);
+                e.addErrorNote("`{}`'s package is not imported", lit.symbol().show(ctx));
             }
+        }
     }
 
     void postTransformConstantLit(core::Context ctx, const ast::ConstantLit &lit) {

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -583,6 +583,9 @@ public:
             }
         }
 
+        auto *import = this->package.importsPackage(otherPackage);
+        auto wasImported = import != nullptr;
+
         bool isExported = pkg.locs.exportAll.exists();
         if (litSymbol.isClassOrModule()) {
             isExported = isExported || litSymbol.asClassOrModuleRef().data(ctx)->flags.isExported;
@@ -590,8 +593,6 @@ public:
             isExported = isExported || litSymbol.asFieldRef().data(ctx)->flags.isExported;
         }
         isExported = isExported || db.allowRelaxedPackagerChecksFor(this->package.mangledName());
-        auto *import = this->package.importsPackage(otherPackage);
-        auto wasImported = import != nullptr;
         isExported = isExported || (wasImported && import->usesInternals);
 
         referencedPackages[otherPackage] = {.importNeeded = !wasImported, .causesModularityError = false};

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -558,14 +558,6 @@ public:
         }
         auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
 
-        if (pkg.testPackage() && !this->package.testPackage()) {
-            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::TestImportMismatch)) {
-                e.setHeader("Package `{}` may not reference `{}` packages", this->package.show(ctx), "test!");
-                e.addErrorLine(this->package.declLoc(), "Defined here");
-                e.addErrorLine(pkg.declLoc(), "Referenced `{}` package defined here", "test!");
-            }
-        }
-
         auto *import = this->package.importsPackage(otherPackage);
         auto wasImported = import != nullptr;
 
@@ -578,6 +570,7 @@ public:
             bool strictDependenciesTooLow = false;
             bool causesCycle = false;
             bool causesVisibilityError = !pkg.isVisibleTo(ctx, this->package);
+            bool badTestReference = pkg.testPackage() && !this->package.testPackage();
             optional<string> path;
             if (db.enforceLayering()) {
                 layeringViolation = strictDepsLevel > core::packages::StrictDependenciesLevel::False &&
@@ -590,7 +583,7 @@ public:
                 causesCycle =
                     strictDepsLevel >= core::packages::StrictDependenciesLevel::LayeredDag && path.has_value();
             }
-            bool hasModularityError = layeringViolation || strictDependenciesTooLow || causesCycle;
+            bool hasModularityError = layeringViolation || strictDependenciesTooLow || causesCycle || badTestReference;
             referencedPackages[otherPackage].causesModularityError = hasModularityError;
             if (!hasModularityError && !causesVisibilityError) {
                 if (db.genPackagesMode() != core::packages::GenPackagesMode::Disabled) {
@@ -623,13 +616,18 @@ public:
             if (hasModularityError) {
                 // TODO(neil): Provide actionable advice and/or link to a doc that would help the user resolve these
                 // layering/strict_dependencies issues.
-                core::ErrorClass error =
-                    causesCycle ? core::errors::Packager::StrictDependenciesViolation
-                                : (layeringViolation ? core::errors::Packager::LayeringViolation
-                                                     : core::errors::Packager::StrictDependenciesViolation);
+                auto error = causesCycle         ? core::errors::Packager::StrictDependenciesViolation
+                             : layeringViolation ? core::errors::Packager::LayeringViolation
+                             : badTestReference  ? core::errors::Packager::TestImportMismatch
+                                                 : core::errors::Packager::StrictDependenciesViolation;
                 if (auto e = ctx.beginError(lit.loc(), error)) {
                     vector<string> reasons;
                     e.addErrorLine(this->package.declLoc(), "Enclosing package declared here");
+                    if (badTestReference) {
+                        reasons.emplace_back(core::ErrorColors::format("`{}` may not reference `{}` packages",
+                                                                       this->package.show(ctx), "test!"));
+                        e.addErrorLine(pkg.declLoc(), "Referenced `{}` package defined here", "test!");
+                    }
                     if (causesCycle) {
                         reasons.emplace_back(core::ErrorColors::format(
                             "importing its package would put `{}` into a cycle", this->package.show(ctx)));
@@ -681,8 +679,10 @@ public:
                         reason = fmt::format("{}, and {}", reasons[0], reasons[1]);
                     } else if (reasons.size() == 3) {
                         reason = fmt::format("{}, {}, and {}", reasons[0], reasons[1], reasons[2]);
+                    } else if (reasons.size() == 4) {
+                        reason = fmt::format("{}, {}, {}, and {}", reasons[0], reasons[1], reasons[2], reasons[3]);
                     } else {
-                        ENFORCE(false, "At most three reasons should be present");
+                        ENFORCE(false, "At most four reasons should be present");
                     }
                     e.setHeader("`{}` cannot be referenced here because {}", lit.symbol().show(ctx), reason);
                     e.addErrorNote("`{}`'s package is not imported", lit.symbol().show(ctx));

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -526,7 +526,10 @@ public:
         }
     }
 
-    static void reportImportError(core::Context ctx, const core::packages::PackageInfo &thisPkg, const core::packages::PackageInfo &pkg, core::LocOffsets errLoc, core::SymbolRef litSymbol) {
+    // Returns whether the reference causes a modularity error
+    static bool reportImportError(core::Context ctx, const core::packages::PackageInfo &thisPkg,
+                                  const core::packages::PackageInfo &pkg, core::LocOffsets errLoc,
+                                  core::SymbolRef litSymbol) {
         auto &db = ctx.state.packageDB();
         auto otherPackage = pkg.mangledName();
         auto strictDepsLevel = thisPkg.strictDependenciesLevel;
@@ -551,10 +554,10 @@ public:
             layeringViolation || strictDependenciesTooLow || causesCycle || badTestReference || causesVisibilityError;
         // visible_to errors are handled separately (by `updateVisibilityFor`),
         // so they're not included in this causesModularityError field of referencedPackages
-        referencedPackages[otherPackage].causesModularityError = hasModularityError && !causesVisibilityError;
+        bool causesModularityError = hasModularityError && !causesVisibilityError;
         if (!hasModularityError) {
             if (db.genPackagesMode() != core::packages::GenPackagesMode::Disabled) {
-                return;
+                return causesModularityError;
             }
 
             if (auto e = ctx.beginError(errLoc, core::errors::Packager::MissingImport)) {
@@ -634,7 +637,7 @@ public:
                     ctx.state.packageDB().updateVisibilityFor(otherPackage)) {
                     // Force the error to build here, so that we don't report an error
                     e.build();
-                    return;
+                    return causesModularityError;
                 }
 
                 ENFORCE(!reasons.empty(), "At least one reason should be present");
@@ -657,6 +660,7 @@ public:
                 e.addErrorNote("`{}`'s package is not imported", litSymbol.show(ctx));
             }
         }
+        return causesModularityError;
     }
 
     void postTransformConstantLit(core::Context ctx, const ast::ConstantLit &lit) {
@@ -697,7 +701,8 @@ public:
         referencedPackages[otherPackage] = {.importNeeded = !wasImported, .causesModularityError = false};
 
         if (!wasImported) {
-            reportImportError(ctx, this->package, pkg, lit.loc(), lit.symbol());
+            referencedPackages[otherPackage].causesModularityError =
+                reportImportError(ctx, this->package, pkg, lit.loc(), lit.symbol());
             return;
         }
 

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -526,44 +526,7 @@ public:
         }
     }
 
-    void postTransformConstantLit(core::Context ctx, const ast::ConstantLit &lit) {
-        if (constantAssignmentDefinitions.contains(&lit)) {
-            return;
-        }
-
-        auto litSymbol = lit.symbol();
-        if (!litSymbol.isClassOrModule() && !litSymbol.isFieldOrStaticField()) {
-            return;
-        }
-
-        // NOTE: this only tracks the information required for computing what symbols needed to be exported, and not for
-        // find all references. For example, if the current symbol is A::B::C::D, then only A::B::C::D will be added to
-        // symbolsReferenced, and not A, A::B, A::B::C.
-        // TODO(neil): we should also track A, A::B, A::B::C, so that we can use this for find all references too.
-        referencedSymbols.insert(litSymbol);
-
-        auto loc = litSymbol.loc(ctx);
-
-        auto otherFile = loc.file();
-        if (!otherFile.exists()) {
-            return;
-        }
-
-        auto &db = ctx.state.packageDB();
-
-        // no need to check visibility for these cases
-        auto otherPackage = litSymbol.enclosingClass(ctx).data(ctx)->package;
-        if (!otherPackage.exists() || this->package.mangledName() == otherPackage) {
-            return;
-        }
-        auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
-
-        auto *import = this->package.importsPackage(otherPackage);
-        auto wasImported = import != nullptr;
-
-        referencedPackages[otherPackage] = {.importNeeded = !wasImported, .causesModularityError = false};
-
-        if (!wasImported) {
+    static void reportImportError(core::Context ctx) {
             auto strictDepsLevel = this->package.strictDependenciesLevel;
             auto importStrictDepsLevel = pkg.strictDependenciesLevel;
             bool layeringViolation = false;
@@ -700,6 +663,47 @@ public:
                     e.addErrorNote("`{}`'s package is not imported", lit.symbol().show(ctx));
                 }
             }
+    }
+
+    void postTransformConstantLit(core::Context ctx, const ast::ConstantLit &lit) {
+        if (constantAssignmentDefinitions.contains(&lit)) {
+            return;
+        }
+
+        auto litSymbol = lit.symbol();
+        if (!litSymbol.isClassOrModule() && !litSymbol.isFieldOrStaticField()) {
+            return;
+        }
+
+        // NOTE: this only tracks the information required for computing what symbols needed to be exported, and not for
+        // find all references. For example, if the current symbol is A::B::C::D, then only A::B::C::D will be added to
+        // symbolsReferenced, and not A, A::B, A::B::C.
+        // TODO(neil): we should also track A, A::B, A::B::C, so that we can use this for find all references too.
+        referencedSymbols.insert(litSymbol);
+
+        auto loc = litSymbol.loc(ctx);
+
+        auto otherFile = loc.file();
+        if (!otherFile.exists()) {
+            return;
+        }
+
+        auto &db = ctx.state.packageDB();
+
+        // no need to check visibility for these cases
+        auto otherPackage = litSymbol.enclosingClass(ctx).data(ctx)->package;
+        if (!otherPackage.exists() || this->package.mangledName() == otherPackage) {
+            return;
+        }
+        auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
+
+        auto *import = this->package.importsPackage(otherPackage);
+        auto wasImported = import != nullptr;
+
+        referencedPackages[otherPackage] = {.importNeeded = !wasImported, .causesModularityError = false};
+
+        if (!wasImported) {
+            reportImportError(ctx);
             return;
         }
 

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -580,7 +580,7 @@ public:
 
         referencedPackages[otherPackage] = {.importNeeded = !wasImported, .causesModularityError = false};
 
-        if (!wasImported || !isExported) {
+        if (!wasImported) {
             auto strictDepsLevel = this->package.strictDependenciesLevel;
             auto importStrictDepsLevel = pkg.strictDependenciesLevel;
             bool layeringViolation = false;
@@ -606,7 +606,6 @@ public:
                     return;
                 }
 
-                if (!wasImported) {
                     if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
                         e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
                         e.addErrorLine(pkg.declLoc(), "Exported from package here");
@@ -617,41 +616,6 @@ public:
                             }
                         }
                     }
-                } else if (!isExported) {
-                    std::optional<core::AutocorrectSuggestion> exportAutocorrect;
-                    auto symToExport = litSymbol;
-                    auto enumClass = getEnumClassForEnumValue(ctx.state, symToExport);
-                    if (enumClass.exists()) {
-                        symToExport = enumClass;
-                    }
-                    bool definesBehavior = !litSymbol.isClassOrModule() ||
-                                           litSymbol.asClassOrModuleRef().data(ctx)->flags.isBehaviorDefining;
-                    if (definesBehavior) {
-                        // For compatibility with gen-packages, we do _not_ add an export if it doesn't define
-                        // behavior. This is mostly because it's easier to get Sorbet to behave like gen-packages
-                        // than the other way around.
-                        //
-                        // If we move to a world where all __package.rb edits are done via Sorbet autocorrects,
-                        // we could make this addExport call unconditional.
-                        if (auto exp = pkg.addExport(ctx, symToExport)) {
-                            exportAutocorrect.emplace(exp.value());
-                        }
-                    }
-
-                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedPackagePrivateName)) {
-                        e.setHeader("`{}` resolves but is not exported from `{}`", litSymbol.show(ctx), pkg.show(ctx));
-                        addExportInfo(ctx, e, litSymbol, definesBehavior);
-
-                        if (exportAutocorrect.has_value()) {
-                            e.maybeAddAutocorrect(move(exportAutocorrect));
-                            if (!db.errorHint().empty()) {
-                                e.addErrorNote("{}", db.errorHint());
-                            }
-                        }
-                    }
-                } else {
-                    ENFORCE(false);
-                }
             }
 
             // We should only report a visibility error if we're not going to add a visible_to to the package
@@ -730,15 +694,44 @@ public:
                         ENFORCE(false, "At most three reasons should be present");
                     }
                     e.setHeader("`{}` cannot be referenced here because {}", lit.symbol().show(ctx), reason);
-                    if (!isExported) {
-                        e.addErrorNote("`{}` is not exported", lit.symbol().show(ctx));
-                    } else if (!wasImported) {
                         e.addErrorNote("`{}`'s package is not imported", lit.symbol().show(ctx));
-                    } else {
-                        ENFORCE(false);
-                    }
                 }
             }
+        } else if (!isExported) {
+                if (db.genPackagesMode() != core::packages::GenPackagesMode::Disabled) {
+                    return;
+                }
+                    std::optional<core::AutocorrectSuggestion> exportAutocorrect;
+                    auto symToExport = litSymbol;
+                    auto enumClass = getEnumClassForEnumValue(ctx.state, symToExport);
+                    if (enumClass.exists()) {
+                        symToExport = enumClass;
+                    }
+                    bool definesBehavior = !litSymbol.isClassOrModule() ||
+                                           litSymbol.asClassOrModuleRef().data(ctx)->flags.isBehaviorDefining;
+                    if (definesBehavior) {
+                        // For compatibility with gen-packages, we do _not_ add an export if it doesn't define
+                        // behavior. This is mostly because it's easier to get Sorbet to behave like gen-packages
+                        // than the other way around.
+                        //
+                        // If we move to a world where all __package.rb edits are done via Sorbet autocorrects,
+                        // we could make this addExport call unconditional.
+                        if (auto exp = pkg.addExport(ctx, symToExport)) {
+                            exportAutocorrect.emplace(exp.value());
+                        }
+                    }
+
+                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedPackagePrivateName)) {
+                        e.setHeader("`{}` resolves but is not exported from `{}`", litSymbol.show(ctx), pkg.show(ctx));
+                        addExportInfo(ctx, e, litSymbol, definesBehavior);
+
+                        if (exportAutocorrect.has_value()) {
+                            e.maybeAddAutocorrect(move(exportAutocorrect));
+                            if (!db.errorHint().empty()) {
+                                e.addErrorNote("{}", db.errorHint());
+                            }
+                        }
+                    }
         }
     }
 

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -658,11 +658,10 @@ public:
                     }
                 }
 
-                if (!isExported && !wasImported) {
+                if (!wasImported) {
                     if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
-                        e.setHeader("`{}` resolves but is not exported from `{}` and `{}` is not imported",
-                                    litSymbol.show(ctx), pkg.show(ctx), pkg.show(ctx));
-                        addExportInfo(ctx, e, litSymbol, definesBehavior);
+                        e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
+                        e.addErrorLine(pkg.declLoc(), "Exported from package here");
                         addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
                     }
                 } else if (!isExported) {
@@ -670,12 +669,6 @@ public:
                         e.setHeader("`{}` resolves but is not exported from `{}`", litSymbol.show(ctx), pkg.show(ctx));
                         addExportInfo(ctx, e, litSymbol, definesBehavior);
 
-                        addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
-                    }
-                } else if (!wasImported) {
-                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
-                        e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
-                        e.addErrorLine(pkg.declLoc(), "Exported from package here");
                         addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
                     }
                 } else {

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -569,15 +569,6 @@ public:
         auto *import = this->package.importsPackage(otherPackage);
         auto wasImported = import != nullptr;
 
-        bool isExported = pkg.locs.exportAll.exists();
-        if (litSymbol.isClassOrModule()) {
-            isExported = isExported || litSymbol.asClassOrModuleRef().data(ctx)->flags.isExported;
-        } else if (litSymbol.isFieldOrStaticField()) {
-            isExported = isExported || litSymbol.asFieldRef().data(ctx)->flags.isExported;
-        }
-        isExported = isExported || db.allowRelaxedPackagerChecksFor(this->package.mangledName());
-        isExported = isExported || (wasImported && import->usesInternals);
-
         referencedPackages[otherPackage] = {.importNeeded = !wasImported, .causesModularityError = false};
 
         if (!wasImported) {
@@ -697,7 +688,19 @@ public:
                     e.addErrorNote("`{}`'s package is not imported", lit.symbol().show(ctx));
                 }
             }
-        } else if (!isExported) {
+            return;
+        }
+
+        bool isExported = pkg.locs.exportAll.exists();
+        if (litSymbol.isClassOrModule()) {
+            isExported = isExported || litSymbol.asClassOrModuleRef().data(ctx)->flags.isExported;
+        } else if (litSymbol.isFieldOrStaticField()) {
+            isExported = isExported || litSymbol.asFieldRef().data(ctx)->flags.isExported;
+        }
+        isExported = isExported || db.allowRelaxedPackagerChecksFor(this->package.mangledName());
+        isExported = isExported || (wasImported && import->usesInternals);
+
+        if (!isExported) {
             if (db.genPackagesMode() != core::packages::GenPackagesMode::Disabled) {
                 return;
             }

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -526,23 +526,23 @@ public:
         }
     }
 
-    static void reportImportError(core::Context ctx) {
-        auto strictDepsLevel = this->package.strictDependenciesLevel;
+    static void reportImportError(core::Context ctx, const core::packages::PackageInfo &thisPkg) {
+        auto strictDepsLevel = thisPkg.strictDependenciesLevel;
         auto importStrictDepsLevel = pkg.strictDependenciesLevel;
         bool layeringViolation = false;
         bool strictDependenciesTooLow = false;
         bool causesCycle = false;
-        bool causesVisibilityError = !pkg.isVisibleTo(ctx, this->package);
-        bool badTestReference = pkg.testPackage() && !this->package.testPackage();
+        bool causesVisibilityError = !pkg.isVisibleTo(ctx, thisPkg);
+        bool badTestReference = pkg.testPackage() && !thisPkg.testPackage();
         optional<string> path;
         if (db.enforceLayering()) {
             layeringViolation = strictDepsLevel > core::packages::StrictDependenciesLevel::False &&
-                                this->package.causesLayeringViolation(db, pkg);
+                                thisPkg.causesLayeringViolation(db, pkg);
             strictDependenciesTooLow = importStrictDepsLevel != core::packages::StrictDependenciesLevel::None &&
-                                       importStrictDepsLevel < this->package.minimumStrictDependenciesLevel();
+                                       importStrictDepsLevel < thisPkg.minimumStrictDependenciesLevel();
             // If there's a path from the imported packaged to this package, then adding the import will close
             // the loop and cause a cycle.
-            path = pkg.pathTo(ctx, this->package.mangledName());
+            path = pkg.pathTo(ctx, thisPkg.mangledName());
             causesCycle = strictDepsLevel >= core::packages::StrictDependenciesLevel::LayeredDag && path.has_value();
         }
         bool hasModularityError =
@@ -558,7 +558,7 @@ public:
             if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
                 e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
                 e.addErrorLine(pkg.declLoc(), "Exported from package here");
-                if (auto importAutocorrect = this->package.addImport(ctx, pkg)) {
+                if (auto importAutocorrect = thisPkg.addImport(ctx, pkg)) {
                     e.maybeAddAutocorrect(move(importAutocorrect));
                     if (!db.errorHint().empty()) {
                         e.addErrorNote("{}", db.errorHint());
@@ -574,45 +574,45 @@ public:
                                              : core::errors::Packager::StrictDependenciesViolation;
             if (auto e = ctx.beginError(lit.loc(), error)) {
                 vector<string> reasons;
-                e.addErrorLine(this->package.declLoc(), "Enclosing package declared here");
+                e.addErrorLine(thisPkg.declLoc(), "Enclosing package declared here");
 
                 // We should only report a visibility error if we're not going to add a visible_to to the package
                 // Otherwise the error is pointless since it'll go away after the new visible_to is added
                 if (causesVisibilityError && !ctx.state.packageDB().updateVisibilityFor(otherPackage)) {
                     reasons.emplace_back(core::ErrorColors::format(
                         "Package `{}` includes explicit visibility modifiers and cannot be imported from `{}`",
-                        pkg.show(ctx), this->package.show(ctx)));
+                        pkg.show(ctx), thisPkg.show(ctx)));
                     e.addErrorNote("Please consult with the owning team before adding a `{}` line to the package `{}`",
                                    "visible_to", pkg.show(ctx));
                 }
 
                 if (badTestReference) {
                     reasons.emplace_back(core::ErrorColors::format("`{}` may not reference `{}` packages",
-                                                                   this->package.show(ctx), "test!"));
+                                                                   thisPkg.show(ctx), "test!"));
                     e.addErrorLine(pkg.declLoc(), "Referenced `{}` package defined here", "test!");
                 }
                 if (causesCycle) {
                     reasons.emplace_back(core::ErrorColors::format("importing its package would put `{}` into a cycle",
-                                                                   this->package.show(ctx)));
+                                                                   thisPkg.show(ctx)));
                     auto currentStrictDepsLevel = fmt::format(
                         "strict_dependencies '{}'", core::packages::strictDependenciesLevelToString(strictDepsLevel));
-                    e.addErrorLine(core::Loc(this->package.file, this->package.locs.strictDependenciesLevel),
-                                   "`{}` is `{}`, which disallows cycles", this->package.show(ctx),
+                    e.addErrorLine(core::Loc(thisPkg.file, thisPkg.locs.strictDependenciesLevel),
+                                   "`{}` is `{}`, which disallows cycles", thisPkg.show(ctx),
                                    currentStrictDepsLevel);
                     ENFORCE(path.has_value(),
-                            "Path from pkg to this->package should always exist if causesCycle is true");
-                    e.addErrorNote("Path from `{}` to `{}`:\n{}", pkg.show(ctx), this->package.show(ctx), path.value());
+                            "Path from pkg to thisPkg should always exist if causesCycle is true");
+                    e.addErrorNote("Path from `{}` to `{}`:\n{}", pkg.show(ctx), thisPkg.show(ctx), path.value());
                 }
 
                 if (layeringViolation) {
                     reasons.emplace_back("importing its package would cause a layering violation");
                     ENFORCE(pkg.layer.exists(), "causesLayeringViolation should return false if layer is not set");
-                    ENFORCE(this->package.layer.exists(),
+                    ENFORCE(thisPkg.layer.exists(),
                             "causesLayeringViolation should return false if layer is not set");
                     e.addErrorLine(core::Loc(pkg.file, pkg.locs.layer),
                                    "Package `{}` must be at most layer `{}` (to match package `{}`) but is "
                                    "currently layer `{}`",
-                                   pkg.show(ctx), this->package.layer.show(ctx), this->package.show(ctx),
+                                   pkg.show(ctx), thisPkg.layer.show(ctx), thisPkg.show(ctx),
                                    pkg.layer.show(ctx));
                 }
 
@@ -623,7 +623,7 @@ public:
                             "strictDependenciesTooLow should be false if strict_dependencies level is not set");
                     auto requiredStrictDepsLevel =
                         fmt::format("strict_dependencies '{}'", core::packages::strictDependenciesLevelToString(
-                                                                    this->package.minimumStrictDependenciesLevel()));
+                                                                    thisPkg.minimumStrictDependenciesLevel()));
                     auto currentStrictDepsLevel =
                         fmt::format("strict_dependencies '{}'",
                                     core::packages::strictDependenciesLevelToString(importStrictDepsLevel));
@@ -699,7 +699,7 @@ public:
         referencedPackages[otherPackage] = {.importNeeded = !wasImported, .causesModularityError = false};
 
         if (!wasImported) {
-            reportImportError(ctx);
+            reportImportError(ctx, this->package);
             return;
         }
 

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -587,8 +587,8 @@ public:
                 }
 
                 if (badTestReference) {
-                    reasons.emplace_back(core::ErrorColors::format("`{}` may not reference `{}` packages",
-                                                                   thisPkg.show(ctx), "test!"));
+                    reasons.emplace_back(
+                        core::ErrorColors::format("`{}` may not reference `{}` packages", thisPkg.show(ctx), "test!"));
                     e.addErrorLine(pkg.declLoc(), "Referenced `{}` package defined here", "test!");
                 }
                 if (causesCycle) {
@@ -597,23 +597,19 @@ public:
                     auto currentStrictDepsLevel = fmt::format(
                         "strict_dependencies '{}'", core::packages::strictDependenciesLevelToString(strictDepsLevel));
                     e.addErrorLine(core::Loc(thisPkg.file, thisPkg.locs.strictDependenciesLevel),
-                                   "`{}` is `{}`, which disallows cycles", thisPkg.show(ctx),
-                                   currentStrictDepsLevel);
-                    ENFORCE(path.has_value(),
-                            "Path from pkg to thisPkg should always exist if causesCycle is true");
+                                   "`{}` is `{}`, which disallows cycles", thisPkg.show(ctx), currentStrictDepsLevel);
+                    ENFORCE(path.has_value(), "Path from pkg to thisPkg should always exist if causesCycle is true");
                     e.addErrorNote("Path from `{}` to `{}`:\n{}", pkg.show(ctx), thisPkg.show(ctx), path.value());
                 }
 
                 if (layeringViolation) {
                     reasons.emplace_back("importing its package would cause a layering violation");
                     ENFORCE(pkg.layer.exists(), "causesLayeringViolation should return false if layer is not set");
-                    ENFORCE(thisPkg.layer.exists(),
-                            "causesLayeringViolation should return false if layer is not set");
+                    ENFORCE(thisPkg.layer.exists(), "causesLayeringViolation should return false if layer is not set");
                     e.addErrorLine(core::Loc(pkg.file, pkg.locs.layer),
                                    "Package `{}` must be at most layer `{}` (to match package `{}`) but is "
                                    "currently layer `{}`",
-                                   pkg.show(ctx), thisPkg.layer.show(ctx), thisPkg.show(ctx),
-                                   pkg.layer.show(ctx));
+                                   pkg.show(ctx), thisPkg.layer.show(ctx), thisPkg.show(ctx), pkg.layer.show(ctx));
                 }
 
                 if (strictDependenciesTooLow) {
@@ -621,9 +617,9 @@ public:
                         core::ErrorColors::format("its `{}` is not strict enough", "strict_dependencies"));
                     ENFORCE(importStrictDepsLevel != core::packages::StrictDependenciesLevel::None,
                             "strictDependenciesTooLow should be false if strict_dependencies level is not set");
-                    auto requiredStrictDepsLevel =
-                        fmt::format("strict_dependencies '{}'", core::packages::strictDependenciesLevelToString(
-                                                                    thisPkg.minimumStrictDependenciesLevel()));
+                    auto requiredStrictDepsLevel = fmt::format(
+                        "strict_dependencies '{}'",
+                        core::packages::strictDependenciesLevelToString(thisPkg.minimumStrictDependenciesLevel()));
                     auto currentStrictDepsLevel =
                         fmt::format("strict_dependencies '{}'",
                                     core::packages::strictDependenciesLevelToString(importStrictDepsLevel));

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -583,9 +583,12 @@ public:
                 causesCycle =
                     strictDepsLevel >= core::packages::StrictDependenciesLevel::LayeredDag && path.has_value();
             }
-            bool hasModularityError = layeringViolation || strictDependenciesTooLow || causesCycle || badTestReference;
-            referencedPackages[otherPackage].causesModularityError = hasModularityError;
-            if (!hasModularityError && !causesVisibilityError) {
+            bool hasModularityError = layeringViolation || strictDependenciesTooLow || causesCycle ||
+                                      badTestReference || causesVisibilityError;
+            // visible_to errors are handled separately (by `updateVisibilityFor`),
+            // so they're not included in this causesModularityError field of referencedPackages
+            referencedPackages[otherPackage].causesModularityError = hasModularityError && !causesVisibilityError;
+            if (!hasModularityError) {
                 if (db.genPackagesMode() != core::packages::GenPackagesMode::Disabled) {
                     return;
                 }
@@ -600,20 +603,7 @@ public:
                         }
                     }
                 }
-            }
-
-            // We should only report a visibility error if we're not going to add a visible_to to the package
-            // Otherwise the error is pointless since it'll go away after the new visible_to is added
-            if (causesVisibilityError && !ctx.state.packageDB().updateVisibilityFor(otherPackage)) {
-                if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::ImportNotVisible)) {
-                    e.setHeader("Package `{}` includes explicit visibility modifiers and cannot be imported from `{}`",
-                                pkg.show(ctx), this->package.show(ctx));
-                    e.addErrorNote("Please consult with the owning team before adding a `{}` line to the package `{}`",
-                                   "visible_to", pkg.show(ctx));
-                }
-            }
-
-            if (hasModularityError) {
+            } else {
                 // TODO(neil): Provide actionable advice and/or link to a doc that would help the user resolve these
                 // layering/strict_dependencies issues.
                 auto error = causesCycle         ? core::errors::Packager::StrictDependenciesViolation
@@ -623,6 +613,18 @@ public:
                 if (auto e = ctx.beginError(lit.loc(), error)) {
                     vector<string> reasons;
                     e.addErrorLine(this->package.declLoc(), "Enclosing package declared here");
+
+                    // We should only report a visibility error if we're not going to add a visible_to to the package
+                    // Otherwise the error is pointless since it'll go away after the new visible_to is added
+                    if (causesVisibilityError && !ctx.state.packageDB().updateVisibilityFor(otherPackage)) {
+                        reasons.emplace_back(core::ErrorColors::format(
+                            "Package `{}` includes explicit visibility modifiers and cannot be imported from `{}`",
+                            pkg.show(ctx), this->package.show(ctx)));
+                        e.addErrorNote(
+                            "Please consult with the owning team before adding a `{}` line to the package `{}`",
+                            "visible_to", pkg.show(ctx));
+                    }
+
                     if (badTestReference) {
                         reasons.emplace_back(core::ErrorColors::format("`{}` may not reference `{}` packages",
                                                                        this->package.show(ctx), "test!"));
@@ -671,6 +673,13 @@ public:
                                        requiredStrictDepsLevel, currentStrictDepsLevel);
                     }
 
+                    if (reasons.empty() && causesVisibilityError &&
+                        ctx.state.packageDB().updateVisibilityFor(otherPackage)) {
+                        // Force the error to build here, so that we don't report an error
+                        e.build();
+                        return;
+                    }
+
                     ENFORCE(!reasons.empty(), "At least one reason should be present");
                     string reason;
                     if (reasons.size() == 1) {
@@ -681,8 +690,11 @@ public:
                         reason = fmt::format("{}, {}, and {}", reasons[0], reasons[1], reasons[2]);
                     } else if (reasons.size() == 4) {
                         reason = fmt::format("{}, {}, {}, and {}", reasons[0], reasons[1], reasons[2], reasons[3]);
+                    } else if (reasons.size() == 5) {
+                        reason = fmt::format("{}, {}, {}, {}, and {}", reasons[0], reasons[1], reasons[2], reasons[3],
+                                             reasons[4]);
                     } else {
-                        ENFORCE(false, "At most four reasons should be present");
+                        ENFORCE(false, "At most five reasons should be present");
                     }
                     e.setHeader("`{}` cannot be referenced here because {}", lit.symbol().show(ctx), reason);
                     e.addErrorNote("`{}`'s package is not imported", lit.symbol().show(ctx));

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -590,8 +590,6 @@ public:
             isExported = isExported || litSymbol.asFieldRef().data(ctx)->flags.isExported;
         }
         isExported = isExported || db.allowRelaxedPackagerChecksFor(this->package.mangledName());
-        bool definesBehavior =
-            !litSymbol.isClassOrModule() || litSymbol.asClassOrModuleRef().data(ctx)->flags.isBehaviorDefining;
         auto *import = this->package.importsPackage(otherPackage);
         auto wasImported = import != nullptr;
         isExported = isExported || (wasImported && import->usesInternals);
@@ -638,6 +636,8 @@ public:
                     if (enumClass.exists()) {
                         symToExport = enumClass;
                     }
+                    bool definesBehavior = !litSymbol.isClassOrModule() ||
+                                           litSymbol.asClassOrModuleRef().data(ctx)->flags.isBehaviorDefining;
                     if (definesBehavior) {
                         // For compatibility with gen-packages, we do _not_ add an export if it doesn't define
                         // behavior. This is mostly because it's easier to get Sorbet to behave like gen-packages

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -526,7 +526,9 @@ public:
         }
     }
 
-    static void reportImportError(core::Context ctx, const core::packages::PackageInfo &thisPkg) {
+    static void reportImportError(core::Context ctx, const core::packages::PackageInfo &thisPkg, const core::packages::PackageInfo &pkg, core::LocOffsets errLoc, core::SymbolRef litSymbol) {
+        auto &db = ctx.state.packageDB();
+        auto otherPackage = pkg.mangledName();
         auto strictDepsLevel = thisPkg.strictDependenciesLevel;
         auto importStrictDepsLevel = pkg.strictDependenciesLevel;
         bool layeringViolation = false;
@@ -555,8 +557,8 @@ public:
                 return;
             }
 
-            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
-                e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
+            if (auto e = ctx.beginError(errLoc, core::errors::Packager::MissingImport)) {
+                e.setHeader("`{}` resolves but its package is not imported", litSymbol.show(ctx));
                 e.addErrorLine(pkg.declLoc(), "Exported from package here");
                 if (auto importAutocorrect = thisPkg.addImport(ctx, pkg)) {
                     e.maybeAddAutocorrect(move(importAutocorrect));
@@ -572,7 +574,7 @@ public:
                          : layeringViolation ? core::errors::Packager::LayeringViolation
                          : badTestReference  ? core::errors::Packager::TestImportMismatch
                                              : core::errors::Packager::StrictDependenciesViolation;
-            if (auto e = ctx.beginError(lit.loc(), error)) {
+            if (auto e = ctx.beginError(errLoc, error)) {
                 vector<string> reasons;
                 e.addErrorLine(thisPkg.declLoc(), "Enclosing package declared here");
 
@@ -651,8 +653,8 @@ public:
                 } else {
                     ENFORCE(false, "At most five reasons should be present");
                 }
-                e.setHeader("`{}` cannot be referenced here because {}", lit.symbol().show(ctx), reason);
-                e.addErrorNote("`{}`'s package is not imported", lit.symbol().show(ctx));
+                e.setHeader("`{}` cannot be referenced here because {}", litSymbol.show(ctx), reason);
+                e.addErrorNote("`{}`'s package is not imported", litSymbol.show(ctx));
             }
         }
     }
@@ -695,7 +697,7 @@ public:
         referencedPackages[otherPackage] = {.importNeeded = !wasImported, .causesModularityError = false};
 
         if (!wasImported) {
-            reportImportError(ctx, this->package);
+            reportImportError(ctx, this->package, pkg, lit.loc(), lit.symbol());
             return;
         }
 

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -506,15 +506,7 @@ class VisibilityCheckerPass final {
         auto &db = ctx.state.packageDB();
         auto hasAutocorrect = importAutocorrect.has_value() || exportAutocorrect.has_value();
 
-        if (importAutocorrect.has_value() && exportAutocorrect.has_value()) {
-            auto combinedTitle = fmt::format("{} and {}", importAutocorrect->title, exportAutocorrect->title);
-            importAutocorrect->edits.insert(importAutocorrect->edits.end(),
-                                            make_move_iterator(exportAutocorrect->edits.begin()),
-                                            make_move_iterator(exportAutocorrect->edits.end()));
-            e.addAutocorrect(core::AutocorrectSuggestion{combinedTitle, move(importAutocorrect->edits),
-                                                         false /* isDidYouMean */, false /* hideEdit */,
-                                                         /* shouldSkipWhenAggregated */ true});
-        } else if (importAutocorrect.has_value()) {
+        if (importAutocorrect.has_value()) {
             e.addAutocorrect(std::move(importAutocorrect.value()));
         } else if (exportAutocorrect.has_value()) {
             e.addAutocorrect(std::move(exportAutocorrect.value()));

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -500,23 +500,6 @@ class VisibilityCheckerPass final {
         }
     }
 
-    void addImportExportAutocorrect(core::Context ctx, core::ErrorBuilder &e,
-                                    optional<core::AutocorrectSuggestion> &&importAutocorrect,
-                                    optional<core::AutocorrectSuggestion> &&exportAutocorrect) {
-        auto &db = ctx.state.packageDB();
-        auto hasAutocorrect = importAutocorrect.has_value() || exportAutocorrect.has_value();
-
-        if (importAutocorrect.has_value()) {
-            e.addAutocorrect(std::move(importAutocorrect.value()));
-        } else if (exportAutocorrect.has_value()) {
-            e.addAutocorrect(std::move(exportAutocorrect.value()));
-        }
-
-        if (hasAutocorrect && !db.errorHint().empty()) {
-            e.addErrorNote("{}", db.errorHint());
-        }
-    }
-
 public:
     const core::packages::PackageInfo &package;
     UnorderedMap<core::packages::MangledName, core::packages::PackageReferenceInfo> referencedPackages;
@@ -624,11 +607,15 @@ public:
                 }
 
                 if (!wasImported) {
-                    auto importAutocorrect = this->package.addImport(ctx, pkg);
                     if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
                         e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
                         e.addErrorLine(pkg.declLoc(), "Exported from package here");
-                        addImportExportAutocorrect(ctx, e, move(importAutocorrect), nullopt);
+                        if (auto importAutocorrect = this->package.addImport(ctx, pkg)) {
+                            e.maybeAddAutocorrect(move(importAutocorrect));
+                            if (!db.errorHint().empty()) {
+                                e.addErrorNote("{}", db.errorHint());
+                            }
+                        }
                     }
                 } else if (!isExported) {
                     std::optional<core::AutocorrectSuggestion> exportAutocorrect;
@@ -655,7 +642,12 @@ public:
                         e.setHeader("`{}` resolves but is not exported from `{}`", litSymbol.show(ctx), pkg.show(ctx));
                         addExportInfo(ctx, e, litSymbol, definesBehavior);
 
-                        addImportExportAutocorrect(ctx, e, nullopt, move(exportAutocorrect));
+                        if (exportAutocorrect.has_value()) {
+                            e.maybeAddAutocorrect(move(exportAutocorrect));
+                            if (!db.errorHint().empty()) {
+                                e.addErrorNote("{}", db.errorHint());
+                            }
+                        }
                     }
                 } else {
                     ENFORCE(false);

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -632,14 +632,15 @@ public:
                     return;
                 }
 
-                std::optional<core::AutocorrectSuggestion> importAutocorrect;
                 if (!wasImported) {
-                    if (auto exp = this->package.addImport(ctx, pkg)) {
-                        importAutocorrect.emplace(exp.value());
+                    auto importAutocorrect = this->package.addImport(ctx, pkg);
+                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
+                        e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
+                        e.addErrorLine(pkg.declLoc(), "Exported from package here");
+                        addImportExportAutocorrect(ctx, e, move(importAutocorrect), nullopt);
                     }
-                }
-                std::optional<core::AutocorrectSuggestion> exportAutocorrect;
-                if (!isExported) {
+                } else if (!isExported) {
+                    std::optional<core::AutocorrectSuggestion> exportAutocorrect;
                     auto symToExport = litSymbol;
                     auto enumClass = getEnumClassForEnumValue(ctx.state, symToExport);
                     if (enumClass.exists()) {
@@ -656,20 +657,12 @@ public:
                             exportAutocorrect.emplace(exp.value());
                         }
                     }
-                }
 
-                if (!wasImported) {
-                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
-                        e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
-                        e.addErrorLine(pkg.declLoc(), "Exported from package here");
-                        addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
-                    }
-                } else if (!isExported) {
                     if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedPackagePrivateName)) {
                         e.setHeader("`{}` resolves but is not exported from `{}`", litSymbol.show(ctx), pkg.show(ctx));
                         addExportInfo(ctx, e, litSymbol, definesBehavior);
 
-                        addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
+                        addImportExportAutocorrect(ctx, e, nullopt, move(exportAutocorrect));
                     }
                 } else {
                     ENFORCE(false);

--- a/test/cli/package-attributed-errors/test.out
+++ b/test/cli/package-attributed-errors/test.out
@@ -1,9 +1,9 @@
-[App] app/main.rb:5: `Lib::Nested::SomeClass` resolves but is not exported from `Lib::Nested` and `Lib::Nested` is not imported https://srb.help/3718
+[App] app/main.rb:5: `Lib::Nested::SomeClass` resolves but its package is not imported https://srb.help/3718
      5 |    Lib::Nested::SomeClass
             ^^^^^^^^^^^^^^^^^^^^^^
-    lib/nested/some_class.rb:3: Defined here
-     3 |class Lib::Nested::SomeClass
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    lib/nested/__package.rb:3: Exported from package here
+     3 |class Lib::Nested < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     app/__package.rb:3: Insert `import Lib::Nested`
      3 |class App < PackageSpec

--- a/test/cli/package-attributed-errors/test.out
+++ b/test/cli/package-attributed-errors/test.out
@@ -8,9 +8,6 @@
     app/__package.rb:3: Insert `import Lib::Nested`
      3 |class App < PackageSpec
                                ^
-    lib/nested/__package.rb:4: Insert `export Lib::Nested::SomeClass`
-     4 |  bad
-             ^
 
 [Lib::Nested] lib/nested/some_class.rb:4: The method `foo` does not have a `sig` https://srb.help/7017
      4 |  def foo; end

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -53,22 +53,15 @@ use_other_package/foo.rb:15: `Foo::Bar::OtherPackage::OtherClass` resolves but i
      7 |  strict_dependencies 'layered'
                                        ^
 
-use_other_package/foo.rb:18: Package `Foo::MyPackage` may not reference `test!` packages https://srb.help/3735
-    18 |  Test::Foo::Bar::OtherPackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_other_package/__package.rb:5: Defined here
-     5 |class Foo::MyPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/test/__package.rb:4: Referenced `test!` package defined here
-     4 |class Test::Foo::Bar::OtherPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-use_other_package/foo.rb:18: `Test::Foo::Bar::OtherPackage::TestUtil` cannot be referenced here because importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
+use_other_package/foo.rb:18: `Test::Foo::Bar::OtherPackage::TestUtil` cannot be referenced here because `Foo::MyPackage` may not reference `test!` packages, importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
     18 |  Test::Foo::Bar::OtherPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_other_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    other/test/__package.rb:4: Referenced `test!` package defined here
+     4 |class Test::Foo::Bar::OtherPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     other/test/__package.rb:6: Package `Test::Foo::Bar::OtherPackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `test`
      6 |  layer 'test'
                 ^^^^^^
@@ -99,7 +92,7 @@ use_other_package/test/foo.test.rb:6: `Foo::Bar::OtherPackage::ImportMeTestOnly`
     use_other_package/test/__package.rb:9: Inserted `import Foo::Bar::OtherPackage`
      9 |
         ^
-Errors: 9
+Errors: 8
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
@@ -136,22 +129,15 @@ use_app_package/foo.rb:7: `Foo::Bar::AppPackageTest::OtherClass` cannot be refer
   Note:
     `Foo::Bar::AppPackageTest::OtherClass`'s package is not imported
 
-use_app_package/foo.rb:13: Package `Foo::MyPackage` may not reference `test!` packages https://srb.help/3735
-    13 |  Test::Foo::Bar::AppPackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_app_package/__package.rb:5: Defined here
-     5 |class Foo::MyPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    app_package/test/__package.rb:4: Referenced `test!` package defined here
-     4 |class Test::Foo::Bar::AppPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-use_app_package/foo.rb:13: `Test::Foo::Bar::AppPackage::TestUtil` cannot be referenced here because importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
+use_app_package/foo.rb:13: `Test::Foo::Bar::AppPackage::TestUtil` cannot be referenced here because `Foo::MyPackage` may not reference `test!` packages, importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
     13 |  Test::Foo::Bar::AppPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    app_package/test/__package.rb:4: Referenced `test!` package defined here
+     4 |class Test::Foo::Bar::AppPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     app_package/test/__package.rb:6: Package `Test::Foo::Bar::AppPackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `test`
      6 |  layer 'test'
                 ^^^^^^
@@ -171,7 +157,7 @@ use_app_package/test/foo.test.rb:6: `Foo::Bar::AppPackage::ImportMeTestOnly` res
     use_app_package/test/__package.rb:9: Inserted `import Foo::Bar::AppPackage`
      9 |
         ^
-Errors: 5
+Errors: 4
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
@@ -207,22 +193,15 @@ use_false_package/foo.rb:7: `Foo::Bar::FalsePackageTest::OtherClass` cannot be r
   Note:
     `Foo::Bar::FalsePackageTest::OtherClass`'s package is not imported
 
-use_false_package/foo.rb:13: Package `Foo::MyPackage` may not reference `test!` packages https://srb.help/3735
-    13 |  Test::Foo::Bar::FalsePackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_false_package/__package.rb:5: Defined here
-     5 |class Foo::MyPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    false_package/test/__package.rb:4: Referenced `test!` package defined here
-     4 |class Test::Foo::Bar::FalsePackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-use_false_package/foo.rb:13: `Test::Foo::Bar::FalsePackage::TestUtil` cannot be referenced here because importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
+use_false_package/foo.rb:13: `Test::Foo::Bar::FalsePackage::TestUtil` cannot be referenced here because `Foo::MyPackage` may not reference `test!` packages, importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
     13 |  Test::Foo::Bar::FalsePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    false_package/test/__package.rb:4: Referenced `test!` package defined here
+     4 |class Test::Foo::Bar::FalsePackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     false_package/test/__package.rb:6: Package `Test::Foo::Bar::FalsePackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `test`
      6 |  layer 'test'
                 ^^^^^^
@@ -242,7 +221,7 @@ use_false_package/test/foo.test.rb:4: `Test::Foo::Bar::FalsePackage::TestUtil` r
     use_false_package/test/__package.rb:11: Inserted `import Test::Foo::Bar::FalsePackage`
     11 |  import Foo::Bar::FalsePackageTest
                                            ^
-Errors: 5
+Errors: 4
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
@@ -284,22 +263,15 @@ use_false_and_app_package/foo.rb:7: `Foo::Bar::FalseAndAppPackageTest::OtherClas
   Note:
     `Foo::Bar::FalseAndAppPackageTest::OtherClass`'s package is not imported
 
-use_false_and_app_package/foo.rb:13: Package `Foo::MyPackage` may not reference `test!` packages https://srb.help/3735
-    13 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_false_and_app_package/__package.rb:5: Defined here
-     5 |class Foo::MyPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    false_and_app_package/test/__package.rb:4: Referenced `test!` package defined here
-     4 |class Test::Foo::Bar::FalseAndAppPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-use_false_and_app_package/foo.rb:13: `Test::Foo::Bar::FalseAndAppPackage::TestUtil` cannot be referenced here because importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
+use_false_and_app_package/foo.rb:13: `Test::Foo::Bar::FalseAndAppPackage::TestUtil` cannot be referenced here because `Foo::MyPackage` may not reference `test!` packages, importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
     13 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_and_app_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    false_and_app_package/test/__package.rb:4: Referenced `test!` package defined here
+     4 |class Test::Foo::Bar::FalseAndAppPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     false_and_app_package/test/__package.rb:6: Package `Test::Foo::Bar::FalseAndAppPackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `test`
      6 |  layer 'test'
                 ^^^^^^
@@ -319,7 +291,7 @@ use_false_and_app_package/test/foo.test.rb:4: `Test::Foo::Bar::FalseAndAppPackag
     use_false_and_app_package/test/__package.rb:11: Inserted `import Test::Foo::Bar::FalseAndAppPackage`
     11 |  import Foo::Bar::FalseAndAppPackageTest
                                                  ^
-Errors: 5
+Errors: 4
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
@@ -365,22 +337,15 @@ use_cycle_package/foo.rb:7: `Foo::Bar::CyclePackageTest::OtherClass` cannot be r
   Note:
     `Foo::Bar::CyclePackageTest::OtherClass`'s package is not imported
 
-use_cycle_package/foo.rb:13: Package `Foo::MyPackage` may not reference `test!` packages https://srb.help/3735
-    13 |  Test::Foo::Bar::CyclePackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_cycle_package/__package.rb:5: Defined here
-     5 |class Foo::MyPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    cycle_package/test/__package.rb:4: Referenced `test!` package defined here
-     4 |class Test::Foo::Bar::CyclePackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-use_cycle_package/foo.rb:13: `Test::Foo::Bar::CyclePackage::TestUtil` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
+use_cycle_package/foo.rb:13: `Test::Foo::Bar::CyclePackage::TestUtil` cannot be referenced here because `Foo::MyPackage` may not reference `test!` packages, importing its package would put `Foo::MyPackage` into a cycle, importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
     13 |  Test::Foo::Bar::CyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_cycle_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    cycle_package/test/__package.rb:4: Referenced `test!` package defined here
+     4 |class Test::Foo::Bar::CyclePackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
      7 |  strict_dependencies 'layered_dag'
                               ^^^^^^^^^^^^^
@@ -409,7 +374,7 @@ use_cycle_package/test/foo.test.rb:4: `Test::Foo::Bar::CyclePackage::TestUtil` r
     use_cycle_package/test/__package.rb:9: Inserted `import Test::Foo::Bar::CyclePackage`
      9 |
         ^
-Errors: 5
+Errors: 4
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
@@ -461,22 +426,15 @@ use_app_cycle_package/foo.rb:7: `Foo::Bar::AppCyclePackageTest::OtherClass` cann
   Note:
     `Foo::Bar::AppCyclePackageTest::OtherClass`'s package is not imported
 
-use_app_cycle_package/foo.rb:13: Package `Foo::MyPackage` may not reference `test!` packages https://srb.help/3735
-    13 |  Test::Foo::Bar::AppCyclePackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_app_cycle_package/__package.rb:5: Defined here
-     5 |class Foo::MyPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    app_cycle_package/test/__package.rb:4: Referenced `test!` package defined here
-     4 |class Test::Foo::Bar::AppCyclePackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-use_app_cycle_package/foo.rb:13: `Test::Foo::Bar::AppCyclePackage::TestUtil` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
+use_app_cycle_package/foo.rb:13: `Test::Foo::Bar::AppCyclePackage::TestUtil` cannot be referenced here because `Foo::MyPackage` may not reference `test!` packages, importing its package would put `Foo::MyPackage` into a cycle, importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
     13 |  Test::Foo::Bar::AppCyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_cycle_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    app_cycle_package/test/__package.rb:4: Referenced `test!` package defined here
+     4 |class Test::Foo::Bar::AppCyclePackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
      7 |  strict_dependencies 'layered_dag'
                               ^^^^^^^^^^^^^
@@ -505,7 +463,7 @@ use_app_cycle_package/test/foo.test.rb:4: `Test::Foo::Bar::AppCyclePackage::Test
     use_app_cycle_package/test/__package.rb:9: Inserted `import Test::Foo::Bar::AppCyclePackage`
      9 |
         ^
-Errors: 5
+Errors: 4
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
@@ -557,22 +515,15 @@ use_false_cycle_package/foo.rb:7: `Foo::Bar::FalseCyclePackageTest::OtherClass` 
   Note:
     `Foo::Bar::FalseCyclePackageTest::OtherClass`'s package is not imported
 
-use_false_cycle_package/foo.rb:13: Package `Foo::MyPackage` may not reference `test!` packages https://srb.help/3735
-    13 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_false_cycle_package/__package.rb:5: Defined here
-     5 |class Foo::MyPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    false_cycle_package/test/__package.rb:4: Referenced `test!` package defined here
-     4 |class Test::Foo::Bar::FalseCyclePackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-use_false_cycle_package/foo.rb:13: `Test::Foo::Bar::FalseCyclePackage::TestUtil` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
+use_false_cycle_package/foo.rb:13: `Test::Foo::Bar::FalseCyclePackage::TestUtil` cannot be referenced here because `Foo::MyPackage` may not reference `test!` packages, importing its package would put `Foo::MyPackage` into a cycle, importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
     13 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_cycle_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    false_cycle_package/test/__package.rb:4: Referenced `test!` package defined here
+     4 |class Test::Foo::Bar::FalseCyclePackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
      7 |  strict_dependencies 'layered_dag'
                               ^^^^^^^^^^^^^
@@ -601,7 +552,7 @@ use_false_cycle_package/test/foo.test.rb:4: `Test::Foo::Bar::FalseCyclePackage::
     use_false_cycle_package/test/__package.rb:11: Inserted `import Test::Foo::Bar::FalseCyclePackage`
     11 |  import Foo::Bar::FalseCyclePackageTest
                                                 ^
-Errors: 5
+Errors: 4
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true
@@ -659,22 +610,15 @@ use_app_false_cycle_package/foo.rb:7: `Foo::Bar::AppFalseCyclePackageTest::Other
   Note:
     `Foo::Bar::AppFalseCyclePackageTest::OtherClass`'s package is not imported
 
-use_app_false_cycle_package/foo.rb:13: Package `Foo::MyPackage` may not reference `test!` packages https://srb.help/3735
-    13 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_app_false_cycle_package/__package.rb:5: Defined here
-     5 |class Foo::MyPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    app_false_cycle_package/test/__package.rb:4: Referenced `test!` package defined here
-     4 |class Test::Foo::Bar::AppFalseCyclePackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-use_app_false_cycle_package/foo.rb:13: `Test::Foo::Bar::AppFalseCyclePackage::TestUtil` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
+use_app_false_cycle_package/foo.rb:13: `Test::Foo::Bar::AppFalseCyclePackage::TestUtil` cannot be referenced here because `Foo::MyPackage` may not reference `test!` packages, importing its package would put `Foo::MyPackage` into a cycle, importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
     13 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_false_cycle_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    app_false_cycle_package/test/__package.rb:4: Referenced `test!` package defined here
+     4 |class Test::Foo::Bar::AppFalseCyclePackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_false_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
      7 |  strict_dependencies 'layered_dag'
                               ^^^^^^^^^^^^^
@@ -703,7 +647,7 @@ use_app_false_cycle_package/test/foo.test.rb:4: `Test::Foo::Bar::AppFalseCyclePa
     use_app_false_cycle_package/test/__package.rb:11: Inserted `import Test::Foo::Bar::AppFalseCyclePackage`
     11 |  import Foo::Bar::AppFalseCyclePackageTest
                                                    ^
-Errors: 5
+Errors: 4
 # frozen_string_literal: true
 # typed: strict
 # enable-packager: true

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -659,11 +659,16 @@ end
 
 --------------------------------------------------------------------------
 
-use_visible_to_package/foo.rb:6: Package `Foo::Bar::OtherPackage` includes explicit visibility modifiers and cannot be imported from `Foo::MyPackage` https://srb.help/3723
+use_visible_to_package/foo.rb:6: `Foo::Bar::OtherPackage::OtherClass` cannot be referenced here because Package `Foo::Bar::OtherPackage` includes explicit visibility modifiers and cannot be imported from `Foo::MyPackage` https://srb.help/3727
      6 |      Foo::Bar::OtherPackage::OtherClass
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_visible_to_package/__package.rb:5: Enclosing package declared here
+     5 |class Foo::MyPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `Foo::Bar::OtherPackage`
+  Note:
+    `Foo::Bar::OtherPackage::OtherClass`'s package is not imported
 Errors: 1
 # frozen_string_literal: true
 # typed: strict

--- a/test/cli/package-error-missing-export-import/test.out
+++ b/test/cli/package-error-missing-export-import/test.out
@@ -1,9 +1,9 @@
-missing_import/foo_class.rb:5: `Other::OtherClass` resolves but is not exported from `Other` and `Other` is not imported https://srb.help/3718
+missing_import/foo_class.rb:5: `Other::OtherClass` resolves but its package is not imported https://srb.help/3718
      5 |    Other::OtherClass
             ^^^^^^^^^^^^^^^^^
-    other/other_class.rb:4: Defined here
-     4 |  class OtherClass
-          ^^^^^^^^^^^^^^^^
+    other/__package.rb:3: Exported from package here
+     3 |class Other < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     missing_import/__package.rb:3: Insert `import Other`
      3 |class Foo::MissingImport < PackageSpec
@@ -14,12 +14,12 @@ missing_import/foo_class.rb:5: `Other::OtherClass` resolves but is not exported 
   Note:
     Try running generate-packages.sh
 Errors: 1
-imported_as_test/foo_class.rb:5: `Other::OtherClass` resolves but is not exported from `Other` and `Other` is not imported https://srb.help/3718
+imported_as_test/foo_class.rb:5: `Other::OtherClass` resolves but its package is not imported https://srb.help/3718
      5 |    Other::OtherClass
             ^^^^^^^^^^^^^^^^^
-    other/other_class.rb:4: Defined here
-     4 |  class OtherClass
-          ^^^^^^^^^^^^^^^^
+    other/__package.rb:3: Exported from package here
+     3 |class Other < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     imported_as_test/__package.rb:3: Insert `import Other`
      3 |class Foo::MissingImport < PackageSpec

--- a/test/cli/package-error-missing-export-import/test.out
+++ b/test/cli/package-error-missing-export-import/test.out
@@ -8,9 +8,6 @@ missing_import/foo_class.rb:5: `Other::OtherClass` resolves but its package is n
     missing_import/__package.rb:3: Insert `import Other`
      3 |class Foo::MissingImport < PackageSpec
                                               ^
-    other/__package.rb:3: Insert `export Other::OtherClass`
-     3 |class Other < PackageSpec
-                                 ^
   Note:
     Try running generate-packages.sh
 Errors: 1
@@ -24,9 +21,6 @@ imported_as_test/foo_class.rb:5: `Other::OtherClass` resolves but its package is
     imported_as_test/__package.rb:3: Insert `import Other`
      3 |class Foo::MissingImport < PackageSpec
                                               ^
-    other/__package.rb:3: Insert `export Other::OtherClass`
-     3 |class Other < PackageSpec
-                                 ^
   Note:
     Try running generate-packages.sh
 Errors: 1

--- a/test/cli/package-error-missing-export/test.out
+++ b/test/cli/package-error-missing-export/test.out
@@ -71,5 +71,5 @@ use_app_false_cycle_package/foo.rb:6: `Foo::Bar::AppFalseCyclePackage::OtherClas
      7 |  strict_dependencies 'false'
                               ^^^^^^^
   Note:
-    `Foo::Bar::AppFalseCyclePackage::OtherClass` is not exported
+    `Foo::Bar::AppFalseCyclePackage::OtherClass`'s package is not imported
 Errors: 1

--- a/test/cli/package-gen-packages/test.out
+++ b/test/cli/package-gen-packages/test.out
@@ -131,11 +131,16 @@ C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_d
   Note:
     `F::CONSTANT_FROM_F`'s package is not imported
 
-C/app.rb:9: Package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3723
+C/app.rb:9: `G::CONSTANT_FROM_G` cannot be referenced here because Package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3727
      9 |      puts G::CONSTANT_FROM_G
                    ^^^^^^^^^^^^^^^^^^
+    C/__package.rb:3: Enclosing package declared here
+     3 |class C < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
+  Note:
+    `G::CONSTANT_FROM_G`'s package is not imported
 Errors: 12
 
 ###### cat B/__package.rb ######
@@ -351,11 +356,16 @@ C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_d
   Note:
     `F::CONSTANT_FROM_F`'s package is not imported
 
-C/app.rb:9: Package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3723
+C/app.rb:9: `G::CONSTANT_FROM_G` cannot be referenced here because Package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3727
      9 |      puts G::CONSTANT_FROM_G
                    ^^^^^^^^^^^^^^^^^^
+    C/__package.rb:3: Enclosing package declared here
+     3 |class C < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
+  Note:
+    `G::CONSTANT_FROM_G`'s package is not imported
 Errors: 11
 
 ###### cat B/__package.rb ######

--- a/test/cli/packager_suggest_nested_crash/test.out
+++ b/test/cli/packager_suggest_nested_crash/test.out
@@ -1,9 +1,9 @@
-consumer_auth/data/identifier_struct.rb:6: `Project::ConsumerAuth::IdentifierType` resolves but is not exported from `Project::ConsumerAuth` and `Project::ConsumerAuth` is not imported https://srb.help/3718
+consumer_auth/data/identifier_struct.rb:6: `Project::ConsumerAuth::IdentifierType` resolves but its package is not imported https://srb.help/3718
      6 |    puts(Project::ConsumerAuth::IdentifierType)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    consumer_auth/identity_type.rb:5: Defined here
-     5 |  class IdentifierType
-          ^^^^^^^^^^^^^^^^^^^^
+    consumer_auth/__package.rb:5: Exported from package here
+     5 |class Project::ConsumerAuth < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     consumer_auth/data/__package.rb:4: Insert `import Project::ConsumerAuth`
      4 |class Project::ConsumerAuth::Data < PackageSpec

--- a/test/cli/packager_suggest_nested_crash/test.out
+++ b/test/cli/packager_suggest_nested_crash/test.out
@@ -8,7 +8,4 @@ consumer_auth/data/identifier_struct.rb:6: `Project::ConsumerAuth::IdentifierTyp
     consumer_auth/data/__package.rb:4: Insert `import Project::ConsumerAuth`
      4 |class Project::ConsumerAuth::Data < PackageSpec
                                                        ^
-    consumer_auth/__package.rb:6: Insert `export Project::ConsumerAuth::IdentifierType`
-     6 |  import Project::ConsumerAuth::Data
-                                            ^
 Errors: 1

--- a/test/testdata/packager/export_for_test/foo/foo.rb
+++ b/test/testdata/packager/export_for_test/foo/foo.rb
@@ -18,14 +18,12 @@ module Opus::Foo
   # via import Opus::Foo::Bar
   Opus::Foo::Bar::BarClass
   Test::Opus::Foo::Bar::BarClassTest
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Package `Opus::Foo` may not reference `test!` packages
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::Foo::Bar::BarClassTest` resolves but its package is not imported
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::Foo::Bar::BarClassTest` cannot be referenced here because `Opus::Foo` may not reference `test!` packages
 
   # via import Opus::Util
   Opus::Util::UtilClass
   Test::Opus::Util::TestUtil
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Package `Opus::Foo` may not reference `test!` packages
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::Util::TestUtil` resolves but its package is not imported
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::Util::TestUtil` cannot be referenced here because `Opus::Foo` may not reference `test!` packages
 
   Opus::Util::Nesting::Public.public_method
 
@@ -38,8 +36,7 @@ module Opus::Foo
   Opus::TestImported::TIClass
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Opus::TestImported::TIClass` resolves but its package is not imported
   Test::Opus::TestImported::TITestClass
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Package `Opus::Foo` may not reference `test!` packages
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::TestImported::TITestClass` resolves but its package is not imported
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::TestImported::TITestClass` cannot be referenced here because `Opus::Foo` may not reference `test!` packages
 
 
   # Private::ImplDetail is local to this package

--- a/test/testdata/packager/lsp_features/family.rb
+++ b/test/testdata/packager/lsp_features/family.rb
@@ -41,8 +41,7 @@ module Simpsons
   end
 
   Test::Krabappel::Popquiz
-# ^^^^^^^^^^^^^^^^^^^^^^^^ error: resolves but its package is not imported
-# ^^^^^^^^^^^^^^^^^^^^^^^^ error: may not reference `test!` packages
+# ^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Krabappel::Popquiz` cannot be referenced here because `Simpsons` may not reference `test!` packages
   #                ^^^^^^^ usage: popquiz
 
   class Private

--- a/test/testdata/packager/package-prefix-enforcement/nested/nested.rb
+++ b/test/testdata/packager/package-prefix-enforcement/nested/nested.rb
@@ -39,7 +39,7 @@ module Root
     sig { void }
     def example
       NOT_IN_PACKAGE
-    # ^^^^^^^^^^^^^^ error: `Root::NOT_IN_PACKAGE` resolves but is not exported from `Root` and `Root` is not imported
+    # ^^^^^^^^^^^^^^ error: `Root::NOT_IN_PACKAGE` resolves but its package is not imported
     end
   end
 end

--- a/test/testdata/packager/simple_test_import/main_lib/lib.rb
+++ b/test/testdata/packager/simple_test_import/main_lib/lib.rb
@@ -8,10 +8,8 @@ class Project::MainLib::Lib
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Project::TestOnly::SomeHelper` resolves but its package is not imported
 
   Test::Project::Util::UtilHelper
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::UtilHelper` resolves but its package is not imported
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Package `Project::MainLib` may not reference `test!` packages
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::UtilHelper` cannot be referenced here because `Project::MainLib` may not reference `test!` packages
 
   Test::Project::Util::Unexported
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::Unexported` resolves but its package is not imported
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Package `Project::MainLib` may not reference `test!` packages
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::Unexported` cannot be referenced here because `Project::MainLib` may not reference `test!` packages
 end

--- a/test/testdata/packager/simple_test_import/main_lib/lib.rb
+++ b/test/testdata/packager/simple_test_import/main_lib/lib.rb
@@ -12,6 +12,6 @@ class Project::MainLib::Lib
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Package `Project::MainLib` may not reference `test!` packages
 
   Test::Project::Util::Unexported
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::Unexported` resolves but is not exported from `Test::Project::Util` and `Test::Project::Util` is not imported
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::Unexported` resolves but its package is not imported
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Package `Project::MainLib` may not reference `test!` packages
 end

--- a/test/testdata/packager/unimported_namespace/aaa/a_class.rb
+++ b/test/testdata/packager/unimported_namespace/aaa/a_class.rb
@@ -3,7 +3,7 @@
 
 class AAA::AClass
   BBB
-# ^^^ error: `BBB` resolves but is not exported from `BBB` and `BBB` is not imported
+# ^^^ error: `BBB` resolves but its package is not imported
 
   CCC
 # ^^^ error: Unable to resolve constant `CCC`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm working on a change to move visibility checking into the resolver, to block
constant resolution. This enables aligning the behavior of the package-directed
and non-package-directed modes of Sorbet.

One of the things that means we have to part ways with is the errors of the form
"is not imported and is not exported," because we can't guarantee that we will
have seen the not-yet-imported package's contents by the time we report the
error. We have to limit ourselves to only what we can see from the package
graph when reporting errors.

This change drops that preemptively from both modes.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>