### PR TITLE
Remove `--experimental-test-packages`

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2208,11 +2208,11 @@ unique_ptr<GlobalState> GlobalState::copyForSlowPath(
         {
             core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*result);
             core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = result->unfreezePackages();
-            result->setPackagerOptions(
-                extraPackageFilesDirectoryUnderscorePrefixes, extraPackageFilesDirectorySlashDeprecatedPrefixes,
-                extraPackageFilesDirectorySlashPrefixes, packageSkipRBIExportEnforcementDirs,
-                allowRelaxedPackagerChecksFor, updateVisibilityFor, packagerLayers, errorHint, genPackagesMode,
-                allowRelaxingTestVisibility, packageAttributedErrors);
+            result->setPackagerOptions(extraPackageFilesDirectoryUnderscorePrefixes,
+                                       extraPackageFilesDirectorySlashDeprecatedPrefixes,
+                                       extraPackageFilesDirectorySlashPrefixes, packageSkipRBIExportEnforcementDirs,
+                                       allowRelaxedPackagerChecksFor, updateVisibilityFor, packagerLayers, errorHint,
+                                       genPackagesMode, allowRelaxingTestVisibility, packageAttributedErrors);
         }
 
         result->copySymbolTableFrom(*this, toStratum);

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2109,8 +2109,7 @@ unique_ptr<GlobalState> GlobalState::copyForIndexThread(
     const vector<string> &extraPackageFilesDirectorySlashPrefixes,
     const vector<string> &packageSkipRBIExportEnforcementDirs, const vector<string> &allowRelaxedPackagerChecksFor,
     const vector<string> &updateVisibilityFor, const vector<string> &packagerLayers, string errorHint,
-    packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility, bool packageAttributedErrors,
-    bool testPackages) const {
+    packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility, bool packageAttributedErrors) const {
     ENFORCE(fileTableFrozen);
     auto result = make_unique<GlobalState>(this->errorQueue, this->epochManager);
 
@@ -2132,7 +2131,7 @@ unique_ptr<GlobalState> GlobalState::copyForIndexThread(
                                    extraPackageFilesDirectorySlashDeprecatedPrefixes,
                                    extraPackageFilesDirectorySlashPrefixes, packageSkipRBIExportEnforcementDirs,
                                    allowRelaxedPackagerChecksFor, updateVisibilityFor, packagerLayers, errorHint,
-                                   genPackagesMode, allowRelaxingTestVisibility, packageAttributedErrors, testPackages);
+                                   genPackagesMode, allowRelaxingTestVisibility, packageAttributedErrors);
     }
 
     return result;
@@ -2144,7 +2143,7 @@ unique_ptr<GlobalState> GlobalState::copyForLSPTypechecker(
     const vector<string> &extraPackageFilesDirectorySlashPrefixes,
     const vector<string> &packageSkipRBIExportEnforcementDirs, const vector<string> &allowRelaxedPackagerChecksFor,
     const vector<string> &updateVisibilityFor, const vector<string> &packagerLayers, string errorHint,
-    packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility, bool testPackages) const {
+    packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility) const {
     auto result = make_unique<GlobalState>(this->errorQueue, this->epochManager);
 
     result->initEmpty();
@@ -2165,7 +2164,7 @@ unique_ptr<GlobalState> GlobalState::copyForLSPTypechecker(
                                    extraPackageFilesDirectorySlashDeprecatedPrefixes,
                                    extraPackageFilesDirectorySlashPrefixes, packageSkipRBIExportEnforcementDirs,
                                    allowRelaxedPackagerChecksFor, updateVisibilityFor, packagerLayers, errorHint,
-                                   genPackagesMode, allowRelaxingTestVisibility, packageAttributedErrors, testPackages);
+                                   genPackagesMode, allowRelaxingTestVisibility, packageAttributedErrors);
     }
 
     return result;
@@ -2178,7 +2177,7 @@ unique_ptr<GlobalState> GlobalState::copyForSlowPath(
     const vector<string> &packageSkipRBIExportEnforcementDirs, const vector<string> &allowRelaxedPackagerChecksFor,
     const vector<string> &updateVisibilityFor, const vector<string> &packagerLayers, string errorHint,
     packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility, bool packageAttributedErrors,
-    bool testPackages, core::packages::Stratum toStratum) const {
+    core::packages::Stratum toStratum) const {
     auto result = make_unique<GlobalState>(this->errorQueue, this->epochManager);
 
     // We omit a call to `initEmpty` here, as the only intended use of this function is to have its symbol table
@@ -2213,7 +2212,7 @@ unique_ptr<GlobalState> GlobalState::copyForSlowPath(
                 extraPackageFilesDirectoryUnderscorePrefixes, extraPackageFilesDirectorySlashDeprecatedPrefixes,
                 extraPackageFilesDirectorySlashPrefixes, packageSkipRBIExportEnforcementDirs,
                 allowRelaxedPackagerChecksFor, updateVisibilityFor, packagerLayers, errorHint, genPackagesMode,
-                allowRelaxingTestVisibility, packageAttributedErrors, testPackages);
+                allowRelaxingTestVisibility, packageAttributedErrors);
         }
 
         result->copySymbolTableFrom(*this, toStratum);
@@ -2464,15 +2463,13 @@ void GlobalState::setPackagerOptions(const vector<string> &extraPackageFilesDire
                                      const vector<string> &allowRelaxedPackagerChecksFor,
                                      const vector<string> &updateVisibilityFor, const vector<string> &packagerLayers,
                                      string errorHint, packages::GenPackagesMode genPackagesMode,
-                                     bool allowRelaxingTestVisibility, bool packageAttributedErrors,
-                                     bool testPackages) {
+                                     bool allowRelaxingTestVisibility, bool packageAttributedErrors) {
     ENFORCE_NO_TIMER(!packageDB_.frozen);
 
     packageDB_.enabled_ = true;
     packageDB_.genPackagesMode_ = genPackagesMode;
     packageDB_.allowRelaxingTestVisibility_ = allowRelaxingTestVisibility;
     packageDB_.packageAttributedErrors_ = packageAttributedErrors;
-    packageDB_.testPackages_ = testPackages;
     packageDB_.extraPackageFilesDirectoryUnderscorePrefixes_ = extraPackageFilesDirectoryUnderscorePrefixes;
     packageDB_.extraPackageFilesDirectorySlashDeprecatedPrefixes_ = extraPackageFilesDirectorySlashDeprecatedPrefixes;
     packageDB_.extraPackageFilesDirectorySlashPrefixes_ = extraPackageFilesDirectorySlashPrefixes;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -682,7 +682,6 @@ public:
         // Think very hard before looking at this value in namer / resolver!
         // (hint: probably you want to find an alternate solution)
         bool runningUnderAutogen = false;
-
     };
     CacheSensitiveOptions cacheSensitiveOptions;
 

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -441,7 +441,7 @@ public:
                             const std::vector<std::string> &updateVisibilityFor,
                             const std::vector<std::string> &packagerLayers, std::string errorHint,
                             packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility,
-                            bool packageAttributedErrors, bool testPackages);
+                            bool packageAttributedErrors);
     packages::UnfreezePackages unfreezePackages();
 
     NameRef nextMangledName(ClassOrModuleRef owner, NameRef origName);
@@ -566,7 +566,7 @@ public:
         const std::vector<std::string> &allowRelaxedPackagerChecksFor,
         const std::vector<std::string> &updateVisibilityFor, const std::vector<std::string> &packagerLayers,
         std::string errorHint, packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility,
-        bool packageAttributedErrors, bool testPackages) const;
+        bool packageAttributedErrors) const;
 
     // Minimally copy the global state, including the file table, to initialize the LSPTypechecker.
     // NOTE: this very intentionally will not copy the symbol or name tables. The symbol tables aren't used or populated
@@ -578,8 +578,7 @@ public:
         const std::vector<std::string> &packageSkipRBIExportEnforcementDirs,
         const std::vector<std::string> &allowRelaxedPackagerChecksFor,
         const std::vector<std::string> &updateVisibilityFor, const std::vector<std::string> &packagerLayers,
-        std::string errorHint, packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility,
-        bool testPackages) const;
+        std::string errorHint, packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility) const;
 
     // Copy the name table, file table and other parts of GlobalState that are required to start the slow path. If the
     // `toStratum` value is passed as something other than the `0` stratum, the prefix of the symbol table leading up to
@@ -592,7 +591,7 @@ public:
                     const std::vector<std::string> &allowRelaxedPackagerChecksFor,
                     const std::vector<std::string> &updateVisibilityFor, const std::vector<std::string> &packagerLayers,
                     std::string errorHint, packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility,
-                    bool packageAttributedErrors, bool testPackages, core::packages::Stratum toStratum) const;
+                    bool packageAttributedErrors, core::packages::Stratum toStratum) const;
 
     // Contains a path prefix that should be stripped from all printed paths.
     std::string pathPrefix;
@@ -684,8 +683,6 @@ public:
         // (hint: probably you want to find an alternate solution)
         bool runningUnderAutogen = false;
 
-        // Whether to enable the new syntax and behavior for test-only packages.
-        bool testPackages = false;
     };
     CacheSensitiveOptions cacheSensitiveOptions;
 

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -85,11 +85,6 @@ public:
         return this->packageAttributedErrors_;
     }
 
-    // Whether we're using separate test packages, or the old-style inline test packages.
-    bool testPackages() const {
-        return this->testPackages_;
-    }
-
     absl::Span<const std::string> extraPackageFilesDirectoryUnderscorePrefixes() const;
     absl::Span<const std::string> extraPackageFilesDirectorySlashDeprecatedPrefixes() const;
     absl::Span<const std::string> extraPackageFilesDirectorySlashPrefixes() const;
@@ -138,7 +133,6 @@ private:
     GenPackagesMode genPackagesMode_ = GenPackagesMode::Disabled;
     bool allowRelaxingTestVisibility_ = false;
     bool packageAttributedErrors_ = false;
-    bool testPackages_ = false;
     std::vector<std::string> extraPackageFilesDirectoryUnderscorePrefixes_;
     std::vector<std::string> extraPackageFilesDirectorySlashDeprecatedPrefixes_;
     std::vector<std::string> extraPackageFilesDirectorySlashPrefixes_;

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -441,7 +441,7 @@ TEST_CASE("isPackageSpecSymbol") {
 
     {
         auto unfrezePackages = gs.packageDB().unfreeze();
-        gs.setPackagerOptions({}, {}, {}, {}, {}, {}, {}, "", packages::GenPackagesMode::Disabled, false, false, false);
+        gs.setPackagerOptions({}, {}, {}, {}, {}, {}, {}, "", packages::GenPackagesMode::Disabled, false, false);
     }
 
     CHECK_FALSE(Symbols::root().isPackageSpecSymbol(gs));

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -277,17 +277,16 @@ void LSPIndexer::transferInitializeState(InitializedTask &task) {
     // indexer and typechecker's file tables will almost immediately diverge, but that's not an issue as we don't share
     // `core::FileRef` values between the two.
     auto enableGenPackagesAllowRelaxingTestVisibility = false;
-    auto typecheckerGS =
-        std::exchange(this->gs, this->gs->copyForLSPTypechecker(
-                                    this->config->opts.cacheSensitiveOptions.sorbetPackages,
-                                    this->config->opts.extraPackageFilesDirectoryUnderscorePrefixes,
-                                    this->config->opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
-                                    this->config->opts.extraPackageFilesDirectorySlashPrefixes,
-                                    this->config->opts.packageSkipRBIExportEnforcementDirs,
-                                    this->config->opts.allowRelaxedPackagerChecksFor,
-                                    this->config->opts.updateVisibilityFor, this->config->opts.packagerLayers,
-                                    this->config->opts.sorbetPackagesHint, core::packages::GenPackagesMode::Disabled,
-                                    enableGenPackagesAllowRelaxingTestVisibility));
+    auto typecheckerGS = std::exchange(
+        this->gs, this->gs->copyForLSPTypechecker(
+                      this->config->opts.cacheSensitiveOptions.sorbetPackages,
+                      this->config->opts.extraPackageFilesDirectoryUnderscorePrefixes,
+                      this->config->opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
+                      this->config->opts.extraPackageFilesDirectorySlashPrefixes,
+                      this->config->opts.packageSkipRBIExportEnforcementDirs,
+                      this->config->opts.allowRelaxedPackagerChecksFor, this->config->opts.updateVisibilityFor,
+                      this->config->opts.packagerLayers, this->config->opts.sorbetPackagesHint,
+                      core::packages::GenPackagesMode::Disabled, enableGenPackagesAllowRelaxingTestVisibility));
 
     task.setGlobalState(std::move(typecheckerGS));
     task.setKeyValueStore(std::move(this->kvstore));

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -287,7 +287,7 @@ void LSPIndexer::transferInitializeState(InitializedTask &task) {
                                     this->config->opts.allowRelaxedPackagerChecksFor,
                                     this->config->opts.updateVisibilityFor, this->config->opts.packagerLayers,
                                     this->config->opts.sorbetPackagesHint, core::packages::GenPackagesMode::Disabled,
-                                    enableGenPackagesAllowRelaxingTestVisibility, this->config->opts.testPackages));
+                                    enableGenPackagesAllowRelaxingTestVisibility));
 
     task.setGlobalState(std::move(typecheckerGS));
     task.setKeyValueStore(std::move(this->kvstore));

--- a/main/lsp/requests/references.cc
+++ b/main/lsp/requests/references.cc
@@ -49,10 +49,8 @@ core::lsp::Query::Symbol::STORAGE getSymsToCheckWithinPackage(const core::Global
     namespacesToCheck.emplace_back(core::Symbols::root());
 
     // TODO(trevor): we can remove this case once we have switched to test-packages
-    if (!gs.packageDB().testPackages()) {
-        namespacesToCheck.emplace_back(
-            core::Symbols::root().data(gs)->findMember(gs, core::packages::PackageDB::TEST_NAMESPACE));
-    }
+    namespacesToCheck.emplace_back(
+        core::Symbols::root().data(gs)->findMember(gs, core::packages::PackageDB::TEST_NAMESPACE));
 
     for (auto &namespaceToCheck : namespacesToCheck) {
         if (!namespaceToCheck.exists()) {

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -654,8 +654,6 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options(section)("experimental-package-directed",
                                  "Enable support for checking by package, instead of processing all files at once",
                                  cxxopts::value<bool>());
-    options.add_options(section)("experimental-test-packages", "Enable support for tests as their own packages",
-                                 cxxopts::value<bool>());
     // }}}
 
     // ----- STRIPE AUTOGEN ----------------------------------------------- {{{
@@ -1251,12 +1249,6 @@ void readOptions(Options &opts,
             logger->error("--package-attributed-errors can only be specified in --sorbet-packages mode");
             throw EarlyReturnWithCode(1);
         }
-        opts.testPackages = raw["experimental-test-packages"].as<bool>();
-        if (opts.testPackages && !opts.cacheSensitiveOptions.sorbetPackages) {
-            logger->error("--experimental-test-packages can only be specified in --sorbet-packages mode");
-            throw EarlyReturnWithCode(1);
-        }
-
         opts.packageDirected = raw["experimental-package-directed"].as<bool>();
         if (opts.packageDirected && !opts.cacheSensitiveOptions.sorbetPackages) {
             logger->error("--experimental-package-directed can only be specified in --sorbet-packages mode");

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -225,8 +225,6 @@ struct Options {
 
     bool packageAttributedErrors = false;
     bool packageDirected = false;
-    bool testPackages = false;
-
     uint32_t reserveClassTableCapacity = 0;
     uint32_t reserveMethodTableCapacity = 0;
     uint32_t reserveFieldTableCapacity = 0;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -112,7 +112,7 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
             opts.extraPackageFilesDirectoryUnderscorePrefixes, opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
             opts.extraPackageFilesDirectorySlashPrefixes, opts.packageSkipRBIExportEnforcementDirs,
             opts.allowRelaxedPackagerChecksFor, opts.updateVisibilityFor, opts.packagerLayers, opts.sorbetPackagesHint,
-            opts.genPackagesMode, opts.allowRelaxingTestVisibility, opts.packageAttributedErrors, opts.testPackages);
+            opts.genPackagesMode, opts.allowRelaxingTestVisibility, opts.packageAttributedErrors);
     }
 #endif
 }
@@ -129,8 +129,7 @@ unique_ptr<core::GlobalState> copyForSlowPath(const core::GlobalState &from, con
         opts.extraPackageFilesDirectoryUnderscorePrefixes, opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
         opts.extraPackageFilesDirectorySlashPrefixes, opts.packageSkipRBIExportEnforcementDirs,
         opts.allowRelaxedPackagerChecksFor, opts.updateVisibilityFor, opts.packagerLayers, opts.sorbetPackagesHint,
-        opts.genPackagesMode, opts.allowRelaxingTestVisibility, opts.packageAttributedErrors, opts.testPackages,
-        forStratum);
+        opts.genPackagesMode, opts.allowRelaxingTestVisibility, opts.packageAttributedErrors, forStratum);
 
     // Fall back on initializing from the payload if we're not copying part of from's symbol table.
     if (forStratum == core::packages::Stratum(0)) {
@@ -721,7 +720,7 @@ ast::ParsedFilesOrCancelled indexSuppliedFiles(core::GlobalState &baseGs, absl::
         opts.extraPackageFilesDirectorySlashDeprecatedPrefixes, opts.extraPackageFilesDirectorySlashPrefixes,
         opts.packageSkipRBIExportEnforcementDirs, opts.allowRelaxedPackagerChecksFor, opts.updateVisibilityFor,
         opts.packagerLayers, opts.sorbetPackagesHint, opts.genPackagesMode, opts.allowRelaxingTestVisibility,
-        opts.packageAttributedErrors, opts.testPackages);
+        opts.packageAttributedErrors);
 
     workers.multiplexJob("indexSuppliedFiles", [emptyGs, &opts, fileq, resultq, &kvstore, cancelable]() {
         Timer timeit(emptyGs->tracer(), "indexSuppliedFilesWorker");
@@ -733,7 +732,7 @@ ast::ParsedFilesOrCancelled indexSuppliedFiles(core::GlobalState &baseGs, absl::
             opts.extraPackageFilesDirectorySlashDeprecatedPrefixes, opts.extraPackageFilesDirectorySlashPrefixes,
             opts.packageSkipRBIExportEnforcementDirs, opts.allowRelaxedPackagerChecksFor, opts.updateVisibilityFor,
             opts.packagerLayers, opts.sorbetPackagesHint, opts.genPackagesMode, opts.allowRelaxingTestVisibility,
-            opts.packageAttributedErrors, opts.testPackages);
+            opts.packageAttributedErrors);
         auto &epochManager = *localGs->epochManager;
 
         IndexThreadResultPack threadResult;

--- a/test/cli/package-gen-packages-test-packages/test.sh
+++ b/test/cli/package-gen-packages-test-packages/test.sh
@@ -16,7 +16,7 @@ echo "###### --gen-packages not allowed without --sorbet-packages ######"
 
 echo "###### --gen-packages not allowed with --lsp ######"
 
-"$cwd/main/sorbet" --max-threads=0 --censor-for-snapshot-tests --silence-dev-message --lsp --sorbet-packages --experimental-test-packages --gen-packages --packager-layers=util,app -a . 2>&1
+"$cwd/main/sorbet" --max-threads=0 --censor-for-snapshot-tests --silence-dev-message --lsp --sorbet-packages --gen-packages --packager-layers=util,app -a . 2>&1
 
 echo "##################################"
 echo "###### Non package directed ######"
@@ -25,7 +25,7 @@ echo "##################################"
 echo
 echo "###### Running gen-packages ######"
 
-"$cwd/main/sorbet" --did-you-mean=false --max-threads=0 --censor-for-snapshot-tests --silence-dev-message --sorbet-packages --experimental-test-packages --gen-packages --packager-layers=util,app  --gen-packages-update-visibility-for=B --gen-packages-update-visibility-for=E --gen-packages-allow-relaxing-test-visibility -a . 2>&1
+"$cwd/main/sorbet" --did-you-mean=false --max-threads=0 --censor-for-snapshot-tests --silence-dev-message --sorbet-packages --gen-packages --packager-layers=util,app  --gen-packages-update-visibility-for=B --gen-packages-update-visibility-for=E --gen-packages-allow-relaxing-test-visibility -a . 2>&1
 
 echo
 echo "###### cat B/__package.rb ######"
@@ -71,7 +71,7 @@ cd "$tmp" || exit 1
 echo
 echo "###### Running gen-packages ######"
 
-"$cwd/main/sorbet" --max-threads=0 --did-you-mean=false --censor-for-snapshot-tests --silence-dev-message --sorbet-packages --experimental-test-packages --experimental-package-directed --gen-packages --packager-layers=util,app  --gen-packages-update-visibility-for=B --gen-packages-update-visibility-for=E --gen-packages-allow-relaxing-test-visibility -a . 2>&1
+"$cwd/main/sorbet" --max-threads=0 --did-you-mean=false --censor-for-snapshot-tests --silence-dev-message --sorbet-packages --experimental-package-directed --gen-packages --packager-layers=util,app  --gen-packages-update-visibility-for=B --gen-packages-update-visibility-for=E --gen-packages-allow-relaxing-test-visibility -a . 2>&1
 
 echo
 echo "###### cat B/__package.rb ######"

--- a/test/cli/packager_min_typed_level_test_packages/test.sh
+++ b/test/cli/packager_min_typed_level_test_packages/test.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 
 cd test/cli/packager_min_typed_level_test_packages || exit 1
 
-../../../main/sorbet --silence-dev-message --sorbet-packages --experimental-test-packages --max-threads=0 . 2>&1
+../../../main/sorbet --silence-dev-message --sorbet-packages --max-threads=0 . 2>&1

--- a/test/cli/test-packages-minimal/test.sh
+++ b/test/cli/test-packages-minimal/test.sh
@@ -9,4 +9,4 @@ cd test/cli/test-packages-minimal || ( echo "Failed to cd!"; exit 1 )
 
 "$root/main/sorbet" \
   --censor-for-snapshot-tests --silence-dev-message --max-threads=0 \
-  --sorbet-packages --experimental-test-packages . 2>&1
+  --sorbet-packages . 2>&1

--- a/test/cli/test-packages-package-directed/test.sh
+++ b/test/cli/test-packages-package-directed/test.sh
@@ -6,4 +6,4 @@ cd test/cli/test-packages-package-directed || ( echo "Failed to cd!"; exit 1 )
 
 "$root/main/sorbet" \
   --censor-for-snapshot-tests --silence-dev-message --max-threads=0 \
-  --sorbet-packages --experimental-test-packages --experimental-package-directed . 2>&1
+  --sorbet-packages --experimental-package-directed . 2>&1

--- a/test/cli/test-packages-test-cycle/test.sh
+++ b/test/cli/test-packages-test-cycle/test.sh
@@ -6,5 +6,5 @@ cd test/cli/test-packages-test-cycle || ( echo "Failed to cd!"; exit 1 )
 
 "$root/main/sorbet" \
   --censor-for-snapshot-tests --silence-dev-message --max-threads=0 \
-  --sorbet-packages --experimental-test-packages --experimental-package-directed \
+  --sorbet-packages --experimental-package-directed \
   --packager-layers=lib,app . 2>&1

--- a/test/cli/test-packages-test-namespace-error/test.sh
+++ b/test/cli/test-packages-test-namespace-error/test.sh
@@ -6,4 +6,4 @@ cd test/cli/test-packages-test-namespace-error || ( echo "Failed to cd!"; exit 1
 
 "$root/main/sorbet" \
   --censor-for-snapshot-tests --silence-dev-message --max-threads=0 \
-  --sorbet-packages --experimental-test-packages . 2>&1
+  --sorbet-packages . 2>&1

--- a/test/helpers/position_assertions.cc
+++ b/test/helpers/position_assertions.cc
@@ -265,7 +265,6 @@ const UnorderedMap<
         {"hierarchy-ref-set", HierarchyRefSetAssertion::make},
         {"find-hierarchy-refs", FindHierarchyRefsAssertion::make},
         {"hierarchy-ref", HierarchyRefAssertion::make},
-        {"enable-test-packages", BooleanPropertyAssertion::make},
         {"stratum", StratumAssertion::make},
 };
 
@@ -661,8 +660,6 @@ realmain::options::Options RangeAssertion::parseOptions(vector<shared_ptr<RangeA
     if (extraDirUnderscore.has_value()) {
         opts.extraPackageFilesDirectoryUnderscorePrefixes.emplace_back(extraDirUnderscore.value());
     }
-
-    opts.testPackages = BooleanPropertyAssertion::getValue("enable-test-packages", assertions).value_or(false);
 
     auto extraDirSlashDeprecated =
         StringPropertyAssertion::getValue("extra-package-files-directory-prefix-slash-deprecated", assertions);

--- a/test/testdata/packager/directed-type-member-unmigrated-test-file-crash/parent/__package.rb
+++ b/test/testdata/packager/directed-type-member-unmigrated-test-file-crash/parent/__package.rb
@@ -1,7 +1,6 @@
 # typed: strict
 # enable-packager: true
 # enable-package-directed: true
-# enable-test-packages: true
 
 # stratum: 0
 

--- a/test/testdata/packager/test-packages-bad-import/__package.rb
+++ b/test/testdata/packager/test-packages-bad-import/__package.rb
@@ -1,6 +1,5 @@
 # typed: strict
 # enable-packager: true
-# enable-test-packages: true
 
 class Root < PackageSpec
   import Root::Test

--- a/test/testdata/packager/test-packages-bad-test/__package.rb
+++ b/test/testdata/packager/test-packages-bad-test/__package.rb
@@ -1,6 +1,5 @@
 # typed: strict
 # enable-packager: true
-# enable-test-packages: true
 
 class Root < PackageSpec
   test!

--- a/test/testdata/packager/test-packages-bad-test/b/__package.rb
+++ b/test/testdata/packager/test-packages-bad-test/b/__package.rb
@@ -1,6 +1,5 @@
 # typed: strict
 # enable-packager: true
-# enable-test-packages: true
 
 class Test::Root::B < PackageSpec
   test!

--- a/test/testdata/packager/test-packages-min-levels/__package.rb
+++ b/test/testdata/packager/test-packages-min-levels/__package.rb
@@ -1,6 +1,5 @@
 # typed: strict
 # enable-packager: true
-# enable-test-packages: true
 
 class Root < PackageSpec
   sorbet min_typed_level: 'true', tests_min_typed_level: 'true'

--- a/test/testdata/packager/test-packages-package-private/__package.rb
+++ b/test/testdata/packager/test-packages-package-private/__package.rb
@@ -1,6 +1,5 @@
 # typed: strict
 # enable-packager: true
-# enable-test-packages: true
 
 class Root < PackageSpec
   export Root::A

--- a/test/testdata/packager/test-packages-references/__package.rb
+++ b/test/testdata/packager/test-packages-references/__package.rb
@@ -1,6 +1,5 @@
 # typed: strict
 # enable-packager: true
-# enable-test-packages: true
 
 class Root < PackageSpec
   #   ^^^^ def: rootpkg

--- a/test/testdata/packager/test-packages-simple/__package.rb
+++ b/test/testdata/packager/test-packages-simple/__package.rb
@@ -1,6 +1,5 @@
 # typed: strict
 # enable-packager: true
-# enable-test-packages: true
 
 class Root < PackageSpec
   export Root::A

--- a/test/testdata/packager/test-packages-strict-deps-layer/__package.rb
+++ b/test/testdata/packager/test-packages-strict-deps-layer/__package.rb
@@ -1,6 +1,5 @@
 # typed: strict
 # enable-packager: true
-# enable-test-packages: true
 # packager-layers: a
 
   class Root < PackageSpec

--- a/test/testdata/packager/test-packages-strict-false/__package.rb
+++ b/test/testdata/packager/test-packages-strict-false/__package.rb
@@ -1,6 +1,5 @@
 # typed: strict
 # enable-packager: true
-# enable-test-packages: true
 # packager-layers: a
 
 class Root < PackageSpec

--- a/test/testdata/packager/test-packages-test-helper/__package.rb
+++ b/test/testdata/packager/test-packages-test-helper/__package.rb
@@ -1,6 +1,5 @@
 # typed: strict
 # enable-packager: true
-# enable-test-packages: true
 
 class Root < PackageSpec
   export Root::A

--- a/test/testdata/packager/test-packages-test-import/__package.rb
+++ b/test/testdata/packager/test-packages-test-import/__package.rb
@@ -1,6 +1,5 @@
 # typed: strict
 # enable-packager: true
-# enable-test-packages: true
 
 class Root < PackageSpec
   export Root::A

--- a/test/testdata/packager/test-packages-visible-to/root/__package.rb
+++ b/test/testdata/packager/test-packages-visible-to/root/__package.rb
@@ -1,6 +1,5 @@
 # typed: strict
 # enable-packager: true
-# enable-test-packages: true
 
 class Root < PackageSpec
   export Root::A

--- a/website/docs/cli-ref.md
+++ b/website/docs/cli-ref.md
@@ -337,8 +337,6 @@ Usage:
       --experimental-package-directed
                                 Enable support for checking by package, instead of
                                 processing all files at once
-      --experimental-test-packages
-                                Enable support for tests as their own packages
 
 ```
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

Based on #10598.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

After ad56313418e, we don't need a separate flag to gate access to
`test!`. We've already started landing `test!` packages too, so it's not
like it's experimental.

It's too easy to accidentally reintroduce behavior that is behind
`testPackages()` if you forget that you're supposed to make the feature
conditional on `usesTestPackages` on an individual `PackageInfo`, so
let's just delete the flag.

We could keep around the flag as a way to _require_ that all tests must
be in a package, but we haven't had a need for that yet (and if we did,
it would probably behave differently, and as such might want its own
name).


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.