### PR TITLE
Preserve instance-vs-singleton error context in --suggest-unsafe mode

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -849,14 +849,16 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 // Note: super is not a method call, and so all the logic in the case below to
                 // compute autocorrects to potentially fix up the method call's receiver can't apply.
                 e.addErrorNote("For help fixing `{}` errors: {}", "super", "https://sorbet.org/docs/typed-super");
-            } else if (args.receiverLoc().exists() &&
-                       (gs.suggestUnsafe.has_value() ||
-                        (args.fullType.type != args.thisType && symbol == Symbols::NilClass() &&
-                         // Don't suggest T.must if the suggestion will produce bottom
-                         !Types::dropNil(gs, args.fullType.type).isBottom()))) {
-                auto wrapInFn = gs.suggestUnsafe.value_or("T.must");
-                autocorrectReceiver(gs, e, args, wrapInFn);
             } else {
+                if (args.receiverLoc().exists() &&
+                    (gs.suggestUnsafe.has_value() ||
+                     (args.fullType.type != args.thisType && symbol == Symbols::NilClass() &&
+                      // Don't suggest T.must if the suggestion will produce bottom
+                      !Types::dropNil(gs, args.fullType.type).isBottom()))) {
+                    auto wrapInFn = gs.suggestUnsafe.value_or("T.must");
+                    autocorrectReceiver(gs, e, args, wrapInFn);
+                }
+
                 auto canSkipFuzzyMatch = false;
                 if (symbol.data(gs)->isModule()) {
                     auto objMeth = core::Symbols::Object().data(gs)->findMethodTransitive(gs, args.name);

--- a/test/testdata/infer/suggest_unsafe_singleton_instance.rb
+++ b/test/testdata/infer/suggest_unsafe_singleton_instance.rb
@@ -1,0 +1,20 @@
+# typed: true
+# enable-suggest-unsafe: true
+extend T::Sig
+
+class A
+  def my_instance_method; end
+  def self.my_singleton_class_method; end
+
+  def example1
+    my_singleton_class_method # error: Method `my_singleton_class_method` does not exist on `A`
+  end
+  def self.example2
+    my_instance_method # error: Method `my_instance_method` does not exist on `T.class_of(A)`
+  end
+end
+
+sig {params(a: A).void}
+def example3(a)
+  a.my_singleton_class_method # error: Method `my_singleton_class_method` does not exist on `A`
+end

--- a/test/testdata/infer/suggest_unsafe_singleton_instance.rb.autocorrects.exp
+++ b/test/testdata/infer/suggest_unsafe_singleton_instance.rb.autocorrects.exp
@@ -1,0 +1,22 @@
+# -- test/testdata/infer/suggest_unsafe_singleton_instance.rb --
+# typed: true
+# enable-suggest-unsafe: true
+extend T::Sig
+
+class A
+  def my_instance_method; end
+  def self.my_singleton_class_method; end
+
+  def example1
+    T.unsafe()my_singleton_class_method # error: Method `my_singleton_class_method` does not exist on `A`
+  end
+  def self.example2
+    T.unsafe()my_instance_method # error: Method `my_instance_method` does not exist on `T.class_of(A)`
+  end
+end
+
+sig {params(a: A).void}
+def example3(a)
+  T.unsafe(a).class.my_singleton_class_method # error: Method `my_singleton_class_method` does not exist on `A`
+end
+# ------------------------------


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

When Sorbet reports an `UnknownMethod` error whose receiver is eligible for the `--suggest-unsafe` autocorrect (or the `T.must`-on-nilable-receiver case), it took an early branch that added *only* the unsafe-wrap autocorrect and skipped the rest of the diagnostic-building logic entirely. That logic is what produces:
- the "There is a singleton class method with the same name" section (and its `.class` / `self.class.` autocorrect), and
- the "Did you mean `X`?" fuzzy-match suggestion, and
- the "actually defined as a method on `Kernel`" hint.

Restructured so the unsafe-wrap autocorrect is added *in addition to* that diagnostic logic, rather than instead of it — the same pattern already used in `SelfTypeParam::dispatchCall` elsewhere in this file, where the suggest-unsafe autocorrect and the explanatory note both get added.

User-visible effect: running with `--suggest-unsafe` (or `-a --suggest-unsafe`) on an instance-vs-singleton-method mistake now keeps the explanatory context and offers both the specific fix and the blanket unsafe-wrap fix, instead of only the unsafe-wrap.

### Motivation

Fixes #8338. `--suggest-unsafe` is meant for bulk codemods, but silently dropping the actual explanation of *why* a call fails (and the correctly-targeted fix) makes it harder to tell real bugs from call sites that genuinely need loosening.

### Test plan

Added `test/testdata/infer/suggest_unsafe_singleton_instance.rb` (+ `.autocorrects.exp`), covering:
- implicit-receiver instance→singleton mismatch (the issue's repro)
- implicit-receiver singleton→instance mismatch (the mirror direction, different code path)
- explicit-receiver mismatch, asserting the two autocorrects (`T.unsafe(...)` wrap + `.class` insert) compose correctly into `T.unsafe(a).class.my_singleton_class_method`

Ran the full `infer` + `resolver` test suites (691 tests) and the related `test/cli` golden-output tests (`suggest_t_unsafe`, `suggest_unsafe_dead`, `type_argument_suggest_unsafe`, `autocorrect_*`, etc.) — all pass, no regressions.