### PR TITLE
Support RBS signatures on `module_function def`

### DIFF
--- a/rbs/CommentsAssociator.cc
+++ b/rbs/CommentsAssociator.cc
@@ -17,6 +17,20 @@ const string_view CommentsAssociator::ANNOTATION_PREFIX = "# @";
 const string_view CommentsAssociator::MULTILINE_RBS_PREFIX = "#|";
 const string_view CommentsAssociator::BIND_PREFIX = "#: self as ";
 
+bool isMethodDefSignatureTarget(pm_node_t *node, const parser::Prism::Parser &parser, const core::GlobalState &gs) {
+    if (parser.isMethodDefModifierCall(node, gs)) {
+        return true;
+    }
+
+    auto *call = down_cast<pm_call_node_t>(node);
+    if (call == nullptr || call->receiver != nullptr || call->arguments == nullptr ||
+        call->arguments->arguments.size != 1 || parser.resolveConstant(call->name) != "module_function") {
+        return false;
+    }
+
+    return isa_node<pm_def_node>(call->arguments->arguments.nodes[0]);
+}
+
 namespace {
 
 // Static regex patterns to avoid recompilation
@@ -745,8 +759,8 @@ void CommentsAssociator::walkNode(pm_node_t *node) {
         case PM_CALL_NODE: {
             auto *call = down_cast_nonnull<pm_call_node_t>(node);
 
-            if (parser.isMethodDefModifierCall(node, ctx.state)) {
-                // This is a modifier wrapping a method definition, like `private def foo; end`
+            if (isMethodDefSignatureTarget(node, parser, ctx.state)) {
+                // This call wraps a method definition, like `private def foo; end` or `module_function def foo; end`.
                 associateSignatureCommentsToNode(node);
                 associateAssertionCommentsToNode(node);
                 walkNode(call->receiver);

--- a/rbs/CommentsAssociator.h
+++ b/rbs/CommentsAssociator.h
@@ -31,6 +31,8 @@ struct CommentMap {
     UnorderedMap<pm_node_t *, std::vector<CommentNode>> assertionsForNode;
 };
 
+bool isMethodDefSignatureTarget(pm_node_t *node, const parser::Prism::Parser &parser, const core::GlobalState &gs);
+
 class CommentsAssociator {
 public:
     static const std::string_view RBS_PREFIX;

--- a/rbs/SigsRewriter.cc
+++ b/rbs/SigsRewriter.cc
@@ -30,7 +30,7 @@ bool canHaveSignature(pm_node_t *node, const parser::Prism::Parser &parser, cons
             // (singleton methods have a receiver field set)
             return true;
         case PM_CALL_NODE: {
-            return parser.isAttrAccessorCall(node) || parser.isMethodDefModifierCall(node, gs);
+            return parser.isAttrAccessorCall(node) || isMethodDefSignatureTarget(node, parser, gs);
         }
         default:
             return false;
@@ -340,8 +340,8 @@ unique_ptr<vector<pm_node_t *>> SigsRewriter::signaturesForNode(pm_node_t *node)
                 signatures->emplace_back(sig);
             }
         } else if (auto *call = down_cast<pm_call_node_t>(node)) {
-            if (parser.isMethodDefModifierCall(node, ctx.state)) {
-                // For method definition modifiers, translate the signature for the inner method definition
+            if (isMethodDefSignatureTarget(node, parser, ctx.state)) {
+                // Translate the signature for the wrapped method definition.
                 auto sig = signatureTranslator.translateMethodSignature(call->arguments->arguments.nodes[0],
                                                                         declaration, comments.annotations);
                 if (sig) {

--- a/test/testdata/rbs/signatures_module_function.rb
+++ b/test/testdata/rbs/signatures_module_function.rb
@@ -1,0 +1,12 @@
+# typed: strict
+# enable-experimental-rbs-comments: true
+
+module Config
+  #: (String key) -> String
+  module_function def fetch(key)
+    key
+  end
+end
+
+T.reveal_type(Config.fetch("a")) # error: Revealed type: `String`
+Config.fetch(0) # error: Expected `String` but found `Integer(0)` for argument `key`

--- a/test/testdata/rbs/signatures_module_function.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_module_function.rb.rewrite-tree.exp
@@ -1,0 +1,27 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C Config><<C <todo sym>>> < ()
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:key, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
+    end
+
+    def fetch<<todo method>>(key, &<blk>)
+      key
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:key, <emptyTree>::<C String>).returns(<emptyTree>::<C String>)
+    end
+
+    def self.fetch<<todo method>>(key, &<blk>)
+      key
+    end
+
+    <self>.private(<runtime method definition of fetch>)
+
+    <runtime method definition of self.fetch>
+  end
+
+  <emptyTree>::<C T>.reveal_type(<emptyTree>::<C Config>.fetch("a"))
+
+  <emptyTree>::<C Config>.fetch(0)
+end


### PR DESCRIPTION
### Motivation

RBS signature comments above `module_function def` were associated with the inner method definition. The RBS rewriter then wrapped that definition in a statements node.

So this:

```ruby
#: () -> void
module_function def foo
end
```

was being translated as this:

```ruby
module_function(
  begin
    sig { void }
    def foo
    end
  end
)
```

This change treats `module_function` def as an RBS signature target. The RBS pass now emits the generated sig immediately before the unchanged `module_function` def call:

 ```ruby
sig { ... }
module_function def foo
 ```

The existing ModuleFunction rewriter can then create the typed instance and singleton methods as it already does for Ruby sig blocks.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.