### PR TITLE
Support skipping typechecking, depending on package

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -409,7 +409,7 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
                         : pipeline::incrementalResolve(*gs, move(updatedIndexed), nullopt, config->opts, workers);
     auto sorted = sortParsedFiles(*gs, *errorReporter, move(resolved));
     const auto cancelable = false;
-    auto relevantPackages = std::nullopt;
+    auto relevantPackages = nullptr;
     pipeline::typecheck(*gs, move(sorted), config->opts, workers, relevantPackages, cancelable, this->lastStratum,
                         nullptr);
 
@@ -893,7 +893,7 @@ pair<bool, core::packages::Stratum> LSPTypechecker::runSlowPath(LSPFileUpdates &
             }
 
             auto sorted = sortParsedFiles(*gs, *errorReporter, move(maybeResolved.result()));
-            auto relevantPackages = std::nullopt;
+            auto relevantPackages = nullptr;
             pipeline::typecheck(*gs, move(sorted), config->opts, workers, relevantPackages, cancelable, currentStratum,
                                 preemptManager);
         }
@@ -1005,7 +1005,7 @@ LSPQueryResult LSPTypechecker::query(const core::lsp::Query &q, const vector<cor
     tryApplyLocalVarSaver(*gs, resolved);
 
     const auto cancelable = true;
-    auto relevantPackages = std::nullopt;
+    auto relevantPackages = nullptr;
     pipeline::sortBySize(*gs, resolved);
     pipeline::typecheck(*gs, move(resolved), config->opts, workers, relevantPackages, cancelable);
     gs->lspQuery = core::lsp::Query::noQuery();

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -409,7 +409,9 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
                         : pipeline::incrementalResolve(*gs, move(updatedIndexed), nullopt, config->opts, workers);
     auto sorted = sortParsedFiles(*gs, *errorReporter, move(resolved));
     const auto cancelable = false;
-    pipeline::typecheck(*gs, move(sorted), config->opts, workers, cancelable, this->lastStratum, nullptr);
+    auto relevantPackages = std::nullopt;
+    pipeline::typecheck(*gs, move(sorted), config->opts, workers, relevantPackages, cancelable, this->lastStratum,
+                        nullptr);
 
     auto duration = timeit.setEndTime();
     std::string files;
@@ -891,7 +893,9 @@ pair<bool, core::packages::Stratum> LSPTypechecker::runSlowPath(LSPFileUpdates &
             }
 
             auto sorted = sortParsedFiles(*gs, *errorReporter, move(maybeResolved.result()));
-            pipeline::typecheck(*gs, move(sorted), config->opts, workers, cancelable, currentStratum, preemptManager);
+            auto relevantPackages = std::nullopt;
+            pipeline::typecheck(*gs, move(sorted), config->opts, workers, relevantPackages, cancelable, currentStratum,
+                                preemptManager);
         }
 
         // [Test only] Ensure that we handled all expected preemptions
@@ -1001,8 +1005,9 @@ LSPQueryResult LSPTypechecker::query(const core::lsp::Query &q, const vector<cor
     tryApplyLocalVarSaver(*gs, resolved);
 
     const auto cancelable = true;
+    auto relevantPackages = std::nullopt;
     pipeline::sortBySize(*gs, resolved);
-    pipeline::typecheck(*gs, move(resolved), config->opts, workers, cancelable);
+    pipeline::typecheck(*gs, move(resolved), config->opts, workers, relevantPackages, cancelable);
     gs->lspQuery = core::lsp::Query::noQuery();
     return LSPQueryResult{queryCollector->drainQueryResponses(), nullptr};
 }

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1495,7 +1495,7 @@ bool shouldTypecheck(const core::GlobalState &gs, const UnorderedSet<core::packa
 } // namespace
 
 void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> &&what, const options::Options &opts,
-               WorkerPool &workers, const optional<UnorderedSet<core::packages::MangledName>> &relevantPackages,
+               WorkerPool &workers, const UnorderedSet<core::packages::MangledName> *const relevantPackages,
                bool cancelable, core::packages::Stratum currentStratum,
                shared_ptr<core::lsp::PreemptionTaskManager> preemptionManager, bool intentionallyLeakASTs) {
     // Unless the error queue had a critical error, only typecheck should flush errors to the client, otherwise we will
@@ -1520,12 +1520,12 @@ void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> &&what, cons
             fileq->push(move(resolved), 1);
         }
 
-        bool checkRelevantPackages = gs.packageDB().enabled() && relevantPackages.has_value();
+        bool checkRelevantPackages = gs.packageDB().enabled() && relevantPackages != nullptr;
 
         {
             ProgressIndicator cfgInferProgress(opts.showProgress, "CFG+Inference", what.size());
-            workers.multiplexJob("typecheck", [&gs, &opts, epoch, &epochManager, &relevantPackages, &preemptionManager,
-                                               fileq, outputq, cancelable, checkRelevantPackages,
+            workers.multiplexJob("typecheck", [&gs, &opts, epoch, &epochManager, &preemptionManager, fileq, outputq,
+                                               cancelable, relevantPackages, checkRelevantPackages,
                                                intentionallyLeakASTs]() {
                 ast::ParsedFile job;
                 int processedByThread = 0;

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1485,7 +1485,8 @@ void typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Op
 } // namespace
 
 void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> &&what, const options::Options &opts,
-               WorkerPool &workers, bool cancelable, core::packages::Stratum currentStratum,
+               WorkerPool &workers, const optional<UnorderedSet<core::packages::MangledName>> &relevantPackages,
+               bool cancelable, core::packages::Stratum currentStratum,
                shared_ptr<core::lsp::PreemptionTaskManager> preemptionManager, bool intentionallyLeakASTs) {
     // Unless the error queue had a critical error, only typecheck should flush errors to the client, otherwise we will
     // drop errors in LSP mode.

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1482,6 +1482,16 @@ void typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Op
     return;
 }
 
+bool shouldTypecheck(const core::GlobalState &gs, const UnorderedSet<core::packages::MangledName> &relevantPackages,
+                     core::FileRef file) {
+    auto pkg = gs.packageDB().getPackageNameForFile(file);
+    if (!pkg.exists()) {
+        return true;
+    }
+
+    return relevantPackages.contains(pkg);
+}
+
 } // namespace
 
 void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> &&what, const options::Options &opts,
@@ -1510,10 +1520,13 @@ void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> &&what, cons
             fileq->push(move(resolved), 1);
         }
 
+        bool checkRelevantPackages = gs.packageDB().enabled() && relevantPackages.has_value();
+
         {
             ProgressIndicator cfgInferProgress(opts.showProgress, "CFG+Inference", what.size());
-            workers.multiplexJob("typecheck", [&gs, &opts, epoch, &epochManager, &preemptionManager, fileq, outputq,
-                                               cancelable, intentionallyLeakASTs]() {
+            workers.multiplexJob("typecheck", [&gs, &opts, epoch, &epochManager, &relevantPackages, &preemptionManager,
+                                               fileq, outputq, cancelable, checkRelevantPackages,
+                                               intentionallyLeakASTs]() {
                 ast::ParsedFile job;
                 int processedByThread = 0;
 
@@ -1537,13 +1550,17 @@ void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> &&what, cons
                             const bool fileWasChanged = preemptionManager && job.file.data(gs).epoch > epoch;
                             if (!isCanceled && !fileWasChanged && gs.errorQueue->wouldFlushErrorsForFile(job.file)) {
                                 core::FileRef file = job.file;
-                                try {
-                                    core::Context ctx(gs, core::Symbols::root(), file);
-                                    typecheckOne(ctx, move(job), opts, intentionallyLeakASTs);
-                                } catch (SorbetException &) {
-                                    Exception::failInFuzzer();
-                                    gs.tracer().error("Exception typing file: {} (backtrace is above)",
-                                                      file.data(gs).path());
+                                if (!checkRelevantPackages || shouldTypecheck(gs, *relevantPackages, file)) {
+                                    try {
+                                        core::Context ctx(gs, core::Symbols::root(), file);
+                                        typecheckOne(ctx, move(job), opts, intentionallyLeakASTs);
+                                    } catch (SorbetException &) {
+                                        Exception::failInFuzzer();
+                                        gs.tracer().error("Exception typing file: {} (backtrace is above)",
+                                                          file.data(gs).path());
+                                    }
+                                } else if (intentionallyLeakASTs) {
+                                    intentionallyLeakMemory(job.tree.release());
                                 }
                                 // Stream out errors
                                 outputq->push(file, processedByThread);

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -107,7 +107,7 @@ std::vector<ast::ParsedFile> incrementalResolve(
 // If `intentionallyLeakASTs` is `true`, typecheck will leak the ASTs rather than pay the cost of deleting them
 // properly, which is a significant speedup on large codebases.
 void typecheck(const core::GlobalState &gs, std::vector<ast::ParsedFile> &&what, const options::Options &opts,
-               WorkerPool &workers, const std::optional<UnorderedSet<core::packages::MangledName>> &relevantPackages,
+               WorkerPool &workers, const UnorderedSet<core::packages::MangledName> *relevantPackages,
                bool cancelable = false, core::packages::Stratum currentStratum = core::packages::Stratum(),
                std::shared_ptr<core::lsp::PreemptionTaskManager> preemptionManager = nullptr,
                bool intentionallyLeakASTs = false);

--- a/main/pipeline/pipeline.h
+++ b/main/pipeline/pipeline.h
@@ -107,8 +107,8 @@ std::vector<ast::ParsedFile> incrementalResolve(
 // If `intentionallyLeakASTs` is `true`, typecheck will leak the ASTs rather than pay the cost of deleting them
 // properly, which is a significant speedup on large codebases.
 void typecheck(const core::GlobalState &gs, std::vector<ast::ParsedFile> &&what, const options::Options &opts,
-               WorkerPool &workers, bool cancelable = false,
-               core::packages::Stratum currentStratum = core::packages::Stratum(),
+               WorkerPool &workers, const std::optional<UnorderedSet<core::packages::MangledName>> &relevantPackages,
+               bool cancelable = false, core::packages::Stratum currentStratum = core::packages::Stratum(),
                std::shared_ptr<core::lsp::PreemptionTaskManager> preemptionManager = nullptr,
                bool intentionallyLeakASTs = false);
 

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -723,7 +723,7 @@ int realmain(int argc, char *argv[]) {
                     pipeline::sortBySize(*gs, stratumFiles);
 
                     bool cancelable = false;
-                    auto relevantPackages = std::nullopt;
+                    auto relevantPackages = nullptr;
                     auto preemptionManager = nullptr;
                     pipeline::typecheck(*gs, move(stratumFiles), opts, *workers, relevantPackages, cancelable,
                                         core::packages::Stratum(currentStratum), preemptionManager,

--- a/main/realmain.cc
+++ b/main/realmain.cc
@@ -721,9 +721,13 @@ int realmain(int argc, char *argv[]) {
                     // In --gen-packages mode, we skip typecheck because we only want to show packaging related errors,
                     // and skipping typecheck saves a significant amount of time.
                     pipeline::sortBySize(*gs, stratumFiles);
-                    pipeline::typecheck(*gs, move(stratumFiles), opts, *workers, /* cancelable */ false,
-                                        core::packages::Stratum(currentStratum),
-                                        /* preemptionManager */ nullptr, intentionallyLeakASTs);
+
+                    bool cancelable = false;
+                    auto relevantPackages = std::nullopt;
+                    auto preemptionManager = nullptr;
+                    pipeline::typecheck(*gs, move(stratumFiles), opts, *workers, relevantPackages, cancelable,
+                                        core::packages::Stratum(currentStratum), preemptionManager,
+                                        intentionallyLeakASTs);
 
                     if (gs->hadCriticalError()) {
                         gs->errorQueue->flushAllErrors(*gs);

--- a/test/fuzz/fuzz_dash_e.cc
+++ b/test/fuzz/fuzz_dash_e.cc
@@ -75,7 +75,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     indexed =
         move(realmain::pipeline::nameAndResolve(*gs, move(indexed.result()), *opts, *workers, foundHashes).result());
     realmain::pipeline::sortBySize(*gs, indexed.result());
-    auto relevantPackages = std::nullopt;
+    auto relevantPackages = nullptr;
     realmain::pipeline::typecheck(*gs, move(indexed.result()), *opts, *workers, relevantPackages);
     return 0;
 }

--- a/test/fuzz/fuzz_dash_e.cc
+++ b/test/fuzz/fuzz_dash_e.cc
@@ -75,6 +75,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     indexed =
         move(realmain::pipeline::nameAndResolve(*gs, move(indexed.result()), *opts, *workers, foundHashes).result());
     realmain::pipeline::sortBySize(*gs, indexed.result());
-    realmain::pipeline::typecheck(*gs, move(indexed.result()), *opts, *workers);
+    auto relevantPackages = std::nullopt;
+    realmain::pipeline::typecheck(*gs, move(indexed.result()), *opts, *workers, relevantPackages);
     return 0;
 }


### PR DESCRIPTION
To better support the changes outlined in #10417, this PR adds the ability to specify a set of relevant packages to `pipeline::typecheck`. When present, this package set indicates which packages are necessary to typecheck, with anything else being skipped. This moves the skipping logic of #10417 out of `LSPTypechecker::runSlowPath` and into `pipeline::typecheck`, where it can drop trees interleaved with typechecking.

For the most part this is just a plumbing change: `pipeline::typecheck` now takes an additional required parameter of the optional set of relevant packages. That set is used in `pipeline::typecheck` to guard the call to `typecheckOne`, and viewing with whitespace changes off should make this pretty obvious.

### Motivation
Prework for landing the changes in #10417, to skip typechecking for packages not affected by a slow path change.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No behavioral changes expected, prework for skipping typechecking.
