### PR TITLE
Check keyword args that are passed alongside a keyword splat

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -718,35 +718,62 @@ ExpressionPtr doUntil(DesugarContext dctx, core::LocOffsets loc, ExpressionPtr c
 }
 
 // Flattens the key/value pairs from the Kwargs Hash into the destination container.
-// If Kwargs Hash contains any splats, we skip the flattening and append the hash as-is.
-template <typename Container> void flattenKwargs(unique_ptr<parser::Hash> kwargsHash, Container &destination) {
+//
+// When the only splat is a `**kwsplat` in trailing position (e.g. `foo(x: 1, **opts)`), the pairs are
+// flattened and the splat's inner expression is appended after them. Keeping the explicitly-passed keys
+// visible lets the type checker check them against the method's keyword parameters, instead of merging
+// everything into one opaque hash. Returns true in that case, to signal that the caller has to wrap the
+// trailing argument in `<Magic>.<to-hash-dup>`.
+//
+// Anything else -- a splat in the middle, more than one splat, a lone splat, or an anonymous `**` forward
+// -- keeps the old behavior of appending the hash as-is, and returns false.
+template <typename Container> bool flattenKwargs(unique_ptr<parser::Hash> kwargsHash, Container &destination) {
     ENFORCE(kwargsHash != nullptr);
 
-    // Skip inlining the kwargs if there are any kwsplat nodes present
-    if (absl::c_any_of(kwargsHash->pairs, [](auto &node) {
-            // the parser guarantees that if we see a kwargs hash it only contains pair,
-            // kwsplat, or forwarded kwrest arg nodes
-            ENFORCE(parser::isa_node<parser::Kwsplat>(node.get()) || parser::isa_node<parser::Pair>(node.get()) ||
-                    parser::isa_node<parser::ForwardedKwrestArg>(node.get()));
+    auto &pairs = kwargsHash->pairs;
 
-            return parser::isa_node<parser::Kwsplat>(node.get()) ||
-                   parser::isa_node<parser::ForwardedKwrestArg>(node.get());
-        })) {
+    auto splatIt = absl::c_find_if(pairs, [](auto &node) {
+        // the parser guarantees that if we see a kwargs hash it only contains pair,
+        // kwsplat, or forwarded kwrest arg nodes
+        ENFORCE(parser::isa_node<parser::Kwsplat>(node.get()) || parser::isa_node<parser::Pair>(node.get()) ||
+                parser::isa_node<parser::ForwardedKwrestArg>(node.get()));
+
+        return parser::isa_node<parser::Kwsplat>(node.get()) ||
+               parser::isa_node<parser::ForwardedKwrestArg>(node.get());
+    });
+
+    // A keyword splat is detected downstream by the parity of the argument count, so it can only be
+    // inlined when it's the sole splat and comes last. There's also nothing to gain from inlining unless
+    // some keys are passed explicitly alongside it, so a lone splat keeps going through the merging path.
+    auto inlineTrailingKwsplat = pairs.size() > 1 && splatIt != pairs.end() && splatIt + 1 == pairs.end() &&
+                                 parser::isa_node<parser::Kwsplat>(splatIt->get());
+
+    // Skip inlining the kwargs if there are any other kwsplat nodes present
+    if (splatIt != pairs.end() && !inlineTrailingKwsplat) {
         destination.emplace_back(move(kwargsHash));
-        return;
+        return false;
     }
 
     // Flatten the key/value pairs into the destination
-    for (auto &entry : kwargsHash->pairs) {
+    for (auto &entry : pairs) {
         if (auto pair = parser::cast_node<parser::Pair>(entry.get())) {
             destination.emplace_back(move(pair->key));
             destination.emplace_back(move(pair->value));
+        } else if (auto splat = parser::cast_node<parser::Kwsplat>(entry.get())) {
+            destination.emplace_back(move(splat->expr));
         } else {
             Exception::raise("Unhandled case");
         }
     }
 
-    return;
+    return inlineTrailingKwsplat;
+}
+
+// A `**kwsplat` argument is converted with `to_hash` before it's passed along. This is also what gives
+// `f(**nil)` its meaning of "no keyword arguments at all".
+void wrapKwsplatArg(ExpressionPtr &arg, core::LocOffsets locZeroLen) {
+    auto loc = arg.loc();
+    arg = MK::Send1(loc, MK::Magic(loc), core::Names::toHashDup(), locZeroLen, move(arg));
 }
 
 // Detects calls to `block_given?`
@@ -936,20 +963,25 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     }
 
                     // Build up an array that represents the keyword args for the send.
-                    // When there is a Kwsplat, treat all keyword arguments as a single argument.
+                    // When the keyword args can't be inlined, they're all treated as a single argument.
                     // If the kwargs hash is not present, make a `nil` to put in the place of that argument.
                     // This will be used in the implementation of the intrinsic to tell the difference between keyword
-                    // args, keyword args with kw splats, and no keyword args at all.
+                    // args and no keyword args at all.
                     ExpressionPtr kwargs;
                     if (kwargsHash != nullptr) {
                         parser::NodeVec kwargElements;
-                        flattenKwargs(move(kwargsHash), kwargElements);
+                        auto inlinedKwsplat = flattenKwargs(move(kwargsHash), kwargElements);
 
                         unique_ptr<parser::Node> kwArray = make_unique<parser::Array>(loc, move(kwargElements));
 
                         kwargs = node2TreeImpl(dctx, kwArray);
 
-                        DuplicateHashKeyCheck::checkSendArgs(dctx.ctx, 0, cast_tree<Array>(kwargs)->elems);
+                        auto &kwargElems = cast_tree<Array>(kwargs)->elems;
+                        if (inlinedKwsplat) {
+                            wrapKwsplatArg(kwargElems.back(), locZeroLen);
+                        }
+
+                        DuplicateHashKeyCheck::checkSendArgs(dctx.ctx, 0, kwargElems);
                     } else {
                         kwargs = MK::Nil(loc);
                     }
@@ -992,10 +1024,11 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     // Count the arguments before we concat in the Kwarg key/value pairs
                     int numPosArgs = send->args.size();
 
+                    auto inlinedKwsplat = false;
                     if (kwargsHash != nullptr) {
                         // Deconstruct the kwargs hash if it's present,
                         // concating the key/value pairs to the end of the args list
-                        flattenKwargs(move(kwargsHash), send->args);
+                        inlinedKwsplat = flattenKwargs(move(kwargsHash), send->args);
                     }
 
                     Send::ARGS_store args;
@@ -1003,6 +1036,10 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                     for (auto &stat : send->args) {
                         args.emplace_back(node2TreeImpl(dctx, stat));
                     };
+
+                    if (inlinedKwsplat) {
+                        wrapKwsplatArg(args.back(), locZeroLen);
+                    }
 
                     DuplicateHashKeyCheck::checkSendArgs(dctx.ctx, numPosArgs, args);
 

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -140,7 +140,7 @@ private:
     template <typename StoreType> StoreType nodeListToStore(const pm_node_list &nodeList);
 
     // Flattens key/value pairs from a keyword hash into the destination, or desugars the whole hash if there are splats
-    template <typename Container> void flattenKwargs(pm_keyword_hash_node *kwargsHashNode, Container &destination);
+    template <typename Container> bool flattenKwargs(pm_keyword_hash_node *kwargsHashNode, Container &destination);
 
     // Helper for Break/Next/Return nodes that take optional arguments
     ast::ExpressionPtr desugarBreakNextReturn(pm_arguments_node *argsNode);
@@ -528,26 +528,53 @@ bool isCallToBlockGivenP(pm_call_node *callNode, core::NameRef methodName, ast::
            MK::isKernelApproximate(receiverExpr);
 };
 
+// A `**kwsplat` argument is converted with `to_hash` before it's passed along. This is also what gives
+// `f(**nil)` its meaning of "no keyword arguments at all".
+void wrapKwsplatArg(ast::ExpressionPtr &arg, core::LocOffsets locZeroLen) {
+    auto loc = arg.loc();
+    arg = MK::Send1(loc, MK::Magic(loc), core::Names::toHashDup(), locZeroLen, move(arg));
+}
+
 // Flattens the key/value pairs from the Kwargs Hash into the destination container.
-// If Kwargs Hash contains any splats, we skip the flattening and desugar the hash as-is.
+//
+// When the only splat is a `**kwsplat` in trailing position (e.g. `foo(x: 1, **opts)`), the pairs are
+// flattened and the splat's inner expression is appended after them. Keeping the explicitly-passed keys
+// visible lets the type checker check them against the method's keyword parameters, instead of merging
+// everything into one opaque hash. Returns true in that case, to signal that the caller has to wrap the
+// trailing argument in `<Magic>.<to-hash-dup>`.
+//
+// Anything else -- a splat in the middle, more than one splat, a lone splat, or an anonymous `**` forward
+// -- keeps the old behavior of desugaring the hash as-is, and returns false.
 template <typename Container>
-void Desugarer::flattenKwargs(pm_keyword_hash_node *kwargsHashNode, Container &destination) {
+bool Desugarer::flattenKwargs(pm_keyword_hash_node *kwargsHashNode, Container &destination) {
     ENFORCE(kwargsHashNode != nullptr);
 
     auto elements = absl::MakeSpan(kwargsHashNode->elements.nodes, kwargsHashNode->elements.size);
 
-    // Check if there are any splats - if so, can't flatten
-    bool hasKwsplat = absl::c_any_of(elements, [](auto *node) { return isa_node<pm_assoc_splat_node>(node); });
+    auto splatIt = absl::c_find_if(elements, [](auto *node) { return isa_node<pm_assoc_splat_node>(node); });
 
-    if (hasKwsplat) {
+    // A keyword splat is detected downstream by the parity of the argument count, so it can only be
+    // inlined when it's the sole splat and comes last. There's also nothing to gain from inlining unless
+    // some keys are passed explicitly alongside it, so a lone splat keeps going through the merging path.
+    // An anonymous `**` forward has no expression to inline, so it stays on that path as well.
+    auto inlineTrailingKwsplat = elements.size() > 1 && splatIt != elements.end() && splatIt + 1 == elements.end() &&
+                                 down_cast_nonnull<pm_assoc_splat_node>(*splatIt)->value != nullptr;
+
+    // Skip inlining the kwargs if there are any other splats present
+    if (splatIt != elements.end() && !inlineTrailingKwsplat) {
         // Desugar the whole hash using desugarKeyValuePairs which handles kwsplats properly
         auto loc = translateLoc(kwargsHashNode->base.location);
         destination.emplace_back(desugarKeyValuePairs(loc, kwargsHashNode->elements));
-        return;
+        return false;
     }
 
     // Flatten each key/value pair directly
     for (auto *element : elements) {
+        if (auto *splat = down_cast<pm_assoc_splat_node>(element)) {
+            destination.emplace_back(desugar(splat->value));
+            continue;
+        }
+
         auto *assoc = down_cast_nonnull<pm_assoc_node>(element);
 
         // Special handling for symbol keys with trailing colon (like `a: 1` instead of `:a => 1`)
@@ -572,6 +599,8 @@ void Desugarer::flattenKwargs(pm_keyword_hash_node *kwargsHashNode, Container &d
         destination.emplace_back(desugar(assoc->key));
         destination.emplace_back(desugar(assoc->value));
     }
+
+    return inlineTrailingKwsplat;
 }
 
 // Helper function to merge multiple string literals into one
@@ -4478,14 +4507,16 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
         }
 
         // Build up an array that represents the keyword args for the send.
-        // When there is a Kwsplat, treat all keyword arguments as a single argument.
+        // When the keyword args can't be inlined, they're all treated as a single argument.
         // If the kwargs hash is not present, make a `nil` to put in the place of that argument.
         // This will be used in the implementation of the intrinsic to tell the difference between keyword
-        // args, keyword args with kw splats, and no keyword args at all.
+        // args and no keyword args at all.
         ExpressionPtr kwargsExpr;
         if (kwargsHashNode != nullptr) {
             ast::Array::ENTRY_store kwargElements;
-            flattenKwargs(kwargsHashNode, kwargElements);
+            if (flattenKwargs(kwargsHashNode, kwargElements)) {
+                wrapKwsplatArg(kwargElements.back(), sendLoc0);
+            }
             ast::desugar::DuplicateHashKeyCheck::checkSendArgs(ctx, 0, kwargElements);
 
             kwargsExpr = MK::Array(sendWithBlockLoc, move(kwargElements));
@@ -4566,7 +4597,9 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
         }
 
         if (kwargsHashNode) {
-            flattenKwargs(kwargsHashNode, magicSendArgs);
+            if (flattenKwargs(kwargsHashNode, magicSendArgs)) {
+                wrapKwsplatArg(magicSendArgs.back(), sendLoc0);
+            }
             ast::desugar::DuplicateHashKeyCheck::checkSendArgs(ctx, magicNumPosArgs, magicSendArgs);
         }
 
@@ -4586,7 +4619,9 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
     }
 
     if (kwargsHashNode) {
-        flattenKwargs(kwargsHashNode, sendArgs);
+        if (flattenKwargs(kwargsHashNode, sendArgs)) {
+            wrapKwsplatArg(sendArgs.back(), sendLoc0);
+        }
         ast::desugar::DuplicateHashKeyCheck::checkSendArgs(ctx, numPosArgs, sendArgs);
     }
 

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -1250,13 +1250,29 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
             const ParamInfo *kwSplatParam = nullptr;
             auto hasRequiredKwParam = false;
             auto kwParams = vector<const ParamInfo *>{};
+
+            // Keyword args written at the call site have a precisely known type, unlike whatever the splat
+            // might supply. Locating them lets us check them directly, and lets a required parameter that
+            // one of them already satisfies stop counting as being left up to the splat.
+            auto explicitIndexForParam = [&keys](NameRef name) -> optional<size_t> {
+                for (size_t i = 0; i < keys.size(); i++) {
+                    if (!isa_type<NamedLiteralType>(keys[i])) {
+                        continue;
+                    }
+                    if (cast_type_nonnull<NamedLiteralType>(keys[i]).name == name) {
+                        return i;
+                    }
+                }
+                return nullopt;
+            };
+
             for (auto &param : methodData->parameters) {
                 if (param.flags.isKeyword && param.flags.isRepeated) {
                     ENFORCE(kwSplatParam == nullptr);
                     kwSplatParam = &param;
                 } else if (param.flags.isKeyword && !param.flags.isRepeated) {
                     kwParams.emplace_back(&param);
-                    hasRequiredKwParam |= !param.flags.isDefault;
+                    hasRequiredKwParam |= !param.flags.isDefault && !explicitIndexForParam(param.name).has_value();
                 }
             }
 
@@ -1317,7 +1333,42 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                         result.main.errors.emplace_back(e.build());
                     }
                 } else {
+                    // Check the keyword args that were written at the call site against their parameters
+                    // directly, rather than against the much wider type covering everything in the splat.
+                    UnorderedSet<NameRef> reportedExplicitly;
                     for (const auto &kwParam : kwParams) {
+                        auto explicitIdx = explicitIndexForParam(kwParam->name);
+                        if (!explicitIdx.has_value()) {
+                            continue;
+                        }
+
+                        Loc originLoc = kwargsLoc;
+                        Loc argLoc = args.callLoc();
+                        auto kwargLocsIt = kwargLocs.find(kwParam->name);
+                        if (kwargLocsIt != kwargLocs.end()) {
+                            auto [kwKeyLoc, kwValLoc] = kwargLocsIt->second;
+                            originLoc = core::Loc(args.locs.file, kwValLoc);
+                            argLoc = originLoc;
+                        }
+
+                        TypeAndOrigins tpe{values[*explicitIdx], originLoc};
+                        if (auto e = matchArgType(gs, *constr, args.receiverLoc(), symbol, method, tpe, *kwParam,
+                                                  args.selfType, args.fullType, args.thisType, targs, argLoc,
+                                                  args.originForUninitialized)) {
+                            reportedExplicitly.insert(kwParam->name);
+                            result.main.errors.emplace_back(std::move(e));
+                        }
+                    }
+
+                    // The splat trails the explicitly-passed keys, so it can overwrite them too. That means
+                    // its values have to fit every keyword parameter, not only the ones it's the sole
+                    // possible source for. Parameters already reported on above are skipped to avoid
+                    // stacking a second error on the same argument.
+                    for (const auto &kwParam : kwParams) {
+                        if (reportedExplicitly.contains(kwParam->name)) {
+                            continue;
+                        }
+
                         auto kwParamType =
                             Types::resultTypeAsSeenFrom(gs, kwParam->type, methodData->owner, symbol, targs);
                         if (kwParamType == nullptr) {

--- a/infer/SigSuggestion.cc
+++ b/infer/SigSuggestion.cc
@@ -73,6 +73,9 @@ void extractSendArgumentKnowledge(core::Context ctx, cfg::CFG &cfg, core::LocOff
     auto numPosArgs = snd->numPosArgs;
     auto numKwArgs = snd->argRefs().size() - numPosArgs;
     bool hasKwSplat = numKwArgs % 2 == 1;
+    // A keyword splat trails the inlined keyword args, and is a single argument rather than a
+    // key/value pair, so it sits past the end of the region that can be read pairwise.
+    auto kwArgsEnd = snd->argRefs().size() - (hasKwSplat ? 1 : 0);
 
     // Since this is a "fake" dispatch and we are not going to display the errors anyway,
     // core::Loc::none() should be okay here.
@@ -99,7 +102,7 @@ void extractSendArgumentKnowledge(core::Context ctx, cfg::CFG &cfg, core::LocOff
     bool inKwArgs = false;
     auto argRefs = snd->argRefs();
     for (int i = 0, argIdx = 0; i < argRefs.size(); i++, argIdx++) {
-        inKwArgs = inKwArgs || (i >= numPosArgs && !hasKwSplat);
+        inKwArgs = i >= numPosArgs && i < kwArgsEnd;
 
         // extract the keyword argument name when the send contains inlined keyword arguments
         optional<core::NameRef> keyword;

--- a/test/cli/autocorrect-kwsplat/test.out
+++ b/test/cli/autocorrect-kwsplat/test.out
@@ -55,24 +55,6 @@ test.rb:21: Cannot call `Object#requires_x` with a `Hash` keyword splat because 
     21 |requires_x(0, 1, 2, **opts, x: 0)
                               ^^^^^^^^^^
 
-test.rb:23: Cannot call `Object#requires_x` with a `Hash` keyword splat because the method has required keyword parameters https://srb.help/7019
-    23 |requires_x(0, 1, 2, x: 0, **opts)
-                            ^^^^^^^^^^^^
-    test.rb:4: Keyword parameters of `Object#requires_x` begin here:
-     4 |sig {params(pos: Integer, x: Integer).void}
-                                  ^
-  Got `T::Hash[T.untyped, T.untyped]` originating from:
-    test.rb:23:
-    23 |requires_x(0, 1, 2, x: 0, **opts)
-                            ^^^^^^^^^^^^
-  Note:
-    Note that Sorbet does not yet handle mixing explicitly-passed keyword args with splats.
-    To ignore this and pass the splat anyways, use `T.unsafe`
-  Autocorrect: Done
-    test.rb:23: Replaced with `**T.unsafe({x: 0, **opts})`
-    23 |requires_x(0, 1, 2, x: 0, **opts)
-                            ^^^^^^^^^^^^
-
 test.rb:25: Cannot call `Object#requires_x` with a `Hash` keyword splat because the method has required keyword parameters https://srb.help/7019
     25 |requires_x(0, 1, 2, **{x => 0})
                             ^^^^^^^^^^
@@ -126,7 +108,7 @@ test.rb:29: Expected `String` for keyword parameter `x` but found `T.nilable(Int
     test.rb:29: Replaced with `T.unsafe(nilble_opts)`
     29 |optional_x(0, 1, 2, **nilble_opts)
                               ^^^^^^^^^^^
-Errors: 7
+Errors: 6
 
 --------------------------------------------------------------------------
 
@@ -152,7 +134,7 @@ requires_x(0, 1, 2, **T.unsafe(opts))
 
 requires_x(0, 1, 2, **T.unsafe({**opts, x: 0}))
 
-requires_x(0, 1, 2, **T.unsafe({x: 0, **opts}))
+requires_x(0, 1, 2, x: 0, **opts)
 
 requires_x(0, 1, 2, **T.unsafe({x => 0}))
 

--- a/test/prism_regression/call_all_args.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_all_args.rb.desugar-tree-raw.exp
@@ -69,70 +69,28 @@ ClassDef{
         }
         Array{
           elems = [
-            InsSeq{
-              stats = [
-                Assign{
-                  lhs = UnresolvedIdent{
-                    kind = Local
-                    name = <D <U <hashTemp>> $2>
-                  }
-                  rhs = Hash{
-                    pairs = [
-                      [
-                        key = Literal{ value = :e }
-                        value = Literal{ value = 6 }
-                      ]
-                    ]
-                  }
-                }
-                Assign{
-                  lhs = UnresolvedIdent{
-                    kind = Local
-                    name = <D <U <hashTemp>> $2>
-                  }
-                  rhs = Send{
-                    flags = {}
-                    recv = ConstantLit{
-                      symbol = (class ::<Magic>)
-                      orig = nullptr
-                    }
-                    fun = <U <merge-hash>>
-                    block = nullptr
-                    pos_args = 2
-                    args = [
-                      UnresolvedIdent{
-                        kind = Local
-                        name = <D <U <hashTemp>> $2>
-                      }
-                      Send{
-                        flags = {}
-                        recv = ConstantLit{
-                          symbol = (class ::<Magic>)
-                          orig = nullptr
-                        }
-                        fun = <U <to-hash-nodup>>
-                        block = nullptr
-                        pos_args = 1
-                        args = [
-                          Send{
-                            flags = {privateOk}
-                            recv = Self
-                            fun = <U f>
-                            block = nullptr
-                            pos_args = 0
-                            args = [
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                }
-              ],
-              expr = UnresolvedIdent{
-                kind = Local
-                name = <D <U <hashTemp>> $2>
+            Literal{ value = :e }
+            Literal{ value = 6 }
+            Send{
+              flags = {}
+              recv = ConstantLit{
+                symbol = (class ::<Magic>)
+                orig = nullptr
               }
+              fun = <U <to-hash-dup>>
+              block = nullptr
+              pos_args = 1
+              args = [
+                Send{
+                  flags = {privateOk}
+                  recv = Self
+                  fun = <U f>
+                  block = nullptr
+                  pos_args = 0
+                  args = [
+                  ]
+                }
+              ]
             }
           ]
         }
@@ -237,70 +195,28 @@ ClassDef{
         }
         Array{
           elems = [
-            InsSeq{
-              stats = [
-                Assign{
-                  lhs = UnresolvedIdent{
-                    kind = Local
-                    name = <D <U <hashTemp>> $3>
-                  }
-                  rhs = Hash{
-                    pairs = [
-                      [
-                        key = Literal{ value = :e }
-                        value = Literal{ value = 6 }
-                      ]
-                    ]
-                  }
-                }
-                Assign{
-                  lhs = UnresolvedIdent{
-                    kind = Local
-                    name = <D <U <hashTemp>> $3>
-                  }
-                  rhs = Send{
-                    flags = {}
-                    recv = ConstantLit{
-                      symbol = (class ::<Magic>)
-                      orig = nullptr
-                    }
-                    fun = <U <merge-hash>>
-                    block = nullptr
-                    pos_args = 2
-                    args = [
-                      UnresolvedIdent{
-                        kind = Local
-                        name = <D <U <hashTemp>> $3>
-                      }
-                      Send{
-                        flags = {}
-                        recv = ConstantLit{
-                          symbol = (class ::<Magic>)
-                          orig = nullptr
-                        }
-                        fun = <U <to-hash-nodup>>
-                        block = nullptr
-                        pos_args = 1
-                        args = [
-                          Send{
-                            flags = {privateOk}
-                            recv = Self
-                            fun = <U f>
-                            block = nullptr
-                            pos_args = 0
-                            args = [
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                }
-              ],
-              expr = UnresolvedIdent{
-                kind = Local
-                name = <D <U <hashTemp>> $3>
+            Literal{ value = :e }
+            Literal{ value = 6 }
+            Send{
+              flags = {}
+              recv = ConstantLit{
+                symbol = (class ::<Magic>)
+                orig = nullptr
               }
+              fun = <U <to-hash-dup>>
+              block = nullptr
+              pos_args = 1
+              args = [
+                Send{
+                  flags = {privateOk}
+                  recv = Self
+                  fun = <U f>
+                  block = nullptr
+                  pos_args = 0
+                  args = [
+                  ]
+                }
+              ]
             }
           ]
         }
@@ -401,70 +317,28 @@ ClassDef{
         }
         Array{
           elems = [
-            InsSeq{
-              stats = [
-                Assign{
-                  lhs = UnresolvedIdent{
-                    kind = Local
-                    name = <D <U <hashTemp>> $4>
-                  }
-                  rhs = Hash{
-                    pairs = [
-                      [
-                        key = Literal{ value = :e }
-                        value = Literal{ value = 6 }
-                      ]
-                    ]
-                  }
-                }
-                Assign{
-                  lhs = UnresolvedIdent{
-                    kind = Local
-                    name = <D <U <hashTemp>> $4>
-                  }
-                  rhs = Send{
-                    flags = {}
-                    recv = ConstantLit{
-                      symbol = (class ::<Magic>)
-                      orig = nullptr
-                    }
-                    fun = <U <merge-hash>>
-                    block = nullptr
-                    pos_args = 2
-                    args = [
-                      UnresolvedIdent{
-                        kind = Local
-                        name = <D <U <hashTemp>> $4>
-                      }
-                      Send{
-                        flags = {}
-                        recv = ConstantLit{
-                          symbol = (class ::<Magic>)
-                          orig = nullptr
-                        }
-                        fun = <U <to-hash-nodup>>
-                        block = nullptr
-                        pos_args = 1
-                        args = [
-                          Send{
-                            flags = {privateOk}
-                            recv = Self
-                            fun = <U f>
-                            block = nullptr
-                            pos_args = 0
-                            args = [
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                }
-              ],
-              expr = UnresolvedIdent{
-                kind = Local
-                name = <D <U <hashTemp>> $4>
+            Literal{ value = :e }
+            Literal{ value = 6 }
+            Send{
+              flags = {}
+              recv = ConstantLit{
+                symbol = (class ::<Magic>)
+                orig = nullptr
               }
+              fun = <U <to-hash-dup>>
+              block = nullptr
+              pos_args = 1
+              args = [
+                Send{
+                  flags = {privateOk}
+                  recv = Self
+                  fun = <U f>
+                  block = nullptr
+                  pos_args = 0
+                  args = [
+                  ]
+                }
+              ]
             }
           ]
         }

--- a/test/testdata/infer/kwargs_splat.rb
+++ b/test/testdata/infer/kwargs_splat.rb
@@ -49,8 +49,8 @@ def h(x, y:, **kw_splat)
 end
 
 untyped_values_hash = T.let({}, T::Hash[Symbol, T.untyped])
+  # `y:` is passed explicitly, so the splat isn't the only possible source for it.
   h(1, y: 2, **untyped_values_hash)
-  #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Cannot call `Object#h` with a `Hash` keyword splat because the method has required keyword parameters
 
 sig {params(kw_splat: T::Hash[Symbol, String]).void}
 def i(**kw_splat)

--- a/test/testdata/infer/kwsplat_is_sometimes_okay.rb
+++ b/test/testdata/infer/kwsplat_is_sometimes_okay.rb
@@ -45,10 +45,10 @@ def example(opts, nilable_opts, mixed_opts, untyped_opts, string_keys)
   takes_some_required_nilable(**opts)
   #                           ^^^^^^ error: Cannot call `Object#takes_some_required_nilable` with a `Hash` keyword splat because the method has required keyword parameters
 
-  # It might be nice to get better locations for these two in the future, and
-  # also to somehow allow them.
+  # `x:` is passed explicitly, so the splat is only left to supply `y:`, which is optional.
   takes_some_required_nilable(x: nil, **opts)
-  #                           ^^^^^^^^^^^^^^ error: Cannot call `Object#takes_some_required_nilable` with a `Hash` keyword splat because the method has required keyword parameters
+  # A splat that isn't in trailing position can overwrite the keys before it, so `x:` isn't
+  # guaranteed here. It might be nice to somehow allow this in the future.
   takes_some_required_nilable(**opts, x: nil)
   #                           ^^^^^^^^^^^^^^ error: Cannot call `Object#takes_some_required_nilable` with a `Hash` keyword splat because the method has required keyword parameters
 

--- a/test/testdata/infer/kwsplat_is_sometimes_okay.rb.autocorrects.exp
+++ b/test/testdata/infer/kwsplat_is_sometimes_okay.rb.autocorrects.exp
@@ -52,10 +52,10 @@ def example(opts, nilable_opts, mixed_opts, untyped_opts, string_keys)
   takes_some_required_nilable(**T.unsafe(opts))
   #                           ^^^^^^ error: Cannot call `Object#takes_some_required_nilable` with a `Hash` keyword splat because the method has required keyword parameters
 
-  # It might be nice to get better locations for these two in the future, and
-  # also to somehow allow them.
-  takes_some_required_nilable(**T.unsafe({x: nil, **opts}))
-  #                           ^^^^^^^^^^^^^^ error: Cannot call `Object#takes_some_required_nilable` with a `Hash` keyword splat because the method has required keyword parameters
+  # `x:` is passed explicitly, so the splat is only left to supply `y:`, which is optional.
+  takes_some_required_nilable(x: nil, **opts)
+  # A splat that isn't in trailing position can overwrite the keys before it, so `x:` isn't
+  # guaranteed here. It might be nice to somehow allow this in the future.
   takes_some_required_nilable(**T.unsafe({**opts, x: nil}))
   #                           ^^^^^^^^^^^^^^ error: Cannot call `Object#takes_some_required_nilable` with a `Hash` keyword splat because the method has required keyword parameters
 

--- a/test/testdata/infer/kwsplat_mixed_with_kwargs.rb
+++ b/test/testdata/infer/kwsplat_mixed_with_kwargs.rb
@@ -1,0 +1,59 @@
+# typed: strict
+extend T::Sig
+
+sig {params(x: Integer, y: String).void}
+def takes_one_int_one_str(x: 0, y: ''); end
+
+sig {params(x: Integer, y: Integer).void}
+def takes_two_ints(x: 0, y: 0); end
+
+sig {params(x: Integer, y: Integer).void}
+def takes_required_int(x:, y: 0); end
+
+sig {params(x: Integer, rest: Integer).void}
+def takes_kwsplat_param(x: 0, **rest); end
+
+sig do
+  params(
+    int_opts: T::Hash[Symbol, Integer],
+    str_opts: T::Hash[Symbol, String],
+    untyped_opts: T::Hash[Symbol, T.untyped],
+  )
+  .void
+end
+def example(int_opts, str_opts, untyped_opts)
+  # A keyword arg written at the call site is known precisely, so it's checked against its
+  # parameter even though a splat is passed along with it.
+  takes_two_ints(x: 'not an int', **int_opts)
+  #                 ^^^^^^^^^^^^ error: Expected `Integer` but found `String("not an int")` for argument `x`
+  takes_two_ints(x: 0, **int_opts)
+
+  # This holds even when nothing can be learned from the splat itself.
+  takes_two_ints(x: 'not an int', **untyped_opts)
+  #                 ^^^^^^^^^^^^ error: Expected `Integer` but found `String("not an int")` for argument `x`
+  takes_two_ints(x: 0, **untyped_opts)
+
+  # The splat trails the explicit keys, so it can overwrite them. Its values still have to fit
+  # every keyword parameter, including the ones that were passed explicitly.
+  takes_one_int_one_str(y: 'ok', **str_opts)
+  #                                ^^^^^^^^ error: Expected `Integer` for keyword parameter `x` but found `String` from keyword splat
+  takes_two_ints(x: 0, **str_opts)
+  #                      ^^^^^^^^ error: Expected `Integer` for keyword parameter `x` but found `String` from keyword splat
+
+  # `x:` is supplied explicitly, so it no longer counts as being left up to the splat.
+  takes_required_int(x: 0, **int_opts)
+  takes_required_int(x: 'not an int', **int_opts)
+  #                     ^^^^^^^^^^^^ error: Expected `Integer` but found `String("not an int")` for argument `x`
+  takes_required_int(**int_opts)
+  #                  ^^^^^^^^^^ error: Cannot call `Object#takes_required_int` with a `Hash` keyword splat because the method has required keyword parameters
+
+  # Keys the splat supplies that aren't named parameters land on `**rest`.
+  takes_kwsplat_param(x: 0, **int_opts)
+  takes_kwsplat_param(x: 'not an int', **int_opts)
+  #                      ^^^^^^^^^^^^ error: Expected `Integer` but found `String("not an int")` for argument `x`
+
+  # A splat that isn't in trailing position, and a call with more than one splat, keep being
+  # merged into a single hash rather than checked one key at a time.
+  takes_two_ints(**int_opts, x: 'not an int')
+  takes_two_ints(x: 'not an int', **int_opts, **untyped_opts)
+end

--- a/test/testdata/infer/sig_suggestion_kwsplat.rb
+++ b/test/testdata/infer/sig_suggestion_kwsplat.rb
@@ -1,0 +1,19 @@
+# typed: strict
+extend T::Sig
+
+sig { params(a: Integer, b: Integer, c: Float, x: String).void }
+def callee(a, b = 0, c = 0.0, x: ''); end
+
+# The keyword arg passed alongside the splat has to be looked up by name. Reading the
+# arguments positionally instead would suggest `c`'s type for `q` rather than `x`'s.
+def suggest_with_kwsplat(p, q, opts) # error: does not have a `sig`
+  callee(p, x: q, **opts)
+end
+
+def suggest_without_kwsplat(p, q) # error: does not have a `sig`
+  callee(p, x: q)
+end
+
+def suggest_with_lone_kwsplat(p, opts) # error: does not have a `sig`
+  callee(p, **opts)
+end

--- a/test/testdata/infer/sig_suggestion_kwsplat.rb.autocorrects.exp
+++ b/test/testdata/infer/sig_suggestion_kwsplat.rb.autocorrects.exp
@@ -1,0 +1,27 @@
+# -- test/testdata/infer/sig_suggestion_kwsplat.rb --
+# typed: strict
+extend T::Sig
+
+sig { params(a: Integer, b: Integer, c: Float, x: String).void }
+def callee(a, b = 0, c = 0.0, x: ''); end
+
+# The keyword arg passed alongside the splat has to be looked up by name. Reading the
+# arguments positionally instead would suggest `c`'s type for `q` rather than `x`'s.
+extend T::Sig
+sig { params(p: Integer, q: String, opts: T.untyped).void }
+def suggest_with_kwsplat(p, q, opts) # error: does not have a `sig`
+  callee(p, x: q, **opts)
+end
+
+extend T::Sig
+sig { params(p: Integer, q: String).void }
+def suggest_without_kwsplat(p, q) # error: does not have a `sig`
+  callee(p, x: q)
+end
+
+extend T::Sig
+sig { params(p: Integer, opts: T.untyped).void }
+def suggest_with_lone_kwsplat(p, opts) # error: does not have a `sig`
+  callee(p, **opts)
+end
+# ------------------------------


### PR DESCRIPTION
Sorbet desugared `foo(x: 1, **opts)` into `foo(**{x: 1}.merge(opts))`, because `flattenKwargs` refused to inline keyword args whenever a splat was present. `Shape_merge` then bailed out on a non-shape `T::Hash`, widening the result to `T::Hash[T.untyped, T.untyped]`, which left the type checker with nothing to check per key.

Both desugarers now inline the explicit pairs and append `<Magic>.<to-hash-dup>(opts)` as a trailing argument when the splat is the only one and comes last — an `ast::Send` shape that was already supported but never produced. A splat that isn't last can overwrite the keys before it, so those keep being merged into a single hash, as do lone splats, calls with more than one splat, and anonymous `**` forwards.

User-visible changes:

- Keyword args written at the call site are checked against their parameters even when a splat is passed too, and the error points at the offending argument rather than at the whole keyword args region.
- A splat's value type is now also checked against keyword parameters that were passed explicitly, since a trailing splat can overwrite them.
- Passing a keyword arg alongside a splat is no longer rejected outright when the explicit args supply the method's required keyword parameters. This resolves the TODO in `kwsplat_is_sometimes_okay.rb` asking to "somehow allow them", along with the better locations the same comment asked for.
- Suggested sigs can read keyword args passed alongside a splat, which they previously could not.

With `opts: T::Hash[Symbol, String]` and `def f(x: Integer, y: String)`:

| Call | Before | After |
| --- | --- | --- |
| `f(**opts)` | error | error (unchanged) |
| `f(y: 'ok', **opts)` | no error | error |
| `f(x: 'not an int', **opts)` | no error | error, pointing at `x` |
| `f(x: 'not an int', **untyped_opts)` | no error | error, pointing at `x` |
| `f(x: 0, **opts)` | no error | error (the splat can overwrite `x`) |

### Motivation

Fixes #9944.

Mixing an explicit keyword arg with a keyword splat silenced keyword arg checking entirely. It turned out to be broader than the issue describes: adding a *valid* explicit keyword arg also silenced the splat's own error that fires without it, so `f(y: 'ok', **opts)` reported nothing while `f(**opts)` reported correctly.

### Test plan

See included automated tests.

`test/testdata/infer/kwsplat_mixed_with_kwargs.rb` covers precise checking of explicit keyword args, splats whose values are untyped, the overwrite case, the required-keyword-parameter relaxation, and the non-trailing and multi-splat paths that intentionally stay unchanged.

`test/testdata/infer/sig_suggestion_kwsplat.rb` covers the sig suggestion side. `extractSendArgumentKnowledge` skipped keyword handling whenever a splat was present, which was harmless while the keys were merged away before it ran. Once the keys are inlined, that skipping left the argument index out of step, so for

```ruby
sig { params(a: Integer, b: Integer, c: Float, x: String).void }
def callee(a, b = 0, c = 0.0, x: ''); end

def caller_method(p, q, opts)
  callee(p, x: q, **opts)
end
```

the suggestion for `q` went from `T.untyped` on master to `Float` (read from the optional positional `c` rather than the keyword `x`) before this was addressed, and is `String` now.

`test_corpus`, `test_corpus_prism`, `prism_regression`, `test_corpus_lsp`, and `test_corpus_lsp_prism` all pass (9065/9065). Two existing testdata files change because calls they asserted on are now legal, and `call_all_args.rb.desugar-tree-raw.exp` is regenerated for the new desugaring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)