### PR TITLE
Fix errors for anonymous forwarding parameters in block args

### DIFF
--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -169,24 +169,32 @@ ExpressionPtr desugarBody(DesugarContext dctx, core::LocOffsets loc, unique_ptr<
     return body;
 }
 
-// It's not possible to use an anonymous rest parameter in a block, as it always refers to the forwarded arguments
-// from the method. This function raises an error if the anonymous rest arg is present in a parameter list.
-void checkBlockRestParam(DesugarContext dctx, const MethodDef::PARAMS_store &args) {
-    auto it = absl::c_find_if(args, [](const auto &arg) { return isa_tree<RestParam>(arg); });
-    if (it == args.end()) {
-        return;
-    }
-
-    auto &rest = cast_tree_nonnull<RestParam>(*it);
-    if (auto local = cast_tree<UnresolvedIdent>(rest.expr)) {
-        if (local->name != core::Names::star()) {
-            return;
+// Anonymous forwarding parameters in a block always refer to the enclosing method's parameters. Naming them avoids
+// runtime syntax errors when the forwarded parameters are used in the block.
+void checkBlockAnonymousParams(DesugarContext dctx, const MethodDef::PARAMS_store &args) {
+    auto report = [&](core::LocOffsets loc, string_view kind, string_view autocorrectTitle) {
+        if (auto e = dctx.ctx.beginIndexerError(loc, core::errors::Desugar::BlockAnonymousParam)) {
+            e.setHeader("Anonymous {} parameter in block args", kind);
+            e.addErrorNote("Naming the {} parameter will ensure you can access it in the block", kind);
+            e.replaceWith(autocorrectTitle, dctx.ctx.locAt(loc.copyEndWithZeroLength()), "_");
         }
+    };
 
-        if (auto e = dctx.ctx.beginIndexerError(it->loc(), core::errors::Desugar::BlockAnonymousRestParam)) {
-            e.setHeader("Anonymous rest parameter in block args");
-            e.addErrorNote("Naming the rest parameter will ensure you can access it in the block");
-            e.replaceWith("Name the rest parameter", dctx.ctx.locAt(it->loc().copyEndWithZeroLength()), "_");
+    for (const auto &arg : args) {
+        if (auto rest = cast_tree<RestParam>(arg)) {
+            if (auto local = cast_tree<UnresolvedIdent>(rest->expr); local && local->name == core::Names::star()) {
+                report(arg.loc(), "rest", "Name the rest parameter");
+            } else if (auto keyword = cast_tree<KeywordArg>(rest->expr)) {
+                if (auto local = cast_tree<UnresolvedIdent>(keyword->expr);
+                    local && local->name == core::Names::starStar()) {
+                    report(arg.loc(), "keyword rest", "Name the keyword rest parameter");
+                }
+            }
+        } else if (auto block = cast_tree<BlockParam>(arg)) {
+            if (auto local = cast_tree<UnresolvedIdent>(block->expr);
+                local && local->name == core::Names::ampersand()) {
+                report(arg.loc(), "block", "Name the block parameter");
+            }
         }
     }
 }
@@ -219,7 +227,7 @@ ExpressionPtr desugarBlock(DesugarContext dctx, parser::Block *block) {
     }
     auto [Params, destructures] = desugarParams(dctx, block->params.get());
 
-    checkBlockRestParam(dctx, Params);
+    checkBlockAnonymousParams(dctx, Params);
 
     auto inBlock = true;
     DesugarContext dctx1(dctx.ctx, dctx.uniqueCounter, dctx.enclosingBlockParamLoc, dctx.enclosingBlockParamName,

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -113,6 +113,8 @@ private:
     ast::ExpressionPtr desugarLiteralBlock(pm_node *blockBodyNode, pm_node *blockParameters,
                                            pm_location_t blockLocation, pm_location_t blockNodeOpeningLoc);
 
+    void checkBlockAnonymousParams(const ast::MethodDef::PARAMS_store &args);
+
     DesugaredBlockArgument desugarBlockPassArgument(pm_block_argument_node *bp);
 
     ast::ExpressionPtr desugarSymbolProc(pm_symbol_node *symbol);
@@ -4159,6 +4161,35 @@ Desugarer::DesugaredBlockArgument Desugarer::desugarBlock(pm_node_t *block, pm_a
     }
 }
 
+void Desugarer::checkBlockAnonymousParams(const ast::MethodDef::PARAMS_store &args) {
+    auto report = [&](core::LocOffsets loc, string_view kind, string_view autocorrectTitle) {
+        if (auto e = ctx.beginIndexerError(loc, core::errors::Desugar::BlockAnonymousParam)) {
+            e.setHeader("Anonymous {} parameter in block args", kind);
+            e.addErrorNote("Naming the {} parameter will ensure you can access it in the block", kind);
+            e.replaceWith(autocorrectTitle, ctx.locAt(loc.copyEndWithZeroLength()), "_");
+        }
+    };
+
+    for (const auto &arg : args) {
+        if (auto rest = ast::cast_tree<ast::RestParam>(arg)) {
+            if (auto local = ast::cast_tree<ast::UnresolvedIdent>(rest->expr);
+                local && local->name == core::Names::star()) {
+                report(arg.loc(), "rest", "Name the rest parameter");
+            } else if (auto keyword = ast::cast_tree<ast::KeywordArg>(rest->expr)) {
+                if (auto local = ast::cast_tree<ast::UnresolvedIdent>(keyword->expr);
+                    local && local->name == core::Names::starStar()) {
+                    report(arg.loc(), "keyword rest", "Name the keyword rest parameter");
+                }
+            }
+        } else if (auto block = ast::cast_tree<ast::BlockParam>(arg)) {
+            if (auto local = ast::cast_tree<ast::UnresolvedIdent>(block->expr);
+                local && local->name == core::Names::ampersand()) {
+                report(arg.loc(), "block", "Name the block parameter");
+            }
+        }
+    }
+}
+
 ast::ExpressionPtr Desugarer::desugarLiteralBlock(pm_node *blockBodyNode, pm_node *blockParameters,
                                                   pm_location_t blockLocation, pm_location_t blockNodeOpeningLoc) {
     auto blockBody = this->enterBlockContext().desugarNullable(blockBodyNode);
@@ -4239,6 +4270,8 @@ ast::ExpressionPtr Desugarer::desugarLiteralBlock(pm_node *blockBodyNode, pm_nod
             }
         }
     }
+
+    checkBlockAnonymousParams(blockParamsStore);
 
     return MK::Block(blockLoc, move(blockBody), move(blockParamsStore));
 }

--- a/core/errors/desugar.h
+++ b/core/errors/desugar.h
@@ -14,7 +14,7 @@ inline constexpr ErrorClass UndefUsage{3008, StrictLevel::Strict};
 inline constexpr ErrorClass UnsupportedRestArgsDestructure{3009, StrictLevel::True};
 inline constexpr ErrorClass CodeInRBI{3010, StrictLevel::False};
 inline constexpr ErrorClass DuplicatedHashKeys{3011, StrictLevel::False};
-inline constexpr ErrorClass BlockAnonymousRestParam{3012, StrictLevel::False};
+inline constexpr ErrorClass BlockAnonymousParam{3012, StrictLevel::False};
 } // namespace sorbet::core::errors::Desugar
 
 #endif

--- a/test/testdata/desugar/forward_args.rb
+++ b/test/testdata/desugar/forward_args.rb
@@ -42,24 +42,28 @@ class Foo
 
   def foo8(**)
     [1,2,3].each do |**|
+                   # ^^ error: Anonymous keyword rest parameter
       T.unsafe(self).p(**)
     end
   end
 
   def foo9(**kwargs)
-    [1,2,3].each do |**|
+    [1,2,3].each do |*args, **|
+                          # ^^ error: Anonymous keyword rest parameter
       T.unsafe(self).p(**)
     end
   end
 
   def foo10(&)
     [1,2,3].each do |&|
+                   # ^ error: Anonymous block parameter
       T.unsafe(self).p(&)
     end
   end
 
   def foo11(&block)
     [1,2,3].each do |&|
+                   # ^ error: Anonymous block parameter
       T.unsafe(self).p(&)
     end
   end

--- a/test/testdata/desugar/forward_args.rb.autocorrects.exp
+++ b/test/testdata/desugar/forward_args.rb.autocorrects.exp
@@ -42,25 +42,29 @@ class Foo
   end
 
   def foo8(**)
-    [1,2,3].each do |**|
+    [1,2,3].each do |**_|
+                   # ^^ error: Anonymous keyword rest parameter
       T.unsafe(self).p(**)
     end
   end
 
   def foo9(**kwargs)
-    [1,2,3].each do |**|
+    [1,2,3].each do |*args, **_|
+                          # ^^ error: Anonymous keyword rest parameter
       T.unsafe(self).p(**)
     end
   end
 
   def foo10(&)
-    [1,2,3].each do |&|
+    [1,2,3].each do |&_|
+                   # ^ error: Anonymous block parameter
       T.unsafe(self).p(&)
     end
   end
 
   def foo11(&block)
-    [1,2,3].each do |&|
+    [1,2,3].each do |&_|
+                   # ^ error: Anonymous block parameter
       T.unsafe(self).p(&)
     end
   end

--- a/test/testdata/desugar/forward_args.rb.desugar-tree.exp
+++ b/test/testdata/desugar/forward_args.rb.desugar-tree.exp
@@ -54,7 +54,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     def foo9<<todo method>>(**kwargs, &<blk>)
-      [1, 2, 3].each() do |**|
+      [1, 2, 3].each() do |*args, **|
         <emptyTree>::<C T>.unsafe(<self>).p(begin
             <hashTemp>$2 = ::<Magic>.<to-hash-dup>(::T.unsafe(<fwd-kwargs>))
             <hashTemp>$2

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -273,19 +273,21 @@ def foo(_a, _b); end
 
 ## 3012
 
-There was an anonymous rest argument defined in the block parameter list.
+There was an anonymous forwarding parameter defined in the block parameter list. This applies to anonymous rest
+(`*`), keyword rest (`**`), and block (`&`) parameters.
 
 ```ruby
-[1,2,3].each do |*|
-  T.unsafe(self).p(*)
+[1,2,3].each do |*, **, &|
+  T.unsafe(self).p(*, **, &)
 end
 ```
 
-The anonymous rest argument may only refer to method parameters, and uses of it will generate runtime syntax errors if it's used in the context of a block that defines it. This can be resolved by naming the rest argument parameter in the block:
+Anonymous forwarding parameters in a block refer to the enclosing method parameters, and using them can generate
+runtime syntax errors. This can be resolved by naming the parameters in the block:
 
 ```ruby
-[1,2,3].each do |*args|
-  T.unsafe(self).p(*args)
+[1,2,3].each do |*args, **kwargs, &block|
+  T.unsafe(self).p(*args, **kwargs, &block)
 end
 ```
 


### PR DESCRIPTION
Report error 3012 for anonymous keyword rest (`**`) and block (`&`) parameters in block argument lists. The check now covers every block parameter in both the legacy and Prism desugarers, and the existing autocorrect names each anonymous parameter.

### Motivation

Fixes #10556.

### Test plan

- `PATH="$PWD:$PATH" tools/scripts/ci_checks.sh`
- `./bazel test //test:test_PosTests/testdata/desugar/forward_args //test:test_PrismPosTests/testdata/desugar/forward_args --config=dbg --test_output=errors`
- `./bazel test --config=dbg --test_output=errors --jobs=4 --keep_going -- //... -//emscripten/...` (10,401 tests passed)
