### PR TITLE
Rewrite RBS signatures inside keyword argument values

### DIFF
--- a/rbs/SigsRewriter.cc
+++ b/rbs/SigsRewriter.cc
@@ -589,6 +589,11 @@ void SigsRewriter::rewriteNode(pm_node_t *node) {
             rewriteNodes(hash->elements);
             break;
         }
+        case PM_KEYWORD_HASH_NODE: {
+            auto *hash = down_cast_nonnull<pm_keyword_hash_node_t>(node);
+            rewriteNodes(hash->elements);
+            break;
+        }
         case PM_ASSOC_NODE: {
             auto *pair = down_cast_nonnull<pm_assoc_node_t>(node);
             rewriteNode(pair->key);

--- a/test/testdata/rbs/signatures_keyword_arguments.rb
+++ b/test/testdata/rbs/signatures_keyword_arguments.rb
@@ -1,0 +1,25 @@
+# typed: strict
+# enable-experimental-rbs-comments: true
+
+module RbsKeywordArgumentSignatures
+
+  #: (Module[top] mod) -> void
+  def self.take(mod); end
+
+  #: (mod: Module[top]) -> void
+  def self.take_kw(mod:); end
+
+  take(Module.new do
+    #: (String name) -> void
+    def from_positional(name)
+      T.reveal_type(name) # error: Revealed type: `String`
+    end
+  end)
+
+  take_kw(mod: Module.new do
+    #: (String name) -> void
+    def from_keyword(name)
+      T.reveal_type(name) # error: Revealed type: `String`
+    end
+  end)
+end

--- a/test/testdata/rbs/signatures_keyword_arguments.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_keyword_arguments.rb.rewrite-tree.exp
@@ -1,0 +1,47 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C RbsKeywordArgumentSignatures><<C <todo sym>>> < ()
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:mod, ::<root>::<C T>::<C Module>.<syntheticSquareBrackets>(::<root>::<C T>.anything())).void()
+    end
+
+    def self.take<<todo method>>(mod, &<blk>)
+      <emptyTree>
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:mod, ::<root>::<C T>::<C Module>.<syntheticSquareBrackets>(::<root>::<C T>.anything())).void()
+    end
+
+    def self.take_kw<<todo method>>(mod:, &<blk>)
+      <emptyTree>
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:name, <emptyTree>::<C String>).void()
+    end
+
+    def from_positional<<todo method>>(name, &<blk>)
+      <emptyTree>::<C T>.reveal_type(name)
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.params(:name, <emptyTree>::<C String>).void()
+    end
+
+    def from_keyword<<todo method>>(name, &<blk>)
+      <emptyTree>::<C T>.reveal_type(name)
+    end
+
+    <runtime method definition of self.take>
+
+    <runtime method definition of self.take_kw>
+
+    <self>.take(<emptyTree>::<C Module>.new() do ||
+        <runtime method definition of from_positional>
+      end)
+
+    <self>.take_kw(:mod, <emptyTree>::<C Module>.new() do ||
+        <runtime method definition of from_keyword>
+      end)
+  end
+end


### PR DESCRIPTION
### Motivation

RBS signature comments inside blocks passed as keyword argument values were not rewritten.

`SigsRewriter` traversed regular hashes and association nodes, but did not traverse Prism's `PM_KEYWORD_HASH_NODE`. This stopped the rewrite walk before reaching blocks nested inside keyword argument values.

Given a call like:

```ruby
take_kw(mod: Module.new do
  #: (String name) -> void
  def from_keyword(name)
    T.reveal_type(name)
  end
end)
 ```

the RBS comment was associated with from_keyword, but its generated Sorbet signature was missing. The equivalent block passed as a positional argument already worked.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
