### PR TITLE
Disallow using package namespaces as mixins or superclasses

### DIFF
--- a/core/errors/resolver.h
+++ b/core/errors/resolver.h
@@ -91,6 +91,7 @@ inline constexpr ErrorClass UnnamedBlockParameter{5082, StrictLevel::False};
 inline constexpr ErrorClass PackageNamespaceMixin{5083, StrictLevel::False};
 inline constexpr ErrorClass ModifyingUnpackagedConstant{5084, StrictLevel::False};
 inline constexpr ErrorClass InvalidPackageExpression{5085, StrictLevel::False};
+inline constexpr ErrorClass PackageAsSuperclassOrMixin{5086, StrictLevel::False};
 } // namespace sorbet::core::errors::Resolver
 
 #endif

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -772,6 +772,21 @@ private:
                 e.addErrorLine(resolvedClass.data(ctx)->loc(), "Other definition");
             }
             resolvedClass = stubSymbolForAncestor(job);
+        } else if (resolvedClass.data(ctx)->isPackageNamespace() &&
+                   ctx.state.packageDB().getPackageInfo(resolvedClass.data(ctx)->package).hasSubPackages) {
+            if (auto e = ctx.beginError(job.ancestor->loc(), core::errors::Resolver::PackageAsSuperclassOrMixin)) {
+                auto &pkgInfo = ctx.state.packageDB().getPackageInfo(resolvedClass.data(ctx)->package);
+                if (job.isSuperclass) {
+                    e.setHeader("Package namespace use as superclass");
+                    e.addErrorLine(job.klass.data(ctx)->loc(), "Class definition");
+                    e.addErrorLine(pkgInfo.declLoc(), "Package definition");
+                } else {
+                    e.setHeader("Package namespaces may not be used with `{}`", job.isInclude ? "include" : "extend");
+                    e.addErrorLine(job.klass.data(ctx)->loc(), "Class definition");
+                    e.addErrorLine(pkgInfo.declLoc(), "Package definition");
+                }
+            }
+            resolvedClass = stubSymbolForAncestor(job);
         }
 
         bool ancestorPresent = true;


### PR DESCRIPTION
Reject uses of package namespace symbols as mixins or superclasses, when the package in question has subpackages. This can cause unexpected ancestor resolution results.

### Motivation
Restricting packages a bit to avoid confusing ancestor resolution situations.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
