### PR TITLE
Fix hash2 type on transform_keys[!] methods

### DIFF
--- a/rbi/core/hash.rbi
+++ b/rbi/core/hash.rbi
@@ -1331,14 +1331,14 @@ class Hash < Object
   # If no block is given, an enumerator is returned instead.
   sig do
     type_parameters(:A).params(
-      hash2: T.nilable(T::Hash[T.type_parameter(:A), V]),
+      hash2: T.nilable(T::Hash[K, T.type_parameter(:A)]),
       blk: T.proc.params(arg0: K).returns(T.type_parameter(:A))
     )
     .returns(T::Hash[T.type_parameter(:A), V])
   end
   sig do
     type_parameters(:A).params(
-      hash2: T::Hash[T.type_parameter(:A), V],
+      hash2: T::Hash[K, T.type_parameter(:A)],
     )
     .returns(T::Hash[T.type_parameter(:A), V])
   end
@@ -1367,14 +1367,14 @@ class Hash < Object
   # If no block is given, an enumerator is returned instead.
   sig do
     type_parameters(:A).params(
-      hash2: T.nilable(T::Hash[T.type_parameter(:A), V]),
+      hash2: T.nilable(T::Hash[K, T.type_parameter(:A)]),
       blk: T.proc.params(arg0: K).returns(T.type_parameter(:A))
     )
     .returns(T::Hash[T.type_parameter(:A), V])
   end
   sig do
     type_parameters(:A).params(
-      hash2: T::Hash[T.type_parameter(:A), V],
+      hash2: T::Hash[K, T.type_parameter(:A)],
     )
     .returns(T::Hash[T.type_parameter(:A), V])
   end

--- a/test/testdata/rbi/hash.rb
+++ b/test/testdata/rbi/hash.rb
@@ -79,6 +79,13 @@ T.assert_type!(transformed_keys_hash2, T::Hash[Symbol, Float])
 transformed_keys_bang_hash2 = initial_hash.dup.transform_keys!({ a: :A, b: :B })
 T.assert_type!(transformed_keys_bang_hash2, T::Hash[Symbol, Float])
 
+key_map = T.let({ a: "a", b: "b" }, T::Hash[Symbol, String])
+transformed_keys_hash3 = initial_hash.dup.transform_keys(key_map)
+T.assert_type!(transformed_keys_hash3, T::Hash[String, Float])
+
+transformed_keys_bang_hash3 = initial_hash.dup.transform_keys!(key_map)
+T.assert_type!(transformed_keys_bang_hash3, T::Hash[String, Float])
+
 transformed_values_hash = initial_hash.transform_values(&:to_s)
 T.assert_type!(transformed_values_hash, T::Hash[Symbol, String])
 initial_hash.transform_values(&:size) # error: Method `size` does not exist on `Float`


### PR DESCRIPTION
### Motivation

The hash maps from old keys to new keys, so it should be a
`Hash[K, A]` not a `Hash[A, V]`.

### Test plan

Tests added to `test/testdata/rbi/hash.rb`.
