### PR TITLE
Replace fastPathEditStratum with earliestReopenedStratum

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2152,7 +2152,7 @@ unique_ptr<GlobalState> GlobalState::copyForLSPTypechecker(
     return result;
 }
 
-pair<unique_ptr<GlobalState>, bool> GlobalState::copyForSlowPath(
+unique_ptr<GlobalState> GlobalState::copyForSlowPath(
     const vector<string> &extraPackageFilesDirectoryUnderscorePrefixes,
     const vector<string> &extraPackageFilesDirectorySlashDeprecatedPrefixes,
     const vector<string> &extraPackageFilesDirectorySlashPrefixes,
@@ -2186,7 +2186,6 @@ pair<unique_ptr<GlobalState>, bool> GlobalState::copyForSlowPath(
     result->typeParameters.reserve(this->typeParameters.capacity());
     result->typeMembers.reserve(this->typeMembers.capacity());
 
-    bool copiedSymbolTablePrefix = false;
     if (packageDB().enabled()) {
         {
             core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*result);
@@ -2198,13 +2197,16 @@ pair<unique_ptr<GlobalState>, bool> GlobalState::copyForSlowPath(
                 allowRelaxingTestVisibility, packageAttributedErrors, testPackages);
         }
 
-        copiedSymbolTablePrefix = result->copySymbolTableFrom(*this, toStratum);
+        result->copySymbolTableFrom(*this, toStratum);
+    } else {
+        ENFORCE(toStratum == packages::Stratum(0),
+                "Cannot copy a nonzero symbol table prefix when packages are disabled");
     }
 
-    return {move(result), copiedSymbolTablePrefix};
+    return result;
 }
 
-bool GlobalState::copySymbolTableFrom(const GlobalState &other, packages::Stratum toStratum) {
+void GlobalState::copySymbolTableFrom(const GlobalState &other, packages::Stratum toStratum) {
     // Copying a prefix of the symbol tables assumes that this global state derives from `other`.
     ENFORCE(this->files->size() == other.files->size());
     ENFORCE(this->constantNames.size() == other.constantNames.size());
@@ -2212,10 +2214,12 @@ bool GlobalState::copySymbolTableFrom(const GlobalState &other, packages::Stratu
     ENFORCE(this->namesByHash.size() == other.namesByHash.size());
     ENFORCE(other.packageDB().enabled(), "Copying a prefix of the symbol table requires --sorbet-packages");
 
-    // Exit early if there's nothing to copy, or if we don't have information about the stratum specified.
-    if (toStratum == packages::Stratum(0) || toStratum.rawId() >= other.symbolOffsets.size()) {
-        return false;
+    // At stratum zero there is no prefix to copy.
+    if (toStratum == packages::Stratum(0)) {
+        return;
     }
+    ENFORCE(toStratum.rawId() < other.symbolOffsets.size(), "No symbol table offset recorded for stratum {}",
+            toStratum.rawId());
 
     ENFORCE(!other.earliestReopenedStratum.has_value() || toStratum <= other.earliestReopenedStratum.value(),
             "Copying the symbol table up to stratum {}, but stratum {} was re-populated by a fast path",
@@ -2273,8 +2277,6 @@ bool GlobalState::copySymbolTableFrom(const GlobalState &other, packages::Stratu
     for (auto i = 0; i < offsets.typeMembersOffset; ++i) {
         this->typeMembers.emplace_back(other.typeMembers[i].deepCopy(*this));
     }
-
-    return true;
 }
 
 string_view GlobalState::getPrintablePath(string_view path) const {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2080,6 +2080,7 @@ unique_ptr<GlobalState> GlobalState::deepCopyGlobalState(bool keepId) const {
         result->creation = timeit2.getFlowEdge();
     }
     result->symbolOffsets = this->symbolOffsets;
+    result->earliestReopenedStratum = this->earliestReopenedStratum;
     return result;
 }
 
@@ -2215,6 +2216,10 @@ bool GlobalState::copySymbolTableFrom(const GlobalState &other, packages::Stratu
     if (toStratum == packages::Stratum(0) || toStratum.rawId() >= other.symbolOffsets.size()) {
         return false;
     }
+
+    ENFORCE(!other.earliestReopenedStratum.has_value() || toStratum <= other.earliestReopenedStratum.value(),
+            "Copying the symbol table up to stratum {}, but stratum {} was re-populated by a fast path",
+            toStratum.rawId(), other.earliestReopenedStratum.value_or(packages::Stratum(0)).rawId());
 
     this->packageDB_ = other.packageDB().deepCopy();
 

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -584,7 +584,7 @@ public:
     // Copy the name table, file table and other parts of GlobalState that are required to start the slow path. If the
     // `toStratum` value is passed as something other than the `0` stratum, the prefix of the symbol table leading up to
     // that stratum will be copied over as well.
-    std::pair<std::unique_ptr<GlobalState>, bool>
+    std::unique_ptr<GlobalState>
     copyForSlowPath(const std::vector<std::string> &extraPackageFilesDirectoryUnderscorePrefixes,
                     const std::vector<std::string> &extraPackageFilesDirectorySlashDeprecatedPrefixes,
                     const std::vector<std::string> &extraPackageFilesDirectorySlashPrefixes,
@@ -841,7 +841,7 @@ private:
     //
     // This method requires that `this` be derived from `other`, as the copied symbol table prefix will assume that
     // their name tables and file tables to match.
-    bool copySymbolTableFrom(const GlobalState &other, packages::Stratum toStratum);
+    void copySymbolTableFrom(const GlobalState &other, packages::Stratum toStratum);
 };
 // CheckSize(GlobalState, 152, 8);
 // Historically commented out because size of unordered_map was different between different versions of stdlib

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -740,6 +740,34 @@ public:
         this->symbolOffsets.emplace_back(SymbolTableOffsets(*this));
     }
 
+    // The earliest stratum whose symbols are no longer a contiguous range of ids. Every stratum
+    // before it forms a self-contained prefix of the symbol table, in the sense that no symbol in
+    // it refers to a symbol outside it.
+    //
+    // Outside of LSP mode, this is the stratum we are in the middle of populating.
+    // In LSP, it might be earlier than the current stratum once a fast path has re-processed an earlier stratum.
+    packages::Stratum firstIncompleteStratum() const {
+        auto recorded = packages::Stratum(this->symbolOffsets.size() - 1);
+        return this->earliestReopenedStratum.has_value() ? std::min(this->earliestReopenedStratum.value(), recorded)
+                                                         : recorded;
+    }
+
+    // Records that a fast path will have entered new symbols for this stratum, so we cannot copy a
+    // prefix for this stratum anymore (because its symbols will live partly in the middle of the
+    // symbol table and partly at the end of the symbol table).
+    //
+    // This deliberately does not truncate `symbolOffsets` to make the fast & slow path
+    // representations "uniform", because a fast path can preempt a running slow path.
+    //
+    // This is also why symbolOffsets is not exposed to callers directly, only these helpers,
+    // because the size of `symbolOffsets` will be different on e.g. the first traversal through the
+    // strata and a fast path edit that revisits an earlier stratum.
+    void reopenStratum(packages::Stratum stratum) {
+        this->earliestReopenedStratum = this->earliestReopenedStratum.has_value()
+                                            ? std::min(this->earliestReopenedStratum.value(), stratum)
+                                            : stratum;
+    }
+
 private:
     uint32_t nameTableDiffCount = 0;
 
@@ -786,6 +814,9 @@ private:
 
     // Symbol table offsets for each stratum of the package graph traversal.
     std::vector<SymbolTableOffsets> symbolOffsets;
+
+    // The earliest stratum passed to `reopenStratum`, if any.
+    std::optional<packages::Stratum> earliestReopenedStratum;
 
     // Copy options over from another GlobalState. Private, as it's only meant to be used as a helper to implement other
     // copying strategies.

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -731,9 +731,9 @@ public:
         return this->newSymbols().typeParameterRefs(*this);
     }
 
-    // Reserve space for internal structures, under the assumption that we'll see `len` strata.
+    // Reserve space for the boundary before the first stratum and one boundary after each stratum.
     void preallocateForStrata(size_t len) {
-        this->symbolOffsets.reserve(len);
+        this->symbolOffsets.reserve(len + 1);
     }
 
     void updateSymbolTableOffsets() {
@@ -744,24 +744,27 @@ public:
     // before it forms a self-contained prefix of the symbol table, in the sense that no symbol in
     // it refers to a symbol outside it.
     //
-    // Outside of LSP mode, this is the stratum we are in the middle of populating.
-    // In LSP, it might be earlier than the current stratum once a fast path has re-processed an earlier stratum.
-    packages::Stratum firstIncompleteStratum() const {
+    // That is, the range from from [0, contiguousStrataUntil()) is a contiguous prefix, and
+    // contiguousStrataUntil() is the first stratum that's not necessarily contiguous.
+    //
+    // A fast path can make this shorter than the number of boundaries recorded in symbolOffsets by
+    // re-processing an earlier stratum and entering its new symbols at the end of the symbol table.
+    packages::Stratum contiguousStrataUntil() const {
         auto recorded = packages::Stratum(this->symbolOffsets.size() - 1);
         return this->earliestReopenedStratum.has_value() ? std::min(this->earliestReopenedStratum.value(), recorded)
                                                          : recorded;
     }
 
-    // Records that a fast path will have entered new symbols for this stratum, so we cannot copy a
-    // prefix for this stratum anymore (because its symbols will live partly in the middle of the
-    // symbol table and partly at the end of the symbol table).
+    // Records that a fast path will have entered new symbols for this stratum, so the reusable
+    // symbol table prefix must end before this stratum (because its symbols will live partly in the
+    // middle of the symbol table and partly at the end of the symbol table).
     //
     // This deliberately does not truncate `symbolOffsets` to make the fast & slow path
     // representations "uniform", because a fast path can preempt a running slow path.
     //
-    // This is also why symbolOffsets is not exposed to callers directly, only these helpers,
-    // because the size of `symbolOffsets` will be different on e.g. the first traversal through the
-    // strata and a fast path edit that revisits an earlier stratum.
+    // This is also why only these helpers (not symbolOffsets itself) is exposed publicly, because
+    // the size of `symbolOffsets` will be different on e.g. the first traversal through the strata
+    // and a fast path edit that revisits an earlier stratum.
     void reopenStratum(packages::Stratum stratum) {
         this->earliestReopenedStratum = this->earliestReopenedStratum.has_value()
                                             ? std::min(this->earliestReopenedStratum.value(), stratum)
@@ -812,7 +815,9 @@ private:
     bool symbolTableFrozen = true;
     bool fileTableFrozen = true;
 
-    // Symbol table offsets for each stratum of the package graph traversal.
+    // Symbol table offsets at the boundaries of the package graph traversal. symbolOffsets[k]
+    // records the symbol table boundary after the prefix of strata [0, k), equivalently before
+    // stratum k. A completed traversal of N strata therefore records N + 1 entries.
     std::vector<SymbolTableOffsets> symbolOffsets;
 
     // The earliest stratum passed to `reopenStratum`, if any.

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -592,8 +592,6 @@ pair<bool, core::packages::Stratum> LSPTypechecker::runSlowPath(LSPFileUpdates &
         auto savedGS =
             std::exchange(this->gs, pipeline::copyForSlowPath(*this->gs, this->config->opts, startingStratum));
 
-        ENFORCE(this->gs->contiguousStrataUntil() == startingStratum, "startingStratum mismatch after exchange call");
-
         // Seed open files with the previous set from `indexedFinalGS`
         for (auto &entry : this->indexedFinalGS) {
             openFiles.insert(entry.first);

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -219,10 +219,6 @@ bool LSPTypechecker::typecheck(unique_ptr<LSPFileUpdates> updates, WorkerPool &w
 
             filesTypechecked = move(result.filesTypechecked);
 
-            // Remember where in the package graph we're making this change, as that will determine how much we can
-            // copy on the next slow path.
-            this->fastPathEditStratum = std::min(this->fastPathEditStratum, result.editStratum);
-
             ENFORCE(updates->updatedFiles.empty());
             ENFORCE(updates->updatedFileRefs.empty());
 
@@ -320,7 +316,7 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
         }
 
         // We track the edit stratum for all files that were updated by the edit, if their source hashes differ. This
-        // will avoid bumping the fastPathEditStratum down when the file was opened by a query like go-to-definition,
+        // will avoid bumping the reopened stratum down when the file was opened by a query like go-to-definition,
         // but is still fairly coarse grained, as any change will mark the package as needing to be re-typechecked.
         if (oldFile->sourceHash() != newHash) {
             editStratum = std::min(this->fileToStratum[fref.id()], editStratum);
@@ -334,6 +330,10 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
 
     updates.updatedFiles.clear();
     updates.updatedFileRefs.clear();
+
+    // Remember where in the package graph we're making this change, as that will determine how much we can
+    // copy on the next slow path.
+    gs->reopenStratum(editStratum);
 
     if (shouldRunIncrementalNamer && gs->packageDB().enabled()) {
         vector<core::FileRef> packageFiles;
@@ -429,7 +429,7 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
         "Running fast path over num_files={} incrementalNamer={} preemption={} duration={} files=[{}]",
         toTypecheck.size(), shouldRunIncrementalNamer, isPreemption, duration.usec, files);
 
-    return FastPathResult{move(toTypecheck), move(toCache), editStratum};
+    return FastPathResult{move(toTypecheck), move(toCache)};
 }
 
 namespace {
@@ -438,11 +438,12 @@ namespace {
 // means that we can't reuse the symbol table.
 core::packages::Stratum determineStartingStratum(const core::GlobalState &gs,
                                                  const vector<core::packages::Stratum> &fileToStratum,
-                                                 const core::packages::Stratum fastPathEditStratum,
+                                                 const core::packages::Stratum lastStratum,
                                                  const LSPFileUpdates &update) {
-    // We start by assuming we can copy up to the last fast path edit stratum, as that may have introduced new
-    // symbols.
-    auto editStratum = fastPathEditStratum;
+    // We start by assuming we can copy as much of the symbol table as GlobalState says is still a self-contained
+    // prefix, which any fast path edit since the last slow path will have lowered. The clamp is because a completed
+    // slow path records an offsets entry for the end of the last stratum, and there is no stratum to start from there.
+    auto editStratum = std::min(lastStratum, gs.firstIncompleteStratum());
 
     int ix = -1;
     for (auto &file : update.updatedFiles) {
@@ -585,7 +586,7 @@ pair<bool, core::packages::Stratum> LSPTypechecker::runSlowPath(LSPFileUpdates &
     if (cancelable) {
         timeit.setTag("cancelable", "true");
 
-        startingStratum = determineStartingStratum(*this->gs, this->fileToStratum, this->fastPathEditStratum, updates);
+        startingStratum = determineStartingStratum(*this->gs, this->fileToStratum, this->lastStratum, updates);
 
         auto savedGS =
             std::exchange(this->gs, pipeline::copyForSlowPath(*this->gs, this->config->opts, startingStratum));
@@ -597,7 +598,7 @@ pair<bool, core::packages::Stratum> LSPTypechecker::runSlowPath(LSPFileUpdates &
 
         this->cancellationUndoState =
             make_unique<UndoState>(std::move(savedGS), std::move(this->indexedFinalGS), move(this->fileToStratum),
-                                   this->lastStratum, this->fastPathEditStratum, this->workspaceFiles, updates.epoch);
+                                   this->lastStratum, this->workspaceFiles, updates.epoch);
     } else {
         timeit.setTag("cancelable", "false");
     }
@@ -725,7 +726,6 @@ pair<bool, core::packages::Stratum> LSPTypechecker::runSlowPath(LSPFileUpdates &
         const auto numStrata = strata.strata.size();
         this->fileToStratum = move(strata.fileToStratum);
         this->lastStratum = core::packages::Stratum(numStrata - 1);
-        this->fastPathEditStratum = this->lastStratum;
         this->gs->preallocateForStrata(numStrata);
 
         // Determine which stratum this edit will be checked at, so that we have a good reference for when to switch
@@ -922,7 +922,7 @@ pair<bool, core::packages::Stratum> LSPTypechecker::runSlowPath(LSPFileUpdates &
         // arbitrarily long time. The next update will be responsible for freeing the underlying UndoState after it
         // makes use of the epoch field to determine additional files to include in the edit.
         cancellationUndoState->restore(this->gs, this->indexedFinalGS, this->fileToStratum, this->lastStratum,
-                                       this->fastPathEditStratum, this->workspaceFiles);
+                                       this->workspaceFiles);
         logger->debug("[Typechecker] Typecheck run for epoch {} was canceled.", updates.epoch);
     }
 

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -436,14 +436,12 @@ namespace {
 
 // Determine how much of the symbol table we can copy when starting a slow path edit: any __package.rb modification
 // means that we can't reuse the symbol table.
-core::packages::Stratum determineStartingStratum(const core::GlobalState &gs,
-                                                 const vector<core::packages::Stratum> &fileToStratum,
-                                                 const core::packages::Stratum lastStratum,
-                                                 const LSPFileUpdates &update) {
+core::packages::Stratum determineMaximumPrefix(const core::GlobalState &gs,
+                                               const vector<core::packages::Stratum> &fileToStratum,
+                                               const LSPFileUpdates &update) {
     // We start by assuming we can copy as much of the symbol table as GlobalState says is still a self-contained
-    // prefix, which any fast path edit since the last slow path will have lowered. The clamp is because a completed
-    // slow path records an offsets entry for the end of the last stratum, and there is no stratum to start from there.
-    auto editStratum = std::min(lastStratum, gs.firstIncompleteStratum());
+    // prefix, which any fast path edit since the last slow path will have lowered.
+    auto editStratum = gs.contiguousStrataUntil();
 
     int ix = -1;
     for (auto &file : update.updatedFiles) {
@@ -586,10 +584,14 @@ pair<bool, core::packages::Stratum> LSPTypechecker::runSlowPath(LSPFileUpdates &
     if (cancelable) {
         timeit.setTag("cancelable", "true");
 
-        startingStratum = determineStartingStratum(*this->gs, this->fileToStratum, this->lastStratum, updates);
+        auto requestedPrefix = determineMaximumPrefix(*this->gs, this->fileToStratum, updates);
 
         auto savedGS =
-            std::exchange(this->gs, pipeline::copyForSlowPath(*this->gs, this->config->opts, startingStratum));
+            std::exchange(this->gs, pipeline::copyForSlowPath(*this->gs, this->config->opts, requestedPrefix));
+
+        // Check how much of the symbol table we copied to know the starting strata.
+        // (Non-package-directed won't have copied anything, thus less than the requested prefix)
+        startingStratum = this->gs->contiguousStrataUntil();
 
         // Seed open files with the previous set from `indexedFinalGS`
         for (auto &entry : this->indexedFinalGS) {

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -439,6 +439,9 @@ namespace {
 core::packages::Stratum determineMaximumPrefix(const core::GlobalState &gs,
                                                const vector<core::packages::Stratum> &fileToStratum,
                                                const LSPFileUpdates &update) {
+    // SorbetWorkspaceEditTask filters out empty workspace edits before they reach the indexer or typechecker.
+    ENFORCE(!update.updatedFiles.empty());
+
     // We start by assuming we can copy as much of the symbol table as GlobalState says is still a self-contained
     // prefix, which any fast path edit since the last slow path will have lowered.
     auto editStratum = gs.contiguousStrataUntil();
@@ -584,14 +587,12 @@ pair<bool, core::packages::Stratum> LSPTypechecker::runSlowPath(LSPFileUpdates &
     if (cancelable) {
         timeit.setTag("cancelable", "true");
 
-        auto requestedPrefix = determineMaximumPrefix(*this->gs, this->fileToStratum, updates);
+        startingStratum = determineMaximumPrefix(*this->gs, this->fileToStratum, updates);
 
         auto savedGS =
-            std::exchange(this->gs, pipeline::copyForSlowPath(*this->gs, this->config->opts, requestedPrefix));
+            std::exchange(this->gs, pipeline::copyForSlowPath(*this->gs, this->config->opts, startingStratum));
 
-        // Check how much of the symbol table we copied to know the starting strata.
-        // (Non-package-directed won't have copied anything, thus less than the requested prefix)
-        startingStratum = this->gs->contiguousStrataUntil();
+        ENFORCE(this->gs->contiguousStrataUntil() == startingStratum, "startingStratum mismatch after exchange call");
 
         // Seed open files with the previous set from `indexedFinalGS`
         for (auto &entry : this->indexedFinalGS) {

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -106,12 +106,6 @@ class LSPTypechecker final {
 
     core::packages::Stratum lastStratum;
 
-    /**
-     * This is the stratum of the last fast-path edit, tracked so that we don't miss additive updates to existing
-     * packages.
-     */
-    core::packages::Stratum fastPathEditStratum;
-
     enum class SlowPathMode {
         Init,
         Cancelable,
@@ -130,9 +124,6 @@ class LSPTypechecker final {
 
         // Copies of the indexed trees that were updated during the fast path, for updating the cache of open files.
         std::vector<ast::ParsedFile> indexedTrees;
-
-        // The stratum that the edit took place, or lastStratum if it didn't affect anything.
-        core::packages::Stratum editStratum;
     };
 
     /** Runs incremental typechecking on the provided updates. Returns the final list of files typechecked. */

--- a/main/lsp/UndoState.cc
+++ b/main/lsp/UndoState.cc
@@ -10,21 +10,19 @@ using namespace std;
 namespace sorbet::realmain::lsp {
 UndoState::UndoState(unique_ptr<core::GlobalState> evictedGs, UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS,
                      vector<core::packages::Stratum> fileToStratum, core::packages::Stratum lastStratum,
-                     core::packages::Stratum fastPathEditStratum, const vector<core::FileRef> &workspaceFiles,
-                     uint32_t epoch)
+                     const vector<core::FileRef> &workspaceFiles, uint32_t epoch)
     : evictedGs(move(evictedGs)), evictedIndexedFinalGS(std::move(evictedIndexedFinalGS)),
-      fileToStratum{move(fileToStratum)}, lastStratum{lastStratum}, fastPathEditStratum{fastPathEditStratum},
-      initialWorkspaceFilesSize{workspaceFiles.size()}, epoch(epoch) {}
+      fileToStratum{move(fileToStratum)}, lastStratum{lastStratum}, initialWorkspaceFilesSize{workspaceFiles.size()},
+      epoch(epoch) {}
 
 void UndoState::restore(unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast::ParsedFile> &indexedFinalGS,
                         vector<core::packages::Stratum> &fileToStratum, core::packages::Stratum &lastStratum,
-                        core::packages::Stratum &fastPathEditStratum, vector<core::FileRef> &workspaceFiles) {
+                        vector<core::FileRef> &workspaceFiles) {
     indexedFinalGS = std::move(evictedIndexedFinalGS);
     gs = move(evictedGs);
 
     fileToStratum = move(this->fileToStratum);
     lastStratum = this->lastStratum;
-    fastPathEditStratum = this->fastPathEditStratum;
 
     if (workspaceFiles.size() != this->initialWorkspaceFilesSize) {
         workspaceFiles.erase(workspaceFiles.begin() + this->initialWorkspaceFilesSize, workspaceFiles.end());

--- a/main/lsp/UndoState.h
+++ b/main/lsp/UndoState.h
@@ -25,9 +25,6 @@ class UndoState final {
     // The id of the last stratum in the previous slow path.
     const core::packages::Stratum lastStratum;
 
-    // The id of the stratum that the last fast-path edit took place in.
-    const core::packages::Stratum fastPathEditStratum;
-
     // The size of the workspaceFiles vector when the slow path started. Tracked so that we can roll back additions to
     // the vector from new files added in the canceled edit.
     const size_t initialWorkspaceFilesSize;
@@ -38,15 +35,14 @@ public:
 
     UndoState(std::unique_ptr<core::GlobalState> evictedGs, UnorderedMap<int, ast::ParsedFile> evictedIndexedFinalGS,
               std::vector<core::packages::Stratum> fileToStratum, core::packages::Stratum lastStratum,
-              core::packages::Stratum fastPathEditStratum, const std::vector<core::FileRef> &workspaceFiles,
-              uint32_t epoch);
+              const std::vector<core::FileRef> &workspaceFiles, uint32_t epoch);
 
     /**
      * Undoes the slow path changes represented by this class.
      */
     void restore(std::unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast::ParsedFile> &indexedFinalGS,
                  std::vector<core::packages::Stratum> &fileToStratum, core::packages::Stratum &lastStratum,
-                 core::packages::Stratum &fastPathEditStratum, std::vector<core::FileRef> &workspaceFiles);
+                 std::vector<core::FileRef> &workspaceFiles);
 
     /**
      * Retrieves the evicted global state.

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -119,13 +119,13 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
 
 unique_ptr<core::GlobalState> copyForSlowPath(const core::GlobalState &from, const options::Options &opts,
                                               core::packages::Stratum forStratum) {
-    if (opts.cacheSensitiveOptions.noStdlib) {
+    if (opts.cacheSensitiveOptions.noStdlib && forStratum == core::packages::Stratum(0)) {
         auto result = make_unique<core::GlobalState>(from.errorQueue, from.epochManager);
         result->initEmpty();
         return result;
     }
 
-    auto [result, symbolTableInitialized] = from.copyForSlowPath(
+    auto result = from.copyForSlowPath(
         opts.extraPackageFilesDirectoryUnderscorePrefixes, opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
         opts.extraPackageFilesDirectorySlashPrefixes, opts.packageSkipRBIExportEnforcementDirs,
         opts.allowRelaxedPackagerChecksFor, opts.updateVisibilityFor, opts.packagerLayers, opts.sorbetPackagesHint,
@@ -133,11 +133,14 @@ unique_ptr<core::GlobalState> copyForSlowPath(const core::GlobalState &from, con
         forStratum);
 
     // Fall back on initializing from the payload if we're not copying part of from's symbol table.
-    if (!symbolTableInitialized) {
+    if (forStratum == core::packages::Stratum(0)) {
         core::serialize::Serializer::loadSymbolTable(*result, PAYLOAD_SYMBOL_TABLE);
     }
 
-    return move(result);
+    ENFORCE(result->contiguousStrataUntil() == forStratum,
+            "Requested a symbol table prefix ending at stratum {}, but copied one ending at stratum {}",
+            forStratum.rawId(), result->contiguousStrataUntil().rawId());
+    return result;
 }
 
 vector<core::FileRef> reserveFiles(core::GlobalState &gs, const vector<string> &files) {

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -120,7 +120,8 @@ void printGlobalTables(const core::GlobalState &gs, const options::Options &opts
 void printUntypedBlames(const core::GlobalState &gs, const UnorderedMap<long, long> &untypedBlames,
                         const options::Options &opts);
 
-// Create a copy of `from` that has its symbol table reset to the payload.
+// Create a copy of `from` containing the requested contiguous prefix of its symbol table.
+// A request for stratum zero initializes the symbol table from the payload (or an empty state under --no-stdlib).
 std::unique_ptr<core::GlobalState> copyForSlowPath(const core::GlobalState &from, const options::Options &opts,
                                                    core::packages::Stratum forStratum);
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I was trying to write some debug assertions for strata, and was at a
loss for what data to attempt to read from.

I think that by moving `fastPathEditStratum` from `LSPTypechecker` to a new
field on `GlobalState` called `earliestReopenedStratum`, we can both:

1.  Expose the data that I need to write the `ENFORCE`s while also
2.  Co-locating data a little better (e.g., in GlobalState, not LSPTypechecker)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See stacked changes.