### PR TITLE
Add `T::Utils.drop_unchecked_sigs!`

### DIFF
--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -42,6 +42,18 @@ module T::Configuration
     T::Private::Methods.set_final_checks_on_hooks(false)
   end
 
+  # Free the signatures whose runtime checks never run: the `.checked(:never)`
+  # sigs, plus the `.checked(:tests)` sigs outside of a test environment. Those
+  # methods carry no wrapper, so their signatures only serve introspection, and
+  # `T::Utils.signature_for_method` returns `nil` for them after this call.
+  #
+  # A freed signature cannot be rebuilt, so there is no way back. Call this
+  # after the application has loaded all of its code, in the same way as
+  # `T::Utils.run_all_sig_blocks`, and again if more code loads later.
+  def self.drop_unchecked_sigs!
+    T::Private::Methods.drop_unchecked_sigs!
+  end
+
   @include_value_in_type_errors = true
   # Whether to include values in TypeError messages.
   #

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -12,6 +12,9 @@ module T::Private::Methods
     @sig_wrappers = {}
   end
   @sigs_that_raised = {}
+  # Whether the app asked us to drop the signatures whose runtime checks never
+  # run. See `T::Configuration.drop_unchecked_sigs!`.
+  @drop_unchecked_sigs = false
   # stores method names that were declared final without regard for where.
   # enables early rejection of names that we know can't induce final method violations.
   @was_ever_final_names = {}.compare_by_identity
@@ -499,7 +502,10 @@ module T::Private::Methods
     if receiving_method != original_method && receiving_method.original_name == original_method.name
       aliasing_mod = receiving_method.owner
       method_sig = method_sig.as_alias(callee)
-      unwrap_method(aliasing_mod, method_sig, original_method)
+      # An alias is the only way a signature that `drop_unchecked_sigs` already
+      # swept away could come back into `@signatures_by_method`, so skip the
+      # bookkeeping here too. The alias is still wrapped (or unwrapped) as usual.
+      unwrap_method(aliasing_mod, method_sig, original_method, record: !drop_sig?(method_sig))
     end
 
     method_sig
@@ -610,9 +616,31 @@ module T::Private::Methods
     @signatures_by_method[key]
   end
 
-  private_class_method def self.unwrap_method(mod, signature, original_method)
+  # `@signatures_by_method` is only read for introspection (e.g.
+  # `T::Utils.signature_for_method` and the `Method#parameters` patch), never to
+  # dispatch a call, so `record: false` skips it to save memory.
+  private_class_method def self.unwrap_method(mod, signature, original_method, record: true)
     maybe_wrapped_method = CallValidation.wrap_method_if_needed(mod, signature, original_method)
-    @signatures_by_method[method_to_key(maybe_wrapped_method)] = signature
+    @signatures_by_method[method_to_key(maybe_wrapped_method)] = signature if record
+  end
+
+  # Whether `signature` is one that `drop_unchecked_sigs` frees: a signature
+  # whose runtime checks never run, either `.checked(:never)` or
+  # `.checked(:tests)` outside of a test environment.
+  #
+  # Signatures on `abstract` methods are never dropped: `T::AbstractUtils` reads
+  # them to detect unimplemented abstract methods long after load time.
+  #
+  # Note this only reads `RuntimeLevels.check_tests?` for a `:tests` signature,
+  # which is exactly when `CallValidation.wrap_method_if_needed` already read it.
+  # That keeps `T::Configuration.enable_checking_for_sigs_marked_checked_tests`
+  # usable for as long as it was usable before.
+  private_class_method def self.drop_sig?(signature)
+    return false if !@drop_unchecked_sigs
+    return false if signature.mode == Modes.abstract
+
+    signature.check_level == :never ||
+      (signature.check_level == :tests && !T::Private::RuntimeLevels.check_tests?)
   end
 
   def self.has_sig_block_for_method(method)
@@ -704,6 +732,12 @@ module T::Private::Methods
 
   def self.all_checked_tests_sigs
     @signatures_by_method.values.select { |sig| sig.check_level == :tests }
+  end
+
+  # Sweeps rather than never recording, so the `run_sig_block_for_key` race fallback still works.
+  def self.drop_unchecked_sigs!
+    @drop_unchecked_sigs = true
+    @signatures_by_method.delete_if { |_key, sig| drop_sig?(sig) }
   end
 
   # the module target is adding the methods from the module source to itself. we need to check that for all instance

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -615,6 +615,17 @@ module T::Private::Methods
     @signatures_by_method[method_to_key(maybe_wrapped_method)] = signature
   end
 
+  # This method tells whether `drop_unchecked_sigs!` can free `signature`.
+  # It returns true for a signature whose runtime checks never run.
+  # It returns false for an `abstract` signature, because `T::AbstractUtils`
+  # reads that signature after load time.
+  private_class_method def self.drop_sig?(signature)
+    return false if signature.mode == Modes.abstract
+
+    signature.check_level == :never ||
+      (signature.check_level == :tests && !T::Private::RuntimeLevels.check_tests?)
+  end
+
   def self.has_sig_block_for_method(method)
     has_sig_block_for_key(method_to_key(method))
   end
@@ -704,6 +715,10 @@ module T::Private::Methods
 
   def self.all_checked_tests_sigs
     @signatures_by_method.values.select { |sig| sig.check_level == :tests }
+  end
+
+  def self.drop_unchecked_sigs!
+    @signatures_by_method.delete_if { |_key, sig| drop_sig?(sig) }
   end
 
   # the module target is adding the methods from the module source to itself. we need to check that for all instance

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
@@ -49,6 +49,7 @@ module T::Private::Methods
   @signatures_by_method = T.let({}, T::Hash[String, Signature])
   @sigs_that_raised = T.let({}, T::Hash[String, TrueClass])
   @old_hooks = T.let(nil, T.nilable([UnboundMethod, UnboundMethod, UnboundMethod]))
+  @drop_unchecked_sigs = T.let(false, T::Boolean)
 
   sig { params(mod: Module, method_name: Symbol, dsl_name: Symbol).returns(T.nilable(DeclarationBlock)) }
   private_class_method def self.ensure_valid_declare_dsl!(mod, method_name, dsl_name); end
@@ -111,8 +112,8 @@ module T::Private::Methods
   sig {params(method: T.any(Method, UnboundMethod)).returns(T.nilable(T::Private::Methods::Signature))}
   def self.signature_for_method(method); end
 
-  sig {params(mod: Module, signature: T::Private::Methods::Signature, original_method: UnboundMethod).void}
-  def self.unwrap_method(mod, signature, original_method); end
+  sig {params(mod: Module, signature: T::Private::Methods::Signature, original_method: UnboundMethod, record: T::Boolean).void}
+  def self.unwrap_method(mod, signature, original_method, record: true); end
 
   sig {params(method: UnboundMethod).returns(T::Boolean)}
   def self.has_sig_block_for_method(method); end
@@ -132,6 +133,9 @@ module T::Private::Methods
   sig {returns(T::Array[T::Private::Methods::Signature])}
   def self.all_checked_tests_sigs; end
 
+  sig {void}
+  def self.drop_unchecked_sigs!; end
+
   sig {params(target: Module, source: Module).void}
   def self._hook_impl(target, source); end
 
@@ -143,6 +147,9 @@ module T::Private::Methods
 
   sig {params(key: String).returns(T.nilable(T::Private::Methods::Signature))}
   private_class_method def self.signature_for_key(key); end
+
+  sig {params(signature: T::Private::Methods::Signature).returns(T::Boolean)}
+  private_class_method def self.drop_sig?(signature); end
 
   sig {params(key: String).returns(T::Boolean)}
   private_class_method def self.has_sig_block_for_key(key); end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rbi
@@ -132,6 +132,9 @@ module T::Private::Methods
   sig {returns(T::Array[T::Private::Methods::Signature])}
   def self.all_checked_tests_sigs; end
 
+  sig {void}
+  def self.drop_unchecked_sigs!; end
+
   sig {params(target: Module, source: Module).void}
   def self._hook_impl(target, source); end
 
@@ -143,6 +146,9 @@ module T::Private::Methods
 
   sig {params(key: String).returns(T.nilable(T::Private::Methods::Signature))}
   private_class_method def self.signature_for_key(key); end
+
+  sig {params(signature: T::Private::Methods::Signature).returns(T::Boolean)}
+  private_class_method def self.drop_sig?(signature); end
 
   sig {params(key: String).returns(T::Boolean)}
   private_class_method def self.has_sig_block_for_key(key); end

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -178,6 +178,18 @@ module T::Utils
     nil
   end
 
+  # Free the signatures whose runtime checks never run: the `.checked(:never)`
+  # sigs, plus the `.checked(:tests)` sigs outside of a test environment. After
+  # this call, `T::Utils.signature_for_method` returns `nil` for those methods,
+  # and nothing can rebuild them.
+  #
+  # Call this while eagerly preloading a codebase (e.g. at service startup) to
+  # trade that introspection for memory, and again if more code loads later.
+  def self.drop_unchecked_sigs!
+    T::Private::Methods.drop_unchecked_sigs!
+    nil
+  end
+
   def self.lift_enum(enum)
     unless enum.is_a?(T::Types::Enum)
       raise ArgumentError.new("#{enum.inspect} is not a T.deprecated_enum")

--- a/gems/sorbet-runtime/lib/types/utils.rbi
+++ b/gems/sorbet-runtime/lib/types/utils.rbi
@@ -47,6 +47,9 @@ module T::Utils
   sig { void }
   def self.eagerly_define_all_lazy_props_methods!; end
 
+  sig { void }
+  def self.drop_unchecked_sigs!; end
+
   # TODO(jez) If we were to move this to the public rbi/ folder, we would
   # probably want the types to all be non-nil. Maybe we should just make this a
   # private helper.

--- a/gems/sorbet-runtime/test/types/drop_unchecked_sigs.rb
+++ b/gems/sorbet-runtime/test/types/drop_unchecked_sigs.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+# typed: ignore
+require_relative '../test_helper'
+
+module Opus::Types::Test
+  class DropUncheckedSigsTest < Critic::Unit::UnitTest
+    it 'drops the unchecked sigs, and keeps the methods and their aliases working' do
+      fixture = "#{__dir__}/fixtures/drop_unchecked_sigs.rb"
+      result, status = Open3.capture2e("ruby", fixture)
+      assert(status.success?, "fixture failed (exit #{status.exitstatus}): #{result}")
+      assert_equal("PASS\n", result)
+    end
+
+    it 'keeps the `.checked(:tests)` sigs in a test environment' do
+      fixture = "#{__dir__}/fixtures/drop_unchecked_sigs_checked_tests.rb"
+      result, status = Open3.capture2e("ruby", fixture)
+      assert(status.success?, "fixture failed (exit #{status.exitstatus}): #{result}")
+      assert_equal("PASS\n", result)
+    end
+  end
+end

--- a/gems/sorbet-runtime/test/types/fixtures/drop_unchecked_sigs.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/drop_unchecked_sigs.rb
@@ -1,0 +1,87 @@
+# typed: true
+# frozen_string_literal: true
+require_relative '../../../lib/sorbet-runtime'
+
+# This fixture runs in a subprocess so that `T::Configuration.drop_unchecked_sigs!`
+# and `T::Utils.run_all_sig_blocks` are isolated from the main test process.
+
+def check(description, loc: caller_locations(1, 1).first)
+  unless yield
+    puts "FAIL: #{loc.path}:#{loc.lineno}: #{description}"
+  end
+end
+
+unchecked = Class.new do
+  extend T::Sig
+
+  sig { params(x: Symbol).returns(Symbol).checked(:never) }
+  def foo(x)
+    x
+  end
+  alias_method :bar, :foo
+end
+
+checked = Class.new do
+  extend T::Sig
+
+  sig { params(x: Symbol).returns(Symbol) }
+  def foo(x)
+    x
+  end
+  alias_method :bar, :foo
+end
+
+abstract_klass = Class.new do
+  extend T::Sig
+  extend T::Helpers
+  abstract!
+
+  sig { abstract.params(x: Symbol).returns(Symbol).checked(:never) }
+  def foo(x); end
+end
+
+T::Utils.run_all_sig_blocks
+
+check("an unchecked sig is kept before the call") do
+  !T::Utils.signature_for_method(unchecked.instance_method(:foo)).nil?
+end
+
+T::Configuration.drop_unchecked_sigs!
+
+# The unchecked signature is freed, but the method and its alias still work.
+check("the unchecked sig is freed") { T::Utils.signature_for_method(unchecked.instance_method(:foo)).nil? }
+check("the unchecked method still runs") { unchecked.new.foo(:foo) == :foo }
+check("the alias still runs") { unchecked.new.bar(:bar) == :bar }
+check("the alias records no sig of its own") do
+  T::Utils.signature_for_method(unchecked.instance_method(:bar)).nil?
+end
+
+# `Method#parameters` still reports the parameters, because the method is unwrapped.
+check("the parameters survive") { unchecked.instance_method(:foo).parameters == [%i[req x]] }
+
+# A checked signature is untouched: it stays introspectable and it still validates,
+# through the original method and through the alias.
+check("a checked sig is kept") { !T::Utils.signature_for_method(checked.instance_method(:foo)).nil? }
+check("the checked method still runs") { checked.new.foo(:foo) == :foo }
+check("the checked alias still runs") { checked.new.bar(:bar) == :bar }
+check("the checked alias still validates") do
+  checked.new.bar(1)
+  false
+rescue TypeError
+  true
+end
+
+# An abstract signature is never dropped: `T::AbstractUtils` reads it to tell
+# whether a method is abstract, long after load time.
+check("an abstract sig is kept") { !T::Utils.signature_for_method(abstract_klass.instance_method(:foo)).nil? }
+check("the method still reads as abstract") do
+  T::AbstractUtils.abstract_method?(abstract_klass.instance_method(:foo))
+end
+check("an unimplemented abstract method still raises") do
+  Class.new(abstract_klass).new.foo(:foo)
+  false
+rescue NotImplementedError
+  true
+end
+
+puts "PASS"

--- a/gems/sorbet-runtime/test/types/fixtures/drop_unchecked_sigs.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/drop_unchecked_sigs.rb
@@ -1,0 +1,85 @@
+# typed: true
+# frozen_string_literal: true
+require_relative '../../../lib/sorbet-runtime'
+
+# This fixture runs in a subprocess so that `T::Utils.drop_unchecked_sigs!`
+# and `T::Utils.run_all_sig_blocks` are isolated from the main test process.
+
+def check(description, loc: caller_locations(1, 1).first)
+  unless yield
+    puts "FAIL: #{loc.path}:#{loc.lineno}: #{description}"
+  end
+end
+
+unchecked = Class.new do
+  extend T::Sig
+
+  sig { params(x: Symbol).returns(Symbol).checked(:never) }
+  def foo(x)
+    x
+  end
+  alias_method :bar, :foo
+end
+
+checked = Class.new do
+  extend T::Sig
+
+  sig { params(x: Symbol).returns(Symbol) }
+  def foo(x)
+    x
+  end
+  alias_method :bar, :foo
+end
+
+abstract_klass = Class.new do
+  extend T::Sig
+  extend T::Helpers
+  abstract!
+
+  sig { abstract.params(x: Symbol).returns(Symbol).checked(:never) }
+  def foo(x); end
+end
+
+T::Utils.run_all_sig_blocks
+
+check("an unchecked sig is kept before the call") do
+  !T::Utils.signature_for_method(unchecked.instance_method(:foo)).nil?
+end
+
+T::Utils.drop_unchecked_sigs!
+
+check("the unchecked sig is freed") { T::Utils.signature_for_method(unchecked.instance_method(:foo)).nil? }
+check("the unchecked method still runs") { unchecked.new.foo(:foo) == :foo }
+check("the alias still runs") { unchecked.new.bar(:bar) == :bar }
+check("the alias records a sig of its own") do
+  !T::Utils.signature_for_method(unchecked.instance_method(:bar)).nil?
+end
+T::Utils.drop_unchecked_sigs!
+check("a later call frees the alias sig") do
+  T::Utils.signature_for_method(unchecked.instance_method(:bar)).nil?
+end
+
+check("the parameters survive") { unchecked.instance_method(:foo).parameters == [%i[req x]] }
+
+check("a checked sig is kept") { !T::Utils.signature_for_method(checked.instance_method(:foo)).nil? }
+check("the checked method still runs") { checked.new.foo(:foo) == :foo }
+check("the checked alias still runs") { checked.new.bar(:bar) == :bar }
+check("the checked alias still validates") do
+  checked.new.bar(1)
+  false
+rescue TypeError
+  true
+end
+
+check("an abstract sig is kept") { !T::Utils.signature_for_method(abstract_klass.instance_method(:foo)).nil? }
+check("the method still reads as abstract") do
+  T::AbstractUtils.abstract_method?(abstract_klass.instance_method(:foo))
+end
+check("an unimplemented abstract method still raises") do
+  Class.new(abstract_klass).new.foo(:foo)
+  false
+rescue NotImplementedError
+  true
+end
+
+puts "PASS"

--- a/gems/sorbet-runtime/test/types/fixtures/drop_unchecked_sigs_checked_tests.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/drop_unchecked_sigs_checked_tests.rb
@@ -1,0 +1,47 @@
+# typed: true
+# frozen_string_literal: true
+require_relative '../../../lib/sorbet-runtime'
+
+# This fixture runs in a subprocess so that `T::Utils.drop_unchecked_sigs!`
+# and `T::Configuration.enable_checking_for_sigs_marked_checked_tests` are isolated
+# from the main test process. It must not call `T::Utils.run_all_sig_blocks`, which
+# wraps the `.checked(:tests)` sigs of sorbet-runtime itself.
+
+def check(description, loc: caller_locations(1, 1).first)
+  unless yield
+    puts "FAIL: #{loc.path}:#{loc.lineno}: #{description}"
+  end
+end
+
+# Dropping must not read `RuntimeLevels.check_tests?` on its own, otherwise it
+# would close the window for turning on `:tests`-level checking.
+T::Utils.drop_unchecked_sigs!
+
+check("test-level checking can still be turned on") do
+  T::Configuration.enable_checking_for_sigs_marked_checked_tests
+  true
+rescue StandardError => e
+  puts "  #{e.message}"
+  false
+end
+
+klass = Class.new do
+  extend T::Sig
+
+  sig { params(x: Symbol).returns(Symbol).checked(:tests) }
+  def foo(x)
+    x
+  end
+  alias_method :bar, :foo
+end
+
+check("the method runs") { klass.new.foo(:foo) == :foo }
+check("the sig is kept") { !T::Utils.signature_for_method(klass.instance_method(:foo)).nil? }
+check("the alias still validates") do
+  klass.new.bar(1)
+  false
+rescue TypeError
+  true
+end
+
+puts "PASS"

--- a/gems/sorbet-runtime/test/types/fixtures/drop_unchecked_sigs_checked_tests.rb
+++ b/gems/sorbet-runtime/test/types/fixtures/drop_unchecked_sigs_checked_tests.rb
@@ -1,0 +1,49 @@
+# typed: true
+# frozen_string_literal: true
+require_relative '../../../lib/sorbet-runtime'
+
+# This fixture runs in a subprocess so that `T::Configuration.drop_unchecked_sigs!`
+# and `T::Configuration.enable_checking_for_sigs_marked_checked_tests` are isolated
+# from the main test process. It must not call `T::Utils.run_all_sig_blocks`, which
+# wraps the `.checked(:tests)` sigs of sorbet-runtime itself.
+
+def check(description, loc: caller_locations(1, 1).first)
+  unless yield
+    puts "FAIL: #{loc.path}:#{loc.lineno}: #{description}"
+  end
+end
+
+# Dropping must not read `RuntimeLevels.check_tests?` on its own, otherwise it
+# would close the window for turning on `:tests`-level checking.
+T::Configuration.drop_unchecked_sigs!
+
+check("test-level checking can still be turned on") do
+  T::Configuration.enable_checking_for_sigs_marked_checked_tests
+  true
+rescue StandardError => e
+  puts "  #{e.message}"
+  false
+end
+
+# In a test environment a `.checked(:tests)` sig is a checked sig, so it is kept
+# and it still validates.
+klass = Class.new do
+  extend T::Sig
+
+  sig { params(x: Symbol).returns(Symbol).checked(:tests) }
+  def foo(x)
+    x
+  end
+  alias_method :bar, :foo
+end
+
+check("the method runs") { klass.new.foo(:foo) == :foo }
+check("the sig is kept") { !T::Utils.signature_for_method(klass.instance_method(:foo)).nil? }
+check("the alias still validates") do
+  klass.new.bar(1)
+  false
+rescue TypeError
+  true
+end
+
+puts "PASS"

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -483,6 +483,9 @@ module T::Utils
   # optimize for first-call/first-request latency.
   sig { void }
   def self.eagerly_define_all_lazy_props_methods!; end
+
+  sig { void }
+  def self.drop_unchecked_sigs!; end
 end
 
 

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -400,6 +400,8 @@ module T::Configuration
   def self.enable_final_checks_on_hooks; end
   def self.enable_legacy_t_enum_migration_mode; end
   def self.reset_final_checks_on_hooks; end
+  sig {void}
+  def self.drop_unchecked_sigs!; end
   sig {returns(T::Boolean)}
   def self.include_value_in_type_errors?; end
   sig {void}

--- a/website/docs/load-time-tuning.md
+++ b/website/docs/load-time-tuning.md
@@ -23,6 +23,13 @@ For certain applications, like HTTP services, these methods mitigate first-call 
 
 Call these methods **after** all application code has been loaded (e.g., in a Rails initializer or a `before_fork` hook) but **before** forking workers (so the initialized state is shared across processes via copy-on-write).
 
+There is also a method that frees memory at that same point, instead of forcing work to happen early:
+
+```ruby
+# Free the signatures whose runtime checks never run
+T::Configuration.drop_unchecked_sigs!
+```
+
 [nakayoshi_fork]: https://github.com/ko1/nakayoshi_fork
 
 ## `T::Utils.run_all_sig_blocks`
@@ -52,3 +59,33 @@ T::Utils.eagerly_define_all_lazy_props_methods!
 Classes that include `T::Props::Serializable` (including `T::Struct`) generate specialized `serialize` and `from_hash` methods using codegen for runtime performance (mostly: to avoid contention for VM-level method call caches). These specialized methods are usually generated lazily on the first call to the ser/de methods. This method eagerly generates these specialized methods.
 
 > **Note**: The `serialize` and `from_hash` methods on `T::Struct` have a number of [gotchas and legacy behaviors](tstruct.md#serialize-and-from_hash-converting-tstruct-to-and-from-hash).
+
+## `T::Configuration.drop_unchecked_sigs!`
+
+```ruby
+T::Configuration.drop_unchecked_sigs!
+```
+
+A `sig` that never checks anything at runtime still costs memory: `sorbet-runtime` keeps its `Signature` object so that tools can introspect the method. These are the sigs marked `.checked(:never)`, plus the sigs marked `.checked(:tests)` outside of a test environment. In a large application they can hold many megabytes.
+
+This frees the signatures that `sorbet-runtime` holds already, and stops it from recording new ones for aliases. There is no way back: nothing can rebuild a freed signature, because its `sig` block has already run. Call the method again after loading more code, to free the new signatures too:
+
+```ruby
+T::Configuration.drop_unchecked_sigs!
+
+# … the application autoloads more code …
+
+T::Utils.run_all_sig_blocks           # evaluates the new sig blocks
+T::Configuration.drop_unchecked_sigs! # frees the ones that never check anything
+```
+
+Runtime dispatch never uses these signatures, so calls behave the same. Methods with such sigs keep no wrapper at all, so `Method#arity`, `Method#source_location` and `Method#parameters` report the same values as before. The option only trades away introspection:
+
+- `T::Utils.signature_for_method` returns `nil` for those methods.
+- Final method violations lose the `Made final here:` source location.
+
+Signatures on `abstract` methods are never dropped, because `T::AbstractUtils` reads them at any time.
+
+> **Note**: An application that prepends `T::CompatibilityPatches::MethodExtensions` must take the `Method` object after the `sig` block has run. A handle taken from the first-call wrapper before that reports the parameters of the wrapper, because the patch can no longer find the dropped signature.
+
+> **Note**: Call this only after the application has loaded all of its code, in the same way as `T::Utils.run_all_sig_blocks`. A `sig` block that runs later cannot see a dropped signature on the method it overrides, so `sorbet-runtime` skips the override checks against that parent signature.

--- a/website/docs/load-time-tuning.md
+++ b/website/docs/load-time-tuning.md
@@ -23,6 +23,13 @@ For certain applications, like HTTP services, these methods mitigate first-call 
 
 Call these methods **after** all application code has been loaded (e.g., in a Rails initializer or a `before_fork` hook) but **before** forking workers (so the initialized state is shared across processes via copy-on-write).
 
+There is also a method that frees memory at that same point, instead of forcing work to happen early:
+
+```ruby
+# Free the signatures whose runtime checks never run
+T::Utils.drop_unchecked_sigs!
+```
+
 [nakayoshi_fork]: https://github.com/ko1/nakayoshi_fork
 
 ## `T::Utils.run_all_sig_blocks`
@@ -52,3 +59,33 @@ T::Utils.eagerly_define_all_lazy_props_methods!
 Classes that include `T::Props::Serializable` (including `T::Struct`) generate specialized `serialize` and `from_hash` methods using codegen for runtime performance (mostly: to avoid contention for VM-level method call caches). These specialized methods are usually generated lazily on the first call to the ser/de methods. This method eagerly generates these specialized methods.
 
 > **Note**: The `serialize` and `from_hash` methods on `T::Struct` have a number of [gotchas and legacy behaviors](tstruct.md#serialize-and-from_hash-converting-tstruct-to-and-from-hash).
+
+## `T::Utils.drop_unchecked_sigs!`
+
+```ruby
+T::Utils.drop_unchecked_sigs!
+```
+
+A `sig` that never checks anything at runtime still costs memory: `sorbet-runtime` keeps its `Signature` object so that tools can introspect the method. These are the sigs marked `.checked(:never)`, plus the sigs marked `.checked(:tests)` outside of a test environment. In a large application they can hold many megabytes.
+
+This frees the signatures that `sorbet-runtime` holds already. There is no way back: nothing can rebuild a freed signature, because its `sig` block has already run. Signatures built after the call are recorded as usual: a `sig` block that runs later, either on the first call to its method or through `T::Utils.run_all_sig_blocks`, and the first call to a method through an alias. Call the method again to free those too:
+
+```ruby
+T::Utils.drop_unchecked_sigs!
+
+# … the application autoloads more code …
+
+T::Utils.run_all_sig_blocks   # evaluates the new sig blocks
+T::Utils.drop_unchecked_sigs! # frees the ones that never check anything
+```
+
+Runtime dispatch never uses these signatures, so calls behave the same. Methods with such sigs keep no wrapper at all, so `Method#arity`, `Method#source_location` and `Method#parameters` report the same values as before. The option only trades away introspection:
+
+- `T::Utils.signature_for_method` returns `nil` for those methods.
+- Final method violations lose the `Made final here:` source location.
+
+Signatures on `abstract` methods are never dropped, because `T::AbstractUtils` reads them at any time.
+
+> **Note**: An application that prepends `T::CompatibilityPatches::MethodExtensions` must take the `Method` object after the `sig` block has run. A handle taken from the first-call wrapper before that reports the parameters of the wrapper, because the patch can no longer find the dropped signature.
+
+> **Note**: Call this only after the application has loaded all of its code, in the same way as `T::Utils.run_all_sig_blocks`. A `sig` block that runs later cannot see a dropped signature on the method it overrides, so `sorbet-runtime` skips the override checks against that parent signature.


### PR DESCRIPTION
A `sig` whose runtime checks never run still costs memory. `sorbet-runtime` keeps every `Signature` in `@signatures_by_method` so that tools can introspect the method. These are the `.checked(:never)` sigs, plus the `.checked(:tests)` sigs outside a test environment. Such methods keep no wrapper at all, so nothing but introspection reads those objects.

This PR adds the following public method for dropping those sigs that are unchecked:

```ruby
T::Utils.run_all_sig_blocks    # eagerly run sig blocks
T::Utils.drop_unchecked_sigs!  # free them from the registry
```

This call frees the signatures `sorbet-runtime` holds already, and keeps no state at all. It touches neither the wrapping nor the dispatch path, so signatures built after the call are recorded as usual: any `sig` block that runs later records the signature it derives back in the lookup table. Calling `drop_unchecked_sigs!` a second time frees those too.

The `drop_unchecked_sigs!` clears signatures from the signature look up table rather than preventing them from being inserted in the first place. This is because `run_sig_block_for_key` needs to read the registry to serve a thread that lost the race to run a `sig` block. Skipping inserting the signature into the lookup table at the source would have turned that benign case into a raise, including inside `run_all_sig_blocks` itself.

Since the method keeps no state, it is on `T::Utils`, next to `run_all_sig_blocks`, `run_all_type_alias_blocks` and `eagerly_define_all_lazy_props_methods!`. It is a one shot action at preload time, and not a configuration. There is also no way to undo it, because nothing can rebuild a freed signature.

The drawbacks of calling `drop_unchecked_sigs!` is documented in `website/docs/load-time-tuning.md` as the following:

- `T::Utils.signature_for_method` will return `nil` for those methods.
- Final method violations will lose the `Made final here:` source location.
- A `sig` block that runs after the call cannot see a dropped parent signature, so `sorbet-runtime` skips the override checks against it. Call it after the application has loaded all of its code, like `T::Utils.run_all_sig_blocks`.

Signatures on abstract methods are never dropped.

### Motivation

At Shopify we run all `sig` blocks after boot with checked level `never`. That unwraps every method eagerly, and the registry, and its associated `Signature` objects, just become dead weight of about 70 megabytes.

The alias path was the blocker for simply clearing the registry: an alias shares the first-call wrapper of the original and re-recorded its own signature on its first call. #10397 has already removed the registry from the alias dispatch path, so only the bookkeeping remained, and #10502 has made further progress on that front, so that this can become a method that needs no persistent state.

All we need at this point, is a safe way to clear the registry.

### Test plan

See the included automated tests.
