### PR TITLE
[DO NOT MERGE] Initialize the WebAssembly LSP inline with RBS options

### DIFF
--- a/emscripten/main.cc
+++ b/emscripten/main.cc
@@ -13,6 +13,8 @@ using namespace std;
 
 namespace {
 
+unique_ptr<sorbet::realmain::lsp::SingleThreadedLSPWrapper> wrapper;
+
 void runSorbet(int argc, char *argv[]) {
     try {
         sorbet::realmain::realmain(argc, argv);
@@ -65,8 +67,71 @@ void EMSCRIPTEN_KEEPALIVE typecheck(const char *optionsJson) {
     runSorbet(argCharStars.size(), argCharStars.data());
 }
 
+void EMSCRIPTEN_KEEPALIVE initializeLsp(const char *optionsJson) {
+    if (wrapper) {
+        return;
+    }
+
+    rapidjson::Document options;
+    options.Parse(optionsJson);
+    if (options.HasParseError() || !options.IsArray()) {
+        fmt::print(stderr, "emscripten/main.cc: LSP options were not a valid JSON array: '{}'. Using defaults.\n",
+                   optionsJson);
+        return;
+    }
+
+    auto opts = make_shared<sorbet::realmain::options::Options>();
+    optional<bool> methodModifiersEnabled;
+
+    for (rapidjson::SizeType i = 0; i < options.Size(); i++) {
+        const auto &value = options[i];
+        if (!value.IsString()) {
+            fmt::print(stderr, "emscripten/main.cc: LSP option {} was not a string. Using defaults.\n", i);
+            return;
+        }
+
+        string_view argument = value.GetString();
+        if (argument == "--parser=prism") {
+            opts->cacheSensitiveOptions.usePrismParser = true;
+        } else if (argument == "--parser=original") {
+            opts->cacheSensitiveOptions.usePrismParser = false;
+        } else if (argument == "--parser") {
+            if (++i == options.Size() || !options[i].IsString()) {
+                fmt::print(stderr, "emscripten/main.cc: Missing value for `--parser`. Using defaults.\n");
+                return;
+            }
+
+            string_view parser = options[i].GetString();
+            if (parser == "prism") {
+                opts->cacheSensitiveOptions.usePrismParser = true;
+            } else if (parser == "original") {
+                opts->cacheSensitiveOptions.usePrismParser = false;
+            }
+        } else if (argument == "--enable-experimental-rbs-comments" ||
+                   argument == "--enable-experimental-rbs-comments=true") {
+            opts->cacheSensitiveOptions.rbsEnabled = true;
+        } else if (argument == "--enable-experimental-rbs-comments=false") {
+            opts->cacheSensitiveOptions.rbsEnabled = false;
+        } else if (argument == "--enable-experimental-method-modifiers" ||
+                   argument == "--enable-experimental-method-modifiers=true") {
+            methodModifiersEnabled = true;
+        } else if (argument == "--enable-experimental-method-modifiers=false") {
+            methodModifiersEnabled = false;
+        }
+    }
+
+    opts->experimentalMethodModifiers =
+        methodModifiersEnabled.value_or(static_cast<bool>(opts->cacheSensitiveOptions.rbsEnabled));
+    if (opts->cacheSensitiveOptions.rbsEnabled && !opts->cacheSensitiveOptions.usePrismParser) {
+        fmt::print(stderr, "emscripten/main.cc: RBS mode requires `--parser=prism`. Using defaults.\n");
+        return;
+    }
+
+    wrapper = sorbet::realmain::lsp::SingleThreadedLSPWrapper::create(string_view(), move(opts));
+    wrapper->enableAllExperimentalFeatures();
+}
+
 void EMSCRIPTEN_KEEPALIVE lsp(void (*respond)(const char *), const char *message) {
-    static unique_ptr<sorbet::realmain::lsp::SingleThreadedLSPWrapper> wrapper;
     if (!wrapper) {
         wrapper = sorbet::realmain::lsp::SingleThreadedLSPWrapper::create();
         wrapper->enableAllExperimentalFeatures();


### PR DESCRIPTION
Port the original January implementation onto the current Sorbet base while preserving its single-file architecture.

Decode and apply parser, RBS comment, and method-modifier options directly in emscripten/main.cc before creating SingleThreadedLSPWrapper. Keep lazy default initialization for callers that do not use the new entry point.

Unlike the primary comparison branch, this approach introduces no helper library or BUILD changes. Its smaller file footprint comes at the cost of mixing command-line semantics with JSON decoding and LSP lifecycle management.

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
