### PR TITLE
Remove `T::Configuration.log_info_handler`

### DIFF
--- a/gems/sorbet-runtime/lib/types/configuration.rb
+++ b/gems/sorbet-runtime/lib/types/configuration.rb
@@ -270,38 +270,6 @@ module T::Configuration
     nil
   end
 
-  @log_info_handler = nil
-  # Set a handler for logging
-  #
-  # @param [Lambda, Proc, Object, nil] value Proc that handles the error
-  #   report (pass nil to reset to default behavior)
-  #
-  # Parameters passed to value.call:
-  #
-  #  @param [String] str Message to be logged
-  #  @param [Hash] extra A hash containing additional parameters to be passed along to the logger.
-  #
-  # @example
-  #   T::Configuration.log_info_handler = lambda do |str, extra|
-  #     puts "#{str}, context: #{extra}"
-  #   end
-  def self.log_info_handler=(value)
-    validate_lambda_given!(value)
-    @log_info_handler = value
-  end
-
-  private_class_method def self.log_info_handler_default(str, extra)
-    puts "#{str}, extra: #{extra}"
-  end
-
-  def self.log_info_handler(str, extra)
-    if @log_info_handler
-      @log_info_handler.call(str, extra)
-    else
-      log_info_handler_default(str, extra)
-    end
-  end
-
   @soft_assert_handler = nil
   # Set a handler for soft assertions
   #

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -141,10 +141,7 @@ module T::Props::Serializable
       # If the prop was already missing during deserialization, that means the application
       # code already had to deal with a nil value, which means we wouldn't be accomplishing
       # much by raising here (other than causing an unnecessary breakage).
-      T::Configuration.log_info_handler(
-        "chalk-odm: missing required property in serialize",
-        prop: prop, class: self.class.name, id: self.class.decorator.get_id(self)
-      )
+      $stderr.puts("chalk-odm: missing required property in serialize prop=#{prop.inspect} class=#{self.class.name} id=#{self.class.decorator.get_id(self).inspect}")
     else
       raise TypeError.new("#{self.class.name}.#{prop} not set for non-optional prop")
     end

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -141,7 +141,7 @@ module T::Props::Serializable
       # If the prop was already missing during deserialization, that means the application
       # code already had to deal with a nil value, which means we wouldn't be accomplishing
       # much by raising here (other than causing an unnecessary breakage).
-      $stderr.puts("chalk-odm: missing required property in serialize prop=#{prop.inspect} class=#{self.class.name} id=#{self.class.decorator.get_id(self).inspect}")
+      warn("chalk-odm: missing required property in serialize prop=#{prop.inspect} class=#{self.class.name} id=#{self.class.decorator.get_id(self).inspect}")
     else
       raise TypeError.new("#{self.class.name}.#{prop} not set for non-optional prop")
     end

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -141,7 +141,7 @@ module T::Props::Serializable
       # If the prop was already missing during deserialization, that means the application
       # code already had to deal with a nil value, which means we wouldn't be accomplishing
       # much by raising here (other than causing an unnecessary breakage).
-      warn("chalk-odm: missing required property in serialize prop=#{prop.inspect} class=#{self.class.name} id=#{self.class.decorator.get_id(self).inspect}")
+      Kernel.warn("chalk-odm: missing required property in serialize prop=#{prop.inspect} class=#{self.class.name} id=#{self.class.decorator.get_id(self).inspect}")
     else
       raise TypeError.new("#{self.class.name}.#{prop} not set for non-optional prop")
     end

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -438,23 +438,16 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       struct = NilSingleFieldStruct.from_hash({})
       assert_nil(struct.foo)
 
-      msg_string = nil
-      extra_hash = nil
-
-      T::Configuration.log_info_handler = proc do |msg, extra|
-        msg_string = msg
-        extra_hash = extra
+      h = nil
+      _stdout, msg_string = capture_io do
+        h = struct.serialize
       end
-
-      h = struct.serialize
 
       assert_instance_of(Hash, h)
       assert(h.empty?)
-      refute_nil(msg_string)
-      refute_nil(extra_hash)
       assert_includes(msg_string, "missing required property in serialize")
-      assert_equal(:foo, extra_hash[:prop])
-      assert_includes(extra_hash[:class], "NilSingleFieldStruct")
+      assert_includes(msg_string, "prop=:foo")
+      assert_includes(msg_string, "class=Opus::Types::Test::Props::SerializableTest::NilSingleFieldStruct")
     end
 
     describe 'with weak constructor' do

--- a/rbi/sorbet/t.rbi
+++ b/rbi/sorbet/t.rbi
@@ -412,8 +412,6 @@ module T::Configuration
   def self.disable_vm_prop_serde; end
   def self.inline_type_error_handler(error, opts={}); end
   def self.inline_type_error_handler=(value); end
-  def self.log_info_handler(str, extra); end
-  def self.log_info_handler=(value); end
   def self.module_name_mangler; end
   def self.module_name_mangler=(value); end
   def self.scalar_types; end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was only used in one place. We don't really need it anymore, we can
just print the log on stdout.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.