### PR TITLE
Expand all error-with-dupes, remove support

### DIFF
--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -52,25 +52,16 @@ string prettyPrintRangeComment(string_view sourceLine, const Range &range, strin
                        string(numLeadingSpaces + sourceLineNumber.length() + 1, ' '), string(numCarets, '^'), comment);
 }
 
-template <typename T> bool isDuplicateDiagnostic(string_view filename, T *assertion, const Diagnostic &d) {
-    return assertion && assertion->matchesDuplicateErrors && assertion->matches(filename, *d.range) == 0 &&
-           d.message.find(assertion->message) != string::npos;
-}
-
 template <typename T>
-void reportMissingError(const string &filename, const T &assertion, string_view sourceLine, string_view errorPrefix,
-                        bool missingDuplicate = false) {
+void reportMissingError(const string &filename, const T &assertion, string_view sourceLine, string_view errorPrefix) {
     // Skip error message checking when running with Prism.
     if (sorbet::test::parser == realmain::options::Parser::PRISM) {
         return;
     }
 
-    auto coreMessage = missingDuplicate ? "Error was not duplicated" : "Did not find expected error";
-    auto messagePostfix = missingDuplicate ? "\nYou can fix this error by changing the assertion to `error:`." : "";
     ADD_FAIL_CHECK_AT(filename.c_str(), assertion.range->start->line + 1,
-                      fmt::format("{}{}:\n{}{}", errorPrefix, coreMessage,
-                                  prettyPrintRangeComment(sourceLine, *assertion.range, assertion.toString()),
-                                  messagePostfix));
+                      fmt::format("{}Did not find expected error:\n{}", errorPrefix,
+                                  prettyPrintRangeComment(sourceLine, *assertion.range, assertion.toString())));
 }
 
 void reportUnexpectedError(const string &filename, const Diagnostic &diagnostic, string_view sourceLine,
@@ -87,9 +78,10 @@ void reportUnexpectedError(const string &filename, const Diagnostic &diagnostic,
     ADD_FAIL_CHECK_AT(
         filename.c_str(), diagnostic.range->start->line + 1,
         fmt::format(
-            "{}Found unexpected error:\n{}\nNote: If there is already an assertion for this error, then this is a "
-            "duplicate error. Change the assertion to `# error-with-dupes: <error message>` if the duplicate is "
-            "expected.",
+            "{}Found unexpected error:\n"
+            "{}\n"
+            "Note: If there is already an assertion for this error, then this is a duplicate error. "
+            "Change the assertion to `# ^^^ error:`-style assertions (one per error) if the duplicates are expected.",
             errorPrefix, prettyPrintRangeComment(sourceLine, *diagnostic.range, diagnosticMessage)));
 }
 string getSourceLine(const UnorderedMap<string, shared_ptr<core::File>> &sourceFileContents, const string &filename,
@@ -143,8 +135,6 @@ bool checkAllInner(const sorbet::UnorderedMap<string, shared_ptr<sorbet::core::F
         });
 
         auto diagnosticsIt = diagnostics.begin();
-        T *lastAssertion = nullptr;
-        bool lastAssertionMatchedDuplicate = false;
 
         while (diagnosticsIt != diagnostics.end() && assertionsIt != errorAssertions.end()) {
             // See if the ranges match.
@@ -154,21 +144,6 @@ bool checkAllInner(const sorbet::UnorderedMap<string, shared_ptr<sorbet::core::F
             if (diagnostic->severity.value_or(T::severity) != T::severity) {
                 diagnosticsIt++;
                 continue;
-            }
-
-            if (isDuplicateDiagnostic(filename, lastAssertion, *diagnostic)) {
-                diagnosticsIt++;
-                lastAssertionMatchedDuplicate = true;
-                continue;
-            } else {
-                if (lastAssertion && lastAssertion->matchesDuplicateErrors && !lastAssertionMatchedDuplicate) {
-                    reportMissingError(lastAssertion->filename, *lastAssertion,
-                                       getSourceLine(files, lastAssertion->filename, lastAssertion->range->start->line),
-                                       errorPrefix, true);
-                    success = false;
-                }
-                lastAssertionMatchedDuplicate = false;
-                lastAssertion = nullptr;
             }
 
             const int cmp = assertion->matches(filename, *diagnostic->range);
@@ -196,8 +171,6 @@ bool checkAllInner(const sorbet::UnorderedMap<string, shared_ptr<sorbet::core::F
                                            errorPrefix) &&
                           success;
                 // We've 'consumed' the diagnostic and assertion.
-                // Save assertion in case it matches multiple diagnostics.
-                lastAssertion = assertion.get();
                 diagnosticsIt++;
                 assertionsIt++;
             }
@@ -212,21 +185,9 @@ bool checkAllInner(const sorbet::UnorderedMap<string, shared_ptr<sorbet::core::F
                 continue;
             }
 
-            if (isDuplicateDiagnostic(filename, lastAssertion, *diagnostic)) {
-                lastAssertionMatchedDuplicate = true;
-            } else {
-                reportUnexpectedError(filename, *diagnostic,
-                                      getSourceLine(files, filename, diagnostic->range->start->line), errorPrefix);
-                success = false;
-
-                if (lastAssertion && lastAssertion->matchesDuplicateErrors && !lastAssertionMatchedDuplicate) {
-                    reportMissingError(lastAssertion->filename, *lastAssertion,
-                                       getSourceLine(files, lastAssertion->filename, lastAssertion->range->start->line),
-                                       errorPrefix, true);
-                }
-                lastAssertion = nullptr;
-                lastAssertionMatchedDuplicate = false;
-            }
+            reportUnexpectedError(filename, *diagnostic, getSourceLine(files, filename, diagnostic->range->start->line),
+                                  errorPrefix);
+            success = false;
             diagnosticsIt++;
         }
     }
@@ -254,7 +215,6 @@ const UnorderedMap<
     assertionConstructors = {
         {"untyped", UntypedAssertion::make},
         {"error", ErrorAssertion::make},
-        {"error-with-dupes", ErrorAssertion::make},
         {"usage", UsageAssertion::make},
         {"import", ImportAssertion::make},
         {"importusage", ImportUsageAssertion::make},
@@ -481,19 +441,16 @@ int RangeAssertion::cmp(const RangeAssertion &b) const {
     return toString().compare(b.toString());
 }
 
-ErrorAssertion::ErrorAssertion(string_view filename, unique_ptr<Range> &range, int assertionLine, string_view message,
-                               bool matchesDuplicateErrors)
-    : RangeAssertion(filename, range, assertionLine), message(message), matchesDuplicateErrors(matchesDuplicateErrors) {
-}
+ErrorAssertion::ErrorAssertion(string_view filename, unique_ptr<Range> &range, int assertionLine, string_view message)
+    : RangeAssertion(filename, range, assertionLine), message(message) {}
 
 shared_ptr<ErrorAssertion> ErrorAssertion::make(string_view filename, unique_ptr<Range> &range, int assertionLine,
                                                 string_view assertionContents, string_view assertionType) {
-    return make_shared<ErrorAssertion>(filename, range, assertionLine, assertionContents,
-                                       assertionType == "error-with-dupes");
+    return make_shared<ErrorAssertion>(filename, range, assertionLine, assertionContents);
 }
 
 string ErrorAssertion::toString() const {
-    return fmt::format("{}: {}", (matchesDuplicateErrors ? "error-with-dupes" : "error"), message);
+    return fmt::format("error: {}", message);
 }
 
 bool ErrorAssertion::check(const Diagnostic &diagnostic, string_view sourceLine, string_view errorPrefix) {

--- a/test/helpers/position_assertions.h
+++ b/test/helpers/position_assertions.h
@@ -96,11 +96,10 @@ public:
                          std::string errorPrefix = "");
 
     const std::string message;
-    const bool matchesDuplicateErrors;
     static constexpr DiagnosticSeverity severity = DiagnosticSeverity::Error;
 
     ErrorAssertion(std::string_view filename, std::unique_ptr<Range> &range, int assertionLine,
-                   std::string_view message, bool matchesDuplicateErrors);
+                   std::string_view message);
 
     std::string toString() const override;
 
@@ -119,9 +118,6 @@ public:
     std::string toString() const override;
     const std::string message;
 
-    // this exists solely to allow us to reuse ErrorAssertion's checkAll
-    // for UntypedAssertion. It should *always* be false.
-    static constexpr bool matchesDuplicateErrors = false;
     static constexpr DiagnosticSeverity severity = DiagnosticSeverity::Information;
 
     static bool checkAll(const UnorderedMap<std::string, std::shared_ptr<core::File>> &files,

--- a/test/testdata/infer/generics/bounds.rb
+++ b/test/testdata/infer/generics/bounds.rb
@@ -91,8 +91,11 @@ class Test
   # There are duplicate errors here because both resolver and infer report the same error. This is not intentional.
   # should fail: Integer is not within the Animal/Persian bounds.
   sig {params(arg1: A2[Integer], arg2: A2[BasicObject]).void}
-  #                    ^^^^^^^ error-with-dupes: `Integer` is not a subtype of upper bound of type member `::A2::X`
-  #                    ^^^^^^^ error-with-dupes: `Integer` is not a supertype of lower bound of type member `::A2::X`
-  #                                       ^^^^^^^^^^^ error-with-dupes: `BasicObject` is not a subtype of upper bound of type member `::A2::X`
+  #                    ^^^^^^^ error: `Integer` is not a subtype of upper bound of type member `::A2::X`
+  #                    ^^^^^^^ error: `Integer` is not a supertype of lower bound of type member `::A2::X`
+  #                                       ^^^^^^^^^^^ error: `BasicObject` is not a subtype of upper bound of type member `::A2::X`
+  #                    ^^^^^^^ error: `Integer` is not a subtype of upper bound of type member `::A2::X`
+  #                    ^^^^^^^ error: `Integer` is not a supertype of lower bound of type member `::A2::X`
+  #                                       ^^^^^^^^^^^ error: `BasicObject` is not a subtype of upper bound of type member `::A2::X`
   def test2(arg1, arg2); end
 end

--- a/test/testdata/lsp/completion/and_and_nil.rb
+++ b/test/testdata/lsp/completion/and_and_nil.rb
@@ -12,7 +12,8 @@ class A
     # Remember, we only show completion results that are valid. Asking for
     # completion results for `a.foo.even?` here would not return any results.
     if a.foo && a.foo.to
-      #               ^^ error-with-dupes: does not exist
+      #               ^^ error: does not exist
+      #               ^^ error: does not exist
       #                 ^ completion: to_c, to_d, to_f, to_i, to_r, ...
       puts a.foo
     end

--- a/test/testdata/lsp/completion/constants_t.rb
+++ b/test/testdata/lsp/completion/constants_t.rb
@@ -2,10 +2,13 @@
 
 class A
   # TODO(jez) We should sort exact prefix matches ahead of fuzzy matches
-  extend T::S # error-with-dupes: Unable to resolve
+  extend T::S # error: Unable to resolve
+       # ^^^^ error: Unable to resolve
   #          ^ completion: ImmutableStruct, InexactStruct, Set, Sig, Struct
-  extend T::H # error-with-dupes: Unable to resolve
+  extend T::H # error: Unable to resolve
+       # ^^^^ error: Unable to resolve
   #          ^ completion: Hash, Helpers
-  extend T::G # error-with-dupes: Unable to resolve
+  extend T::G # error: Unable to resolve
+       # ^^^^ error: Unable to resolve
   #          ^ completion: Generic
 end

--- a/test/testdata/lsp/completion/constants_type_members.rb
+++ b/test/testdata/lsp/completion/constants_type_members.rb
@@ -7,7 +7,8 @@ class Box
   Elem = type_member
 
   # We get a duplicate constant resolution error here because of the Initializer rewrite pass.
-  sig {params(val: Ele).void} # error-with-dupes: Unable to resolve
+  sig {params(val: Ele).void} # error: Unable to resolve
+                 # ^^^ error: Unable to resolve
   #                   ^ completion: Elem
   def initialize(val)
     @val = val

--- a/test/testdata/lsp/completion/instance_var.rb
+++ b/test/testdata/lsp/completion/instance_var.rb
@@ -47,7 +47,7 @@ class ClassVariable
     #
     # If the parser gets fixed to return some kind of node for bare `@@`, we
     # should be able to start producing completion results here.
-    @@ # error-with-dupes: unexpected
+    @@ # error: unexpected
     # ^ completion: @@different_prefix, @@my, @@my_cvar
   end
 end

--- a/test/testdata/lsp/completion/send_with_block.rb
+++ b/test/testdata/lsp/completion/send_with_block.rb
@@ -9,6 +9,7 @@ end
 
 class B
   extend T::Sig
-  sig do end # error-with-dupes: Malformed `sig`
+  sig do end # error: Malformed `sig`
+# ^^^^^^^^^^ error: Malformed `sig`
     #   ^ completion: (nothing)
 end

--- a/test/testdata/lsp/fast_path/static_field_change_type__def.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_change_type__def.1.rbupdate
@@ -4,3 +4,4 @@
 STATIC_FIELD = T.let({}, T::Hash[Symbol, ])
 #                                      ^ error: Not enough arguments provided
 #                                ^^^^^^ error: Wrong number of type parameters
+#                                ^^^^^^ error: Wrong number of type parameters

--- a/test/testdata/lsp/fast_path/static_field_change_type__def.1.rbupdate
+++ b/test/testdata/lsp/fast_path/static_field_change_type__def.1.rbupdate
@@ -3,4 +3,4 @@
 
 STATIC_FIELD = T.let({}, T::Hash[Symbol, ])
 #                                      ^ error: Not enough arguments provided
-#                                ^^^^^^ error-with-dupes: Wrong number of type parameters
+#                                ^^^^^^ error: Wrong number of type parameters

--- a/test/testdata/lsp/hover_methods_inside_block.rb
+++ b/test/testdata/lsp/hover_methods_inside_block.rb
@@ -15,7 +15,7 @@ module Foo
       def foo
         errors = enabled_methods
           .filter_map {|(_, foo)| foo}
-          .flat_map {|validation| validation.public_send(validation)} # error-with-dupes: This code is unreachable
+          .flat_map {|validation| validation.public_send(validation)} # error: This code is unreachable
                                                # ^ hover: def public_send(arg0, *args, &blk); end
         errors
       end

--- a/test/testdata/parser/error_recovery/missing_shadow_args.rb
+++ b/test/testdata/parser/error_recovery/missing_shadow_args.rb
@@ -10,4 +10,4 @@ lambda { |;| }
 #          ^ error: unexpected token "|"
 
 -> (;) {}
-#    ^ error-with-dupes: unexpected token ")"
+#    ^ error: unexpected token ")"

--- a/test/testdata/parser/error_recovery/missing_shadow_args_prism.rb
+++ b/test/testdata/parser/error_recovery/missing_shadow_args_prism.rb
@@ -8,4 +8,4 @@ lambda { |;| }
 #          ^ error: expected a local variable name in the block parameters
 
 -> (;) {}
-#    ^ error-with-dupes: expected a local variable name in the block parameters
+#    ^ error: expected a local variable name in the block parameters

--- a/test/testdata/rbs/signatures_generics.rb
+++ b/test/testdata/rbs/signatures_generics.rb
@@ -105,14 +105,18 @@ end
 class G4; end
 
 g4 = G4.new #: G4[Integer]
-#                 ^^^^^^^ error-with-dupes: `Integer` is not a subtype of upper bound of type member `::G4::U`
+#                 ^^^^^^^ error: `Integer` is not a subtype of upper bound of type member `::G4::U`
+#                 ^^^^^^^ error: `Integer` is not a subtype of upper bound of type member `::G4::U`
+#                 ^^^^^^^ error: `Integer` is not a subtype of upper bound of type member `::G4::U`
 T.reveal_type(g4) # error: Revealed type: `G4[T.untyped]`
 
 #: [U > BasicObject]
 class G5; end
 
 g5 = G5.new #: G5[String]
-#                 ^^^^^^ error-with-dupes: `String` is not a supertype of lower bound of type member `::G5::U`
+#                 ^^^^^^ error: `String` is not a supertype of lower bound of type member `::G5::U`
+#                 ^^^^^^ error: `String` is not a supertype of lower bound of type member `::G5::U`
+#                 ^^^^^^ error: `String` is not a supertype of lower bound of type member `::G5::U`
 T.reveal_type(g5) # error: Revealed type: `G5[T.untyped]`
 
 #: [U]
@@ -172,7 +176,8 @@ class G11; end
 class G12; end
 
 #: (G12[Object]) -> void
-#       ^^^^^^ error-with-dupes: `Object` is not a subtype of upper bound of type member `::G12::U`
+#       ^^^^^^ error: `Object` is not a subtype of upper bound of type member `::G12::U`
+#       ^^^^^^ error: `Object` is not a subtype of upper bound of type member `::G12::U`
 def take_g12(g12); end
 
 #: [

--- a/test/testdata/resolver/bad_param_ordering.rb
+++ b/test/testdata/resolver/bad_param_ordering.rb
@@ -34,5 +34,5 @@ class B
   def f3(v, w = T2.new, *y, z:, x: T1.new); end
   #                      ^ error: Bad parameter ordering for `y`, expected `x` instead
   #                         ^^ error: Bad parameter ordering for `z`, expected `y` instead
-  #                             ^^ error-with-dupes: Bad parameter ordering for `x`, expected `z` instead
+  #                             ^^ error: Bad parameter ordering for `x`, expected `z` instead
 end

--- a/test/testdata/resolver/fuzz_type_member_forget.rb
+++ b/test/testdata/resolver/fuzz_type_member_forget.rb
@@ -9,4 +9,5 @@ class DifferentArityChild < Parent # error: Type `TParent` declared by parent `P
   TChild = type_member {{fixed: String}}
 end
 
-T.cast(1, DifferentArityChild[Integer, String, Symbol]) # error-with-dupes: All type parameters for `DifferentArityChild` have already been fixed
+T.cast(1, DifferentArityChild[Integer, String, Symbol]) # error: All type parameters for `DifferentArityChild` have already been fixed
+                            # ^^^^^^^^^^^^^^^^^^^^^^^ error: All type parameters for `DifferentArityChild` have already been fixed

--- a/test/testdata/resolver/infinite.rb
+++ b/test/testdata/resolver/infinite.rb
@@ -8,25 +8,63 @@ def f(s); end
 sig {params(s: U60).void} # current resolution limit is 30, but because we're iterative we sometimes can resolve past it.
 def f_long(s); end
 
-U0 = Integer # error-with-dupes: Too many alias expansions
-U1 = U0 # error-with-dupes: Too many alias expansions
-U2 = U1 # error-with-dupes: Too many alias expansions
-U3 = U2 # error-with-dupes: Too many alias expansions
-U4 = U3 # error-with-dupes: Too many alias expansions
-U5 = U4 # error-with-dupes: Too many alias expansions
-U6 = U5 # error-with-dupes: Too many alias expansions
-U7 = U6 # error-with-dupes: Too many alias expansions
-U8 = U7 # error-with-dupes: Too many alias expansions
-U9 = U8 # error-with-dupes: Too many alias expansions
-U10 = U9 # error-with-dupes: Too many alias expansions
-U11 = U10 # error-with-dupes: Too many alias expansions
-U12 = U11 # error-with-dupes: Too many alias expansions
-U13 = U12 # error-with-dupes: Too many alias expansions
-U14 = U13 # error-with-dupes: Too many alias expansions
-U15 = U14 # error-with-dupes: Too many alias expansions
-U16 = U15 # error-with-dupes: Too many alias expansions
-U17 = U16 # error-with-dupes: Too many alias expansions
-U18 = U17 # error-with-dupes: Too many alias expansions
+U0 = Integer # error: Too many alias expansions
+# error: Too many alias expansions
+# error: Too many alias expansions
+U1 = U0 # error: Too many alias expansions
+# error: Too many alias expansions
+# error: Too many alias expansions
+U2 = U1 # error: Too many alias expansions
+# error: Too many alias expansions
+# error: Too many alias expansions
+U3 = U2 # error: Too many alias expansions
+# error: Too many alias expansions
+# error: Too many alias expansions
+U4 = U3 # error: Too many alias expansions
+# error: Too many alias expansions
+# error: Too many alias expansions
+U5 = U4 # error: Too many alias expansions
+# error: Too many alias expansions
+# error: Too many alias expansions
+U6 = U5 # error: Too many alias expansions
+# error: Too many alias expansions
+# error: Too many alias expansions
+U7 = U6 # error: Too many alias expansions
+# error: Too many alias expansions
+# error: Too many alias expansions
+U8 = U7 # error: Too many alias expansions
+# error: Too many alias expansions
+# error: Too many alias expansions
+U9 = U8 # error: Too many alias expansions
+# error: Too many alias expansions
+# error: Too many alias expansions
+U10 = U9 # error: Too many alias expansions
+# error: Too many alias expansions
+# error: Too many alias expansions
+U11 = U10 # error: Too many alias expansions
+# error: Too many alias expansions
+# error: Too many alias expansions
+U12 = U11 # error: Too many alias expansions
+# error: Too many alias expansions
+# error: Too many alias expansions
+U13 = U12 # error: Too many alias expansions
+# error: Too many alias expansions
+# error: Too many alias expansions
+U14 = U13 # error: Too many alias expansions
+# error: Too many alias expansions
+# error: Too many alias expansions
+U15 = U14 # error: Too many alias expansions
+# error: Too many alias expansions
+# error: Too many alias expansions
+U16 = U15 # error: Too many alias expansions
+# error: Too many alias expansions
+# error: Too many alias expansions
+U17 = U16 # error: Too many alias expansions
+# error: Too many alias expansions
+# error: Too many alias expansions
+U18 = U17 # error: Too many alias expansions
+# error: Too many alias expansions
+# error: Too many alias expansions
 U19 = U18
 U20 = U19
 U21 = U20

--- a/test/testdata/resolver/object_include_stub.rb
+++ b/test/testdata/resolver/object_include_stub.rb
@@ -1,4 +1,5 @@
 # typed: true
 class Object
-  include(E) # error-with-dupes: Unable to resolve constant `E`
+  include(E) # error: Unable to resolve constant `E`
+        # ^ error: Unable to resolve constant `E`
 end

--- a/test/testdata/resolver/overloads_test.rb
+++ b/test/testdata/resolver/overloads_test.rb
@@ -41,8 +41,12 @@ class Wrap1
 #                         ^ error: Unknown parameter name
   def arg_in_sig_but_not_method(x:, &blk); end # error: against an overloaded signature
 
-  sig {params(x: Integer, y: String).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
-  sig {params(y: String, x: Integer).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
+  sig {params(x: Integer, y: String).void}
+  #           ^ error: Overloaded functions cannot have keyword arguments
+  #                       ^ error: Overloaded functions cannot have keyword arguments
+  sig {params(y: String, x: Integer).void}
+  #           ^ error: Overloaded functions cannot have keyword arguments
+  #                      ^ error: Overloaded functions cannot have keyword arguments
   def keyword_ordering_matters(x:, y:); end # error: against an overloaded signature
   #                            ^^ error: Bad parameter ordering
   #                                ^^ error: Bad parameter ordering
@@ -129,18 +133,27 @@ class Wrap2
   extend T::Sig
 
   sig {params(x: Integer).void} # error: Overloaded functions cannot have keyword arguments
-  sig {params(x: Integer, y: String).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
+  sig {params(x: Integer, y: String).void}
+  #           ^ error: Overloaded functions cannot have keyword arguments
+  #                       ^ error: Overloaded functions cannot have keyword arguments
   def missing_kw1(x:, y: ''); end # error: against an overloaded signature
 
-  sig {params(x: Integer, y: String).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
+  sig {params(x: Integer, y: String).void}
+  #           ^ error: Overloaded functions cannot have keyword arguments
+  #                       ^ error: Overloaded functions cannot have keyword arguments
   sig {params(x: Integer).void} # error: Overloaded functions cannot have keyword arguments
   def missing_kw2(x:, y: ''); end # error: against an overloaded signature
 
   # Same pattern as the above, but 3 sigs will error where two will not.
   # TODO(froydnj): can we test what happens when the relevant error is suppressed?
   sig {params(x: Integer).void} # error: Overloaded functions cannot have keyword arguments
-  sig {params(x: Integer, y: String).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
-  sig {params(x: Integer, y: String, z: Float).void} # error-with-dupes: Overloaded functions cannot have keyword arguments
+  sig {params(x: Integer, y: String).void}
+  #           ^ error: Overloaded functions cannot have keyword arguments
+  #                       ^ error: Overloaded functions cannot have keyword arguments
+  sig {params(x: Integer, y: String, z: Float).void}
+  #           ^ error: Overloaded functions cannot have keyword arguments
+  #                       ^ error: Overloaded functions cannot have keyword arguments
+  #                                  ^ error: Overloaded functions cannot have keyword arguments
   def multiple_missing_kw(x:, y: '', z: 0.0); end # error: against an overloaded signature
 
   sig {params(z: String, x: Integer).void} # error: Overloaded functions cannot have keyword arguments
@@ -158,7 +171,9 @@ Wrap2.new.missing_kw2(x: 0, y: 'foo') # error: Unrecognized keyword argument
 Wrap2.new.missing_kw2(x: 0)
 
 Wrap2.new.multiple_missing_kw(x: 1)
-Wrap2.new.multiple_missing_kw(x: 1, y: 'bar', z: 0.1) # error-with-dupes: Unrecognized keyword argument
+Wrap2.new.multiple_missing_kw(x: 1, y: 'bar', z: 0.1)
+#                                   ^^^^^^^^ error: Unrecognized keyword argument
+#                                             ^^^^^^ error: Unrecognized keyword argument
 
 # These errors are wrong; they are artifacts of overload matching ignoring keyword arguments.
 Wrap2.new.mismatched_positional_args1('z', x: 0) # error: Too many positional arguments

--- a/test/testdata/resolver/resolution_order.rb
+++ b/test/testdata/resolver/resolution_order.rb
@@ -8,7 +8,9 @@
 A::AB::BC
 
 class HasError
-  include D::DA::DOES_NOT_EXIST # error-with-dupes: Unable to resolve constant
+  include D::DA::DOES_NOT_EXIST
+  #       ^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant
+  #       ^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant
 end
 
 class IsGood

--- a/test/testdata/resolver/resolution_order.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/resolution_order.rb.symbol-table-raw.exp
@@ -1,67 +1,67 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=8:1 end=64:4}
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=8:1 end=66:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/resolution_order.rb start=??? end=???}
-  module <C <U A>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=34:1 end=34:9}
-    static-field <C <U A>>::<C <U AB>> -> AliasType { symbol = <C <U B>> } @ Loc {file=test/testdata/resolver/resolution_order.rb start=35:3 end=35:5}
-    static-field <C <U A>>::<C <U AV>> -> Integer @ Loc {file=test/testdata/resolver/resolution_order.rb start=37:3 end=37:5}
-  class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=34:1 end=34:9}
-    type-member(+) <S <C <U A>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/resolver/resolution_order.rb start=34:1 end=34:9}
-    method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=34:1 end=38:4}
+  module <C <U A>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=36:1 end=36:9}
+    static-field <C <U A>>::<C <U AB>> -> AliasType { symbol = <C <U B>> } @ Loc {file=test/testdata/resolver/resolution_order.rb start=37:3 end=37:5}
+    static-field <C <U A>>::<C <U AV>> -> Integer @ Loc {file=test/testdata/resolver/resolution_order.rb start=39:3 end=39:5}
+  class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=36:1 end=36:9}
+    type-member(+) <S <C <U A>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/resolver/resolution_order.rb start=36:1 end=36:9}
+    method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=36:1 end=40:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/resolution_order.rb start=??? end=???}
-  class <C <U B>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=40:1 end=40:8}
-    static-field <C <U B>>::<C <U BC>> -> AliasType { symbol = <C <U C>> } @ Loc {file=test/testdata/resolver/resolution_order.rb start=41:3 end=41:5}
-  class <S <C <U B>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=40:1 end=40:8}
-    type-member(+) <S <C <U B>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U B>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=B) @ Loc {file=test/testdata/resolver/resolution_order.rb start=40:1 end=40:8}
-    method <S <C <U B>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=40:1 end=42:4}
+  class <C <U B>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=42:1 end=42:8}
+    static-field <C <U B>>::<C <U BC>> -> AliasType { symbol = <C <U C>> } @ Loc {file=test/testdata/resolver/resolution_order.rb start=43:3 end=43:5}
+  class <S <C <U B>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=42:1 end=42:8}
+    type-member(+) <S <C <U B>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U B>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=B) @ Loc {file=test/testdata/resolver/resolution_order.rb start=42:1 end=42:8}
+    method <S <C <U B>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=42:1 end=44:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/resolution_order.rb start=??? end=???}
-  class <C <U C>> < <C <U B>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=44:1 end=44:12}
-  class <S <C <U C>> $1>[<C <U <AttachedClass>>>] < <S <C <U B>> $1> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=44:1 end=44:12}
-    type-member(+) <S <C <U C>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U C>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=C) @ Loc {file=test/testdata/resolver/resolution_order.rb start=44:1 end=44:12}
-    method <S <C <U C>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=44:1 end=45:4}
+  class <C <U C>> < <C <U B>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=46:1 end=46:12}
+  class <S <C <U C>> $1>[<C <U <AttachedClass>>>] < <S <C <U B>> $1> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=46:1 end=46:12}
+    type-member(+) <S <C <U C>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U C>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=C) @ Loc {file=test/testdata/resolver/resolution_order.rb start=46:1 end=46:12}
+    method <S <C <U C>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=46:1 end=47:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/resolution_order.rb start=??? end=???}
-  module <C <U D>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=62:1 end=62:9}
-    static-field <C <U D>>::<C <U DA>> -> AliasType { symbol = <C <U A>> } @ Loc {file=test/testdata/resolver/resolution_order.rb start=63:3 end=63:5}
-  class <S <C <U D>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=62:1 end=62:9}
-    type-member(+) <S <C <U D>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U D>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=D) @ Loc {file=test/testdata/resolver/resolution_order.rb start=62:1 end=62:9}
-    method <S <C <U D>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=62:1 end=64:4}
+  module <C <U D>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=64:1 end=64:9}
+    static-field <C <U D>>::<C <U DA>> -> AliasType { symbol = <C <U A>> } @ Loc {file=test/testdata/resolver/resolution_order.rb start=65:3 end=65:5}
+  class <S <C <U D>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=64:1 end=64:9}
+    type-member(+) <S <C <U D>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U D>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=D) @ Loc {file=test/testdata/resolver/resolution_order.rb start=64:1 end=64:9}
+    method <S <C <U D>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=64:1 end=66:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/resolution_order.rb start=??? end=???}
-  module <C <U E>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> (<C <U D>>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=56:1 end=56:9}
-    static-field <C <U E>>::<C <U EA>> -> AliasType { symbol = <C <U D>>::<C <U DA>> } @ Loc {file=test/testdata/resolver/resolution_order.rb start=58:3 end=58:5}
-    static-field <C <U E>>::<C <U EC>> -> AliasType { symbol = <C <U B>>::<C <U BC>> } @ Loc {file=test/testdata/resolver/resolution_order.rb start=59:3 end=59:5}
-  class <S <C <U E>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=56:1 end=56:9}
-    type-member(+) <S <C <U E>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U E>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=E) @ Loc {file=test/testdata/resolver/resolution_order.rb start=56:1 end=56:9}
-    method <S <C <U E>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=56:1 end=60:4}
+  module <C <U E>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> (<C <U D>>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=58:1 end=58:9}
+    static-field <C <U E>>::<C <U EA>> -> AliasType { symbol = <C <U D>>::<C <U DA>> } @ Loc {file=test/testdata/resolver/resolution_order.rb start=60:3 end=60:5}
+    static-field <C <U E>>::<C <U EC>> -> AliasType { symbol = <C <U B>>::<C <U BC>> } @ Loc {file=test/testdata/resolver/resolution_order.rb start=61:3 end=61:5}
+  class <S <C <U E>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=58:1 end=58:9}
+    type-member(+) <S <C <U E>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U E>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=E) @ Loc {file=test/testdata/resolver/resolution_order.rb start=58:1 end=58:9}
+    method <S <C <U E>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=58:1 end=62:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/resolution_order.rb start=??? end=???}
-  module <C <U F>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> (<C <U E>>, <C <U D>>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=47:1 end=47:9}
-  class <S <C <U F>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=47:1 end=47:9}
-    type-member(+) <S <C <U F>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U F>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=F) @ Loc {file=test/testdata/resolver/resolution_order.rb start=47:1 end=47:9}
-    method <S <C <U F>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=47:1 end=54:4}
+  module <C <U F>> < <C <U Sorbet>>::<C <U Private>>::<C <U Static>>::<C <U ImplicitModuleSuperclass>> (<C <U E>>, <C <U D>>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=49:1 end=49:9}
+  class <S <C <U F>> $1>[<C <U <AttachedClass>>>] < <C <U Module>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=49:1 end=49:9}
+    type-member(+) <S <C <U F>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U F>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=F) @ Loc {file=test/testdata/resolver/resolution_order.rb start=49:1 end=49:9}
+    method <S <C <U F>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=49:1 end=56:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/resolution_order.rb start=??? end=???}
   class <C <U HasError>> < <C <U Object>> (<C <U <StubModule>>>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=10:1 end=10:15}
   class <S <C <U HasError>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=10:1 end=10:15}
     type-member(+) <S <C <U HasError>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U HasError>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=HasError) @ Loc {file=test/testdata/resolver/resolution_order.rb start=10:1 end=10:15}
-    method <S <C <U HasError>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=10:1 end=12:4}
+    method <S <C <U HasError>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=10:1 end=14:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/resolution_order.rb start=??? end=???}
-  class <C <U IsGood>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=14:1 end=14:13}
-    method <C <U IsGood>>#<U foo1> (a, <blk>) -> Integer @ Loc {file=test/testdata/resolver/resolution_order.rb start=18:3 end=18:14}
-      argument a<> -> C @ Loc {file=test/testdata/resolver/resolution_order.rb start=17:15 end=17:16}
+  class <C <U IsGood>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=16:1 end=16:13}
+    method <C <U IsGood>>#<U foo1> (a, <blk>) -> Integer @ Loc {file=test/testdata/resolver/resolution_order.rb start=20:3 end=20:14}
+      argument a<> -> C @ Loc {file=test/testdata/resolver/resolution_order.rb start=19:15 end=19:16}
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/resolver/resolution_order.rb start=??? end=???}
-    method <C <U IsGood>>#<U foo2> (a, <blk>) -> Integer @ Loc {file=test/testdata/resolver/resolution_order.rb start=23:3 end=23:14}
-      argument a<> -> A @ Loc {file=test/testdata/resolver/resolution_order.rb start=22:15 end=22:16}
+    method <C <U IsGood>>#<U foo2> (a, <blk>) -> Integer @ Loc {file=test/testdata/resolver/resolution_order.rb start=25:3 end=25:14}
+      argument a<> -> A @ Loc {file=test/testdata/resolver/resolution_order.rb start=24:15 end=24:16}
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/resolver/resolution_order.rb start=??? end=???}
-  class <S <C <U IsGood>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U Sig>>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=14:1 end=14:13}
-    type-member(+) <S <C <U IsGood>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U IsGood>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=IsGood) @ Loc {file=test/testdata/resolver/resolution_order.rb start=14:1 end=14:13}
-    method <S <C <U IsGood>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=14:1 end=26:4}
+  class <S <C <U IsGood>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U Sig>>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=16:1 end=16:13}
+    type-member(+) <S <C <U IsGood>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U IsGood>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=IsGood) @ Loc {file=test/testdata/resolver/resolution_order.rb start=16:1 end=16:13}
+    method <S <C <U IsGood>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=16:1 end=28:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/resolution_order.rb start=??? end=???}
-  class <C <U TestInheritace1>> < <C <U B>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=28:1 end=28:30}
-  class <S <C <U TestInheritace1>> $1>[<C <U <AttachedClass>>>] < <S <C <U B>> $1> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=28:1 end=28:30}
-    type-member(+) <S <C <U TestInheritace1>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U TestInheritace1>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=TestInheritace1) @ Loc {file=test/testdata/resolver/resolution_order.rb start=28:1 end=28:30}
-    method <S <C <U TestInheritace1>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=28:1 end=29:4}
+  class <C <U TestInheritace1>> < <C <U B>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=30:1 end=30:30}
+  class <S <C <U TestInheritace1>> $1>[<C <U <AttachedClass>>>] < <S <C <U B>> $1> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=30:1 end=30:30}
+    type-member(+) <S <C <U TestInheritace1>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U TestInheritace1>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=TestInheritace1) @ Loc {file=test/testdata/resolver/resolution_order.rb start=30:1 end=30:30}
+    method <S <C <U TestInheritace1>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=30:1 end=31:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/resolution_order.rb start=??? end=???}
-  class <C <U TestInheritace2>> < <C <U A>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=31:1 end=31:30}
-  class <S <C <U TestInheritace2>> $1>[<C <U <AttachedClass>>>] < <S <C <U A>> $1> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=31:1 end=31:30}
-    type-member(+) <S <C <U TestInheritace2>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U TestInheritace2>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=TestInheritace2) @ Loc {file=test/testdata/resolver/resolution_order.rb start=31:1 end=31:30}
-    method <S <C <U TestInheritace2>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=31:1 end=32:4}
+  class <C <U TestInheritace2>> < <C <U A>> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=33:1 end=33:30}
+  class <S <C <U TestInheritace2>> $1>[<C <U <AttachedClass>>>] < <S <C <U A>> $1> () @ Loc {file=test/testdata/resolver/resolution_order.rb start=33:1 end=33:30}
+    type-member(+) <S <C <U TestInheritace2>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U TestInheritace2>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=TestInheritace2) @ Loc {file=test/testdata/resolver/resolution_order.rb start=33:1 end=33:30}
+    method <S <C <U TestInheritace2>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/resolution_order.rb start=33:1 end=34:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/resolution_order.rb start=??? end=???}
 

--- a/test/testdata/resolver/resolution_scoping.rb
+++ b/test/testdata/resolver/resolution_scoping.rb
@@ -1,5 +1,5 @@
 # typed: true
-class A < B # error-with-dupes: Unable to resolve constant `B`
+class A < B # error: Unable to resolve constant `B`
   module C
   end
   module B

--- a/test/testdata/resolver/sealed_with_rbi__2.rb
+++ b/test/testdata/resolver/sealed_with_rbi__2.rb
@@ -1,7 +1,7 @@
 # typed: false
 
 class D
-  include M # error-with-dupes: `M` is sealed and cannot be included in `D`
+  include M # error: `M` is sealed and cannot be included in `D`
 
   define_method(:from_d) do
   end

--- a/test/testdata/resolver/sealed_with_rbi__3.rbi
+++ b/test/testdata/resolver/sealed_with_rbi__3.rbi
@@ -20,6 +20,6 @@ class C
 end
 
 class D
-  include M # error-with-dupes: `M` is sealed and cannot be included in `D`
+  include M # error: `M` is sealed and cannot be included in `D`
   def from_d; end
 end

--- a/test/testdata/resolver/top_level_include.rb
+++ b/test/testdata/resolver/top_level_include.rb
@@ -1,4 +1,5 @@
 # typed: true
 
 # Reports two errors because one of them comes from the keep_for_ide call.
-include A # error-with-dupes: Unable to resolve
+include A # error: Unable to resolve
+      # ^ error: Unable to resolve

--- a/test/testdata/rewriter/prop_default.rb
+++ b/test/testdata/rewriter/prop_default.rb
@@ -1,5 +1,7 @@
 # typed: true
 
 class A < T::Struct
-  prop :foo, T.nilable(Integer), default: '' # error-with-dupes: Argument does not have asserted type `T.nilable(Integer)`
+  prop :foo, T.nilable(Integer), default: ''
+  #     ^^^ error: Argument does not have asserted type `T.nilable(Integer)`
+  #                                       ^^ error: Argument does not have asserted type `T.nilable(Integer)`
 end

--- a/test/testdata/rewriter/rspec_shared_examples_bare_in_parameterized_context.rb
+++ b/test/testdata/rewriter/rspec_shared_examples_bare_in_parameterized_context.rb
@@ -47,9 +47,12 @@ end
 # the registry has no entry for these names.
 RSpec.describe 'consumer that does not include the outer' do
   include_context 'bare nested context inside parameterized'
-  #               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error-with-dupes: Unable to resolve constant `<shared_examples 'bare nested context inside parameterized'>`
+  #               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `<shared_examples 'bare nested context inside parameterized'>`
+  #               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `<shared_examples 'bare nested context inside parameterized'>`
   include_examples 'bare nested examples inside parameterized'
-  #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error-with-dupes: Unable to resolve constant `<shared_examples 'bare nested examples inside parameterized'>`
+  #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `<shared_examples 'bare nested examples inside parameterized'>`
+  #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `<shared_examples 'bare nested examples inside parameterized'>`
   include_examples 'bare nested examples_for inside parameterized'
-  #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error-with-dupes: Unable to resolve constant `<shared_examples 'bare nested examples_for inside parameterized'>`
+  #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `<shared_examples 'bare nested examples_for inside parameterized'>`
+  #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `<shared_examples 'bare nested examples_for inside parameterized'>`
 end

--- a/test/testdata/rewriter/rspec_shared_examples_bare_in_parameterized_context_deeper.rb
+++ b/test/testdata/rewriter/rspec_shared_examples_bare_in_parameterized_context_deeper.rb
@@ -29,9 +29,11 @@ end
 
 RSpec.describe 'two-level consumer that skips the outer' do
   include_context 'middle bare context'
-  #               ^^^^^^^^^^^^^^^^^^^^^ error-with-dupes: Unable to resolve constant `<shared_examples 'middle bare context'>`
+  #               ^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `<shared_examples 'middle bare context'>`
+  #               ^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `<shared_examples 'middle bare context'>`
   include_examples 'inner bare examples'
-  #                ^^^^^^^^^^^^^^^^^^^^^ error-with-dupes: Unable to resolve constant `<shared_examples 'inner bare examples'>`
+  #                ^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `<shared_examples 'inner bare examples'>`
+  #                ^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `<shared_examples 'inner bare examples'>`
 end
 
 # `it_behaves_like 'bare nested name'`: the synthesized isolation class
@@ -51,7 +53,8 @@ end
 
 RSpec.describe 'consumer using it_behaves_like without including the outer' do
   it_behaves_like 'bare nested for it_behaves_like'
-  #               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error-with-dupes: Unable to resolve constant `<shared_examples 'bare nested for it_behaves_like'>`
+  #               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `<shared_examples 'bare nested for it_behaves_like'>`
+  #               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `<shared_examples 'bare nested for it_behaves_like'>`
 end
 
 # Root-scope vs. bare-nested name collision: when an `RSpec.`-prefixed
@@ -131,7 +134,8 @@ end
 # through the consumer's ancestors.
 RSpec.describe 'consumer skipping the transitive chain' do
   include_examples 'bare nested in transitive A'
-  #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error-with-dupes: Unable to resolve constant `<shared_examples 'bare nested in transitive A'>`
+  #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `<shared_examples 'bare nested in transitive A'>`
+  #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `<shared_examples 'bare nested in transitive A'>`
 end
 
 # Bare shared_examples with block params nested in a parameterized outer.
@@ -155,5 +159,6 @@ end
 
 RSpec.describe 'consumer that skips the outer for parameterized inner' do
   include_examples 'inner with params'
-  #                ^^^^^^^^^^^^^^^^^^^ error-with-dupes: Unable to resolve constant `<shared_examples 'inner with params'>`
+  #                ^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `<shared_examples 'inner with params'>`
+  #                ^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `<shared_examples 'inner with params'>`
 end

--- a/test/testdata/rewriter/t_struct/default_bad.rb
+++ b/test/testdata/rewriter/t_struct/default_bad.rb
@@ -2,5 +2,7 @@
 # TODO enable on the fast path
 
 class DefaultBad < T::Struct
-  prop :foo, Integer, default: "bad" # error-with-dupes: Argument does not have asserted type `Integer`
+  prop :foo, Integer, default: "bad"
+  #     ^^^ error: Argument does not have asserted type `Integer`
+  #                            ^^^^^ error: Argument does not have asserted type `Integer`
 end

--- a/test/whitequark/test_assignment_to_numparams_0.rb
+++ b/test/whitequark/test_assignment_to_numparams_0.rb
@@ -1,4 +1,4 @@
 # typed: true
 
 proc {_1 = nil}
-    # ^^ error-with-dupes: _1 is reserved for numbered parameter
+    # ^^ error: _1 is reserved for numbered parameter

--- a/test/whitequark/test_assignment_to_numparams_5.rb
+++ b/test/whitequark/test_assignment_to_numparams_5.rb
@@ -1,4 +1,4 @@
 # typed: true
 
-_1 = true # error-with-dupes: _1 is reserved for numbered parameter
+_1 = true # error: _1 is reserved for numbered parameter
 puts _1

--- a/test/whitequark/test_reserved_for_numparam_since_30_0.rb
+++ b/test/whitequark/test_reserved_for_numparam_since_30_0.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-proc {_1 = nil} # error-with-dupes: _1 is reserved for numbered parameter
+proc {_1 = nil} # error: _1 is reserved for numbered parameter

--- a/test/whitequark/test_reserved_for_numparam_since_30_1.rb
+++ b/test/whitequark/test_reserved_for_numparam_since_30_1.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-_2 = 1 # error-with-dupes: _2 is reserved for numbered parameter
+_2 = 1 # error: _2 is reserved for numbered parameter

--- a/test/whitequark/test_reserved_for_numparam_since_30_10.rb
+++ b/test/whitequark/test_reserved_for_numparam_since_30_10.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-proc {|&_3|} # error-with-dupes: _3 is reserved for numbered parameter
+proc {|&_3|} # error: _3 is reserved for numbered parameter

--- a/test/whitequark/test_reserved_for_numparam_since_30_11.rb
+++ b/test/whitequark/test_reserved_for_numparam_since_30_11.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-proc {|;_3|} # error-with-dupes: _3 is reserved for numbered parameter
+proc {|;_3|} # error: _3 is reserved for numbered parameter

--- a/test/whitequark/test_reserved_for_numparam_since_30_12.rb
+++ b/test/whitequark/test_reserved_for_numparam_since_30_12.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def _5; end # error-with-dupes: _5 is reserved for numbered parameter
+def _5; end # error: _5 is reserved for numbered parameter

--- a/test/whitequark/test_reserved_for_numparam_since_30_13.rb
+++ b/test/whitequark/test_reserved_for_numparam_since_30_13.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def self._5; end # error-with-dupes: _5 is reserved for numbered parameter
+def self._5; end # error: _5 is reserved for numbered parameter

--- a/test/whitequark/test_reserved_for_numparam_since_30_14.rb
+++ b/test/whitequark/test_reserved_for_numparam_since_30_14.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def _5() = nil # error-with-dupes: _5 is reserved for numbered parameter
+def _5() = nil # error: _5 is reserved for numbered parameter

--- a/test/whitequark/test_reserved_for_numparam_since_30_15.rb
+++ b/test/whitequark/test_reserved_for_numparam_since_30_15.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-def self._5() = nil # error-with-dupes: _5 is reserved for numbered parameter
+def self._5() = nil # error: _5 is reserved for numbered parameter

--- a/test/whitequark/test_reserved_for_numparam_since_30_2.rb
+++ b/test/whitequark/test_reserved_for_numparam_since_30_2.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-proc {|_3|} # error-with-dupes: _3 is reserved for numbered parameter
+proc {|_3|} # error: _3 is reserved for numbered parameter

--- a/test/whitequark/test_reserved_for_numparam_since_30_3.rb
+++ b/test/whitequark/test_reserved_for_numparam_since_30_3.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-proc {|_3,|} # error-with-dupes: _3 is reserved for numbered parameter
+proc {|_3,|} # error: _3 is reserved for numbered parameter

--- a/test/whitequark/test_reserved_for_numparam_since_30_4.rb
+++ b/test/whitequark/test_reserved_for_numparam_since_30_4.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-proc {|_3 = 42|} # error-with-dupes: _3 is reserved for numbered parameter
+proc {|_3 = 42|} # error: _3 is reserved for numbered parameter

--- a/test/whitequark/test_reserved_for_numparam_since_30_5.rb
+++ b/test/whitequark/test_reserved_for_numparam_since_30_5.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-proc {|(_3)|} # error-with-dupes: _3 is reserved for numbered parameter
+proc {|(_3)|} # error: _3 is reserved for numbered parameter

--- a/test/whitequark/test_reserved_for_numparam_since_30_6.rb
+++ b/test/whitequark/test_reserved_for_numparam_since_30_6.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-proc {|*_3|} # error-with-dupes: _3 is reserved for numbered parameter
+proc {|*_3|} # error: _3 is reserved for numbered parameter

--- a/test/whitequark/test_reserved_for_numparam_since_30_7.rb
+++ b/test/whitequark/test_reserved_for_numparam_since_30_7.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-proc {|_3:|} # error-with-dupes: _3 is reserved for numbered parameter
+proc {|_3:|} # error: _3 is reserved for numbered parameter

--- a/test/whitequark/test_reserved_for_numparam_since_30_8.rb
+++ b/test/whitequark/test_reserved_for_numparam_since_30_8.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-proc {|_3: 42|} # error-with-dupes: _3 is reserved for numbered parameter
+proc {|_3: 42|} # error: _3 is reserved for numbered parameter

--- a/test/whitequark/test_reserved_for_numparam_since_30_9.rb
+++ b/test/whitequark/test_reserved_for_numparam_since_30_9.rb
@@ -1,3 +1,3 @@
 # typed: true
 
-proc {|**_3|} # error-with-dupes: _3 is reserved for numbered parameter
+proc {|**_3|} # error: _3 is reserved for numbered parameter


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm working on a script that programmatically updates `# error:` comments in our
tests. It's substantially easier if I can ignore `error-with-dupes`.

We added this before we had the `# ^^^ error`-style assertions. Let's just get
rid of it.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.