### PR TITLE
Preserve shape types through Hash#merge!

### DIFF
--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -106,6 +106,7 @@ NameDef names[] = {
     {"extend"},
     {"currentFile", "__FILE__"},
     {"merge"},
+    {"mergeBang", "merge!"},
 
     // T keywords
     {"sig"},

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -4694,6 +4694,7 @@ const vector<Intrinsic> intrinsics{
 
     {Symbols::Shape(), Intrinsic::Kind::Instance, Names::squareBracketsEq(), &Shape_squareBracketsEq},
     {Symbols::Shape(), Intrinsic::Kind::Instance, Names::merge(), &Shape_merge},
+    {Symbols::Shape(), Intrinsic::Kind::Instance, Names::mergeBang(), &Shape_merge},
     {Symbols::Shape(), Intrinsic::Kind::Instance, Names::toHash(), &Shape_to_hash},
     {Symbols::Shape(), Intrinsic::Kind::Instance, Names::toH(), &Shape_to_h},
 

--- a/rbi/sorbet/sorbet.rbi
+++ b/rbi/sorbet/sorbet.rbi
@@ -69,6 +69,7 @@ class Sorbet::Private::Static::Shape < Hash
   Elem = type_member(:out)
 
   def merge(other); end
+  def merge!(other); end
   def to_hash(); end
 end
 

--- a/test/testdata/infer/shape_merge.rb
+++ b/test/testdata/infer/shape_merge.rb
@@ -36,6 +36,45 @@ T.assert_type!(
   }
 )
 
+T.assert_type!(
+  {
+    hi: "there",
+  }.merge!({
+             llamas: 17
+           }),
+  {
+    hi: String,
+    llamas: Integer,
+  }
+)
+
+Before = T.type_alias do
+  {
+    "int" => Integer,
+    "changed" => String,
+  }
+end
+
+After = T.type_alias do
+  {
+    "int" => Integer,
+    "changed" => Symbol,
+    "new_int" => Integer,
+    "new_nil_str" => T.nilable(String),
+  }
+end
+
+extend T::Sig
+
+sig {params(to_transform: Before).returns(After)}
+def transform_type_alias(to_transform)
+  to_transform.merge!(
+    "changed" => :new_value,
+    "new_int" => 1,
+    "new_nil_str" => nil,
+  )
+end
+
 def has_kwargs(a:, b:, c:)
 end
 


### PR DESCRIPTION
In our application, migration upcasters use shape types to describe
records before and after a schema change. Hash#merge! currently widens
its result to an untyped hash. Upcasters must use Hash#merge to keep
type safety, which allocates a new hash.

Preserve shape information through Hash#merge! so upcasters can mutate
rows in place without an unnecessary allocation.
