### PR TITLE
Fix duplicate `allow_incompatible` errors

### DIFF
--- a/definition_validator/validator.cc
+++ b/definition_validator/validator.cc
@@ -167,26 +167,33 @@ constructAllowIncompatibleAutocorrect(const core::Context ctx, const ast::Expres
 
     auto methodLoc = ctx.locAt(methodDef.declLoc);
 
-    // XXX cwong: This causes a duplicate error to be reported if the signature is syntactically
-    // malformed (e.g. `allow_incompatible: :bad`). There are a few ways to resolve this (e.g.
-    // have `findSignature` return an error vector and make it the caller's responsibility to
-    // display them).
-    auto parsedSig = sig_finder::SigFinder::findSignature(ctx, tree, methodLoc.copyWithZeroLength());
-    if (!parsedSig.has_value()) {
+    auto *origSend = sig_finder::SigFinder::findSignatureSend(ctx, tree, methodLoc.copyWithZeroLength());
+    if (origSend == nullptr) {
         return nullopt;
     }
 
-    auto *block = parsedSig->origSend.block();
+    auto *block = origSend->block();
     if (!block) {
+        return nullopt;
+    }
+
+    // Walk the send chain in the sig block body to find the `override` call.
+    const ast::Send *overrideSend = nullptr;
+    for (auto cursor = ast::cast_tree<ast::Send>(block->body); cursor != nullptr;
+         cursor = ast::cast_tree<ast::Send>(cursor->recv)) {
+        if (cursor->fun == core::Names::override_()) {
+            overrideSend = cursor;
+            break;
+        }
+    }
+
+    if (overrideSend == nullptr) {
         return nullopt;
     }
 
     didReport = true;
 
-    auto blockBody = ast::cast_tree<ast::Send>(block->body);
-    ENFORCE(blockBody != nullptr);
-
-    auto replaceLoc = ctx.locAt(parsedSig->sig.seen.override_);
+    auto replaceLoc = ctx.locAt(overrideSend->funLoc.join(overrideSend->loc.copyEndWithZeroLength()));
 
     if (!replaceLoc.exists()) {
         return nullopt;

--- a/test/testdata/resolver/allow_incompatible_visibility_unsafe.rb
+++ b/test/testdata/resolver/allow_incompatible_visibility_unsafe.rb
@@ -28,7 +28,7 @@ end
 # This one will overwrite to `allow_incompatible: :visibility`, but w/e
 class ChildBadSymbol < Parent
   sig {override(allow_incompatible: :bad).returns(Integer)}
-  #                                 ^^^^ error-with-dupes: `override(allow_incompatible: ...)` expects either `true` or `:visibility
+  #                                 ^^^^ error: `override(allow_incompatible: ...)` expects either `true` or `:visibility
   private def some_public_api; 0; end
   #       ^^^^^^^^^^^^^^^^^^^ error: Method `some_public_api` is private in `ChildBadSymbol` but not in `Parent`
 end

--- a/test/testdata/resolver/allow_incompatible_visibility_unsafe.rb.autocorrects.exp
+++ b/test/testdata/resolver/allow_incompatible_visibility_unsafe.rb.autocorrects.exp
@@ -29,7 +29,7 @@ end
 # This one will overwrite to `allow_incompatible: :visibility`, but w/e
 class ChildBadSymbol < Parent
   sig {override(allow_incompatible: :visibility).returns(Integer)}
-  #                                 ^^^^ error-with-dupes: `override(allow_incompatible: ...)` expects either `true` or `:visibility
+  #                                 ^^^^ error: `override(allow_incompatible: ...)` expects either `true` or `:visibility
   private def some_public_api; 0; end
   #       ^^^^^^^^^^^^^^^^^^^ error: Method `some_public_api` is private in `ChildBadSymbol` but not in `Parent`
 end

--- a/test/testdata/resolver/suggest_unsafe_override.rb
+++ b/test/testdata/resolver/suggest_unsafe_override.rb
@@ -34,11 +34,8 @@ class Child3 < Parent
   extend T::Sig
   extend T::Helpers
 
-  # The error-with-dupes below is because `--suggest-unsafe` runs `sig_finder`,
-  # which calls type_syntax parsing, which unconditionally reports errors.
-  # We probably want some way to swallow errors when sig_finder runs type_syntax parsing.
   sig {override(allow_incompatible: false).params(x: T::Boolean).void}
-  #                                 ^^^^^ error-with-dupes: `override(allow_incompatible: ...)` expects either `true` or `:visibility`
+  #                                 ^^^^^ error: `override(allow_incompatible: ...)` expects either `true` or `:visibility`
   #                                               ^ error: Parameter `x` of type `T::Boolean` not compatible with type of overridden method `Parent#foo`
   def foo(x); end
 end

--- a/test/testdata/resolver/suggest_unsafe_override.rb.autocorrects.exp
+++ b/test/testdata/resolver/suggest_unsafe_override.rb.autocorrects.exp
@@ -35,11 +35,8 @@ class Child3 < Parent
   extend T::Sig
   extend T::Helpers
 
-  # The error-with-dupes below is because `--suggest-unsafe` runs `sig_finder`,
-  # which calls type_syntax parsing, which unconditionally reports errors.
-  # We probably want some way to swallow errors when sig_finder runs type_syntax parsing.
   sig {override().params(x: T::Boolean).void}
-  #                                 ^^^^^ error-with-dupes: `override(allow_incompatible: ...)` expects either `true` or `:visibility`
+  #                                 ^^^^^ error: `override(allow_incompatible: ...)` expects either `true` or `:visibility`
   #                                               ^ error: Parameter `x` of type `T::Boolean` not compatible with type of overridden method `Parent#foo`
   def foo(x); end
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Uses `findSignatureSend` in `validator.cc`, which was added in #10526.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes #9088

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.