### PR TITLE
sorbet-runtime: Add `T::Utils` methods for eager loading

### DIFF
--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -157,6 +157,27 @@ module T::Utils
     "#{start_part}#{ellipsis}#{end_part}"
   end
 
+  # Force all TypeAlias instances to resolve their effective_aliased_type eagerly.
+  #
+  # Call this while eagerly preloading a codebase (e.g. at service startup) to
+  # optimize for first-call/first-request latency.
+  def self.run_all_type_alias_blocks
+    require 'objspace'
+    ObjectSpace.each_object(T::Private::Types::TypeAlias, &:effective_aliased_type)
+    nil
+  end
+
+  # Force all T::Props::Serializable decorators to eagerly define their lazily
+  # specialized methods (serialization, deserialization, etc.).
+  #
+  # Call this while eagerly preloading a codebase (e.g. at service startup) to
+  # optimize for first-call/first-request latency.
+  def self.eagerly_define_all_lazy_props_methods!
+    require 'objspace'
+    ObjectSpace.each_object(T::Props::Serializable::DecoratorMethods, &:eagerly_define_lazy_methods!)
+    nil
+  end
+
   def self.lift_enum(enum)
     unless enum.is_a?(T::Types::Enum)
       raise ArgumentError.new("#{enum.inspect} is not a T.deprecated_enum")

--- a/gems/sorbet-runtime/lib/types/utils.rbi
+++ b/gems/sorbet-runtime/lib/types/utils.rbi
@@ -32,6 +32,21 @@ module T::Utils
   end
   def self.wrap_method_with_call_validation_if_needed(mod, method_sig, original_method); end
 
+  # Force all TypeAlias instances to resolve their effective_aliased_type eagerly.
+  #
+  # Call this while eagerly preloading a codebase (e.g. at service startup) to
+  # optimize for first-call/first-request latency.
+  sig { void }
+  def self.run_all_type_alias_blocks; end
+
+  # Force all T::Props::Serializable decorators to eagerly define their lazily
+  # specialized methods (serialization, deserialization, etc.).
+  #
+  # Call this while eagerly preloading a codebase (e.g. at service startup) to
+  # optimize for first-call/first-request latency.
+  sig { void }
+  def self.eagerly_define_all_lazy_props_methods!; end
+
   # TODO(jez) If we were to move this to the public rbi/ folder, we would
   # probably want the types to all be non-nil. Maybe we should just make this a
   # private helper.

--- a/gems/sorbet-runtime/test/types/fixtures/eagerly_define_all_lazy_props_methods.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/eagerly_define_all_lazy_props_methods.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require_relative '../../../lib/sorbet-runtime'
+
+# This fixture runs in a subprocess so that ObjectSpace iteration
+# is isolated from the main test process.
+
+def check(description, loc: caller_locations(1, 1).first)
+  unless yield
+    puts "FAIL: #{loc.path}:#{loc.lineno}: #{description}"
+  end
+end
+
+class MyStruct < T::Struct
+  prop :name, String
+  prop :age, Integer
+end
+
+check("lazy methods pending before") {
+  !MyStruct.decorator.lazily_defined_methods.empty?
+}
+
+T::Utils.eagerly_define_all_lazy_props_methods!
+
+check("lazy methods resolved after") {
+  MyStruct.decorator.lazily_defined_methods.empty?
+}
+
+# After eager definition, serialization should still work correctly
+instance = MyStruct.new(name: "Alice", age: 30)
+serialized = instance.serialize
+
+check("serialize produces correct hash") { serialized == {"name" => "Alice", "age" => 30} }
+
+deserialized = MyStruct.from_hash(serialized)
+check("from_hash round-trips correctly") { deserialized.name == "Alice" && deserialized.age == 30 }
+
+puts "PASS"

--- a/gems/sorbet-runtime/test/types/fixtures/eagerly_define_all_lazy_props_methods.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/eagerly_define_all_lazy_props_methods.rb
@@ -15,15 +15,15 @@ class MyStruct < T::Struct
   prop :age, Integer
 end
 
-check("lazy methods pending before") {
+check("lazy methods pending before") do
   !MyStruct.decorator.lazily_defined_methods.empty?
-}
+end
 
 T::Utils.eagerly_define_all_lazy_props_methods!
 
-check("lazy methods resolved after") {
+check("lazy methods resolved after") do
   MyStruct.decorator.lazily_defined_methods.empty?
-}
+end
 
 # After eager definition, serialization should still work correctly
 instance = MyStruct.new(name: "Alice", age: 30)

--- a/gems/sorbet-runtime/test/types/fixtures/eagerly_define_all_lazy_props_methods.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/eagerly_define_all_lazy_props_methods.rb
@@ -16,13 +16,15 @@ class MyStruct < T::Struct
 end
 
 check("lazy methods pending before") do
-  !MyStruct.decorator.lazily_defined_methods.empty?
+  # private method call
+  !MyStruct.decorator.send(:lazily_defined_methods).empty?
 end
 
 T::Utils.eagerly_define_all_lazy_props_methods!
 
 check("lazy methods resolved after") do
-  MyStruct.decorator.lazily_defined_methods.empty?
+  # private method call
+  MyStruct.decorator.send(:lazily_defined_methods).empty?
 end
 
 # After eager definition, serialization should still work correctly

--- a/gems/sorbet-runtime/test/types/fixtures/resolve_all_type_aliases.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/resolve_all_type_aliases.rb
@@ -1,0 +1,34 @@
+# typed: true
+# frozen_string_literal: true
+require_relative '../../../lib/sorbet-runtime'
+
+# This fixture runs in a subprocess so that ObjectSpace iteration
+# is isolated from the main test process.
+
+A1 = T.type_alias { Integer }.checked(:always)
+A2 = T.type_alias { String }.checked(:never)
+
+gc = GC
+a1 = A1
+a2 = A2
+
+before = gc.stat(:total_allocated_objects)
+a1.effective_aliased_type
+allocs_first = gc.stat(:total_allocated_objects) - before
+
+before = gc.stat(:total_allocated_objects)
+a1.effective_aliased_type
+allocs_second = gc.stat(:total_allocated_objects) - before
+
+T::Utils.run_all_type_alias_blocks
+
+before = gc.stat(:total_allocated_objects)
+a2.effective_aliased_type
+allocs_after = gc.stat(:total_allocated_objects) - before
+
+if allocs_first > 0 && allocs_second == 0 && allocs_after == 0
+  puts "PASS"
+else
+  puts "FAIL: first=#{allocs_first} (expected >0), second=#{allocs_second} (expected 0), after_run_all=#{allocs_after} (expected 0)"
+  exit 1
+end

--- a/gems/sorbet-runtime/test/types/utils_eager_resolution.rb
+++ b/gems/sorbet-runtime/test/types/utils_eager_resolution.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+# typed: ignore
+require_relative '../test_helper'
+
+module Opus::Types::Test
+  class UtilsEagerResolutionTest < Critic::Unit::UnitTest
+    it 'run_all_type_alias_blocks forces effective_aliased_type on all TypeAlias objects' do
+      fixture = "#{__dir__}/fixtures/resolve_all_type_aliases.rb"
+      result, status = Open3.capture2e("ruby", fixture)
+      assert(status.success?, "fixture failed (exit #{status.exitstatus}): #{result}")
+      assert_equal("PASS\n", result)
+    end
+
+    it 'eagerly_define_all_lazy_props_methods! defines all lazy prop methods' do
+      fixture = "#{__dir__}/fixtures/eagerly_define_all_lazy_props_methods.rb"
+      result, status = Open3.capture2e("ruby", fixture)
+      assert(status.success?, "fixture failed (exit #{status.exitstatus}): #{result}")
+      assert_equal("PASS\n", result)
+    end
+  end
+end

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -468,6 +468,21 @@ module T::Utils
 
   # only one caller; delete
   def self.methods_excluding_object(mod); end
+
+  # Force all TypeAlias instances to resolve their effective_aliased_type eagerly.
+  #
+  # Call this while eagerly preloading a codebase (e.g. at service startup) to
+  # optimize for first-call/first-request latency.
+  sig { void }
+  def self.run_all_type_alias_blocks; end
+
+  # Force all T::Props::Serializable decorators to eagerly define their lazily
+  # specialized methods (serialization, deserialization, etc.).
+  #
+  # Call this while eagerly preloading a codebase (e.g. at service startup) to
+  # optimize for first-call/first-request latency.
+  sig { void }
+  def self.eagerly_define_all_lazy_props_methods!; end
 end
 
 

--- a/website/docs/load-time-tuning.md
+++ b/website/docs/load-time-tuning.md
@@ -1,0 +1,54 @@
+---
+id: load-time-tuning
+title: Load-time Tuning
+---
+
+`sorbet-runtime` uses lazy initialization internally, sometimes to eliminate load-time cycles, and sometimes to keep development code loading fast, but some applications benefit from **eager loading**, instead of lazy loading.
+
+These methods force that deferred work to happen eagerly:
+
+```ruby
+# Run all `sig {...}` blocks, redefining all associated methods with runtime checking
+# (or dropping the first-call wrapper, for `.checked(:never)` sigs)
+T::Utils.run_all_sig_blocks
+
+# The same, but for `T.type_alias` blocks
+T::Utils.run_all_type_alias_blocks
+
+# Force all T::Struct classes to generate their specialized serialization methods
+T::Utils.eagerly_define_all_lazy_props_methods!
+```
+
+For certain applications, like HTTP services, these methods mitigate first-call or first-request latency spikes. It's the same idea behind projects like [nakayoshi_fork] and patterns like zeitwerk's `eager_load`.
+
+Call these methods **after** all application code has been loaded (e.g., in a Rails initializer or a `before_fork` hook) but **before** forking workers (so the initialized state is shared across processes via copy-on-write).
+
+[nakayoshi_fork]: https://github.com/ko1/nakayoshi_fork
+
+## `T::Utils.run_all_sig_blocks`
+
+```ruby
+T::Utils.run_all_sig_blocks
+```
+
+Method signatures (`sig { ... }`) are lazily evaluated: the block inside a `sig` doesn't run until the method is first called. This means the first call to any sig'd method is slower than subsequent calls.
+
+`run_all_sig_blocks` forces every pending sig block to evaluate immediately, so that the first real call to each method has no extra overhead.
+
+## `T::Utils.run_all_type_alias_blocks`
+
+```ruby
+T::Utils.run_all_type_alias_blocks
+```
+
+Type aliases created with `T.type_alias { ... }` lazily compute the aliased type the first time it's needed (either for runtime type checking or for reflection). This method forces all type alias objects in the process to resolve that computation eagerly.
+
+## `T::Utils.eagerly_define_all_lazy_props_methods!`
+
+```ruby
+T::Utils.eagerly_define_all_lazy_props_methods!
+```
+
+Classes that include `T::Props::Serializable` (including `T::Struct`) generate specialized `serialize` and `from_hash` methods using codegen for runtime performance (mostly: to avoid contention for VM-level method call caches). These specialized methods are usually generated lazily on the first call to the ser/de methods. This method eagerly generates these specialized methods.
+
+> **Note**: The `serialize` and `from_hash` methods on `T::Struct` have a number of [gotchas and legacy behaviors](tstruct.md#serialize-and-from_hash-converting-tstruct-to-and-from-hash).

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -12,6 +12,7 @@
       "gradual",
       "static",
       "runtime",
+      "load-time-tuning",
       "rbi",
       "cli",
       "cli-ref",


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We just added code that looks like this `run_all_type_alias_blocks` to Stripe's
preloading routines. We've had this `eagerly_define_all_lazy_props_methods`
snippet in Stripe's preloading routines for many years.

I wanted to explicitly codify these patterns behind helper methods and also
write a doc advertising them.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.