### PR TITLE
Stop checking for test namespace references when test-packages are in use

### DIFF
--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -604,17 +604,6 @@ public:
             return;
         }
 
-        // If the imported symbol comes from the test namespace, we must also be in the test namespace.
-        // TODO(neil): is this check valid in --test-packages mode?
-        if ((otherFile.data(ctx).isPackagedTestHelper() || otherFile.data(ctx).isPackagedTest()) &&
-            !this->isAnyTestFile()) {
-            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
-                e.setHeader("`{}` is defined in a test namespace and cannot be referenced in a non-test file",
-                            litSymbol.show(ctx));
-            }
-            return;
-        }
-
         auto &db = ctx.state.packageDB();
 
         // no need to check visibility for these cases
@@ -622,7 +611,20 @@ public:
         if (!otherPackage.exists() || this->package.mangledName() == otherPackage) {
             return;
         }
+
         auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
+
+        // If the imported symbol comes from the test namespace, we must also be in the test namespace.
+        // TODO(trevor): this check is redundant with import checking after the test-packages migration is complete.
+        if (!pkg.usesTestPackages &&
+            (otherFile.data(ctx).isPackagedTestHelper() || otherFile.data(ctx).isPackagedTest()) &&
+            !this->isAnyTestFile()) {
+            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
+                e.setHeader("`{}` is defined in a test namespace and cannot be referenced in a non-test file",
+                            litSymbol.show(ctx));
+            }
+            return;
+        }
 
         if (this->package.usesTestPackages) {
             if (pkg.testPackage() && !this->package.testPackage()) {

--- a/test/testdata/packager/test-packages-namespace-error/a/__package.rb
+++ b/test/testdata/packager/test-packages-namespace-error/a/__package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+#
+# enable-packager: true
+# enable-package-directed: true
+
+class Root::A < PackageSpec
+  export_all!
+end

--- a/test/testdata/packager/test-packages-namespace-error/a/test/__package.rb
+++ b/test/testdata/packager/test-packages-namespace-error/a/test/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Root::A::Test < PackageSpec
+  test!
+end

--- a/test/testdata/packager/test-packages-namespace-error/a/test/foo.test.rb
+++ b/test/testdata/packager/test-packages-namespace-error/a/test/foo.test.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+module Root::A
+  module Test
+    class FooTest
+    end
+  end
+end

--- a/test/testdata/packager/test-packages-namespace-error/b/__package.rb
+++ b/test/testdata/packager/test-packages-namespace-error/b/__package.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+class Root::B < PackageSpec
+
+  import Root::A
+
+end

--- a/test/testdata/packager/test-packages-namespace-error/b/foo.rb
+++ b/test/testdata/packager/test-packages-namespace-error/b/foo.rb
@@ -3,6 +3,5 @@
 module Root::B
   class Foo
     RA = Root::A
-    #    ^^^^^^^ error: `Root::A` is defined in a test namespace
   end
 end

--- a/test/testdata/packager/test-packages-namespace-error/b/foo.rb
+++ b/test/testdata/packager/test-packages-namespace-error/b/foo.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+module Root::B
+  class Foo
+    RA = Root::A
+    #    ^^^^^^^ error: `Root::A` is defined in a test namespace
+  end
+end


### PR DESCRIPTION

This PR skips checking if a symbol comes from a file in a test path when the package that owns that symbol has been migrated to test-packages. The reasoning is that the original error guards against referring to part of a package that would only exist at test time, but test packages make that separation explicit so this check is redundant with import checking for migrated packages.

### Motivation
Getting rid of invalid errors for packages that have been migrated to test-packages.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
