### PR TITLE
Expose syntax for Symbol literal types

### DIFF
--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -435,6 +435,8 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         if (class1.symbol == class2.symbol) {
                             if (l1.equals(l2)) {
                                 result = t1;
+                            } else if (l1.kind == NamedLiteralType::Kind::Symbol) {
+                                result = OrType::make_shared(t1, t2);
                             } else {
                                 result = l1.underlying(gs);
                             }

--- a/core/types/subtyping.cc
+++ b/core/types/subtyping.cc
@@ -443,6 +443,8 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
                         } else {
                             result = lubGround(gs, l1.underlying(gs), l2.underlying(gs));
                         }
+                    } else if (l1.kind == NamedLiteralType::Kind::Symbol) {
+                        result = OrType::make_shared(t1, t2);
                     } else {
                         result = lub(gs, l1.underlying(gs), t2.underlying(gs));
                     }
@@ -474,7 +476,9 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
             ENFORCE(result != nullptr);
             return result;
         } else {
-            bool allowProxyInLub = isa_type<TupleType>(t1) || isa_type<ShapeType>(t1);
+            bool allowProxyInLub = isa_type<TupleType>(t1) || isa_type<ShapeType>(t1) ||
+                                   (isa_type<NamedLiteralType>(t1) &&
+                                    cast_type_nonnull<NamedLiteralType>(t1).kind == NamedLiteralType::Kind::Symbol);
             // only 1st is proxy
             TypePtr und = t1.underlying(gs);
             if (isSubType(gs, und, t2)) {
@@ -487,7 +491,9 @@ TypePtr Types::lub(const GlobalState &gs, const TypePtr &t1, const TypePtr &t2) 
         }
     } else if (is_proxy_type(t2)) {
         // only 2nd is proxy
-        bool allowProxyInLub = isa_type<TupleType>(t2) || isa_type<ShapeType>(t2);
+        bool allowProxyInLub = isa_type<TupleType>(t2) || isa_type<ShapeType>(t2) ||
+                               (isa_type<NamedLiteralType>(t2) &&
+                                cast_type_nonnull<NamedLiteralType>(t2).kind == NamedLiteralType::Kind::Symbol);
         // only 1st is proxy
         TypePtr und = t2.underlying(gs);
         if (isSubType(gs, und, t1)) {

--- a/core/types/types.cc
+++ b/core/types/types.cc
@@ -1041,6 +1041,12 @@ TypePtr Types::unwrapType(const GlobalState &gs, Loc loc, const TypePtr &tp) {
         return make_type<TupleType>(move(unwrappedElems));
     }
 
+    // Symbol literals are allowed in type syntax: sig {returns(:ok)}
+    if (isa_type<NamedLiteralType>(tp) &&
+        cast_type_nonnull<NamedLiteralType>(tp).kind == NamedLiteralType::Kind::Symbol) {
+        return tp;
+    }
+
     if (auto e = gs.beginError(loc, errors::Infer::BareTypeUsage)) {
         e.setHeader("Unexpected bare `{}` value found in type position", tp.show(gs));
     }

--- a/gems/sorbet-runtime/lib/sorbet-runtime.rb
+++ b/gems/sorbet-runtime/lib/sorbet-runtime.rb
@@ -86,6 +86,7 @@ require_relative 'types/boolean'
 
 # Depends on types/utils
 require_relative 'types/types/typed_array'
+require_relative 'types/types/literal_value'
 require_relative 'types/types/typed_module'
 require_relative 'types/types/typed_class'
 

--- a/gems/sorbet-runtime/lib/types/_types.rb
+++ b/gems/sorbet-runtime/lib/types/_types.rb
@@ -278,6 +278,12 @@ module T
     end
   end
 
+  ### Literal types ###
+
+  def self.Symbol(sym)
+    T::Types::LiteralValue.new(sym)
+  end
+
   ### Generic classes ###
 
   module Array

--- a/gems/sorbet-runtime/lib/types/types/literal_value.rb
+++ b/gems/sorbet-runtime/lib/types/types/literal_value.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+# typed: true
+
+module T::Types
+  class LiteralValue < Base
+    attr_reader :val
+
+    def initialize(val)
+      raise ArgumentError.new("LiteralValue expects a Symbol, got #{val.class}") unless val.is_a?(::Symbol)
+      @val = val
+    end
+
+    def build_type
+      nil
+    end
+
+    # overrides Base
+    def name
+      @name ||= "T::Symbol(:#{val})".freeze
+    end
+
+    # overrides Base
+    def valid?(obj)
+      obj == @val
+    end
+
+    # overrides Base
+    private def subtype_of_single?(other)
+      case other
+      when LiteralValue
+        @val == other.val
+      when Simple
+        @val.is_a?(other.raw_type)
+      else
+        false
+      end
+    end
+  end
+end

--- a/gems/sorbet-runtime/lib/types/utils.rb
+++ b/gems/sorbet-runtime/lib/types/utils.rb
@@ -5,6 +5,7 @@ module T::Utils
   module Private
     def self.coerce_and_check_module_types(val, check_val, check_module_type)
       # rubocop:disable Style/CaseLikeIf
+      # We intentionally call `is_a?` instead of using a `case` expression, because it's often overridden by users.
       if val.is_a?(T::Types::Base)
         if val.is_a?(T::Private::Types::TypeAlias)
           val.aliased_type
@@ -25,12 +26,14 @@ module T::Utils
         T::Private::Methods.finalize_proc(val.decl)
       elsif val.is_a?(::T::Enum)
         T::Types::TEnum.new(val)
+      elsif val.is_a?(::Symbol)
+        T::Types::LiteralValue.new(val)
       elsif val.is_a?(::String)
         raise "Invalid String literal for type constraint. Must be an #{T::Types::Base}, a " \
-              "class/module, or an array. Got a String with value `#{val}`."
+              "class/module, a symbol, or an array. Got a String with value `#{val}`."
       else
         raise "Invalid value for type constraint. Must be an #{T::Types::Base}, a " \
-              "class/module, or an array. Got a `#{val.class}`."
+              "class/module, a symbol, or an array. Got a `#{val.class}`."
       end
       # rubocop:enable Style/CaseLikeIf
     end

--- a/gems/sorbet-runtime/test/types/literal_value.rb
+++ b/gems/sorbet-runtime/test/types/literal_value.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+require_relative '../test_helper'
+
+module Opus::Types::Test
+  class LiteralValueTest < Critic::Unit::UnitTest
+    describe 'T::Symbol' do
+      it 'creates a LiteralValue type' do
+        type = T::Symbol(:foo)
+        assert_instance_of(T::Types::LiteralValue, type)
+      end
+
+      it 'has the correct name' do
+        assert_equal('T::Symbol(:foo)', T::Symbol(:foo).name)
+      end
+
+      it 'validates matching symbols' do
+        type = T::Symbol(:foo)
+        assert(type.valid?(:foo))
+      end
+
+      it 'rejects non-matching symbols' do
+        type = T::Symbol(:foo)
+        refute(type.valid?(:bar))
+        refute(type.valid?("foo"))
+        refute(type.valid?(nil))
+      end
+
+      it 'works with T.assert_type!' do
+        assert_equal(:foo, T.assert_type!(:foo, T::Symbol(:foo)))
+      end
+
+      it 'raises on T.assert_type! mismatch' do
+        assert_raises(TypeError) do
+          T.assert_type!(:bar, T::Symbol(:foo))
+        end
+      end
+
+      it 'is a subtype of Symbol' do
+        assert(T::Symbol(:foo).subtype_of?(T::Utils.coerce(Symbol)))
+      end
+
+      it 'is not a subtype of a different symbol literal' do
+        refute(T::Symbol(:foo).subtype_of?(T::Symbol(:bar)))
+      end
+
+      it 'is a subtype of the same symbol literal' do
+        assert(T::Symbol(:foo).subtype_of?(T::Symbol(:foo)))
+      end
+
+      it 'rejects non-symbol arguments' do
+        assert_raises(ArgumentError) do
+          T::Symbol("foo")
+        end
+      end
+    end
+
+    describe 'T::Utils.coerce with symbols' do
+      it 'coerces a bare symbol to LiteralValue' do
+        type = T::Utils.coerce(:foo)
+        assert_instance_of(T::Types::LiteralValue, type)
+        assert_equal(:foo, type.val)
+      end
+
+      it 'coerced symbol validates correctly' do
+        type = T::Utils.coerce(:foo)
+        assert(type.valid?(:foo))
+        refute(type.valid?(:bar))
+      end
+    end
+  end
+end

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -166,6 +166,9 @@ module T
   # For more information, see https://sorbet.org/docs/generics#generic-methods
   def self.type_parameter(name); end
 
+  # Type syntax to declare a symbol literal type.
+  def self.Symbol(sym); end
+
   # Type syntax to declare a type equivalent to the receiver of the method
   # (i.e., the type of the `self` keyword).
   #

--- a/rbs/prism/TypeToParserNodePrism.cc
+++ b/rbs/prism/TypeToParserNodePrism.cc
@@ -404,6 +404,10 @@ pm_node_t *TypeToParserNodePrism::toPrismNode(const rbs_node_t *node, const RBSD
                     // * `false` -> `FalseClass`
                     return boolNode->value ? prism.TrueClass(nodeLoc) : prism.FalseClass(nodeLoc);
                 }
+                case RBS_AST_SYMBOL: {
+                    auto *symNode = rbs_down_cast<rbs_ast_symbol_t>(literalNode->literal);
+                    return prism.Symbol(nodeLoc, parser.resolveConstant(symNode));
+                }
                 default: {
                     // We don't have a good way to represent other literal types, so we just return T.untyped for them.
                     if (auto e = ctx.beginIndexerError(nodeLoc, core::errors::Rewriter::RBSUnsupported)) {

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -806,6 +806,27 @@ optional<TypeSyntax::ResultType> interpretTCombinator(core::Context ctx, const a
                                                       TypeSyntaxArgs args) {
     auto &recvi = ast::cast_tree_nonnull<ast::ConstantLit>(send.recv);
 
+    // T::Symbol(:sym) creates a symbol literal type.
+    // We can't use a well-known name here because the UTF8 name "Symbol" is already
+    // implicitly created by the constant name registration for the Symbol class.
+    if (send.fun.shortName(ctx) == "Symbol") {
+        if (send.numPosArgs() != 1 || send.hasKwArgs()) {
+            checkTypeFunArity(ctx, send, 1, 1);
+            checkUnexpectedKwargs(ctx, send);
+            return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
+        }
+        auto lit = ast::cast_tree<ast::Literal>(send.getPosArg(0));
+        if (!lit || !lit->isSymbol()) {
+            if (auto e = ctx.beginError(send.loc, core::errors::Resolver::InvalidTypeDeclaration)) {
+                e.setHeader("`{}` requires a symbol literal argument", "T::Symbol");
+            }
+            return TypeSyntax::ResultType{core::Types::untypedUntracked(), core::Symbols::noClassOrModule()};
+        }
+        auto name = lit->asSymbol();
+        return TypeSyntax::ResultType{core::make_type<core::NamedLiteralType>(core::Symbols::Symbol(), name),
+                                      core::Symbols::noClassOrModule()};
+    }
+
     switch (send.fun.rawId()) {
         case core::Names::nilable().rawId(): {
             if (send.numPosArgs() != 1 || send.hasKwArgs()) {

--- a/resolver/type_syntax/type_syntax.cc
+++ b/resolver/type_syntax/type_syntax.cc
@@ -1552,6 +1552,13 @@ optional<TypeSyntax::ResultType> getResultTypeAndBindWithSelfTypeParamsImpl(core
         result.type = core::Types::untypedUntracked();
     } else if (ast::isa_tree<ast::Literal>(expr)) {
         const auto &lit = ast::cast_tree_nonnull<ast::Literal>(expr);
+
+        // Bare symbol literals are allowed in type syntax: sig {returns(:ok)}
+        if (lit.isSymbol()) {
+            result.type = lit.value;
+            return result;
+        }
+
         core::TypePtr underlying;
         if (core::isa_type<core::NamedLiteralType>(lit.value)) {
             underlying = lit.value.underlying(ctx);

--- a/test/testdata/cfg/break.rb
+++ b/test/testdata/cfg/break.rb
@@ -36,4 +36,4 @@ T.reveal_type(b) # error: Revealed type: `T.nilable(String)`
 c = while 1.to_s == ""
       break :abc if 1.to_s == ""
     end
-T.reveal_type(c) # error: Revealed type: `T.nilable(Symbol)`
+T.reveal_type(c) # error: Revealed type: `T.nilable(Symbol(:abc))`

--- a/test/testdata/cfg/break.rb.cfg-text.exp
+++ b/test/testdata/cfg/break.rb.cfg-text.exp
@@ -175,10 +175,10 @@ bb19[firstDead=-1]():
 # backedges
 # - bb19
 # - bb22
-bb20[firstDead=3](c: T.nilable(Symbol)):
+bb20[firstDead=3](c: T.nilable(Symbol(:abc))):
     <cfgAlias>$87: T.class_of(T) = alias <C T>
-    <returnMethodTemp>$2: T.nilable(Symbol) = <cfgAlias>$87: T.class_of(T).reveal_type(c: T.nilable(Symbol))
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Symbol)
+    <returnMethodTemp>$2: T.nilable(Symbol(:abc)) = <cfgAlias>$87: T.class_of(T).reveal_type(c: T.nilable(Symbol(:abc)))
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: T.nilable(Symbol(:abc))
     <unconditional> -> bb1
 
 # backedges

--- a/test/testdata/infer/casts.rb
+++ b/test/testdata/infer/casts.rb
@@ -32,7 +32,6 @@ class TestCasts
     str = T.cast("x", "y") # error: `T.cast` is useless
                     # ^^^ error: Unsupported literal in type syntax
 
-    sym = T.cast(:x, :y) # error: `T.cast` is useless
-                   # ^^ error: Unsupported literal in type syntax
+    sym = T.cast(:x, :y)
   end
 end

--- a/test/testdata/infer/casts.rb.cfg-text.exp
+++ b/test/testdata/infer/casts.rb.cfg-text.exp
@@ -104,9 +104,9 @@ bb0[firstDead=63]():
     keep_for_ide$60: Symbol(:y) = :y
     keep_for_ide$60: T.untyped = <keep-alive> keep_for_ide$60
     <castTemp>$61: Symbol(:x) = :x
-    sym: Symbol = cast(<castTemp>$61: Symbol(:x), Symbol);
-    <returnMethodTemp>$2: Symbol = sym
-    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol
+    sym: Symbol(:y) = cast(<castTemp>$61: Symbol(:x), Symbol(:y));
+    <returnMethodTemp>$2: Symbol(:y) = sym
+    <finalReturn>: T.noreturn = return <returnMethodTemp>$2: Symbol(:y)
     <unconditional> -> bb1
 
 # backedges

--- a/test/testdata/infer/casts.rb.flatten-tree.exp
+++ b/test/testdata/infer/casts.rb.flatten-tree.exp
@@ -22,7 +22,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         s.+(3)
         f = <cast:cast>(6.000000, Float, 7.000000)
         str = <cast:cast>("x", String, "y")
-        sym = <cast:cast>(:x, Symbol, :y)
+        sym = <cast:cast>(:x, Symbol(:y), :y)
       end
     end
 

--- a/test/testdata/infer/metatype_instantiation.rb
+++ b/test/testdata/infer/metatype_instantiation.rb
@@ -10,7 +10,7 @@ T::Array[{foo: Integer.new}].new # error: Unexpected bare `Integer` value found 
 T::Array[{foo: 3}].new # error: Unexpected bare `Integer(3)` value found in type position
 T::Array[{foo: 3.0}].new # error: Unexpected bare `Float(3.000000)` value found in type position
 T::Array[{foo: "x"}].new # error: Unexpected bare `String("x")` value found in type position
-T::Array[{foo: :y}].new # error: Unexpected bare `Symbol(:y)` value found in type position
+T::Array[{foo: :y}].new
 
 # Make sure we don't mutate the types when unwrapping
 t = [Integer]

--- a/test/testdata/infer/t_symbol_literal.rb
+++ b/test/testdata/infer/t_symbol_literal.rb
@@ -1,0 +1,24 @@
+# typed: true
+
+s = :abc
+T.assert_type!(s, T::Symbol(:abc))
+
+s2 = :xyz
+T.assert_type!(s2, T::Symbol(:abc)) # error: does not have asserted type `Symbol(:abc)`
+
+extend T::Sig
+
+sig {params(x: T::Symbol(:foo)).void}
+def takes_foo(x); end
+
+takes_foo(:foo)
+takes_foo(:bar) # error: Expected `Symbol(:foo)` but found `Symbol(:bar)`
+
+# Joining different symbol literals across branches should produce a union
+coin_flip = T.unsafe(nil)
+x = if coin_flip
+  :heads
+else
+  :tails
+end
+T.reveal_type(x) # error: Revealed type: `T.any(Symbol(:heads), Symbol(:tails))`

--- a/test/testdata/infer/t_symbol_literal.rb
+++ b/test/testdata/infer/t_symbol_literal.rb
@@ -22,3 +22,29 @@ else
   :tails
 end
 T.reveal_type(x) # error: Revealed type: `T.any(Symbol(:heads), Symbol(:tails))`
+
+# Bare symbol literals in type syntax
+sig {params(x: :foo).void}
+def takes_foo_bare(x); end
+
+takes_foo_bare(:foo)
+takes_foo_bare(:bar) # error: Expected `Symbol(:foo)` but found `Symbol(:bar)`
+
+sig {returns(:ok)}
+def returns_ok
+  :ok
+end
+
+T.assert_type!(returns_ok, T::Symbol(:ok))
+
+# Bare symbols in T.any
+y = T.let(:heads, T.any(:heads, :tails))
+T.reveal_type(y) # error: Revealed type: `T.any(Symbol(:heads), Symbol(:tails))`
+
+# Bare symbol in T.let
+z = T.let(:foo, :foo)
+T.reveal_type(z) # error: Revealed type: `Symbol(:foo)`
+
+# Bare symbol in T.nilable
+w = T.let(nil, T.nilable(:foo))
+T.reveal_type(w) # error: Revealed type: `T.nilable(Symbol(:foo))`

--- a/test/testdata/rbs/signatures_symbol_literals.rb
+++ b/test/testdata/rbs/signatures_symbol_literals.rb
@@ -1,0 +1,30 @@
+# typed: strict
+# enable-experimental-rbs-comments: true
+
+extend T::Sig
+
+# Symbol literal return type
+#: () -> :foo
+def symbol_literal_return; :foo; end
+
+T.reveal_type(symbol_literal_return) # error: Revealed type: `Symbol(:foo)`
+
+# Symbol literal parameter type
+#: (:foo) -> void
+def symbol_literal_param(x); end
+
+# Symbol literal union
+#: (:heads | :tails) -> void
+def symbol_literal_union(x); end
+
+symbol_literal_union(:heads)
+symbol_literal_union(:other) # error: Expected `T.any(Symbol(:heads), Symbol(:tails))` but found `Symbol(:other)`
+
+# Non-symbol literals are still unsupported
+#: () -> "foo"
+#        ^^^^^ error: RBS literal types are not supported
+def string_literal; T.unsafe(nil); end
+
+#: () -> 42
+#        ^^ error: RBS literal types are not supported
+def integer_literal; T.unsafe(nil); end

--- a/test/testdata/resolver/proc.rb
+++ b/test/testdata/resolver/proc.rb
@@ -29,8 +29,6 @@ class TestProc
       #                                      ^ error: Unexpected bare `Integer(0)` value found in type position
       #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `params` expects keyword arguments
       w: T.proc.params(x: :f).returns(Integer),
-      #                   ^^ error: Unsupported literal in type syntax
-      #                   ^^ error: Unexpected bare `Symbol(:f)` value found in type position
     ).returns(NilClass)
   end
   def bad(x, y, z, w)

--- a/test/testdata/resolver/proc.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/proc.rb.symbol-table-raw.exp
@@ -1,19 +1,19 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/proc.rb start=3:1 end=49:4}
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/proc.rb start=3:1 end=47:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/proc.rb start=??? end=???}
   class <C <U TestProc>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/proc.rb start=3:1 end=3:15}
-    method <C <U TestProc>>#<U bad> (x, y, z, w, <blk>) -> NilClass @ Loc {file=test/testdata/resolver/proc.rb start=36:3 end=36:22}
+    method <C <U TestProc>>#<U bad> (x, y, z, w, <blk>) -> NilClass @ Loc {file=test/testdata/resolver/proc.rb start=34:3 end=34:22}
       argument x<> -> T.proc.returns(T.untyped) @ Loc {file=test/testdata/resolver/proc.rb start=24:7 end=24:8}
       argument y<> -> T.proc.returns(Integer) @ Loc {file=test/testdata/resolver/proc.rb start=25:7 end=25:8}
       argument z<> -> T.proc.returns(Integer) @ Loc {file=test/testdata/resolver/proc.rb start=27:7 end=27:8}
-      argument w<> -> T.proc.params(arg0: Symbol).returns(Integer) @ Loc {file=test/testdata/resolver/proc.rb start=31:7 end=31:8}
+      argument w<> -> T.proc.params(arg0: Symbol(:f)).returns(Integer) @ Loc {file=test/testdata/resolver/proc.rb start=31:7 end=31:8}
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/resolver/proc.rb start=??? end=???}
-    method <C <U TestProc>>#<U foo> (x, <blk>) -> Integer @ Loc {file=test/testdata/resolver/proc.rb start=40:3 end=40:13}
-      argument x<> -> Integer @ Loc {file=test/testdata/resolver/proc.rb start=39:15 end=39:16}
+    method <C <U TestProc>>#<U foo> (x, <blk>) -> Integer @ Loc {file=test/testdata/resolver/proc.rb start=38:3 end=38:13}
+      argument x<> -> Integer @ Loc {file=test/testdata/resolver/proc.rb start=37:15 end=37:16}
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/resolver/proc.rb start=??? end=???}
-    method <C <U TestProc>>#<U foo1> (x, <blk>) -> Integer @ Loc {file=test/testdata/resolver/proc.rb start=48:3 end=48:14}
-      argument x<> -> T.proc.params(arg0: Integer).returns(Integer) @ Loc {file=test/testdata/resolver/proc.rb start=44:7 end=44:8}
+    method <C <U TestProc>>#<U foo1> (x, <blk>) -> Integer @ Loc {file=test/testdata/resolver/proc.rb start=46:3 end=46:14}
+      argument x<> -> T.proc.params(arg0: Integer).returns(Integer) @ Loc {file=test/testdata/resolver/proc.rb start=42:7 end=42:8}
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/resolver/proc.rb start=??? end=???}
     method <C <U TestProc>>#<U good1> (blk) -> Integer @ Loc {file=test/testdata/resolver/proc.rb start=10:3 end=10:18}
       argument blk<block> -> T.proc.params(arg0: Integer).returns(Integer) @ Loc {file=test/testdata/resolver/proc.rb start=7:12 end=7:15}
@@ -21,6 +21,6 @@ class <C <U <root>>> < <C <U Object>> ()
       argument blk<block> -> T.proc.params(arg0: T::Array[String]).returns(T::Array[Integer]) @ Loc {file=test/testdata/resolver/proc.rb start=15:12 end=15:15}
   class <S <C <U TestProc>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U Sig>>) @ Loc {file=test/testdata/resolver/proc.rb start=3:1 end=3:15}
     type-member(+) <S <C <U TestProc>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U TestProc>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=TestProc) @ Loc {file=test/testdata/resolver/proc.rb start=3:1 end=3:15}
-    method <S <C <U TestProc>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/proc.rb start=3:1 end=49:4}
+    method <S <C <U TestProc>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/proc.rb start=3:1 end=47:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/proc.rb start=??? end=???}
 

--- a/test/testdata/resolver/sig_bad.rb
+++ b/test/testdata/resolver/sig_bad.rb
@@ -65,8 +65,6 @@ class A
       #              ^^^  error: Unexpected bare `String("a")` value found in type position
       k3: T.class_of(:b),
       #   ^^^^^^^^^^^^^^ error: `T.class_of` needs a class or module as its argument
-      #              ^^  error: Unsupported literal in type syntax
-      #              ^^  error: Unexpected bare `Symbol(:b)` value found in type position
       l: {[] => String}, # error: Shape keys must be literals
       m: {foo: 0}, # error: Unsupported literal in type syntax
       n: T.all, # error: Not enough arguments provided for method

--- a/test/testdata/resolver/sig_bad.rb.symbol-table-raw.exp
+++ b/test/testdata/resolver/sig_bad.rb.symbol-table-raw.exp
@@ -1,9 +1,9 @@
 class <C <U <root>>> < <C <U Object>> ()
   class <S <C <U <root>>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> ()
-    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/sig_bad.rb start=2:1 end=80:4}
+    method <S <C <U <root>>> $1>#<N <U <static-init>> $CENSORED> (<blk>) @ Loc {file=test/testdata/resolver/sig_bad.rb start=2:1 end=78:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/sig_bad.rb start=??? end=???}
   class <C <U A>> < <C <U Object>> () @ Loc {file=test/testdata/resolver/sig_bad.rb start=10:1 end=10:8}
-    method <C <U A>>#<U bad> (a, b, c, c1, c2, c3, d, e, b1, c11, c12, c13, c14, d1, e1, f, g, h, i, j, k, k1, k2, k3, l, m, n, o, <blk>) -> T2 @ Loc {file=test/testdata/resolver/sig_bad.rb start=77:3 end=77:111}
+    method <C <U A>>#<U bad> (a, b, c, c1, c2, c3, d, e, b1, c11, c12, c13, c14, d1, e1, f, g, h, i, j, k, k1, k2, k3, l, m, n, o, <blk>) -> T2 @ Loc {file=test/testdata/resolver/sig_bad.rb start=75:3 end=75:111}
       argument a<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=17:7 end=17:8}
       argument b<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=18:7 end=18:8}
       argument c<> -> Object @ Loc {file=test/testdata/resolver/sig_bad.rb start=20:7 end=20:8}
@@ -28,14 +28,14 @@ class <C <U <root>>> < <C <U Object>> ()
       argument k1<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=58:7 end=58:9}
       argument k2<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=62:7 end=62:9}
       argument k3<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=66:7 end=66:9}
-      argument l<> -> {} @ Loc {file=test/testdata/resolver/sig_bad.rb start=70:7 end=70:8}
-      argument m<> -> {foo: Integer} @ Loc {file=test/testdata/resolver/sig_bad.rb start=71:7 end=71:8}
-      argument n<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=72:7 end=72:8}
-      argument o<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=73:7 end=73:8}
+      argument l<> -> {} @ Loc {file=test/testdata/resolver/sig_bad.rb start=68:7 end=68:8}
+      argument m<> -> {foo: Integer} @ Loc {file=test/testdata/resolver/sig_bad.rb start=69:7 end=69:8}
+      argument n<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=70:7 end=70:8}
+      argument o<> -> T.untyped @ Loc {file=test/testdata/resolver/sig_bad.rb start=71:7 end=71:8}
       argument <blk><block> -> T.noreturn @ Loc {file=test/testdata/resolver/sig_bad.rb start=??? end=???}
   class <S <C <U A>> $1>[<C <U <AttachedClass>>>] < <S <C <U Object>> $1> (<C <U Sig>>) @ Loc {file=test/testdata/resolver/sig_bad.rb start=10:1 end=10:8}
     type-member(+) <S <C <U A>> $1>::<C <U <AttachedClass>>> -> LambdaParam(<S <C <U A>> $1>::<C <U <AttachedClass>>>, lower=T.noreturn, upper=A) @ Loc {file=test/testdata/resolver/sig_bad.rb start=10:1 end=10:8}
-    method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/sig_bad.rb start=10:1 end=80:4}
+    method <S <C <U A>> $1>#<U <static-init>> (<blk>) @ Loc {file=test/testdata/resolver/sig_bad.rb start=10:1 end=78:4}
       argument <blk><block> @ Loc {file=test/testdata/resolver/sig_bad.rb start=??? end=???}
     method <S <C <U A>> $1>#<U unsupported> (<blk>) @ Loc {file=test/testdata/resolver/sig_bad.rb start=13:3 end=13:23}
       argument <blk><block> @ Loc {file=test/testdata/resolver/sig_bad.rb start=??? end=???}

--- a/test/testdata/resolver/t_combinator_kwargs.rb
+++ b/test/testdata/resolver/t_combinator_kwargs.rb
@@ -9,12 +9,8 @@ module M
       #        ^^^^^^^^^^^^^^^^^^^^^ error: `T.nilable` does not accept keyword arguments
       all: T.all(Integer, M, a: Integer, b: String),
       #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `T.all` does not accept keyword arguments
-      #                      ^ error: Unexpected bare `Symbol(:a)` value found in type position
-      #                                  ^ error: Unexpected bare `Symbol(:b)` value found in type position
       any: T.any(Integer, String, a: Integer, b: String),
       #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `T.any` does not accept keyword arguments
-      #                           ^ error: Unexpected bare `Symbol(:a)` value found in type position
-      #                                       ^ error: Unexpected bare `Symbol(:b)` value found in type position
       param: T.type_parameter(a: Integer),
       #      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `T.type_parameter` does not accept keyword arguments
       enum: T.deprecated_enum(a: Integer),


### PR DESCRIPTION
### Motivation

Sorbet's static typechecker can already reason about literal symbol values as types, but there was no way to use those types in Ruby code.

This PR exposes it via a new `T::Symbol(:abc)` syntax.

Future PRs can expand upon this to expose syntax for the other literal types (strings, intergers and floats).

Currently stacked on #10505

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
