### PR TITLE
Added StringIO to the possible src/dst of IO.copy_stream

### DIFF
--- a/rbi/core/io.rbi
+++ b/rbi/core/io.rbi
@@ -2825,8 +2825,8 @@ class IO < Object
   # doesn't move the current file offset.
   sig do
     params(
-        src: T.any(String, IO, Tempfile),
-        dst: T.any(String, IO, Tempfile),
+        src: T.any(String, IO, StringIO, Tempfile),
+        dst: T.any(String, IO, StringIO, Tempfile),
         copy_length: Integer,
         src_offset: Integer,
     )


### PR DESCRIPTION
These are also supported. RBS defines this via interfaces, which sorbet still does not support.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

