### PR TITLE
Auto-correct missing `extend T::Generic`

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -835,10 +835,17 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 auto attachedClass = symbol.data(gs)->attachedClass(gs);
                 TypeErrorDiagnostics::maybeInsertDSLMethod(gs, e, args.locs.file, args.callLoc(), attachedClass,
                                                            Symbols::T_Helpers(), "");
-            } else if (args.name == core::Names::sig()) {
+            } else if (args.name == core::Names::sig()) { // Suggest `extend T::Sig`
                 auto attachedClass = symbol.data(gs)->attachedClass(gs);
                 TypeErrorDiagnostics::maybeInsertDSLMethod(gs, e, args.locs.file, args.callLoc(), attachedClass,
                                                            Symbols::T_Sig(), "");
+            } else if (args.name == core::Names::typeMember() || args.name == core::Names::typeTemplate() ||
+                       args.name == core::Names::declareHasAttachedClass()) { // Suggest `extend T::Generic`
+                auto attachedClass = symbol.data(gs)->attachedClass(gs);
+                if (attachedClass.exists()) {
+                    TypeErrorDiagnostics::maybeInsertDSLMethod(gs, e, args.locs.file, args.callLoc(), attachedClass,
+                                                               Symbols::T_Generic(), "");
+                }
             } else if (args.name == Names::super()) {
                 // TODO(jez) Special error for super.
                 // - If identical name exists as self/instance method in parent but we're currently

--- a/test/cli/struct_fuzz/test.out
+++ b/test/cli/struct_fuzz/test.out
@@ -29,6 +29,10 @@ test/cli/struct_fuzz/struct_fuzz.rb:2: Method `type_member` does not exist on `T
     test/cli/struct_fuzz/struct_fuzz.rb:2:
      2 |::B=Struct.new:x
         ^
+  Autocorrect: Use `-a` to autocorrect
+    test/cli/struct_fuzz/struct_fuzz.rb:3: Insert `extend T::Generic`
+     3 |# these errors aren't actually what we're checking for, we just want to make sure sorbet doesn't crash on this input
+        ^
 
 test/cli/struct_fuzz/struct_fuzz.rb:2: Method `raise` does not exist on `T.class_of(Kernel)` https://srb.help/7003
      2 |::B=Struct.new:x
@@ -60,5 +64,9 @@ test/cli/struct_fuzz/struct_fuzz.rb:2: Method `type_member` does not exist on `T
   Got `T.class_of(B)` originating from:
     test/cli/struct_fuzz/struct_fuzz.rb:2:
      2 |::B=Struct.new:x
+        ^
+  Autocorrect: Use `-a` to autocorrect
+    test/cli/struct_fuzz/struct_fuzz.rb:3: Insert `extend T::Generic`
+     3 |# these errors aren't actually what we're checking for, we just want to make sure sorbet doesn't crash on this input
         ^
 Errors: 8

--- a/test/testdata/resolver/missing_extend_t_generic.autocorrects.exp
+++ b/test/testdata/resolver/missing_extend_t_generic.autocorrects.exp
@@ -1,0 +1,22 @@
+# -- test/testdata/resolver/missing_extend_t_generic.rb --
+# typed: true
+
+class HasTypeMember
+  extend T::Generic
+  Elem = type_member
+#        ^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(HasTypeMember)`
+end
+
+class HasTypeTemplate
+  extend T::Generic
+  Elem = type_template
+#        ^^^^^^^^^^^^^ error: Method `type_template` does not exist on `T.class_of(HasTypeTemplate)[T.attached_class (of HasTypeTemplate), T.class_of(HasTypeTemplate)::Elem]`
+end
+
+module HasAttachedClass
+  extend T::Generic
+  has_attached_class!
+# ^^^^^^^^^^^^^^^^^^^ error: Method `has_attached_class!` does not exist on `T.class_of(HasAttachedClass)`
+# ^^^^^^^^^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(HasAttachedClass)`
+end
+# ------------------------------

--- a/test/testdata/resolver/missing_extend_t_generic.rb
+++ b/test/testdata/resolver/missing_extend_t_generic.rb
@@ -1,0 +1,17 @@
+# typed: true
+
+class HasTypeMember
+  Elem = type_member
+#        ^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(HasTypeMember)`
+end
+
+class HasTypeTemplate
+  Elem = type_template
+#        ^^^^^^^^^^^^^ error: Method `type_template` does not exist on `T.class_of(HasTypeTemplate)[T.attached_class (of HasTypeTemplate), T.class_of(HasTypeTemplate)::Elem]`
+end
+
+module HasAttachedClass
+  has_attached_class!
+# ^^^^^^^^^^^^^^^^^^^ error: Method `has_attached_class!` does not exist on `T.class_of(HasAttachedClass)`
+# ^^^^^^^^^^^^^^^^^^^ error: Method `type_member` does not exist on `T.class_of(HasAttachedClass)`
+end

--- a/test/testdata/rewriter/has_attached_class.rb.autocorrects.exp
+++ b/test/testdata/rewriter/has_attached_class.rb.autocorrects.exp
@@ -13,6 +13,7 @@ module A2
 end
 
 module A3
+  extend T::Generic
   has_attached_class!
  #^^^^^^^^^^^^^^^^^^^ error: does not exist
  #^^^^^^^^^^^^^^^^^^^ error: does not exist


### PR DESCRIPTION
### Motivation

Similar to the preexisting auto-correction for `extend T::Helpers` and `extend T::Sig`.

### Test plan

```sh
./bazel test --config=dbg --test_summary=short --test_output=errors \
    //test:test_PosTests/testdata/resolver/missing_extend_t_generic
```
