### PR TITLE
Add tests for `Insert T::{Sig, Helpers}` autocorrection

### DIFF
--- a/test/testdata/resolver/missing_extend_t_helpers.autocorrects.exp
+++ b/test/testdata/resolver/missing_extend_t_helpers.autocorrects.exp
@@ -1,0 +1,46 @@
+# -- test/testdata/resolver/missing_extend_t_helpers.rb --
+# typed: true
+# (enable-experimental-requires-ancestor defaulted to false)
+
+module Interface
+  extend T::Helpers
+  interface!
+# ^^^^^^^^^^ error: Method `interface!` does not exist on `T.class_of(Interface)`
+end
+
+module AbstractModule
+  extend T::Helpers
+  abstract!
+# ^^^^^^^^^ error: Method `abstract!` does not exist on `T.class_of(AbstractModule)`
+end
+
+class AbstractClass
+  extend T::Helpers
+  abstract!
+# ^^^^^^^^^ error: Method `abstract!` does not exist on `T.class_of(AbstractClass)`
+end
+
+class FinalClass
+  extend T::Helpers
+  final!
+# ^^^^^^ error: Method `final!` does not exist on `T.class_of(FinalClass)`
+end
+
+class SealedClass
+  extend T::Helpers
+  sealed!
+# ^^^^^^^ error: Method `sealed!` does not exist on `T.class_of(SealedClass)`
+end
+
+module RequiresAncestor
+  # No auto-correction, because enable-experimental-requires-ancestor is off by default.
+  requires_ancestor { Kernel }
+# ^^^^^^^^^^^^^^^^^ error: Method `requires_ancestor` does not exist on `T.class_of(RequiresAncestor)`
+end
+
+module MixesInClassMethods
+  extend T::Helpers
+  mixes_in_class_methods { Kernel }
+# ^^^^^^^^^^^^^^^^^^^^^^ error: Method `mixes_in_class_methods` does not exist on `T.class_of(MixesInClassMethods)`
+end
+# ------------------------------

--- a/test/testdata/resolver/missing_extend_t_helpers.rb
+++ b/test/testdata/resolver/missing_extend_t_helpers.rb
@@ -1,0 +1,38 @@
+# typed: true
+# (enable-experimental-requires-ancestor defaulted to false)
+
+module Interface
+  interface!
+# ^^^^^^^^^^ error: Method `interface!` does not exist on `T.class_of(Interface)`
+end
+
+module AbstractModule
+  abstract!
+# ^^^^^^^^^ error: Method `abstract!` does not exist on `T.class_of(AbstractModule)`
+end
+
+class AbstractClass
+  abstract!
+# ^^^^^^^^^ error: Method `abstract!` does not exist on `T.class_of(AbstractClass)`
+end
+
+class FinalClass
+  final!
+# ^^^^^^ error: Method `final!` does not exist on `T.class_of(FinalClass)`
+end
+
+class SealedClass
+  sealed!
+# ^^^^^^^ error: Method `sealed!` does not exist on `T.class_of(SealedClass)`
+end
+
+module RequiresAncestor
+  # No auto-correction, because enable-experimental-requires-ancestor is off by default.
+  requires_ancestor { Kernel }
+# ^^^^^^^^^^^^^^^^^ error: Method `requires_ancestor` does not exist on `T.class_of(RequiresAncestor)`
+end
+
+module MixesInClassMethods
+  mixes_in_class_methods { Kernel }
+# ^^^^^^^^^^^^^^^^^^^^^^ error: Method `mixes_in_class_methods` does not exist on `T.class_of(MixesInClassMethods)`
+end

--- a/test/testdata/resolver/missing_extend_t_helpers_requires_ancestors.autocorrects.exp
+++ b/test/testdata/resolver/missing_extend_t_helpers_requires_ancestors.autocorrects.exp
@@ -1,0 +1,10 @@
+# -- test/testdata/resolver/missing_extend_t_helpers_requires_ancestors.rb --
+# typed: true
+# enable-experimental-requires-ancestor: true
+
+module RequiresAncestor
+  extend T::Helpers
+  requires_ancestor { Kernel }
+# ^^^^^^^^^^^^^^^^^ error: Method `requires_ancestor` does not exist on `T.class_of(RequiresAncestor)`
+end
+# ------------------------------

--- a/test/testdata/resolver/missing_extend_t_helpers_requires_ancestors.rb
+++ b/test/testdata/resolver/missing_extend_t_helpers_requires_ancestors.rb
@@ -1,0 +1,7 @@
+# typed: true
+# enable-experimental-requires-ancestor: true
+
+module RequiresAncestor
+  requires_ancestor { Kernel }
+# ^^^^^^^^^^^^^^^^^ error: Method `requires_ancestor` does not exist on `T.class_of(RequiresAncestor)`
+end

--- a/test/testdata/resolver/missing_extend_t_sig.autocorrects.exp
+++ b/test/testdata/resolver/missing_extend_t_sig.autocorrects.exp
@@ -1,0 +1,13 @@
+# -- test/testdata/resolver/missing_extend_t_sig.rb --
+# typed: true
+
+class C
+  extend T::Sig
+  extend T::Helpers
+  def self.void; end # define this so `void` below doesn't autocorrect to `load`
+
+  sig { void }
+# ^^^ error: Method `sig` does not exist on `T.class_of(C)`
+  def foo; end
+end
+# ------------------------------

--- a/test/testdata/resolver/missing_extend_t_sig.rb
+++ b/test/testdata/resolver/missing_extend_t_sig.rb
@@ -1,0 +1,10 @@
+# typed: true
+
+class C
+  extend T::Helpers
+  def self.void; end # define this so `void` below doesn't autocorrect to `load`
+
+  sig { void }
+# ^^^ error: Method `sig` does not exist on `T.class_of(C)`
+  def foo; end
+end

--- a/test/testdata/resolver/missing_helpers_abstract.rb
+++ b/test/testdata/resolver/missing_helpers_abstract.rb
@@ -1,6 +1,0 @@
-# typed: true
-
-class A
-  abstract!
-# ^^^^^^^^^ error: Method `abstract!` does not exist on `T.class_of(A)`
-end

--- a/test/testdata/resolver/missing_helpers_interface.rb
+++ b/test/testdata/resolver/missing_helpers_interface.rb
@@ -1,6 +1,0 @@
-# typed: true
-
-module M
-  interface!
-# ^^^^^^^^^^ error: Method `interface!` does not exist on `T.class_of(M)`
-end


### PR DESCRIPTION
### Motivation

This was partially covered for only `abstract!` and `interface!`. This extends to all methods from `T::Helpers`, and `sig {}` from `T::Sig`.

### Test plan

```sh
./bazel test --config=dbg --test_summary=short --test_output=errors \
    //test:test_PosTests/testdata/resolver/missing_extend_t_sig \
    //test:test_PosTests/testdata/resolver/missing_extend_t_helpers \
    //test:test_PosTests/testdata/resolver/missing_extend_t_helpers_requires_ancestors
```