### PR TITLE
Keep nested constants under unpackaged namespaces unpackaged

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1199,6 +1199,16 @@ ClassOrModuleRef GlobalState::enterClassOrModuleSymbol(Loc loc, ClassOrModuleRef
 
     auto ownerData = owner.data(*this);
     auto ownerPackageRegistryOwner = ownerData->packageRegistryOwner;
+    auto ownerCanStartPackageLookup =
+        owner == Symbols::root() || owner.isPackageSpecSymbol(*this) ||
+        (ownerData->owner == Symbols::root() && ownerData->name == packages::PackageDB::TEST_NAMESPACE);
+    if (!ownerCanStartPackageLookup && !ownerData->package.exists() &&
+        ownerPackageRegistryOwner == Symbols::PackageSpecRegistry()) {
+        // This owner is implicitly unpackaged. Definitions nested under it must remain unpackaged rather than
+        // resuming a package-name search below the unpackaged namespace.
+        ownerPackageRegistryOwner = Symbols::noClassOrModule();
+    }
+
     if (!ownerPackageRegistryOwner.exists()) {
         // Our owner was already past the end of the PackageSpecRegistry namespace.
         // Propogate that we are too, and mark us as being owned by whatever package our owner was.

--- a/test/cli/package-non-prefix-collision/other/__package.rb
+++ b/test/cli/package-non-prefix-collision/other/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Other < PackageSpec
+  prelude_package
+end

--- a/test/cli/package-non-prefix-collision/other/absolute_regexp_parser.rbi
+++ b/test/cli/package-non-prefix-collision/other/absolute_regexp_parser.rbi
@@ -1,0 +1,10 @@
+# typed: true
+
+class ::Regexp::Parser
+end
+
+class ::Regexp::Parser::AbsoluteError < StandardError
+end
+
+class ::Regexp::AbsoluteScannerError < ::Regexp::Parser::AbsoluteError
+end

--- a/test/cli/package-non-prefix-collision/other/regexp_parser.rbi
+++ b/test/cli/package-non-prefix-collision/other/regexp_parser.rbi
@@ -1,0 +1,10 @@
+# typed: true
+
+class Regexp::Parser
+end
+
+class Regexp::Parser::Error < StandardError
+end
+
+class Regexp::ScannerError < Regexp::Parser::Error
+end

--- a/test/cli/package-non-prefix-collision/parser/__package.rb
+++ b/test/cli/package-non-prefix-collision/parser/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Parser < PackageSpec
+end

--- a/test/cli/package-non-prefix-collision/test.out
+++ b/test/cli/package-non-prefix-collision/test.out
@@ -1,0 +1,87 @@
+other/absolute_regexp_parser.rbi:6: Superclasses may only be set on constants in the package that owns them https://srb.help/5084
+     6 |class ::Regexp::Parser::AbsoluteError < StandardError
+                                                ^^^^^^^^^^^^^
+    other/absolute_regexp_parser.rbi:6: Symbol originally defined here
+     6 |class ::Regexp::Parser::AbsoluteError < StandardError
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    other/__package.rb:3: Package where the `include` occurs
+     3 |class Other < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
+    parser/__package.rb:3: Package where `Regexp::Parser::AbsoluteError` is defined
+     3 |class Parser < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+other/absolute_regexp_parser.rbi:9: `Regexp::Parser::AbsoluteError` resolves but is not exported from `Parser` and `Parser` is not imported https://srb.help/3718
+     9 |class ::Regexp::AbsoluteScannerError < ::Regexp::Parser::AbsoluteError
+                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  `Regexp::Parser::AbsoluteError` does not define behavior and thus will not be automatically exported
+    other/absolute_regexp_parser.rbi:6:
+     6 |class ::Regexp::Parser::AbsoluteError < StandardError
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Either export it manually, or better, restructure the code so that package namespaces do not define behavior.
+  Autocorrect: Use `-a` to autocorrect
+    other/__package.rb:4: Insert `import Parser`
+     4 |  prelude_package
+                         ^
+
+other/regexp_parser.rbi:3: File belongs to package `Other` but defines a constant that does not match this namespace https://srb.help/3713
+     3 |class Regexp::Parser
+              ^^^^^^^^^^^^^^
+    other/__package.rb:3: Enclosing package declared here
+     3 |class Other < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
+    parser/__package.rb:3: Must belong to this package, given constant name `Regexp::Parser`
+     3 |class Parser < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+other/regexp_parser.rbi:6: This file must only define behavior in enclosing package `Other` https://srb.help/3713
+     6 |class Regexp::Parser::Error < StandardError
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    other/regexp_parser.rbi:6: Defining behavior in `Regexp::Parser::Error` instead:
+     6 |class Regexp::Parser::Error < StandardError
+              ^^^^^^^^^^^^^^^^^^^^^
+    other/__package.rb:3: Enclosing package `Other` declared here
+     3 |class Other < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
+    parser/__package.rb:3: Package `Regexp::Parser::Error` declared here
+     3 |class Parser < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+other/regexp_parser.rbi:9: This file must only define behavior in enclosing package `Other` https://srb.help/3713
+     9 |class Regexp::ScannerError < Regexp::Parser::Error
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    other/regexp_parser.rbi:9: Defining behavior in `Regexp::ScannerError` instead:
+     9 |class Regexp::ScannerError < Regexp::Parser::Error
+              ^^^^^^^^^^^^^^^^^^^^
+    other/__package.rb:3: Enclosing package `Other` declared here
+     3 |class Other < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+other/regexp_parser.rbi:6: Superclasses may only be set on constants in the package that owns them https://srb.help/5084
+     6 |class Regexp::Parser::Error < StandardError
+                                      ^^^^^^^^^^^^^
+    other/regexp_parser.rbi:6: Symbol originally defined here
+     6 |class Regexp::Parser::Error < StandardError
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    other/__package.rb:3: Package where the `include` occurs
+     3 |class Other < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
+    parser/__package.rb:3: Package where `Regexp::Parser::Error` is defined
+     3 |class Parser < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+other/regexp_parser.rbi:9: `Regexp::Parser::Error` resolves but is not exported from `Parser` and `Parser` is not imported https://srb.help/3718
+     9 |class Regexp::ScannerError < Regexp::Parser::Error
+                                     ^^^^^^^^^^^^^^^^^^^^^
+  `Regexp::Parser::Error` does not define behavior and thus will not be automatically exported
+    other/regexp_parser.rbi:6:
+     6 |class Regexp::Parser::Error < StandardError
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Either export it manually, or better, restructure the code so that package namespaces do not define behavior.
+  Autocorrect: Use `-a` to autocorrect
+    other/__package.rb:4: Insert `import Parser`
+     4 |  prelude_package
+                         ^
+Errors: 7

--- a/test/cli/package-non-prefix-collision/test.out
+++ b/test/cli/package-non-prefix-collision/test.out
@@ -1,39 +1,9 @@
-other/absolute_regexp_parser.rbi:6: Superclasses may only be set on constants in the package that owns them https://srb.help/5084
-     6 |class ::Regexp::Parser::AbsoluteError < StandardError
-                                                ^^^^^^^^^^^^^
-    other/absolute_regexp_parser.rbi:6: Symbol originally defined here
-     6 |class ::Regexp::Parser::AbsoluteError < StandardError
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Package where the `include` occurs
-     3 |class Other < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^
-    parser/__package.rb:3: Package where `Regexp::Parser::AbsoluteError` is defined
-     3 |class Parser < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-other/absolute_regexp_parser.rbi:9: `Regexp::Parser::AbsoluteError` resolves but is not exported from `Parser` and `Parser` is not imported https://srb.help/3718
-     9 |class ::Regexp::AbsoluteScannerError < ::Regexp::Parser::AbsoluteError
-                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  `Regexp::Parser::AbsoluteError` does not define behavior and thus will not be automatically exported
-    other/absolute_regexp_parser.rbi:6:
-     6 |class ::Regexp::Parser::AbsoluteError < StandardError
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Note:
-    Either export it manually, or better, restructure the code so that package namespaces do not define behavior.
-  Autocorrect: Use `-a` to autocorrect
-    other/__package.rb:4: Insert `import Parser`
-     4 |  prelude_package
-                         ^
-
 other/regexp_parser.rbi:3: File belongs to package `Other` but defines a constant that does not match this namespace https://srb.help/3713
      3 |class Regexp::Parser
               ^^^^^^^^^^^^^^
     other/__package.rb:3: Enclosing package declared here
      3 |class Other < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^
-    parser/__package.rb:3: Must belong to this package, given constant name `Regexp::Parser`
-     3 |class Parser < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 other/regexp_parser.rbi:6: This file must only define behavior in enclosing package `Other` https://srb.help/3713
      6 |class Regexp::Parser::Error < StandardError
@@ -44,9 +14,6 @@ other/regexp_parser.rbi:6: This file must only define behavior in enclosing pack
     other/__package.rb:3: Enclosing package `Other` declared here
      3 |class Other < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^
-    parser/__package.rb:3: Package `Regexp::Parser::Error` declared here
-     3 |class Parser < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 other/regexp_parser.rbi:9: This file must only define behavior in enclosing package `Other` https://srb.help/3713
      9 |class Regexp::ScannerError < Regexp::Parser::Error
@@ -57,31 +24,4 @@ other/regexp_parser.rbi:9: This file must only define behavior in enclosing pack
     other/__package.rb:3: Enclosing package `Other` declared here
      3 |class Other < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^
-
-other/regexp_parser.rbi:6: Superclasses may only be set on constants in the package that owns them https://srb.help/5084
-     6 |class Regexp::Parser::Error < StandardError
-                                      ^^^^^^^^^^^^^
-    other/regexp_parser.rbi:6: Symbol originally defined here
-     6 |class Regexp::Parser::Error < StandardError
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Package where the `include` occurs
-     3 |class Other < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^
-    parser/__package.rb:3: Package where `Regexp::Parser::Error` is defined
-     3 |class Parser < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-other/regexp_parser.rbi:9: `Regexp::Parser::Error` resolves but is not exported from `Parser` and `Parser` is not imported https://srb.help/3718
-     9 |class Regexp::ScannerError < Regexp::Parser::Error
-                                     ^^^^^^^^^^^^^^^^^^^^^
-  `Regexp::Parser::Error` does not define behavior and thus will not be automatically exported
-    other/regexp_parser.rbi:6:
-     6 |class Regexp::Parser::Error < StandardError
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Note:
-    Either export it manually, or better, restructure the code so that package namespaces do not define behavior.
-  Autocorrect: Use `-a` to autocorrect
-    other/__package.rb:4: Insert `import Parser`
-     4 |  prelude_package
-                         ^
-Errors: 7
+Errors: 3

--- a/test/cli/package-non-prefix-collision/test.sh
+++ b/test/cli/package-non-prefix-collision/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cd test/cli/package-non-prefix-collision || exit 1
+
+../../../main/sorbet --silence-dev-message --sorbet-packages --max-threads=0 . 2>&1


### PR DESCRIPTION
^ That's a mouthful, but it's kind of the only way to describe it.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Package lookup could restart at the registry root beneath an implicitly
unpackaged namespace, e.g. a namespace defined in the payload (today) or
in the future "first-class" unpackaged code.

A concrete example of this came when I tried to define a `__package.rb`
for the `Parser` gem in pay-server, only to have Sorbet think that the
`Regexp::Parser` definitions "belonged" to the newly-defined `Parser`
package.

We can fix this by only allowing `<root>`, `Test`, and symbols under
`<PackageSpecRegistry>` to start the package lookup. Otherwise, we
propagate the owner's unpackaged state.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Tests show before and after, and the behavior both for `::`-prefixed and normal
constant definitions.