### PR TITLE
Hoist method defs from top-level Const.class_eval blocks into class reopenings

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -377,6 +377,8 @@ NameDef names[] = {
     {"blockPassTemp", "<block-pass>"},
     {"forTemp"},
     {"new_", "new"},
+    {"classEval", "class_eval"},
+    {"classExec", "class_exec"},
     {"blockCall", "<block-call>"},
     {"blockBreakAssign", "<block-break-assign>"},
     {"arg", "<arg>"},

--- a/rewriter/ClassEval.cc
+++ b/rewriter/ClassEval.cc
@@ -1,0 +1,151 @@
+#include "rewriter/ClassEval.h"
+#include "absl/algorithm/container.h"
+#include "ast/Helpers.h"
+#include "ast/ast.h"
+#include "core/Context.h"
+#include "core/Names.h"
+#include "core/core.h"
+#include "rewriter/rewriter.h"
+#include "rewriter/util/Util.h"
+
+using namespace std;
+
+namespace sorbet::rewriter {
+
+namespace {
+
+// A `def`, or a visibility-wrapped def like `private def`.
+bool definesMethod(const ast::ExpressionPtr &stat) {
+    if (ast::isa_tree<ast::MethodDef>(stat)) {
+        return true;
+    }
+    if (auto send = ast::cast_tree<ast::Send>(stat)) {
+        for (auto &arg : send->posArgs()) {
+            if (ast::isa_tree<ast::MethodDef>(arg)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+// A bare `private`/`protected`/`public`, which changes the default visibility of the defs
+// that follow it. These must move together with the defs they modify.
+bool isBareVisibilityModifier(const ast::ExpressionPtr &stat) {
+    auto send = ast::cast_tree<ast::Send>(stat);
+    if (send == nullptr || send->hasPosArgs() || send->hasKwArgs() || send->hasBlock()) {
+        return false;
+    }
+    if (!send->recv.isSelfReference()) {
+        return false;
+    }
+    return send->fun == core::Names::private_() || send->fun == core::Names::protected_() ||
+           send->fun == core::Names::public_();
+}
+
+} // namespace
+
+vector<ast::ExpressionPtr> ClassEval::run(core::MutableContext ctx, ast::Send *send) {
+    vector<ast::ExpressionPtr> empty;
+
+    if (ctx.state.cacheSensitiveOptions.runningUnderAutogen) {
+        // Not safe to run under autogen for the same reason as ClassNew: the synthesized
+        // class definition would end up predeclared in autoloader files.
+        return empty;
+    }
+
+    if (send->fun != core::Names::classEval() && send->fun != core::Names::classExec()) {
+        return empty;
+    }
+
+    if (!ast::isa_tree<ast::UnresolvedConstantLit>(send->recv)) {
+        return empty;
+    }
+
+    // A literal block is required; this also rules out the string form of class_eval.
+    auto *block = send->block();
+    if (block == nullptr) {
+        return empty;
+    }
+
+    // Only act when the block actually defines methods; anything else (including blocks on
+    // receivers that may well be modules, like `Enumerable.class_eval { |mod| puts mod }`)
+    // is left untouched.
+    bool anyMethodDef = false;
+    if (auto insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
+        anyMethodDef = definesMethod(insSeq->expr) || absl::c_any_of(insSeq->stats, definesMethod);
+    } else {
+        anyMethodDef = definesMethod(block->body);
+    }
+    if (!anyMethodDef) {
+        return empty;
+    }
+
+    // Partition the block's statements: defs move into the synthesized class body together
+    // with their sigs and any bare visibility modifiers (in original relative order, since
+    // visibility applies to subsequent defs); everything else stays in the block, keeping
+    // its closure semantics (locals captured from the enclosing scope keep working). Note
+    // that `def` is a scope gate even inside `class_eval` blocks in Ruby, so moving the
+    // defs out cannot sever any local variable capture.
+    ast::ClassDef::RHS_store hoisted;
+    ast::InsSeq::STATS_store residual;
+    vector<ast::ExpressionPtr> pendingSigs;
+
+    auto processStat = [&](ast::ExpressionPtr &stat) {
+        // Sigs are buffered until we know whether the statement they annotate is a def
+        // (hoist them together, so the resolver still sees them adjacent) or not.
+        if (ASTUtil::castSig(stat) != nullptr) {
+            pendingSigs.emplace_back(move(stat));
+            return;
+        }
+
+        if (definesMethod(stat)) {
+            absl::c_move(pendingSigs, back_inserter(hoisted));
+            pendingSigs.clear();
+            hoisted.emplace_back(move(stat));
+            return;
+        }
+
+        absl::c_move(pendingSigs, back_inserter(residual));
+        pendingSigs.clear();
+
+        if (isBareVisibilityModifier(stat)) {
+            hoisted.emplace_back(move(stat));
+        } else {
+            residual.emplace_back(move(stat));
+        }
+    };
+
+    if (auto insSeq = ast::cast_tree<ast::InsSeq>(block->body)) {
+        for (auto &stat : insSeq->stats) {
+            processStat(stat);
+        }
+        processStat(insSeq->expr);
+    } else {
+        processStat(block->body);
+    }
+    absl::c_move(pendingSigs, back_inserter(residual));
+    pendingSigs.clear();
+
+    // Rebuild the block around the statements that stayed behind. The send itself is left
+    // in place; the synthesized class definition is inserted after it.
+    if (residual.empty()) {
+        block->body = ast::MK::EmptyTree();
+    } else {
+        auto expr = move(residual.back());
+        residual.pop_back();
+        block->body = ast::MK::InsSeq(block->loc, move(residual), move(expr));
+    }
+
+    ast::ClassDef::ANCESTORS_store ancestors;
+    ancestors.emplace_back(ast::MK::Constant(send->loc, core::Symbols::todo()));
+
+    auto declLoc = core::LocOffsets(send->loc.beginPos(), block->loc.beginPos());
+
+    vector<ast::ExpressionPtr> stats;
+    stats.emplace_back(
+        ast::MK::Class(send->loc, declLoc, send->recv.deepCopy(), std::move(ancestors), std::move(hoisted)));
+    return stats;
+}
+
+}; // namespace sorbet::rewriter

--- a/rewriter/ClassEval.h
+++ b/rewriter/ClassEval.h
@@ -1,0 +1,69 @@
+#ifndef SORBET_REWRITER_CLASS_EVAL_H
+#define SORBET_REWRITER_CLASS_EVAL_H
+#include "ast/ast.h"
+
+namespace sorbet::rewriter {
+
+/**
+ * This rewriter handles top-level `class_eval`/`class_exec` calls whose receiver is a
+ * constant literal and whose block defines methods. The method-defining statements (defs,
+ * visibility-wrapped defs like `private def`, their sigs, and bare visibility modifiers)
+ * are hoisted out of the block into a synthesized reopening of the receiver, while every
+ * other statement stays in the block untouched. For example
+ *
+ *   x = true
+ *   Foo.class_eval do
+ *     sig {void}
+ *     def bar; end
+ *     if x; raise; end
+ *   end
+ *
+ * Is rewritten into
+ *
+ *   x = true
+ *   Foo.class_eval do
+ *     if x; raise; end
+ *   end
+ *   class Foo
+ *     sig {void}
+ *     def bar; end
+ *   end
+ *
+ * so that the methods defined inside the block are owned by `Foo` (with normal method
+ * visibility) instead of being hoisted to top-level `Object` and marked implicitly private,
+ * while the rest of the block keeps its closure semantics (locals captured from the
+ * enclosing scope keep working). Moving the defs out cannot sever any local variable
+ * capture, because `def` is a scope gate even inside `class_eval` blocks in Ruby.
+ * See https://github.com/sorbet/sorbet/issues/10452 and
+ * https://github.com/sorbet/sorbet/issues/10436
+ *
+ * The rewrite is deliberately narrow. It only applies when all of these hold:
+ *
+ * - the call is a top-level statement (not nested inside a class, module, method, or block),
+ *   so that constant lookup of the receiver and of `class Foo` agree
+ * - the receiver is a constant literal (`Foo`, `A::B`); dynamic receivers
+ *   (`klass.class_eval`) keep their current behavior
+ * - a literal block is present (which rules out the string form of `class_eval`)
+ * - the block body defines at least one method; blocks that don't define methods — the
+ *   common incidental uses on receivers that may be modules, like
+ *   `Enumerable.class_eval { |mod| puts mod }` — keep their current behavior
+ *
+ * Known limitations of the prototype:
+ *
+ * - `M.class_eval` where `M` is a module and the block defines methods synthesizes
+ *   `class M`, which Sorbet reports as a class/module redefinition mismatch
+ * - a misspelled receiver defines a new class instead of reporting an unresolved constant
+ * - constants inside the hoisted defs resolve in the lexical scope of `class Foo`, not the
+ *   scope at the call site (these differ once `Foo` itself defines constants with the same
+ *   name)
+ */
+class ClassEval final {
+public:
+    static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, ast::Send *send);
+
+    ClassEval() = delete;
+};
+
+} // namespace sorbet::rewriter
+
+#endif

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -4,6 +4,7 @@
 #include "common/typecase.h"
 #include "main/pipeline/semantic_extension/SemanticExtension.h"
 #include "rewriter/AttrReader.h"
+#include "rewriter/ClassEval.h"
 #include "rewriter/ClassNew.h"
 #include "rewriter/Cleanup.h"
 #include "rewriter/Command.h"
@@ -92,6 +93,18 @@ public:
 
                 [&](ast::Send &send) {
                     vector<ast::ExpressionPtr> nodes;
+
+                    // Only applies to top-level statements (the synthetic root ClassDef), where
+                    // `Foo.class_eval` and a synthesized `class Foo` resolve `Foo` identically.
+                    // The send stays in place (with the method defs removed from its block); the
+                    // synthesized class definition is inserted after it.
+                    if (classDef->symbol == core::Symbols::root()) {
+                        nodes = ClassEval::run(ctx, &send);
+                        if (!nodes.empty()) {
+                            insertNodes[stat.get()] = std::move(nodes);
+                            return;
+                        }
+                    }
 
                     nodes = MixinEncryptedProp::run(ctx, &send);
                     if (!nodes.empty()) {

--- a/test/testdata/rewriter/class_eval.rb
+++ b/test/testdata/rewriter/class_eval.rb
@@ -1,0 +1,141 @@
+# typed: true
+
+# Regression tests for https://github.com/sorbet/sorbet/issues/10452 and
+# https://github.com/sorbet/sorbet/issues/10436
+#
+# For a top-level `Foo.class_eval do ... end` with a constant literal receiver, the
+# method-defining statements in the block are hoisted into a synthesized reopening of
+# `class Foo`, so they are owned by `Foo` with normal public visibility instead of being
+# hoisted to `Object` and marked implicitly private. All other statements stay in the
+# block, keeping their closure semantics.
+
+class Module
+  include T::Sig
+end
+
+class A; end
+
+A.class_eval do
+  def foo
+    0
+  end
+
+  sig {returns(Integer)}
+  def bar
+    0
+  end
+
+  def self.baz; end
+
+  private def hidden; end
+end
+
+A.new.foo
+T.reveal_type(A.new.bar) # error: Revealed type: `Integer`
+A.baz
+A.new.hidden # error: Non-private call to private method `hidden` on `A`
+
+class B; end
+
+B.class_exec do
+  def foo; end
+end
+
+B.new.foo
+
+# A bare visibility modifier applies to the defs hoisted after it.
+class BareVisibility; end
+
+BareVisibility.class_eval do
+  private
+  def also_hidden; end
+end
+
+BareVisibility.new.also_hidden # error: Non-private call to private method `also_hidden` on `BareVisibility`
+
+# Statements that are not method definitions stay in the block, so locals captured from
+# the enclosing scope keep working alongside hoisted defs.
+x = T.let(true, T::Boolean)
+
+class Mixed; end
+
+Mixed.class_eval do
+  def hoisted; end
+
+  if x
+    puts "captured local still works"
+  end
+end
+
+Mixed.new.hoisted
+
+# Block parameters are fine: they stay on the block, and the defs are still hoisted.
+class C; end
+
+C.class_eval do |klass|
+  puts klass
+  def quux; end
+end
+
+C.new.quux
+
+# Reopening a class from the stdlib must not clobber visibility of existing methods
+# (https://github.com/sorbet/sorbet/issues/10452: `Object#==` used to become private).
+Range.class_eval do
+  def ==(other)
+    super
+  end
+end
+
+(1..5) == (1..5)
+nil == (1..5)
+
+# Reopening also works for constants nested inside other modules when written as a
+# qualified literal at the top level.
+module Outer
+  class Inner; end
+end
+
+Outer::Inner.class_eval do
+  def qux; end
+end
+
+Outer::Inner.new.qux
+
+# A block that defines no methods is left completely untouched, so incidental uses on
+# receivers that may be modules keep working.
+module SomeModule; end
+SomeModule.class_eval do |mod|
+  puts mod
+end
+
+# A dynamic receiver is not rewritten: the def is hoisted to Object as before, and the
+# method is not visible on the receiver's class.
+class Dynamic; end
+klass = Dynamic
+klass.class_eval do
+  def not_rewritten; end
+end
+
+# A class_eval that is not a top-level statement is not rewritten, because `Foo.class_eval`
+# and `class Foo` would not necessarily resolve `Foo` to the same constant there.
+class NotTopLevel; end
+module Wrapper
+  NotTopLevel.class_eval do
+    def nested_not_rewritten; end
+  end
+end
+NotTopLevel.new.nested_not_rewritten # error: Method `nested_not_rewritten` does not exist on `NotTopLevel`
+
+# The string form of class_eval is not rewritten.
+class StringForm; end
+StringForm.class_eval("def from_string; end")
+StringForm.new.from_string # error: Method `from_string` does not exist on `StringForm`
+
+# class_exec arguments are forwarded to the block; the defs are still hoisted.
+class ExecWithParams; end
+ExecWithParams.class_exec(1) do |arg|
+  puts arg
+  def now_rewritten; end
+end
+ExecWithParams.new.now_rewritten


### PR DESCRIPTION
Prototype of the narrow proposal from the discussion in #10454, in hybrid form: for a top-level `Foo.class_eval do ... end` / `Foo.class_exec do ... end` with a constant literal receiver, the method-defining statements in the block (defs, visibility-wrapped defs, their sigs, and bare visibility modifiers) are hoisted into a synthesized reopening of `class Foo`, inserted after the send. All other statements stay in the block, keeping closure semantics for locals captured from the enclosing scope (defs are scope gates even inside class_eval blocks in Ruby, so hoisting them cannot sever any capture).

Dynamic receivers, string-form class_eval, blocks that define no methods, and non-top-level statements keep current behavior.

Follows the precedent of the ClassNew rewriter (A = Class.new do ... end).



<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
See https://github.com/sorbet/sorbet/issues/10452
See https://github.com/sorbet/sorbet/issues/10436

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
