### PR TITLE
[RFC] Propagate RBS options to sorbet.run LSP

### DIFF
--- a/emscripten/BUILD
+++ b/emscripten/BUILD
@@ -29,6 +29,7 @@ cc_binary(
         "//main/pipeline/semantic_extension:none",
         "//payload/binary:some",
         "//payload/text:empty",
+        "@com_google_absl//absl/strings",
     ],
 )
 

--- a/emscripten/main.cc
+++ b/emscripten/main.cc
@@ -76,6 +76,25 @@ void EMSCRIPTEN_KEEPALIVE typecheck(const char *optionsJson) {
     runSorbet(argCharStars.size(), argCharStars.data());
 }
 
+void EMSCRIPTEN_KEEPALIVE initializeLsp(const char *optionsJson) {
+    rapidjson::Document options;
+    options.Parse(optionsJson);
+    if (options.HasParseError() || !options.IsArray()) {
+        fmt::print(stderr, "emscripten/main.cc: LSP options were not a valid JSON array: '{}'. Using defaults.\n",
+                   optionsJson);
+        return;
+    }
+
+    for (rapidjson::SizeType i = 0; i < options.Size(); i++) {
+        if (!options[i].IsString()) {
+            fmt::print(stderr, "emscripten/main.cc: LSP option {} was not a string. Using defaults.\n", i);
+            return;
+        }
+    }
+
+    initializeLSPWrapper();
+}
+
 void EMSCRIPTEN_KEEPALIVE lsp(void (*respond)(const char *), const char *message) {
     initializeLSPWrapper();
 

--- a/emscripten/main.cc
+++ b/emscripten/main.cc
@@ -1,3 +1,4 @@
+#include "absl/strings/match.h"
 #include "common/EarlyReturnWithCode.h"
 #include "main/lsp/wrapper.h"
 #include "main/realmain.h"
@@ -15,13 +16,100 @@ namespace {
 
 unique_ptr<sorbet::realmain::lsp::SingleThreadedLSPWrapper> lspWrapper;
 
-void initializeLSPWrapper() {
+void initializeLSPWrapper(
+    shared_ptr<sorbet::realmain::options::Options> options = make_shared<sorbet::realmain::options::Options>()) {
     if (lspWrapper) {
         return;
     }
 
-    lspWrapper = sorbet::realmain::lsp::SingleThreadedLSPWrapper::create();
+    lspWrapper = sorbet::realmain::lsp::SingleThreadedLSPWrapper::create(string_view(), move(options));
     lspWrapper->enableAllExperimentalFeatures();
+}
+
+optional<string> applyParser(sorbet::realmain::options::Options &options, string_view parser) {
+    if (parser == "prism") {
+        options.cacheSensitiveOptions.usePrismParser = true;
+        return nullopt;
+    } else if (parser == "original") {
+        options.cacheSensitiveOptions.usePrismParser = false;
+        return nullopt;
+    } else {
+        return "Unknown `--parser` option: " + string(parser);
+    }
+}
+
+optional<string> applyBooleanArgument(const string &argument, string_view name, bool &value) {
+    if (argument == name) {
+        value = true;
+        return nullopt;
+    } else {
+        auto prefix = string(name) + "=";
+        auto argumentValue = argument.substr(prefix.size());
+        if (argumentValue == "true") {
+            value = true;
+            return nullopt;
+        } else if (argumentValue == "false") {
+            value = false;
+            return nullopt;
+        } else {
+            return "Expected `" + prefix + "true` or `" + prefix + "false`";
+        }
+    }
+}
+
+optional<string> applyLSPOptions(sorbet::realmain::options::Options &options, const vector<string> &arguments) {
+    constexpr string_view rbsComments = "--enable-experimental-rbs-comments";
+    constexpr string_view methodModifiers = "--enable-experimental-method-modifiers";
+    constexpr string_view parserPrefix = "--parser=";
+
+    bool rbsEnabled = options.cacheSensitiveOptions.rbsEnabled;
+    // No override means method modifiers follow the final RBS setting, matching the native CLI.
+    optional<bool> methodModifiersOverride;
+
+    for (size_t i = 0; i < arguments.size(); ++i) {
+        const auto &argument = arguments[i];
+
+        if (argument == rbsComments || absl::StartsWith(argument, string(rbsComments) + "=")) {
+            if (auto error = applyBooleanArgument(argument, rbsComments, rbsEnabled)) {
+                return error;
+            }
+            continue;
+        }
+
+        if (argument == methodModifiers || absl::StartsWith(argument, string(methodModifiers) + "=")) {
+            bool enabled = false;
+            if (auto error = applyBooleanArgument(argument, methodModifiers, enabled)) {
+                return error;
+            }
+            methodModifiersOverride = enabled;
+            continue;
+        }
+
+        if (argument == "--parser") {
+            if (++i == arguments.size()) {
+                return "Missing value for `--parser`";
+            }
+            if (auto error = applyParser(options, arguments[i])) {
+                return error;
+            }
+            continue;
+        }
+
+        if (absl::StartsWith(argument, parserPrefix)) {
+            if (auto error = applyParser(options, argument.substr(parserPrefix.size()))) {
+                return error;
+            }
+        }
+    }
+
+    options.cacheSensitiveOptions.rbsEnabled = rbsEnabled;
+    options.experimentalMethodModifiers = methodModifiersOverride.value_or(rbsEnabled);
+
+    if (rbsEnabled && !options.cacheSensitiveOptions.usePrismParser) {
+        return "RBS mode requires `--parser=prism`";
+    }
+
+    return nullopt;
 }
 
 void runSorbet(int argc, char *argv[]) {
@@ -85,14 +173,24 @@ void EMSCRIPTEN_KEEPALIVE initializeLsp(const char *optionsJson) {
         return;
     }
 
+    vector<string> arguments;
+    arguments.reserve(options.Size());
     for (rapidjson::SizeType i = 0; i < options.Size(); i++) {
-        if (!options[i].IsString()) {
+        const auto &argument = options[i];
+        if (!argument.IsString()) {
             fmt::print(stderr, "emscripten/main.cc: LSP option {} was not a string. Using defaults.\n", i);
             return;
         }
+        arguments.emplace_back(argument.GetString());
     }
 
-    initializeLSPWrapper();
+    auto lspOptions = make_shared<sorbet::realmain::options::Options>();
+    if (auto error = applyLSPOptions(*lspOptions, arguments)) {
+        fmt::print(stderr, "emscripten/main.cc: Invalid LSP options: {}. Using defaults.\n", *error);
+        return;
+    }
+
+    initializeLSPWrapper(move(lspOptions));
 }
 
 void EMSCRIPTEN_KEEPALIVE lsp(void (*respond)(const char *), const char *message) {

--- a/emscripten/main.cc
+++ b/emscripten/main.cc
@@ -15,6 +15,15 @@ namespace {
 
 unique_ptr<sorbet::realmain::lsp::SingleThreadedLSPWrapper> lspWrapper;
 
+void initializeLSPWrapper() {
+    if (lspWrapper) {
+        return;
+    }
+
+    lspWrapper = sorbet::realmain::lsp::SingleThreadedLSPWrapper::create();
+    lspWrapper->enableAllExperimentalFeatures();
+}
+
 void runSorbet(int argc, char *argv[]) {
     try {
         sorbet::realmain::realmain(argc, argv);
@@ -68,10 +77,7 @@ void EMSCRIPTEN_KEEPALIVE typecheck(const char *optionsJson) {
 }
 
 void EMSCRIPTEN_KEEPALIVE lsp(void (*respond)(const char *), const char *message) {
-    if (!lspWrapper) {
-        lspWrapper = sorbet::realmain::lsp::SingleThreadedLSPWrapper::create();
-        lspWrapper->enableAllExperimentalFeatures();
-    }
+    initializeLSPWrapper();
 
     auto responses = lspWrapper->getLSPResponsesFor(message);
     for (auto &response : responses) {

--- a/emscripten/main.cc
+++ b/emscripten/main.cc
@@ -13,6 +13,8 @@ using namespace std;
 
 namespace {
 
+unique_ptr<sorbet::realmain::lsp::SingleThreadedLSPWrapper> lspWrapper;
+
 void runSorbet(int argc, char *argv[]) {
     try {
         sorbet::realmain::realmain(argc, argv);
@@ -66,13 +68,12 @@ void EMSCRIPTEN_KEEPALIVE typecheck(const char *optionsJson) {
 }
 
 void EMSCRIPTEN_KEEPALIVE lsp(void (*respond)(const char *), const char *message) {
-    static unique_ptr<sorbet::realmain::lsp::SingleThreadedLSPWrapper> wrapper;
-    if (!wrapper) {
-        wrapper = sorbet::realmain::lsp::SingleThreadedLSPWrapper::create();
-        wrapper->enableAllExperimentalFeatures();
+    if (!lspWrapper) {
+        lspWrapper = sorbet::realmain::lsp::SingleThreadedLSPWrapper::create();
+        lspWrapper->enableAllExperimentalFeatures();
     }
 
-    auto responses = wrapper->getLSPResponsesFor(message);
+    auto responses = lspWrapper->getLSPResponsesFor(message);
     for (auto &response : responses) {
         respond(response->toJSON().c_str());
     }

--- a/emscripten/main.cc
+++ b/emscripten/main.cc
@@ -16,10 +16,13 @@ namespace {
 
 unique_ptr<sorbet::realmain::lsp::SingleThreadedLSPWrapper> lspWrapper;
 
-void initializeLSPWrapper(
-    shared_ptr<sorbet::realmain::options::Options> options = make_shared<sorbet::realmain::options::Options>()) {
+void initializeLSPWrapper(shared_ptr<sorbet::realmain::options::Options> options = nullptr) {
     if (lspWrapper) {
         return;
+    }
+
+    if (!options) {
+        options = make_shared<sorbet::realmain::options::Options>();
     }
 
     lspWrapper = sorbet::realmain::lsp::SingleThreadedLSPWrapper::create(string_view(), move(options));
@@ -170,6 +173,7 @@ void EMSCRIPTEN_KEEPALIVE initializeLsp(const char *optionsJson) {
     if (options.HasParseError() || !options.IsArray()) {
         fmt::print(stderr, "emscripten/main.cc: LSP options were not a valid JSON array: '{}'. Using defaults.\n",
                    optionsJson);
+        initializeLSPWrapper();
         return;
     }
 
@@ -179,6 +183,7 @@ void EMSCRIPTEN_KEEPALIVE initializeLsp(const char *optionsJson) {
         const auto &argument = options[i];
         if (!argument.IsString()) {
             fmt::print(stderr, "emscripten/main.cc: LSP option {} was not a string. Using defaults.\n", i);
+            initializeLSPWrapper();
             return;
         }
         arguments.emplace_back(argument.GetString());
@@ -187,6 +192,7 @@ void EMSCRIPTEN_KEEPALIVE initializeLsp(const char *optionsJson) {
     auto lspOptions = make_shared<sorbet::realmain::options::Options>();
     if (auto error = applyLSPOptions(*lspOptions, arguments)) {
         fmt::print(stderr, "emscripten/main.cc: Invalid LSP options: {}. Using defaults.\n", *error);
+        initializeLSPWrapper();
         return;
     }
 


### PR DESCRIPTION
Related to https://github.com/sorbet/sorbet.run/pull/140

Best read commit-by-commit.

### Motivation
The LSP in sorbet.run does not currently support command line arguments passed in from the URL. This means we cannot use RBS signatures in Sorbet.run, which would really help us test and debug our RBS work.

### Implementation
This PR adds an initialization step to the LSP that is eventually compiled into WASM and used in sorbet.run. Before the LSP starts receiving commands, we first pass along any url options from sorbet.run and initialize the LSP with those options.

1. [sorbet.run calls `initializeLsp` and passes a JSON string of URL params](https://github.com/sorbet/sorbet.run/pull/142/changes)
2. `initializeLSP` creates an LSP wrapper that contains the options; this object persists across calls to the LSP
3. The `lsp` method uses this shared wrapper

### Open Questions
1. This part of the code doesn't really have any tests. Should we introduce some?
4. This basically re-implements [options handling](https://github.com/sorbet/sorbet/blob/3e3c5be2dd4b4c4aedfbceacd04f40c9fa15809c/main/options/options.cc#L918). The problem is that the `readOptions` method handles other things like [worker pool creation](https://github.com/sorbet/sorbet/blob/3e3c5be2dd4b4c4aedfbceacd04f40c9fa15809c/main/options/options.cc#L949) and [sorbet/config discovery](https://github.com/sorbet/sorbet/blob/3e3c5be2dd4b4c4aedfbceacd04f40c9fa15809c/main/options/options.cc#L926), so it's not super portable. Is that by design? Do we want to create a shared options handler?

### Test plan

#### Manual Testing:
In sorbet/sorbet:

```
./bazel build //emscripten:sorbet-wasm.d --config=webasm
```

For sorbet/sorbet.run ([checkout my branch first](https://github.com/sorbet/sorbet.run/pull/142/changes)):

```
cp sorbet/bazel-bin/emscripten/sorbet-wasm.d/sorbet-wasm.{js,wasm} \
  sorbet.run/docs/

cd sorbet.run
npm install
npm start
```

Then finally open sorbet.run locally and you should see it working: http://localhost:8000/?arg=--parser=prism&arg=--enable-experimental-rbs-comments

<img width="790" height="206" alt="Screenshot 2026-08-12 at 1 14 45 PM" src="https://github.com/user-attachments/assets/27b8fc7d-60e0-42d7-aa58-9d3611ea9682" />
