### PR TITLE
RBS `absurd` annotations require a `raise`

### DIFF
--- a/core/errors/rewriter.h
+++ b/core/errors/rewriter.h
@@ -33,6 +33,7 @@ inline constexpr ErrorClass RBSMultilineMisformatted{3555, StrictLevel::False};
 inline constexpr ErrorClass RBSIncorrectParameterKind{3556, StrictLevel::False};
 inline constexpr ErrorClass RBSMultipleGenericSignatures{3557, StrictLevel::False};
 inline constexpr ErrorClass RBSAbstractMethodNoRaises{3558, StrictLevel::False};
+inline constexpr ErrorClass RBSAbsurdError{3559, StrictLevel::False};
 
 } // namespace sorbet::core::errors::Rewriter
 #endif

--- a/rbs/AssertionsRewriter.cc
+++ b/rbs/AssertionsRewriter.cc
@@ -2,6 +2,7 @@
 
 #include "absl/strings/match.h"
 #include "core/errors/rewriter.h"
+#include "rbs/PrismUtils.h"
 #include "rbs/SignatureTranslator.h"
 #include <cctype>
 #include <regex>
@@ -15,7 +16,8 @@ namespace {
 
 const regex notNilPattern("^\\s*!nil\\s*(#.*)?$");
 const regex untypedPattern("^\\s*untyped\\s*(#.*)?$");
-const regex absurdPattern("^\\s*absurd\\s*(#.*)?$");
+const regex absurdPrefixPattern("^\\s*absurd(?:\\s|\\(|#|$)");
+const regex absurdPattern("^(\\s*absurd\\s*\\(\\s*((?:@@|@|\\$)?[A-Za-z_][A-Za-z0-9_]*|self)\\s*\\))\\s*(#.*)?$");
 
 /*
  * Parse the comment and return the type as a `pm_node_t*` and the kind of assertion we need to apply (let, cast,
@@ -30,8 +32,7 @@ parseComment(core::MutableContext ctx, parser::Prism::Parser &parser, InlineComm
              absl::Span<pair<core::LocOffsets, core::NameRef>> typeParams) {
     Factory prism{parser};
 
-    if (comment.kind == InlineComment::Kind::MUST || comment.kind == InlineComment::Kind::UNSAFE ||
-        comment.kind == InlineComment::Kind::ABSURD) {
+    if (comment.kind == InlineComment::Kind::MUST || comment.kind == InlineComment::Kind::UNSAFE) {
         // The type should never be used but we need to hold the location...
         return pair{prism.Nil(comment.comment.typeLoc), comment.kind};
     }
@@ -382,7 +383,7 @@ optional<rbs::InlineComment> AssertionsRewriter::commentForNode(pm_node_t *node)
             } else if (regex_match(content.begin(), content.end(), untypedPattern)) {
                 kind = InlineComment::Kind::UNSAFE;
             }
-        } else if (regex_match(content.begin(), content.end(), absurdPattern)) {
+        } else if (regex_search(content.begin(), content.end(), absurdPrefixPattern)) {
             kind = InlineComment::Kind::ABSURD;
         } else if (absl::StartsWith(content, "self as ")) {
             kind = InlineComment::Kind::BIND;
@@ -416,7 +417,7 @@ optional<rbs::InlineComment> AssertionsRewriter::commentForNode(pm_node_t *node)
  * - `x #: X`: `T.let(x, X)`
  * - `x #: as X`: `T.cast(x, X)`
  * - `x #: as !nil`: `T.must(x)`
- * - `x #: as untyped`: `T.unsafe(x)`
+ * - `raise #: absurd(x)`: `T.absurd(x)`
  */
 pm_node_t *AssertionsRewriter::insertCast(pm_node_t *node, optional<pair<pm_node_t *, InlineComment::Kind>> pair) {
     if (!pair) {
@@ -443,7 +444,7 @@ pm_node_t *AssertionsRewriter::insertCast(pm_node_t *node, optional<pair<pm_node
         case InlineComment::Kind::UNSAFE:
             return prism.TUnsafe(typeLoc, node);
         case InlineComment::Kind::ABSURD:
-            return prism.TAbsurd(typeLoc, node);
+            unreachable("RBS absurd assertions are handled before generic assertions");
         case InlineComment::Kind::BIND:
             if (auto e = ctx.beginIndexerError(typeLoc, core::errors::Rewriter::RBSUnsupported)) {
                 e.setHeader("`{}` binding can't be used as a trailing comment", "self");
@@ -476,8 +477,75 @@ pm_node_t *AssertionsRewriter::replaceSyntheticBind(pm_node_t *node) {
     return prism.TBindSelf(typeLoc, type);
 }
 
+namespace {
+
+pm_node_t *variableReadNode(Factory &prism, parser::Prism::Parser &parser, string_view name, core::LocOffsets loc) {
+    if (name == "self") {
+        return prism.Self(loc);
+    }
+
+    auto nameId = prism.addConstantToPool(name);
+    auto pmLoc = parser.convertLocOffsets(loc);
+
+    if (absl::StartsWith(name, "@@")) {
+        auto *node = prism.allocateNode<pm_class_variable_read_node_t>();
+        *node = {.base = prism.initializeBaseNode(PM_CLASS_VARIABLE_READ_NODE, pmLoc), .name = nameId};
+        return up_cast(node);
+    }
+    if (absl::StartsWith(name, "@")) {
+        auto *node = prism.allocateNode<pm_instance_variable_read_node_t>();
+        *node = {.base = prism.initializeBaseNode(PM_INSTANCE_VARIABLE_READ_NODE, pmLoc), .name = nameId};
+        return up_cast(node);
+    }
+    if (absl::StartsWith(name, "$")) {
+        auto *node = prism.allocateNode<pm_global_variable_read_node_t>();
+        *node = {.base = prism.initializeBaseNode(PM_GLOBAL_VARIABLE_READ_NODE, pmLoc), .name = nameId};
+        return up_cast(node);
+    }
+
+    auto *node = prism.allocateNode<pm_local_variable_read_node_t>();
+    *node = {.base = prism.initializeBaseNode(PM_LOCAL_VARIABLE_READ_NODE, pmLoc), .name = nameId, .depth = 0};
+    return up_cast(node);
+}
+
+} // namespace
+
 /**
- * Insert a cast into the given Prism node if there is an not yet consumed RBS assertion comment.
+ * Rewrite `raise #: absurd(x)` to `T.absurd(x)`.
+ */
+pm_node_t *AssertionsRewriter::rewriteAbsurd(pm_node_t *node, const InlineComment &comment) {
+    auto errorLoc = comment.comment.typeLoc;
+    if (!isRaiseCall(node, parser)) {
+        if (auto e = ctx.beginIndexerError(errorLoc, core::errors::Rewriter::RBSAbsurdError)) {
+            e.setHeader("RBS `{}` must annotate a `{}`", "absurd", "raise");
+        }
+        return node;
+    }
+
+    match_results<string_view::const_iterator> matches;
+    auto content = comment.comment.string;
+    if (!regex_match(content.begin(), content.end(), matches, absurdPattern)) {
+        if (auto e = ctx.beginIndexerError(errorLoc, core::errors::Rewriter::RBSAbsurdError)) {
+            e.setHeader("RBS `{}` requires a variable name", "absurd");
+        }
+        return node;
+    }
+
+    auto invocationLoc = core::LocOffsets{
+        errorLoc.beginPos() + static_cast<uint32_t>(matches.position(1)),
+        errorLoc.beginPos() + static_cast<uint32_t>(matches.position(1) + matches.length(1)),
+    };
+    auto variableLoc = core::LocOffsets{
+        errorLoc.beginPos() + static_cast<uint32_t>(matches.position(2)),
+        errorLoc.beginPos() + static_cast<uint32_t>(matches.position(2) + matches.length(2)),
+    };
+    auto variableName = content.substr(matches.position(2), matches.length(2));
+    auto *replacement = prism.TAbsurd(invocationLoc, variableReadNode(prism, parser, variableName, variableLoc));
+    return replacement;
+}
+
+/**
+ * Insert an assertion into the given Prism node if there is an unconsumed RBS assertion comment.
  */
 pm_node_t *AssertionsRewriter::maybeInsertCast(pm_node_t *node) {
     if (node == nullptr) {
@@ -485,6 +553,9 @@ pm_node_t *AssertionsRewriter::maybeInsertCast(pm_node_t *node) {
     }
 
     if (auto inlineComment = commentForNode(node)) {
+        if (inlineComment->kind == InlineComment::Kind::ABSURD) {
+            return rewriteAbsurd(node, *inlineComment);
+        }
         if (auto type = parseComment(ctx, parser, inlineComment.value(), absl::MakeSpan(typeParams))) {
             return insertCast(node, type);
         }

--- a/rbs/AssertionsRewriter.h
+++ b/rbs/AssertionsRewriter.h
@@ -60,6 +60,7 @@ private:
     pm_node_t *maybeInsertCast(pm_node_t *node);
     pm_node_t *insertCast(pm_node_t *node, std::optional<std::pair<pm_node_t *, InlineComment::Kind>> pair);
     pm_node_t *replaceSyntheticBind(pm_node_t *node);
+    pm_node_t *rewriteAbsurd(pm_node_t *node, const InlineComment &comment);
 };
 
 } // namespace sorbet::rbs

--- a/rbs/MethodTypeToParserNode.cc
+++ b/rbs/MethodTypeToParserNode.cc
@@ -3,6 +3,7 @@
 #include "absl/algorithm/container.h"
 #include "core/errors/rewriter.h"
 #include "parser/prism/Helpers.h"
+#include "rbs/PrismUtils.h"
 #include "rbs/TypeToParserNode.h"
 #include "rbs/rbs_method_common.h"
 
@@ -16,29 +17,6 @@ using namespace sorbet::parser::Prism;
 namespace sorbet::rbs {
 
 namespace {
-
-bool isSelfOrKernel(pm_node_t *node, const parser::Prism::Parser *prismParser) {
-    if (isa_node<pm_self_node>(node)) {
-        return true;
-    }
-
-    if (auto *constant = down_cast<pm_constant_read_node_t>(node)) {
-        auto name = prismParser->resolveConstant(constant->name);
-        // Check if it's Kernel constant with no scope (::Kernel or bare Kernel)
-        return name == "Kernel";
-    }
-
-    if (auto *constantPath = down_cast<pm_constant_path_node_t>(node)) {
-        // Check if it's ::Kernel (parent is nullptr, representing root ::)
-        // We reject Foo::Kernel or any other scoped constant
-        if (constantPath->parent == nullptr) {
-            auto name = prismParser->resolveConstant(constantPath->name);
-            return name == "Kernel";
-        }
-    }
-
-    return false;
-}
 
 core::AutocorrectSuggestion autocorrectAbstractBody(core::MutableContext ctx, pm_node_t *method,
                                                     const parser::Prism::Parser *prismParser, pm_node_t *method_body) {
@@ -91,15 +69,7 @@ bool isValidAbstractMethod(pm_node_t *node, const parser::Prism::Parser *prismPa
         bodyNode = stmts->body.nodes[0];
     }
 
-    auto *call = down_cast<pm_call_node_t>(bodyNode);
-    if (call == nullptr) {
-        return false;
-    }
-
-    auto methodName = prismParser->resolveConstant(call->name);
-
-    // Check if it's a raise call with no receiver or self/Kernel receiver
-    return methodName == "raise" && (call->receiver == nullptr || isSelfOrKernel(call->receiver, prismParser));
+    return isRaiseCall(bodyNode, *prismParser);
 }
 
 void ensureAbstractMethodRaises(core::MutableContext ctx, pm_node_t *node, parser::Prism::Parser *prismParser) {

--- a/rbs/PrismUtils.h
+++ b/rbs/PrismUtils.h
@@ -1,0 +1,37 @@
+#ifndef SORBET_RBS_PRISM_UTILS_H
+#define SORBET_RBS_PRISM_UTILS_H
+
+#include "parser/prism/Helpers.h"
+#include "parser/prism/Parser.h"
+
+namespace sorbet::rbs {
+
+inline bool isSelfOrKernel(pm_node_t *node, const parser::Prism::Parser &parser) {
+    using namespace parser::Prism;
+
+    if (isa_node<pm_self_node_t>(node)) {
+        return true;
+    }
+
+    if (auto *constant = down_cast<pm_constant_read_node_t>(node)) {
+        return parser.resolveConstant(constant->name) == "Kernel";
+    }
+
+    if (auto *constantPath = down_cast<pm_constant_path_node_t>(node)) {
+        return constantPath->parent == nullptr && parser.resolveConstant(constantPath->name) == "Kernel";
+    }
+
+    return false;
+}
+
+inline bool isRaiseCall(pm_node_t *node, const parser::Prism::Parser &parser) {
+    using namespace parser::Prism;
+
+    auto *call = down_cast<pm_call_node_t>(node);
+    return call != nullptr && parser.resolveConstant(call->name) == "raise" &&
+           (call->receiver == nullptr || isSelfOrKernel(call->receiver, parser));
+}
+
+} // namespace sorbet::rbs
+
+#endif // SORBET_RBS_PRISM_UTILS_H

--- a/test/testdata/rbs/assertions_absurd.rb
+++ b/test/testdata/rbs/assertions_absurd.rb
@@ -9,7 +9,7 @@ def normal_usage(x)
   when String
     puts x
   else
-    x #: absurd
+    raise #: absurd(x)
   end
 end
 
@@ -19,7 +19,7 @@ def forgotten_case(x)
   when Integer
     puts x
   else
-    x #: absurd # error: Control flow could reach `T.absurd` because the type `String` wasn't handled
+    raise #: absurd(x) # error: Control flow could reach `T.absurd` because the type `String` wasn't handled
   end
 end
 
@@ -32,7 +32,7 @@ def got_all_cases_but_untyped(x)
   when String
     puts y
   else
-    y #: absurd # error: Control flow could reach `T.absurd` because argument was `T.untyped`
+    raise RuntimeError #: absurd(y) # error: Control flow could reach `T.absurd` because argument was `T.untyped`
   end
 end
 
@@ -42,7 +42,7 @@ def forgotten_two_cases(x)
   when Integer
     puts x
   else
-    x #: absurd # error: Control flow could reach `T.absurd` because the type `T.any(String, T::Array[Integer])` wasn't handled
+    raise RuntimeError, "Unhandled value" #: absurd(x) # error: Control flow could reach `T.absurd` because the type `T.any(String, T::Array[Integer])` wasn't handled
   end
 end
 
@@ -52,7 +52,7 @@ def missing_case_with_generic(x)
   when Array
     puts x
   else
-    x #: absurd # error: Control flow could reach `T.absurd` because the type `String` wasn't handled
+    raise #: absurd(x) # error: Control flow could reach `T.absurd` because the type `String` wasn't handled
   end
 end
 
@@ -62,7 +62,7 @@ def ok_when_generic_cases_overlap(x)
   when Array
     puts x
   else
-    x #: absurd
+    raise #: absurd(x)
   end
 end
 
@@ -75,7 +75,7 @@ def dead_code_before(x)
     puts x
   else
     puts 1 # error: This code is unreachable
-    x #: absurd
+    raise #: absurd(x)
   end
 end
 
@@ -87,7 +87,7 @@ def dead_code_after(x)
   when String
     puts x
   else
-    x #: absurd
+    raise #: absurd(x)
     puts 1 # error: This code is unreachable
   end
 end
@@ -105,7 +105,7 @@ def cant_alias_local_variables(x)
     # with it, and couldn't see a simple solution that avoided emitting one.
     y = x
     #   ^ error: This code is unreachable
-    y #: absurd
+    raise #: absurd(y)
   end
 end
 
@@ -116,7 +116,7 @@ def normal_usage_with_isa(x)
   elsif x.is_a?(String)
     puts x
   else
-    x #: absurd
+    raise #: absurd(x)
   end
 end
 
@@ -125,7 +125,7 @@ def missing_case_with_isa(x)
   if x.is_a?(Integer)
     puts x
   else
-    x #: absurd # error: Control flow could reach `T.absurd` because the type `String` wasn't handled
+    raise #: absurd(x) # error: Control flow could reach `T.absurd` because the type `String` wasn't handled
   end
 end
 
@@ -134,7 +134,7 @@ def enforce_something_is_always_non_nil(x)
   if !x.nil?
     puts x
   else
-    x #: absurd
+    raise #: absurd(x)
   end
 end
 
@@ -143,7 +143,7 @@ def error_when_predicate_always_true(x)
   if !x.nil?
     puts 1 # not a dead code error, because it's always true!
     # This is a strange error message given the test case.
-    x #: absurd # error: Control flow could reach `T.absurd` because the type `Integer` wasn't handled
+    raise #: absurd(x) # error: Control flow could reach `T.absurd` because the type `Integer` wasn't handled
   end
 end
 
@@ -151,27 +151,27 @@ end
 
 def only_absurd
   temp1 = T.let(T.unsafe(nil), T.noreturn)
-  temp1 #: absurd
+  raise #: absurd(temp1)
 end
 
 #: (bot) -> void
 def allows_arg_noreturn(x)
-  x #: absurd
+  raise #: absurd(x)
   puts(x)
 # ^^^^^^^ error: This code is unreachable
 end
 
 #: (bot, bot) -> void
 def allows_args_noreturn(x, y)
-  x #: absurd
-  y #: absurd
+  raise #: absurd(x)
+  raise #: absurd(y)
   puts(x)
 # ^^^^^^^ error: This code is unreachable
 end
 
 #: (Integer & String) -> void
 def intersects_to_bottom(x)
-  x #: absurd
+  raise #: absurd(x)
   puts(x)
 # ^^^^^^^ error: This code is unreachable
 end
@@ -184,14 +184,14 @@ def absurd_not_reached_on_global_var
   case $some_global
   when TrueClass
   when FalseClass
-  else $some_global #: absurd # error: Control flow could reach `T.absurd` because argument was `T.untyped`
+  else raise #: absurd($some_global) # error: Control flow could reach `T.absurd` because argument was `T.untyped`
   end
 end
 
 #: -> void
 def absurd_reached_on_global_var
   if !$some_global
-    $some_global #: absurd # error: Control flow could reach `T.absurd` because the type `T.nilable(FalseClass)` wasn't handled
+    raise #: absurd($some_global) # error: Control flow could reach `T.absurd` because the type `T.nilable(FalseClass)` wasn't handled
   end
 end
 
@@ -209,14 +209,14 @@ class SomeClass
     when TrueClass
     when FalseClass
     else
-      @@some_class_var #: absurd
+      raise #: absurd(@@some_class_var)
     end
   end
 
   #: -> void
   def absurd_reached_on_class_var
     if !@@some_class_var
-      @@some_class_var #: absurd # error: Control flow could reach `T.absurd` because the type `FalseClass` wasn't handled
+      raise #: absurd(@@some_class_var) # error: Control flow could reach `T.absurd` because the type `FalseClass` wasn't handled
     end
   end
 
@@ -226,14 +226,14 @@ class SomeClass
     when TrueClass
     when FalseClass
     else
-      @some_instance_var #: absurd
+      raise #: absurd(@some_instance_var)
     end
   end
 
   #: -> void
   def absurd_reached_on_instance_var
     if !@some_instance_var
-      @some_instance_var #: absurd # error: Control flow could reach `T.absurd` because the type `FalseClass` wasn't handled
+      raise #: absurd(@some_instance_var) # error: Control flow could reach `T.absurd` because the type `FalseClass` wasn't handled
     end
   end
 end
@@ -241,20 +241,28 @@ end
 #: (bool) -> void
 def absurd_reached_on_local_var(some_local_var)
   if !some_local_var
-    some_local_var #: absurd # error: Control flow could reach `T.absurd` because the type `FalseClass` wasn't handled
+    raise #: absurd(some_local_var) # error: Control flow could reach `T.absurd` because the type `FalseClass` wasn't handled
   end
 end
 
 # --- incorrect usage ---------------------------------------------------------
 
 #: (Integer) -> void
-def not_enough_args(x)
-  #: absurd # error: Unexpected RBS assertion comment found in `method`
+def old_syntax(x)
+  x #: absurd # error: RBS `absurd` must annotate a `raise`
+end
+
+#: -> void
+def missing_variable
+  raise #: absurd # error: RBS `absurd` requires a variable name
 end
 
 #: (Integer) -> void
-def too_many_args(x)
-  if x.nil?
-    nil #: absurd # error: `T.absurd` expects to be called on a variable
-  end
+def invalid_variable(x)
+  raise #: absurd(x.to_s) # error: RBS `absurd` requires a variable name
+end
+
+#: (Integer) -> void
+def not_a_raise(x)
+  puts #: absurd(x) # error: RBS `absurd` must annotate a `raise`
 end

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -594,6 +594,31 @@ def baz
 end
 ```
 
+## 3559
+
+> This error is specific to RBS support when using the `--enable-experimental-rbs-comments` flag.
+
+RBS `absurd` assertions must annotate a `raise` and name the variable whose type should be checked for exhaustiveness:
+
+```ruby
+#: (Integer | String) -> void
+def handle(value)
+  case value
+  when Integer
+  when String
+  else
+    raise #: absurd(value)
+  end
+end
+```
+
+Annotating the variable directly, or omitting the variable name, raises this error:
+
+```ruby
+value #: absurd
+raise #: absurd
+```
+
 ## 3702
 
 > This error is specific to Stripe's custom `--sorbet-packages` mode. If you are at Stripe, please see [go/modularity](http://go/modularity) for more.

--- a/website/docs/rbs-support.md
+++ b/website/docs/rbs-support.md
@@ -1069,7 +1069,7 @@ x.undefined_method
 
 ### `T.absurd`
 
-[`T.absurd`](exhaustiveness.md) can be expressed using RBS comments:
+[`T.absurd`](exhaustiveness.md) can be expressed with an `absurd(variable)` comment on a `raise`:
 
 ```ruby
 #: (Integer | String) -> void
@@ -1078,16 +1078,24 @@ def foo(x)
   when Integer
   when String
   else
-    x #: absurd
+    raise #: absurd(x)
   end
 end
 ```
 
-This is equivalent to:
+Sorbet rewrites the annotated `raise` to the following expression internally:
 
 ```ruby
 T.absurd(x)
 ```
+
+The `raise` can include an exception type and message. These are used when the Ruby program runs, while Sorbet still uses the variable named by `absurd` to check exhaustiveness:
+
+```ruby
+raise ArgumentError, "Unexpected value: #{x}" #: absurd(x)
+```
+
+The `absurd` comment must annotate a `raise`, and it must name exactly one variable.
 
 ### `T.bind`
 


### PR DESCRIPTION
RBS comments currently express `T.absurd(x)` by annotating the variable:

```ruby
x #: absurd
```

This PR changes the syntax to annotate a `raise` and name the variable explicitly:

```ruby
raise #: absurd(x)
```

The `raise` may include an exception type and message:

```ruby
raise ArgumentError, "Unexpected value: #{x}" #: absurd(x)
```

Sorbet rewrites these forms internally to:

```ruby
T.absurd(x)
```

The new syntax supports local, instance, class, and global variables, as well as `self`.

Invalid uses receive a dedicated RBS error:

```ruby
x #: absurd
# error: RBS `absurd` must annotate a `raise`

raise #: absurd
# error: RBS `absurd` requires a variable name
```

### Motivation

The previous syntax does not preserve the runtime intent of `T.absurd`.

If Sorbet's exhaustiveness assumptions are violated, `T.absurd(x)` raises at runtime. In contrast, the old RBS form merely evaluates `x`:

```ruby
x #: absurd
```

That means the source can silently continue or return `x` at runtime even though Sorbet analyzes it as `T.absurd(x)`.

Requiring the annotation on a real `raise` keeps the Ruby program's runtime behavior aligned with Sorbet's exhaustiveness model. It also lets callers choose an appropriate exception type and message while Sorbet continues to analyze the branch as `T.absurd(x)`.

The explicit `absurd(x)` operand also separates the exhaustiveness subject from the expression carrying the annotation. This is necessary because the annotated expression is now the `raise`, not the variable being checked.