### PR TITLE
Add `enable-experimental-method-modifiers` option

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1991,6 +1991,7 @@ void GlobalState::copyOptions(const core::GlobalState &other) {
     this->cacheSensitiveOptions = other.cacheSensitiveOptions;
     this->ruby3KeywordArgs = other.ruby3KeywordArgs;
     this->parseWithPrism = other.parseWithPrism;
+    this->experimentalMethodModifiers = other.experimentalMethodModifiers;
     this->suppressPayloadSuperclassRedefinitionFor = other.suppressPayloadSuperclassRedefinitionFor;
     this->trackUntyped = other.trackUntyped;
     this->highlightUntypedDiagnosticSeverity = other.highlightUntypedDiagnosticSeverity;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -652,6 +652,9 @@ public:
     // If 'true', use the Prism parser.
     bool parseWithPrism = false;
 
+    // Enable support experimental method modifiers, such as `abstract def foo; end`
+    bool experimentalMethodModifiers = false;
+
     // Some options change the behavior of things that might be cached, including ASTs, the file
     // table, the name table, the symbol table, etc.
     //

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -745,6 +745,9 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
         "Enables experimental support for RSpec. "
         "There are many RSpec constructs that are impossible for Sorbet to handle. "
         "As a result, there is no path to this flag ever being stable: RSpec support is best effort.");
+    options.add_options(section)("enable-experimental-method-modifiers",
+                                 "Enable experimental support for method def modifiers like `abstract def foo; end`.\n"
+                                 "Implicitly enabled if you enable RBS support.");
     // }}}
 
     // ----- OTHER -------------------------------------------------------- {{{
@@ -995,6 +998,14 @@ void readOptions(Options &opts,
                 "been combined into the `--enable-experimental-rbs-comments` option. Please update your Sorbet config "
                 "to use `--enable-experimental-rbs-comments` instead.");
             opts.cacheSensitiveOptions.rbsEnabled = true;
+        }
+
+        if (raw.count("enable-experimental-method-modifiers") > 0) {
+            opts.experimentalMethodModifiers = raw["enable-experimental-method-modifiers"].as<bool>();
+        } else {
+            // Abstract methods can only work correctly with RBS syntax in their modifier form,
+            // so we default to enabling the option unless it's explicitly disabled.
+            opts.experimentalMethodModifiers = opts.cacheSensitiveOptions.rbsEnabled;
         }
 
         opts.cacheSensitiveOptions.requiresAncestorEnabled = raw["enable-experimental-requires-ancestor"].as<bool>();

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -220,6 +220,9 @@ struct Options {
     };
     CacheSensitiveOptions cacheSensitiveOptions;
 
+    // Enable support experimental method modifiers, such as `abstract def foo; end`
+    bool experimentalMethodModifiers = false;
+
     bool packageAttributedErrors = false;
     bool packageDirected = false;
     bool testPackages = false;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -76,6 +76,7 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
         gs.includeErrorSections = false;
     }
     gs.parseWithPrism = opts.cacheSensitiveOptions.usePrismParser;
+    gs.experimentalMethodModifiers = opts.experimentalMethodModifiers;
     gs.ruby3KeywordArgs = opts.ruby3KeywordArgs;
     gs.suppressPayloadSuperclassRedefinitionFor = opts.suppressPayloadSuperclassRedefinitionFor;
     if (!opts.uniquelyDefinedBehavior) {

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -272,6 +272,7 @@ const UnorderedMap<
         {"enable-experimental-rbs-comments", BooleanPropertyAssertion::make},
         {"enable-experimental-requires-ancestor", BooleanPropertyAssertion::make},
         {"enable-experimental-rspec", BooleanPropertyAssertion::make},
+        {"enable-experimental-method-modifiers", BooleanPropertyAssertion::make},
         {"experimental-ruby3-keyword-args", BooleanPropertyAssertion::make},
         {"typed-super", BooleanPropertyAssertion::make},
         {"enable-suggest-unsafe", BooleanPropertyAssertion::make},
@@ -676,6 +677,10 @@ realmain::options::Options RangeAssertion::parseOptions(vector<shared_ptr<RangeA
         BooleanPropertyAssertion::getValue("enable-experimental-requires-ancestor", assertions).value_or(false);
     opts.cacheSensitiveOptions.rspecRewriterEnabled =
         BooleanPropertyAssertion::getValue("enable-experimental-rspec", assertions).value_or(false);
+    auto experimentalMethodModifiers =
+        BooleanPropertyAssertion::getValue("enable-experimental-method-modifiers", assertions);
+    opts.experimentalMethodModifiers = experimentalMethodModifiers.has_value() ? experimentalMethodModifiers.value()
+                                                                               : opts.cacheSensitiveOptions.rbsEnabled;
     opts.ruby3KeywordArgs =
         BooleanPropertyAssertion::getValue("experimental-ruby3-keyword-args", assertions).value_or(false);
     opts.cacheSensitiveOptions.typedSuper =

--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -185,6 +185,10 @@ for this_src in "${rb_src[@]}" DUMMY; do
       args+=("--enable-experimental-rbs-comments")
     fi
 
+    if grep -q '^# enable-experimental-method-modifiers: true' "${srcs[@]}"; then
+      args+=("--enable-experimental-method-modifiers")
+    fi
+
     if grep -q '^# typed-super: false' "${srcs[@]}"; then
       args+=("--typed-super=false")
     fi

--- a/website/docs/cli-ref.md
+++ b/website/docs/cli-ref.md
@@ -440,6 +440,10 @@ Usage:
                                 RSpec constructs that are impossible for Sorbet to
                                 handle. As a result, there is no path to this flag ever
                                 being stable: RSpec support is best effort.
+      --enable-experimental-method-modifiers
+                                Enable experimental support for method def modifiers like
+                                `abstract def foo; end`.
+                                Implicitly enabled if you enable RBS support.
 
 ```
 


### PR DESCRIPTION
### Motivation

Pre-work split out this noise from #9963 and #10090

### Test plan

None yet, it'll come with the PRs that use it
