### PR TITLE
test: Get rid of extra whitespace between `^^` and `error:`

### DIFF
--- a/test/testdata/desugar/integers.rb
+++ b/test/testdata/desugar/integers.rb
@@ -6,7 +6,7 @@ def test_large_int
     00,
     9223372036854775807,
     -9223372036854775808,
-    18446744073709551616,   # error: Unsupported integer
+    18446744073709551616, # error: Unsupported integer
     0xcafe,
     0_0,
     1_, # error: trailing `_`

--- a/test/testdata/infer/arg_matching.rb
+++ b/test/testdata/infer/arg_matching.rb
@@ -136,7 +136,7 @@ class TestArgs
     optkw(u: 1)
     #         ^ error: Missing required keyword argument `u`
     optkw(1, 2, 3)
-    #            ^    error: Missing required keyword argument `u` for method `TestArgs#optkw`
+    #            ^ error: Missing required keyword argument `u` for method `TestArgs#optkw`
     #           ^ error: Too many positional arguments provided for method `TestArgs#optkw`. Expected: `1..2`, got: `3`
   end
 

--- a/test/testdata/infer/arg_matching.rb.autocorrects.exp
+++ b/test/testdata/infer/arg_matching.rb.autocorrects.exp
@@ -137,7 +137,7 @@ class TestArgs
     optkw(u: 1, u:)
     #         ^ error: Missing required keyword argument `u`
     optkw(1, 2, u:)
-    #            ^    error: Missing required keyword argument `u` for method `TestArgs#optkw`
+    #            ^ error: Missing required keyword argument `u` for method `TestArgs#optkw`
     #           ^ error: Too many positional arguments provided for method `TestArgs#optkw`. Expected: `1..2`, got: `3`
   end
 

--- a/test/testdata/infer/autocorrect_remove_extra_pos_args.rb
+++ b/test/testdata/infer/autocorrect_remove_extra_pos_args.rb
@@ -15,7 +15,7 @@ takes_one_arg(0)
 takes_one_arg(0, 0)
 #                ^ error: Too many arguments
 takes_one_arg(0, 0, 0)
-#                ^^^^  error: Too many arguments
+#                ^^^^ error: Too many arguments
 
 takes_one_arg(0) do
   nil

--- a/test/testdata/infer/autocorrect_remove_extra_pos_args.rb.autocorrects.exp
+++ b/test/testdata/infer/autocorrect_remove_extra_pos_args.rb.autocorrects.exp
@@ -16,7 +16,7 @@ takes_one_arg(0)
 takes_one_arg(0)
 #                ^ error: Too many arguments
 takes_one_arg(0)
-#                ^^^^  error: Too many arguments
+#                ^^^^ error: Too many arguments
 
 takes_one_arg(0) do
   nil

--- a/test/testdata/infer/block_return_loc.rb
+++ b/test/testdata/infer/block_return_loc.rb
@@ -6,7 +6,7 @@ def example(&blk)
 end
 
 example {0}
-#        ^  error: Expected `String` but found `Integer(0)` for block result type
+#        ^ error: Expected `String` but found `Integer(0)` for block result type
 
 example do 0 end
 #          ^ error: Expected `String` but found `Integer(0)` for block result type

--- a/test/testdata/packager/invalid_package_control_flow/__package.rb
+++ b/test/testdata/packager/invalid_package_control_flow/__package.rb
@@ -36,7 +36,7 @@ class MyPackage < PackageSpec
   #   ^^^^^^ error: Invalid expression in package: `Block` not allowed
   def package_method; end
 # ^^^^^^^^^^^^^^^^^^^^^^^ error: Invalid expression in package: `MethodDef`
-# ^^^^^^^^^^^^^^^^^^      error: Invalid expression in package: `RuntimeMethodDefinition`
+# ^^^^^^^^^^^^^^^^^^ error: Invalid expression in package: `RuntimeMethodDefinition`
 
   sig {void}
   #   ^^^^^^ error: Invalid expression in package: `Block` not allowed

--- a/test/testdata/packager/package_scope_no_const/b/inner/_impl.rb
+++ b/test/testdata/packager/package_scope_no_const/b/inner/_impl.rb
@@ -3,6 +3,6 @@
 class B
   Inner = type_member
 # ^^^^^^^^^^^^^^^^^^^ error: `B::Inner` shares a name with a package and thus must be a class or module, not a constant assignment
-# ^^^^^               error: File belongs to package `B::Inner` but defines a constant that does not match this namespace
+# ^^^^^ error: File belongs to package `B::Inner` but defines a constant that does not match this namespace
 #         ^^^^^^^^^^^ error: `type_member` may only be used on constants in the package that owns them
 end

--- a/test/testdata/parser/error_recovery/forward_args_with_block.rb
+++ b/test/testdata/parser/error_recovery/forward_args_with_block.rb
@@ -3,6 +3,6 @@
 def test(...)
   [1,2,3].each do
     foo(...) do end
-  #     ^^^         error: both block argument and literal block are passed
+  #     ^^^ error: both block argument and literal block are passed
   end
 end

--- a/test/testdata/resolver/bad_hash.rb
+++ b/test/testdata/resolver/bad_hash.rb
@@ -1,5 +1,5 @@
 # typed: true
 T.let({}, Hash[Integer, String])
         # ^^^^^^^^^^^^^^^^^^^^^ error: Use `T::Hash[...]`, not `Hash[...]` to declare a typed `Hash`
-        #      ^^^^^^^          error: Expected `T.any(T::Array[[T.type_parameter(:U), T.type_parameter(:V)]], T::Hash[T.type_parameter(:U), T.type_parameter(:V)])` but found `T.class_of(Integer)` for argument `arg0`
-        #               ^^^^^^  error: Expected `T.any(T::Array[[T.type_parameter(:U), T.type_parameter(:V)]], T::Hash[T.type_parameter(:U), T.type_parameter(:V)])` but found `T.class_of(String)` for argument `arg0`
+        #      ^^^^^^^ error: Expected `T.any(T::Array[[T.type_parameter(:U), T.type_parameter(:V)]], T::Hash[T.type_parameter(:U), T.type_parameter(:V)])` but found `T.class_of(Integer)` for argument `arg0`
+        #               ^^^^^^ error: Expected `T.any(T::Array[[T.type_parameter(:U), T.type_parameter(:V)]], T::Hash[T.type_parameter(:U), T.type_parameter(:V)])` but found `T.class_of(String)` for argument `arg0`

--- a/test/testdata/rewriter/attr.rb
+++ b/test/testdata/rewriter/attr.rb
@@ -51,7 +51,7 @@ class TestAttr
   attr_writer :v4, :v5
 # ^^^^^^^^^^^^^^^^^^^^ error: The method `v4=` does not have a `sig`
 # ^^^^^^^^^^^^^^^^^^^^ error: The method `v5=` does not have a `sig`
-  #            ^^        error: The instance variable `@v4` must be declared using `T.let` when specifying `# typed: strict`
+  #            ^^ error: The instance variable `@v4` must be declared using `T.let` when specifying `# typed: strict`
   #                 ^^   error: The instance variable `@v5` must be declared using `T.let` when specifying `# typed: strict`
 
   sig {returns(Float)}

--- a/test/testdata/rewriter/prop_missing.rb
+++ b/test/testdata/rewriter/prop_missing.rb
@@ -2,7 +2,7 @@
 
 class ForgotTStructOrTProps
   prop :foo, Integer
-# ^^^^               error: `prop` does not exist
+# ^^^^ error: `prop` does not exist
   const :bar, Integer
-# ^^^^^               error: `const` does not exist
+# ^^^^^ error: `const` does not exist
 end

--- a/test/testdata/rewriter/prop_prohibit_shapes_and_tuples.rb
+++ b/test/testdata/rewriter/prop_prohibit_shapes_and_tuples.rb
@@ -4,7 +4,7 @@ class A
   # We don't support shape or tuple types for props, and the way that manifests
   # is that the prop rewrite pass just skips these two declarations.
   prop :shape, {a: Integer, b: String}
-# ^^^^                                 error: Method `prop` does not exist
+# ^^^^ error: Method `prop` does not exist
   prop :tuple, [Integer, String]
-# ^^^^                           error: Method `prop` does not exist
+# ^^^^ error: Method `prop` does not exist
 end

--- a/test/testdata/rewriter/struct.rb
+++ b/test/testdata/rewriter/struct.rb
@@ -132,5 +132,5 @@ class ImmutableTest
 
   obj = Immutable.new(b: "foo")
   obj.b = "bar"
-    # ^   error: Setter method `b=` does not exist on `Immutable`
+    # ^ error: Setter method `b=` does not exist on `Immutable`
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm working on a script which automatically updates `error:` assertions
in `test/testdata/` files. One of the guiding principles is that running
it on `master` should not produce any changes, within reason.

For example, I'm not interested in preserving this whitespace (but I am
interested in preserving when an `error:` assertion only has a substring
of the error header in question).



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Test-only change