### PR TITLE
Make `canModifySymbol` aware of test packages

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1263,6 +1263,15 @@ TypeMemberRef GlobalState::enterTypeMember(Loc loc, ClassOrModuleRef owner, Name
     }
 
     ENFORCE_NO_TIMER(!symbolTableFrozen);
+
+    auto contiguousStrataUntil = this->contiguousStrataUntil();
+    const auto &boundary = this->symbolOffsets[contiguousStrataUntil.rawId()];
+    ENFORCE(!owner.exists() || owner.id() >= boundary.classAndModulesOffset,
+            "Entering type member `{}` at {} into `{}`, which belongs to an earlier stratum: owner_id={} "
+            "contiguous_strata_until={} class_boundary={}",
+            name.show(*this), loc.showRaw(*this), owner.show(*this), owner.id(), contiguousStrataUntil.rawId(),
+            boundary.classAndModulesOffset);
+
     auto result = TypeMemberRef(*this, typeMembers.size());
     store = result; // DO NOT MOVE this assignment down. emplace_back on typeMembers invalidates `store`
     typeMembers.emplace_back();

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -1067,7 +1067,7 @@ PackageInfo::CanModifyResult PackageInfo::canModifySymbol(core::Context ctx, Cla
         // In package-directed mode, test files must not modify symbols that were defined on the non-test side of
         // the package. Doing so would create type members (or mixins) at the test stratum that dangle after
         // copySymbolTableFrom filters by stratum boundary.
-        if (ctx.file.exists() && ctx.file.data(gs).isPackagedTest()) {
+        if (ctx.file.exists() && !gs.packageDB().testPackages() && ctx.file.data(gs).isPackagedTest()) {
             for (auto &loc : symData->locs()) {
                 if (loc.exists() && !loc.file().data(gs).isPackagedTest()) {
                     return CanModifyResult::TestModifyingNonTest;

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -1033,13 +1033,15 @@ vector<MangledName> PackageInfo::directSubPackages(const core::GlobalState &gs) 
     return subpackages;
 }
 
-PackageInfo::CanModifyResult PackageInfo::canModifySymbol(const core::GlobalState &gs, ClassOrModuleRef sym) const {
+PackageInfo::CanModifyResult PackageInfo::canModifySymbol(core::Context ctx, ClassOrModuleRef sym) const {
     ENFORCE(sym.exists());
 
     // Unpackaged code is allowed to modify anything.
     if (!this->exists()) {
         return CanModifyResult::CanModify;
     }
+
+    auto &gs = ctx.state;
 
     // Ensure we're not working with a singleton class before performing any further checks.
     sym = sym.data(gs)->topAttachedClass(gs);
@@ -1058,11 +1060,22 @@ PackageInfo::CanModifyResult PackageInfo::canModifySymbol(const core::GlobalStat
     // namespace, and if so that there aren't any subpackages, as that could introduce ordering dependencies that don't
     // work with package-directed type checking.
     if (symPackage == this->mangledName_) {
-        if (!this->hasSubPackages || !symData->isPackageNamespace()) {
-            return CanModifyResult::CanModify;
-        } else {
+        if (this->hasSubPackages && symData->isPackageNamespace()) {
             return CanModifyResult::Subpackages;
         }
+
+        // In package-directed mode, test files must not modify symbols that were defined on the non-test side of
+        // the package. Doing so would create type members (or mixins) at the test stratum that dangle after
+        // copySymbolTableFrom filters by stratum boundary.
+        if (ctx.file.exists() && ctx.file.data(gs).isPackagedTest()) {
+            for (auto &loc : symData->locs()) {
+                if (loc.exists() && !loc.file().data(gs).isPackagedTest()) {
+                    return CanModifyResult::TestModifyingNonTest;
+                }
+            }
+        }
+
+        return CanModifyResult::CanModify;
     }
 
     // Modifying an unpackaged symbol is only allowed from prelude packages.

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -3,6 +3,7 @@
 
 #include "absl/types/span.h"
 
+#include "core/Context.h"
 #include "core/Loc.h"
 #include "core/NameRef.h"
 #include "core/StrictLevel.h"
@@ -323,12 +324,15 @@ public:
 
         // The symbol is unpackaged, and the context is not a prelude package.
         UnpackagedSymbol,
+
+        // The file is on the test side of the package but the symbol was defined on the non-test side.
+        TestModifyingNonTest,
     };
 
     // True when it's safe to modify this symbol from the context of a file owned by this package. Modification in this
     // case is something that fundamentally changes the meaning of the symbol (adding type members or mixins, for
     // example).
-    CanModifyResult canModifySymbol(const core::GlobalState &gs, ClassOrModuleRef sym) const;
+    CanModifyResult canModifySymbol(core::Context ctx, ClassOrModuleRef sym) const;
 
     // It's okay to access the internals of `other` if it's this package, or if test packages are enabled and we
     // imported `other` with `uses_internals: true`.

--- a/definition_validator/variance.cc
+++ b/definition_validator/variance.cc
@@ -1,4 +1,3 @@
-#include "common/strings/formatting.h"
 #include "common/typecase.h"
 #include "core/Polarity.h"
 #include "core/Symbols.h"
@@ -70,22 +69,9 @@ private:
                 auto members = app.klass.data(ctx)->typeMembers();
                 auto params = app.targs;
 
-                if (members.size() != params.size()) [[unlikely]] {
-                    auto memberNames = fmt::map_join(members, ", ", [&](core::TypeMemberRef m) {
-                        if (!m.exists()) {
-                            return "<missing member>"s;
-                        }
-
-                        if (m.id() >= ctx.state.typeMembersUsed()) {
-                            return "<type member from a future stratum>"s;
-                        }
-
-                        return m.data(ctx)->name.show(ctx);
-                    });
-                    fatalLogger->error(R"(msg="types should be fully saturated" loc="{}" members="[{}]" app="{}")",
-                                       this->loc.showRaw(ctx), memberNames, app.show(ctx));
-                    ENFORCE(false);
-                }
+                ENFORCE(members.size() == params.size(),
+                        "types should be fully saturated, but there are {} members and {} params", members.size(),
+                        params.size());
 
                 for (int i = 0; i < members.size(); ++i) {
                     auto memberVariance = members[i].data(ctx)->variance();

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -2226,6 +2226,20 @@ public:
                 }
                 return ignoreBadTypeMember(ctx, move(tree));
 
+            case core::packages::PackageInfo::CanModifyResult::TestModifyingNonTest: {
+                if (auto e = ctx.beginError(send->loc, core::errors::Namer::ModifyingUnpackagedConstant)) {
+                    e.setHeader("`{}` in a test file cannot modify a non-test class in the same package",
+                                isTypeTemplate ? "type_template" : "type_member");
+                    for (auto &loc : onSymbol.data(ctx)->locs()) {
+                        if (loc.exists() && !loc.file().data(ctx).isPackagedTest()) {
+                            e.addErrorLine(loc, "`{}` defined here (non-test)", ctx.owner.show(ctx));
+                            break;
+                        }
+                    }
+                }
+                return ignoreBadTypeMember(ctx, move(tree));
+            }
+
             case core::packages::PackageInfo::CanModifyResult::NotOwner:
             case core::packages::PackageInfo::CanModifyResult::UnpackagedSymbol:
                 if (auto e = ctx.beginError(send->loc, core::errors::Namer::ModifyingUnpackagedConstant)) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -831,27 +831,35 @@ private:
                     }
                     break;
 
+                case core::packages::PackageInfo::CanModifyResult::TestModifyingNonTest:
                 case core::packages::PackageInfo::CanModifyResult::NotOwner:
                 case core::packages::PackageInfo::CanModifyResult::UnpackagedSymbol:
                     if (auto e =
                             ctx.beginError(job.ancestor->loc(), core::errors::Resolver::ModifyingUnpackagedConstant)) {
-                        e.setHeader("Superclasses may only be set on constants in the package that owns them");
-
-                        e.addErrorLine(job.klass.data(ctx)->loc(), "Symbol originally defined here");
-
-                        if (canModify == core::packages::PackageInfo::CanModifyResult::NotOwner) {
-                            e.addErrorLine(filePackageInfo.declLoc(), "Package where the `{}` occurs",
-                                           job.isInclude ? "include" : "extend");
-
-                            auto &ownerPackage = ctx.state.packageDB().getPackageInfo(job.klass.data(ctx)->package);
-                            ENFORCE(ownerPackage.exists());
-                            e.addErrorLine(ownerPackage.declLoc(), "Package where `{}` is defined",
+                        if (canModify == core::packages::PackageInfo::CanModifyResult::TestModifyingNonTest) {
+                            e.setHeader(
+                                "Superclasses in a test file cannot modify a non-test class in the same package");
+                            e.addErrorLine(job.klass.data(ctx)->loc(), "`{}` defined here (non-test)",
                                            job.klass.show(ctx));
                         } else {
-                            e.addErrorLine(filePackageInfo.declLoc(), "Package defined here is not a `{}`",
-                                           "prelude_package");
-                            e.addErrorNote("`{}` is unpackaged, and may be reopened from a package marked `{}`",
-                                           job.klass.show(ctx), "prelude_package");
+                            e.setHeader("Superclasses may only be set on constants in the package that owns them");
+
+                            e.addErrorLine(job.klass.data(ctx)->loc(), "Symbol originally defined here");
+
+                            if (canModify == core::packages::PackageInfo::CanModifyResult::NotOwner) {
+                                e.addErrorLine(filePackageInfo.declLoc(), "Package where the `{}` occurs",
+                                               job.isInclude ? "include" : "extend");
+
+                                auto &ownerPackage = ctx.state.packageDB().getPackageInfo(job.klass.data(ctx)->package);
+                                ENFORCE(ownerPackage.exists());
+                                e.addErrorLine(ownerPackage.declLoc(), "Package where `{}` is defined",
+                                               job.klass.show(ctx));
+                            } else {
+                                e.addErrorLine(filePackageInfo.declLoc(), "Package defined here is not a `{}`",
+                                               "prelude_package");
+                                e.addErrorNote("`{}` is unpackaged, and may be reopened from a package marked `{}`",
+                                               job.klass.show(ctx), "prelude_package");
+                            }
                         }
                     }
                     break;
@@ -893,28 +901,36 @@ private:
                     }
                     break;
 
+                case core::packages::PackageInfo::CanModifyResult::TestModifyingNonTest:
                 case core::packages::PackageInfo::CanModifyResult::NotOwner:
                 case core::packages::PackageInfo::CanModifyResult::UnpackagedSymbol:
                     if (auto e =
                             ctx.beginError(job.ancestor->loc(), core::errors::Resolver::ModifyingUnpackagedConstant)) {
-                        e.setHeader("`{}` may only be used on constants in the package that owns them",
-                                    job.isInclude ? "include" : "extend");
-
-                        e.addErrorLine(job.klass.data(ctx)->loc(), "Symbol originally defined here");
-
-                        if (canModify == core::packages::PackageInfo::CanModifyResult::NotOwner) {
-                            e.addErrorLine(filePackageInfo.declLoc(), "Package where the `{}` occurs",
-                                           job.isInclude ? "include" : "extend");
-
-                            auto &ownerPackage = ctx.state.packageDB().getPackageInfo(job.klass.data(ctx)->package);
-                            ENFORCE(ownerPackage.exists());
-                            e.addErrorLine(ownerPackage.declLoc(), "Package where `{}` is defined",
+                        if (canModify == core::packages::PackageInfo::CanModifyResult::TestModifyingNonTest) {
+                            e.setHeader("`{}` in a test file cannot modify a non-test class in the same package",
+                                        job.isInclude ? "include" : "extend");
+                            e.addErrorLine(job.klass.data(ctx)->loc(), "`{}` defined here (non-test)",
                                            job.klass.show(ctx));
                         } else {
-                            e.addErrorLine(filePackageInfo.declLoc(), "Package defined here is not a `{}`",
-                                           "prelude_package");
-                            e.addErrorNote("`{}` is unpackaged, and may be reopened from a package marked `{}`",
-                                           job.klass.show(ctx), "prelude_package");
+                            e.setHeader("`{}` may only be used on constants in the package that owns them",
+                                        job.isInclude ? "include" : "extend");
+
+                            e.addErrorLine(job.klass.data(ctx)->loc(), "Symbol originally defined here");
+
+                            if (canModify == core::packages::PackageInfo::CanModifyResult::NotOwner) {
+                                e.addErrorLine(filePackageInfo.declLoc(), "Package where the `{}` occurs",
+                                               job.isInclude ? "include" : "extend");
+
+                                auto &ownerPackage = ctx.state.packageDB().getPackageInfo(job.klass.data(ctx)->package);
+                                ENFORCE(ownerPackage.exists());
+                                e.addErrorLine(ownerPackage.declLoc(), "Package where `{}` is defined",
+                                               job.klass.show(ctx));
+                            } else {
+                                e.addErrorLine(filePackageInfo.declLoc(), "Package defined here is not a `{}`",
+                                               "prelude_package");
+                                e.addErrorNote("`{}` is unpackaged, and may be reopened from a package marked `{}`",
+                                               job.klass.show(ctx), "prelude_package");
+                            }
                         }
                     }
                     break;

--- a/test/testdata/packager/directed-test-stratum-include/child/__package.rb
+++ b/test/testdata/packager/directed-test-stratum-include/child/__package.rb
@@ -1,0 +1,9 @@
+# typed: strict
+# enable-packager: true
+# enable-package-directed: true
+
+# stratum: 1
+
+class Child < PackageSpec
+  import Parent
+end

--- a/test/testdata/packager/directed-test-stratum-include/child/uses.1.rbupdate
+++ b/test/testdata/packager/directed-test-stratum-include/child/uses.1.rbupdate
@@ -1,0 +1,7 @@
+# typed: strict
+# frozen_string_literal: true
+# assert-slow-path: true
+
+class Child::Uses; end
+
+class Child::NewClass; end

--- a/test/testdata/packager/directed-test-stratum-include/child/uses.rb
+++ b/test/testdata/packager/directed-test-stratum-include/child/uses.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# frozen_string_literal: true
+
+# stratum: 1
+
+class Child::Uses; end

--- a/test/testdata/packager/directed-test-stratum-include/parent/__package.rb
+++ b/test/testdata/packager/directed-test-stratum-include/parent/__package.rb
@@ -1,0 +1,9 @@
+# typed: strict
+
+# stratum: 0
+
+class Parent < PackageSpec
+  export Parent::MyClass
+
+  test_import Child
+end

--- a/test/testdata/packager/directed-test-stratum-include/parent/my_class.rb
+++ b/test/testdata/packager/directed-test-stratum-include/parent/my_class.rb
@@ -1,0 +1,7 @@
+# typed: strict
+# frozen_string_literal: true
+
+# stratum: 0
+
+class Parent::MyClass
+end

--- a/test/testdata/packager/directed-test-stratum-include/parent/test/my_module.1.rbupdate
+++ b/test/testdata/packager/directed-test-stratum-include/parent/test/my_module.1.rbupdate
@@ -1,0 +1,7 @@
+# typed: strict
+# frozen_string_literal: true
+# exclude-from-file-update: true
+# stratum: 2
+
+module Parent::TestMixin # error: Tests in the `Parent` package must define tests in the `Test::Parent` namespace
+end

--- a/test/testdata/packager/directed-test-stratum-include/parent/test/my_module.rb
+++ b/test/testdata/packager/directed-test-stratum-include/parent/test/my_module.rb
@@ -1,0 +1,7 @@
+# typed: strict
+# frozen_string_literal: true
+
+# stratum: 2
+
+module Parent::TestMixin # error: Tests in the `Parent` package must define tests in the `Test::Parent` namespace
+end

--- a/test/testdata/packager/directed-test-stratum-include/parent/test/reopen.1.rbupdate
+++ b/test/testdata/packager/directed-test-stratum-include/parent/test/reopen.1.rbupdate
@@ -1,0 +1,8 @@
+# typed: strict
+# frozen_string_literal: true
+# exclude-from-file-update: true
+# stratum: 2
+
+class Parent::MyClass # error: Tests in the `Parent` package must define tests in the `Test::Parent` namespace
+  include Parent::TestMixin # error: `include` in a test file cannot modify a non-test class in the same package
+end

--- a/test/testdata/packager/directed-test-stratum-include/parent/test/reopen.rb
+++ b/test/testdata/packager/directed-test-stratum-include/parent/test/reopen.rb
@@ -1,0 +1,8 @@
+# typed: strict
+# frozen_string_literal: true
+
+# stratum: 2
+
+class Parent::MyClass # error: Tests in the `Parent` package must define tests in the `Test::Parent` namespace
+  include Parent::TestMixin # error: `include` in a test file cannot modify a non-test class in the same package
+end

--- a/test/testdata/packager/directed-type-member-variance-crash/child/__package.rb
+++ b/test/testdata/packager/directed-type-member-variance-crash/child/__package.rb
@@ -1,0 +1,10 @@
+# typed: strict
+# enable-packager: true
+# enable-package-directed: true
+# disable-fast-path: true
+
+# stratum: 1
+
+class Child < PackageSpec
+  import Parent
+end

--- a/test/testdata/packager/directed-type-member-variance-crash/child/my_child.1.rbupdate
+++ b/test/testdata/packager/directed-type-member-variance-crash/child/my_child.1.rbupdate
@@ -1,0 +1,10 @@
+# typed: strict
+# frozen_string_literal: true
+# assert-slow-path: true
+
+class Child::MyChild2
+  extend T::Sig
+
+  sig {returns(Parent::ParentAlias)}
+  def self.bar = raise
+end

--- a/test/testdata/packager/directed-type-member-variance-crash/child/my_child.rb
+++ b/test/testdata/packager/directed-type-member-variance-crash/child/my_child.rb
@@ -1,0 +1,11 @@
+# typed: strict
+# frozen_string_literal: true
+
+# stratum: 1
+
+class Child::MyChild
+  extend T::Sig
+
+  sig {returns(Parent::ParentAlias)}
+  def self.bar = raise
+end

--- a/test/testdata/packager/directed-type-member-variance-crash/parent/__package.rb
+++ b/test/testdata/packager/directed-type-member-variance-crash/parent/__package.rb
@@ -1,0 +1,10 @@
+# typed: strict
+
+# stratum: 0
+
+class Parent < PackageSpec
+  export Parent::MyGeneric
+  export Parent::ParentAlias
+
+  test_import Child
+end

--- a/test/testdata/packager/directed-type-member-variance-crash/parent/my_generic.rb
+++ b/test/testdata/packager/directed-type-member-variance-crash/parent/my_generic.rb
@@ -1,0 +1,12 @@
+# typed: strict
+# frozen_string_literal: true
+
+# stratum: 0
+
+class Parent::MyGeneric
+  extend T::Generic
+
+  Elem = type_member
+end
+
+Parent::ParentAlias = T.type_alias {Parent::MyGeneric[Integer]}

--- a/test/testdata/packager/directed-type-member-variance-crash/parent/test/reopen.1.rbupdate
+++ b/test/testdata/packager/directed-type-member-variance-crash/parent/test/reopen.1.rbupdate
@@ -1,0 +1,9 @@
+# typed: strict
+# frozen_string_literal: true
+# exclude-from-file-update: true
+# stratum: 2
+
+class Parent::MyGeneric # error: Tests in the `Parent` package must define tests in the `Test::Parent` namespace
+  Elem2 = type_member
+  #       ^^^^^^^^^^^ error: `type_member` in a test file cannot modify a non-test class in the same package
+end

--- a/test/testdata/packager/directed-type-member-variance-crash/parent/test/reopen.rb
+++ b/test/testdata/packager/directed-type-member-variance-crash/parent/test/reopen.rb
@@ -1,0 +1,9 @@
+# typed: strict
+# frozen_string_literal: true
+
+# stratum: 2
+
+class Parent::MyGeneric # error: Tests in the `Parent` package must define tests in the `Test::Parent` namespace
+  Elem2 = type_member
+  #       ^^^^^^^^^^^ error: `type_member` in a test file cannot modify a non-test class in the same package
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Fixes a crash in variance.cc that we were seeing when running Sorbet in LSP mode
with `--experimental-package-directed` in Stripe's codebase.

The core fix looks better ignoring whitespace.

The trickiest part of this was coming up with a test case to reproduce the bug,
because it seems to only reproduce when re-opening a non-test namespace from a
test file. Those two files (non-test and test) will get scheduled to be
typechecked in different strata, and so we might copy the wrong prefix.

`canModifySymbol` attempts to prevent bad mutations to `GlobalState` such
that copying a prefix of the symbol table would not copy the right data.
The logic implicily assumed that mutations created while processing the
test files in a package were safe because we're modifying the "same"
package.

In the process, I see that `canModifySymbol` also gets called while dealing with
rejecting bad `include` for a similar reason. I was not able to trigger a crash
that deals with `include`, but I included a test case for the new logic anyways.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Commit messages shows the `lldb` result of where the test crashed before fixing it.