### PR TITLE
Fix truncated runtime.md docs page

### DIFF
--- a/website/docs/runtime.md
+++ b/website/docs/runtime.md
@@ -227,11 +227,9 @@ For example, this should probably be placed as the first line of any `rake test`
 
 ### `.checked(:tests)` and `.void`
 
-<!--
-This is the only part that threw me. Maybe change the sentence to "...changes how .void returns values."? And then the next paragraph describes what's going on?
+<!-- This is the only part that threw me. Maybe change the sentence to "...changes how .void returns values."? And then the next paragraph describes what's going on? -->
 
-"changes the meaning to .returns(T.anything)" is technically correct, but the way this is worded makes me think it has static behavior changes...but it can't have static behavior changes, because it's only a runtime thing.
--->
+<!-- "changes the meaning to .returns(T.anything)" is technically correct, but the way this is worded makes me think it has static behavior changes...but it can't have static behavior changes, because it's only a runtime thing. -->
 
 As of sorbet-runtime 0.6.13065, using `.checked(:tests)` on a sig that returns `.void` makes the sig behave like `.returns(T.anything)` at runtime, that is: the return value is not substituted with a dummy value. (Statically, `.void` and `.returns(T.anything)` remain equivalent).
 


### PR DESCRIPTION
Splits a doc comment that contains a blank line into two comments, so it reaches the browser closed.

### Motivation

https://sorbet.org/docs/runtime is truncated. "`.checked(:tests)` and `.void`" is the last thing rendered, and the four sections after that heading are missing from the page.

Docusaurus 1 renders markdown with Remarkable, which ends a raw HTML block at the first blank line rather than at the closing `-->`. The comment at the top of that section has a blank line in it, so Remarkable emits an unterminated `<!--` and the browser comments out the remaining 9,490 characters. Multi-line comments are fine without an interior blank line, which is why the ones in `from-typescript.md` and `vscode.md` render correctly.

### Test plan

No screenshot, since the evidence is in the generated markup rather than the layout. Rendered through the site's own `renderMarkdown.js`, the old version leaves the comment open and swallows the body. The new one closes both comments, and the page runs through to the footnotes.

I also rendered all 85 markdown files under `website/docs` and `website/blog` and checked for unbalanced `<!--`. This was the only affected file.

### Would you like a lint for this?

The source looks correct and GitHub renders it correctly, so this only surfaces once the site is built. I am happy to follow up with a linter step that renders each page and fails on an unterminated comment, if that seems worth the machinery.
