### PR TITLE
Add String.dedup to core RBIs

### DIFF
--- a/rbi/core/string.rbi
+++ b/rbi/core/string.rbi
@@ -2899,6 +2899,18 @@ class String < Object
   end
   def self.try_convert(obj); end
 
+  # Returns a frozen, possibly pre-existing copy of the string.
+  #
+  # The string will be deduplicated as long as it does not have any instance
+  # variables set on it.
+  sig do
+    params(
+        string: String,
+    )
+    .returns(String)
+  end
+  def self.dedup(string); end
+
   # Element Reference --- If passed a single `index`, returns a substring of one
   # character at that index. If passed a `start` index and a `length`, returns a
   # substring containing `length` characters starting at the `start` index. If

--- a/test/testdata/infer/string_dedup.rb
+++ b/test/testdata/infer/string_dedup.rb
@@ -1,0 +1,10 @@
+# typed: true
+
+# Verify that String.dedup is defined in core RBIs with the correct signature.
+
+T.reveal_type(String.dedup("foo")) # error: Revealed type: `String`
+
+String.dedup("foo")
+String.dedup(1) # error: Expected `String` but found `Integer(1)` for argument `string`
+String.dedup()  # error: Not enough arguments
+String.dedup("foo", "bar") # error: Too many arguments


### PR DESCRIPTION
[String.dedup](https://docs.ruby-lang.org/en/3.4/String.html#method-i-dedup) is a class method that returns a frozen, possibly pre-existing deduplicated copy of the given string. It was missing from the core RBIs.

It is identical to [-string](https://docs.ruby-lang.org/en/3.4/String.html#method-i-2D-40), already present in RBI.
