### PR TITLE
Fix Flatten hoisting non-signature `sig` calls out of method bodies

### DIFF
--- a/rewriter/Flatten.cc
+++ b/rewriter/Flatten.cc
@@ -320,12 +320,32 @@ public:
         tree = ast::MK::EmptyTree();
     };
 
+    // This mirrors (a subset of) resolver::TypeSyntax::isSig, which we can't call directly here because `rewriter`
+    // runs before `resolver` exists in the pipeline. We only want to treat a `sig` call as a real Sorbet signature
+    // when it's shaped like one: a bare `sig { ... }` (implicit self receiver) or `T::Sig::WithoutRuntime.sig { ... }`
+    // -- not just any method happening to be named `sig` on an arbitrary receiver.
+    static bool isSigCall(const ast::Send &send) {
+        if (send.fun != core::Names::sig()) {
+            return false;
+        }
+        if (!send.hasBlock()) {
+            return false;
+        }
+        if (send.recv.isSelfReference()) {
+            return true;
+        }
+        if (auto recv = ast::cast_tree<ast::ConstantLit>(send.recv)) {
+            return recv->symbol() == core::Symbols::T_Sig_WithoutRuntime();
+        }
+        return false;
+    }
+
     void preTransformSend(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
         // we might want to move sigs, so we mostly use the same logic that we use for methods. The one exception is
         // that we don't know the 'staticness level' of a sig, as it depends on the method that follows it (whether that
         // method has a `self.` or not), so we'll fill that information in later
-        if (send.fun == core::Names::sig()) {
+        if (isSigCall(send)) {
             curMethodSet().pushScope(computeScopeInfo(ScopeType::StaticMethodScope));
         }
     }
@@ -334,7 +354,7 @@ public:
         auto &send = ast::cast_tree_nonnull<ast::Send>(tree);
         auto &methods = curMethodSet();
         // if it's not a send, then we didn't make a stack frame for it
-        if (send.fun != core::Names::sig()) {
+        if (!isSigCall(send)) {
             return;
         }
         // if we get a MethodData back, then we need to move this and replace it with a `nil`

--- a/rewriter/Flatten.cc
+++ b/rewriter/Flatten.cc
@@ -320,6 +320,25 @@ public:
         tree = ast::MK::EmptyTree();
     };
 
+    // Detects a receiver of `T::Sig::WithoutRuntime`. Flatten runs before the namer/resolver, so a source-level
+    // constant reference like this is still an `UnresolvedConstantLit` scope chain, not a resolved `ConstantLit`
+    // (that only happens later); we still also check the resolved form since some earlier-running rewriter passes
+    // synthesize sigs with an already-resolved receiver (see ast::MK::Sig/SigVoid/Sig0 in ast/Helpers.h).
+    static bool isWithoutRuntimeSigReceiver(const ast::ExpressionPtr &recv) {
+        if (auto unresolved = ast::cast_tree<ast::UnresolvedConstantLit>(recv)) {
+            if (unresolved->cnst != core::Names::Constants::WithoutRuntime()) {
+                return false;
+            }
+            auto scope = ast::cast_tree<ast::UnresolvedConstantLit>(unresolved->scope);
+            return scope != nullptr && scope->cnst == core::Names::Constants::Sig() &&
+                   ast::MK::isTApproximate(scope->scope);
+        }
+        if (auto resolved = ast::cast_tree<ast::ConstantLit>(recv)) {
+            return resolved->symbol() == core::Symbols::T_Sig_WithoutRuntime();
+        }
+        return false;
+    }
+
     // This mirrors (a subset of) resolver::TypeSyntax::isSig, which we can't call directly here because `rewriter`
     // runs before `resolver` exists in the pipeline. We only want to treat a `sig` call as a real Sorbet signature
     // when it's shaped like one: a bare `sig { ... }` (implicit self receiver) or `T::Sig::WithoutRuntime.sig { ... }`
@@ -334,10 +353,7 @@ public:
         if (send.recv.isSelfReference()) {
             return true;
         }
-        if (auto recv = ast::cast_tree<ast::ConstantLit>(send.recv)) {
-            return recv->symbol() == core::Symbols::T_Sig_WithoutRuntime();
-        }
-        return false;
+        return isWithoutRuntimeSigReceiver(send.recv);
     }
 
     void preTransformSend(core::Context ctx, ast::ExpressionPtr &tree) {

--- a/test/testdata/rewriter/flatten_sig_wrong_receiver.rb
+++ b/test/testdata/rewriter/flatten_sig_wrong_receiver.rb
@@ -28,24 +28,49 @@ class UsesHasSigMethod
   end
 end
 
+# A receiver whose constant chain looks superficially similar to
+# `T::Sig::WithoutRuntime` (same leaf name and nesting depth) but isn't --
+# Flatten must not treat this as a real signature either.
+module NotSorbet
+  module Sig
+    module WithoutRuntime
+      def self.sig(&blk); end
+    end
+  end
+end
+
+class UsesFakeWithoutRuntime
+  def outer
+    NotSorbet::Sig::WithoutRuntime.sig { void } # error: Method `void` does not exist on `UsesFakeWithoutRuntime`
+    def inner(x)
+      T.reveal_type(x) # error: Revealed type: `T.untyped`
+    end
+  end
+end
+
+# Real signatures must still be found and flattened alongside their nested
+# `def`, with the type info actually applying to the resulting method (not
+# just the method existing).
 class RealSigStillFlattened
   extend T::Sig
 
   def outer
-    sig { void }
-    def inner; end
+    sig { params(x: Integer).void }
+    def inner(x); end
   end
 end
 
 RealSigStillFlattened.new.outer
-RealSigStillFlattened.new.inner
+RealSigStillFlattened.new.inner(1)
+RealSigStillFlattened.new.inner("nope") # error: Expected `Integer` but found `String("nope")` for argument `x`
 
 class WithoutRuntimeSigStillFlattened
   def outer
-    T::Sig::WithoutRuntime.sig { void }
-    def inner; end
+    T::Sig::WithoutRuntime.sig { params(x: Integer).void }
+    def inner(x); end
   end
 end
 
 WithoutRuntimeSigStillFlattened.new.outer
-WithoutRuntimeSigStillFlattened.new.inner
+WithoutRuntimeSigStillFlattened.new.inner(1)
+WithoutRuntimeSigStillFlattened.new.inner("nope") # error: Expected `Integer` but found `String("nope")` for argument `x`

--- a/test/testdata/rewriter/flatten_sig_wrong_receiver.rb
+++ b/test/testdata/rewriter/flatten_sig_wrong_receiver.rb
@@ -1,0 +1,51 @@
+# typed: true
+# https://github.com/sorbet/sorbet/issues/7768
+#
+# The Flatten rewriter pass used to hoist any Send named `sig` out of a method
+# body, regardless of receiver, mistaking `x.sig { ... }` for a real Sorbet
+# signature. That moved the call to class scope where `x` didn't exist,
+# producing bogus type errors. Flatten should only treat a `sig` call as a
+# real signature when it's a bare `sig { ... }` (implicit self) or
+# `T::Sig::WithoutRuntime.sig { ... }`.
+
+class A
+  extend T::Sig
+
+  def foo(x)
+    x.sig { void } # error: Method `void` does not exist on `A`
+  end
+end
+
+class HasSigMethod
+  def sig
+    "not a signature"
+  end
+end
+
+class UsesHasSigMethod
+  def bar(h)
+    T.reveal_type(h.sig) # error: Revealed type: `T.untyped`
+  end
+end
+
+class RealSigStillFlattened
+  extend T::Sig
+
+  def outer
+    sig { void }
+    def inner; end
+  end
+end
+
+RealSigStillFlattened.new.outer
+RealSigStillFlattened.new.inner
+
+class WithoutRuntimeSigStillFlattened
+  def outer
+    T::Sig::WithoutRuntime.sig { void }
+    def inner; end
+  end
+end
+
+WithoutRuntimeSigStillFlattened.new.outer
+WithoutRuntimeSigStillFlattened.new.inner


### PR DESCRIPTION
The `rewriter::Flatten` pass matched any `Send` named `sig`, regardless of receiver, and hoisted it out of the enclosing method body to class scope. This meant a call like `x.sig { void }` (where `x` is just some local variable, unrelated to Sorbet signatures) was mistaken for a real `sig { ... }` declaration and moved to a context where `x` no longer exists, producing bogus errors such as `Method 'sig' does not exist on 'NilClass'`.

This PR restricts the hoisting to calls that are actually shaped like a real Sorbet signature: a bare `sig { ... }` (implicit `self` receiver) or `T::Sig::WithoutRuntime.sig { ... }`, each requiring a block. This mirrors (a subset of) the logic in `resolver::TypeSyntax::isSig`, which `Flatten` can't call directly since rewriter passes run before the resolver exists in the pipeline, so the relevant check is duplicated locally.

### Motivation

Fixes #7768.

### Test plan

Added `test/testdata/rewriter/flatten_sig_wrong_receiver.rb`, covering:
- The original bug case (`x.sig { void }` inside a method body) — now type-checks sensibly instead of producing the bogus NilClass error.
- A false-positive guard: a user-defined `.sig` method on an unrelated class, called through an untyped receiver.
- Confirmation that real signatures — both bare `sig { ... }` and `T::Sig::WithoutRuntime.sig { ... }` — are still correctly hoisted alongside a nested `def`.

Verified locally:
- Reproduced the original bug against unmodified `master` (confirmed the exact `NilClass` error from the issue).
- Confirmed the fix resolves it.
- Ran the full `test/testdata/rewriter` suite (154 files) and all `.flatten-tree.exp` snapshot tests repo-wide — no regressions.
