### PR TITLE
Fix another problem with canModifySymbol

### DIFF
--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -1067,7 +1067,11 @@ PackageInfo::CanModifyResult PackageInfo::canModifySymbol(core::Context ctx, Cla
         // In package-directed mode, test files must not modify symbols that were defined on the non-test side of
         // the package. Doing so would create type members (or mixins) at the test stratum that dangle after
         // copySymbolTableFrom filters by stratum boundary.
-        if (ctx.file.exists() && !gs.packageDB().testPackages() && ctx.file.data(gs).isPackagedTest()) {
+        //
+        // Migrated packages (usesTestPackages) have applicationStratum == testStratum, so there is no cross-stratum
+        // violation and this check is unnecessary (and unreachable in practice, since test files belong to the test
+        // package and hit NotOwner above).
+        if (ctx.file.exists() && !this->usesTestPackages && ctx.file.data(gs).isPackagedTest()) {
             for (auto &loc : symData->locs()) {
                 if (loc.exists() && !loc.file().data(gs).isPackagedTest()) {
                     return CanModifyResult::TestModifyingNonTest;

--- a/test/testdata/packager/directed-type-member-unmigrated-test-file-crash/parent/__package.rb
+++ b/test/testdata/packager/directed-type-member-unmigrated-test-file-crash/parent/__package.rb
@@ -1,0 +1,10 @@
+# typed: strict
+# enable-packager: true
+# enable-package-directed: true
+# enable-test-packages: true
+
+# stratum: 0
+
+class Parent < PackageSpec
+  export Parent::MyGeneric
+end

--- a/test/testdata/packager/directed-type-member-unmigrated-test-file-crash/parent/my_generic.rb
+++ b/test/testdata/packager/directed-type-member-unmigrated-test-file-crash/parent/my_generic.rb
@@ -1,0 +1,10 @@
+# typed: strict
+# frozen_string_literal: true
+
+# stratum: 0
+
+class Parent::MyGeneric
+  extend T::Generic
+
+  Elem = type_member
+end

--- a/test/testdata/packager/directed-type-member-unmigrated-test-file-crash/parent/test/reopen.rb
+++ b/test/testdata/packager/directed-type-member-unmigrated-test-file-crash/parent/test/reopen.rb
@@ -1,0 +1,7 @@
+# typed: strict
+# frozen_string_literal: true
+
+class Parent::MyGeneric # error: Tests in the `Parent` package must define tests in the `Test::Parent` namespace
+  Elem2 = type_member
+  #       ^^^^^^^^^^^ error: `type_member` in a test file cannot modify a non-test class in the same package
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

At the last minute in #10579 while debugging the previous variance.cc crash, I
made a change to `canModifySymbol` which allowed the bug to continue to live:

> I updated the condition to mention `testPackages()` so that when I remove that
> function I will see an impossible-to-miss compiler error here. Good catch—the
> PR that removes testPackages (#10349) does not remove isPackagedTest, so it
> wouldn't have been flagged if I forgot to revert these changes.

<https://github.com/sorbet/sorbet/pull/10579/changes/6b1ff637b487c02f23864cc09dd52ec89f4878ba#r3818811624>

The problem with that is that this bug is present even if `opts.testPackages` is
enabled because we made a change to more incrementally roll out test packages.
There's a `usesTestPackages` flag on each `PackageInfo` which individually
controls whether that package an it's associated `/test/` folder have been
migrated to `test!` packages or not, and if not, then the old `test_import` +
"assign to fake test code package" logic still applies even when
`--test-packages` is passed.

I hadn't considered that (and honestly didn't fully appreciate that
`usesTestPackages` even existed), so the `canModifySymbol` patch failed to
account for that.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The test shows the crash before.