### PR TITLE
Support RBS assertions in super blocks

### DIFF
--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -1046,10 +1046,19 @@ pm_node_t *AssertionsRewriter::rewriteNode(pm_node_t *node) {
         }
 
         // Super
+        case PM_FORWARDING_SUPER_NODE: {
+            auto *super_ = down_cast_nonnull<pm_forwarding_super_node_t>(node);
+            node = maybeInsertCast(node);
+            if (super_->block != nullptr) {
+                super_->block = down_cast_nonnull<pm_block_node_t>(rewriteNode(up_cast(super_->block)));
+            }
+            return node;
+        }
         case PM_SUPER_NODE: {
             auto *super_ = down_cast_nonnull<pm_super_node_t>(node);
             rewriteArgumentsNode(super_->arguments);
             node = maybeInsertCast(node);
+            super_->block = rewriteNullableNode(super_->block);
             return node;
         }
 

--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -1037,6 +1037,13 @@ void CommentsAssociator::walkNode(pm_node_t *node) {
             }
             break;
         }
+        case PM_FORWARDING_SUPER_NODE: {
+            auto *super_ = down_cast_nonnull<pm_forwarding_super_node_t>(node);
+            associateAssertionCommentsToNode(node);
+            walkNode(up_cast(super_->block));
+            consumeCommentsInsideNode(node, "super");
+            break;
+        }
         case PM_SUPER_NODE: {
             auto *super_ = down_cast_nonnull<pm_super_node_t>(node);
             associateAssertionCommentsToNode(node);

--- a/test/testdata/rbs/assertions_super.rb
+++ b/test/testdata/rbs/assertions_super.rb
@@ -40,3 +40,31 @@ class Qux < Foo
     #                                  ^^^^^^^ error: Expected `String` but found `Integer` for method result type
   end
 end
+
+class SuperBlockParent
+  #: (*untyped) { (untyped) -> untyped } -> untyped
+  def forwarding_super(*args); end
+
+  #: (Symbol) { (untyped) -> untyped } -> untyped
+  def explicit_super(arg); end
+end
+
+class SuperBlockChild < SuperBlockParent
+  # @override
+  #: (*untyped) { (untyped) -> untyped } -> untyped
+  def forwarding_super(*args)
+    super do |local_record|
+      return_value = nil #: Hash[Symbol, untyped]?
+      T.reveal_type(return_value) # error: Revealed type: `T.nilable(T::Hash[Symbol, T.untyped])`
+    end
+  end
+
+  # @override
+  #: (Symbol) { (untyped) -> untyped } -> untyped
+  def explicit_super(arg)
+    super(arg) do |local_record|
+      return_value = nil #: String?
+      T.reveal_type(return_value) # error: Revealed type: `T.nilable(String)`
+    end
+  end
+end

--- a/test/testdata/rbs/assertions_super.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/assertions_super.rb.rewrite-tree.exp
@@ -46,4 +46,42 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
 
     <runtime method definition of foo>
   end
+
+  class <emptyTree>::<C SuperBlockParent><<C <todo sym>>> < (::<todo sym>)
+    def forwarding_super<<todo method>>(*args, &<blk>)
+      <emptyTree>
+    end
+
+    def explicit_super<<todo method>>(arg, &<blk>)
+      <emptyTree>
+    end
+
+    <runtime method definition of forwarding_super>
+
+    <runtime method definition of explicit_super>
+  end
+
+  class <emptyTree>::<C SuperBlockChild><<C <todo sym>>> < (<emptyTree>::<C SuperBlockParent>)
+    def forwarding_super<<todo method>>(*args, &<blk>)
+      <self>.<super>(ZSuperArgs) do |local_record|
+        begin
+          return_value = <cast:let>(nil, <todo sym>, ::<root>::<C T>.nilable(::<root>::<C T>::<C Hash>.<syntheticSquareBrackets>(<emptyTree>::<C Symbol>, ::<root>::<C T>.untyped())))
+          <emptyTree>::<C T>.reveal_type(return_value)
+        end
+      end
+    end
+
+    def explicit_super<<todo method>>(arg, &<blk>)
+      <self>.<super>(arg) do |local_record|
+        begin
+          return_value = <cast:let>(nil, <todo sym>, ::<root>::<C T>.nilable(<emptyTree>::<C String>))
+          <emptyTree>::<C T>.reveal_type(return_value)
+        end
+      end
+    end
+
+    <runtime method definition of forwarding_super>
+
+    <runtime method definition of explicit_super>
+  end
 end


### PR DESCRIPTION
### Motivation

Fix rejected valid assertions inside a bare `super` block:

```ruby
super do |record|
  value = nil #: Hash[Symbol, untyped]? # error: Unexpected RBS assertion comment found in `other`
end
 ```

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
