### PR TITLE
Preserve signatures preceding Minitest methods

### DIFF
--- a/rewriter/Minitest.cc
+++ b/rewriter/Minitest.cc
@@ -7,6 +7,7 @@
 #include "core/core.h"
 #include "core/errors/rewriter.h"
 #include "rewriter/rewriter.h"
+#include "rewriter/util/Util.h"
 
 using namespace std;
 
@@ -411,7 +412,7 @@ ast::ExpressionPtr prepareParameterizedBody(core::MutableContext ctx, core::Name
                                             ast::ExpressionPtr &iteratee, bool insideDescribe);
 
 ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::ExpressionPtr &maybeSharedExamplesName,
-                             ast::Send *send, bool insideDescribe);
+                             ast::Send *send, bool insideDescribe, bool hasPrecedingSig);
 
 ast::ExpressionPtr invalidUnderParameterizedBody(core::MutableContext ctx, core::NameRef eachName,
                                                  ast::ExpressionPtr stmt) {
@@ -543,8 +544,8 @@ ast::ExpressionPtr runUnderParameterized(core::MutableContext ctx, core::NameRef
             // `RSpec.`-prefixed registers globally, bare-receiver scopes to the consumer on
             // each include of the outer. `runSingle` distinguishes the two by checking the
             // receiver — see the comment on its `sharedExamples` arm.
-            auto result =
-                runSingle(ctx, /* isClass */ false, /* maybeSharedExamplesName */ nullptr, send, insideDescribe);
+            auto result = runSingle(ctx, /* isClass */ false, /* maybeSharedExamplesName */ nullptr, send,
+                                    insideDescribe, /* hasPrecedingSig */ false);
             if (result != nullptr) {
                 return result;
             }
@@ -643,10 +644,10 @@ ast::ExpressionPtr prepareParameterizedBody(core::MutableContext ctx, core::Name
 
 ast::ExpressionPtr tryRunSingleOnSend(core::MutableContext ctx, bool isClass,
                                       const ast::ExpressionPtr &maybeSharedExamplesName, ast::ExpressionPtr body,
-                                      bool insideDescribe) {
+                                      bool insideDescribe, bool hasPrecedingSig) {
     auto bodySend = ast::cast_tree<ast::Send>(body);
     if (bodySend) {
-        auto change = runSingle(ctx, isClass, move(maybeSharedExamplesName), bodySend, insideDescribe);
+        auto change = runSingle(ctx, isClass, move(maybeSharedExamplesName), bodySend, insideDescribe, hasPrecedingSig);
         if (change) {
             return change;
         }
@@ -657,21 +658,27 @@ ast::ExpressionPtr tryRunSingleOnSend(core::MutableContext ctx, bool isClass,
 ast::ExpressionPtr prepareBody(core::MutableContext ctx, bool isClass,
                                const ast::ExpressionPtr &maybeSharedExamplesName, ast::ExpressionPtr body,
                                bool insideDescribe) {
-    body = tryRunSingleOnSend(ctx, isClass, maybeSharedExamplesName, std::move(body), insideDescribe);
+    body = tryRunSingleOnSend(ctx, isClass, maybeSharedExamplesName, std::move(body), insideDescribe,
+                              /* hasPrecedingSig */ false);
 
     if (auto bodySeq = ast::cast_tree<ast::InsSeq>(body)) {
+        const ast::ExpressionPtr *prevStat = nullptr;
         for (auto &exp : bodySeq->stats) {
-            exp = tryRunSingleOnSend(ctx, isClass, maybeSharedExamplesName, std::move(exp), insideDescribe);
+            auto hasPrecedingSig = prevStat != nullptr && ASTUtil::castSig(*prevStat) != nullptr;
+            exp = tryRunSingleOnSend(ctx, isClass, maybeSharedExamplesName, std::move(exp), insideDescribe,
+                                     hasPrecedingSig);
+            prevStat = &exp;
         }
 
         bodySeq->expr =
-            tryRunSingleOnSend(ctx, isClass, maybeSharedExamplesName, std::move(bodySeq->expr), insideDescribe);
+            tryRunSingleOnSend(ctx, isClass, maybeSharedExamplesName, std::move(bodySeq->expr), insideDescribe,
+                               prevStat != nullptr && ASTUtil::castSig(*prevStat) != nullptr);
     }
     return body;
 }
 
 ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::ExpressionPtr &maybeSharedExamplesName,
-                             ast::Send *send, bool insideDescribe) {
+                             ast::Send *send, bool insideDescribe, bool hasPrecedingSig) {
     auto *block = send->block();
 
     switch (send->fun.rawId()) {
@@ -877,7 +884,9 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::
             // defined methods, we don't actually need to care about the RuntimeMethodDefinition, and
             // omitting it saves memory.
             ast::cast_tree_nonnull<ast::MethodDef>(method).flags.discardDef = true;
-            method = addSigVoid(ctx, move(method));
+            if (!hasPrecedingSig) {
+                method = addSigVoid(ctx, move(method));
+            }
             if (send->numPosArgs() > 0 && !ast::isa_tree<ast::Literal>(send->getPosArg(0))) {
                 method = ast::MK::InsSeq1(send->loc, send->getPosArg(0).deepCopy(), move(method));
             }
@@ -925,7 +934,9 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::
                                                       prepareBody(ctx, /* isClass */ true, maybeSharedExamplesName,
                                                                   std::move(itBody), /* insideDescribe */ true));
             ast::cast_tree_nonnull<ast::MethodDef>(itMethod).flags.discardDef = true;
-            itMethod = addSigVoid(ctx, move(itMethod));
+            if (!hasPrecedingSig) {
+                itMethod = addSigVoid(ctx, move(itMethod));
+            }
             itMethod = constantMover.addConstantsToExpression(send->loc, move(itMethod));
 
             ast::ClassDef::RHS_store describeBody;
@@ -1094,7 +1105,8 @@ ast::ExpressionPtr runSingle(core::MutableContext ctx, bool isClass, const ast::
 
 } // namespace
 
-vector<ast::ExpressionPtr> Minitest::run(core::MutableContext ctx, bool isClass, ast::Send *send) {
+vector<ast::ExpressionPtr> Minitest::run(core::MutableContext ctx, bool isClass, ast::Send *send,
+                                         const ast::ExpressionPtr *prevStat) {
     vector<ast::ExpressionPtr> stats;
     if (ctx.state.cacheSensitiveOptions.runningUnderAutogen) {
         return stats;
@@ -1112,7 +1124,7 @@ vector<ast::ExpressionPtr> Minitest::run(core::MutableContext ctx, bool isClass,
         auto processStmt = [&](ast::ExpressionPtr &stmt) {
             if (auto bodySend = ast::cast_tree<ast::Send>(stmt)) {
                 auto result = runSingle(ctx, /* isClass */ false, /* maybeSharedExamplesName */ nullptr, bodySend,
-                                        /* insideDescribe */ false);
+                                        /* insideDescribe */ false, /* hasPrecedingSig */ false);
                 if (result != nullptr) {
                     stats.emplace_back(std::move(result));
                 }
@@ -1131,7 +1143,8 @@ vector<ast::ExpressionPtr> Minitest::run(core::MutableContext ctx, bool isClass,
     }
 
     auto insideDescribe = false;
-    auto exp = runSingle(ctx, isClass, /* maybeSharedExamplesName */ nullptr, send, insideDescribe);
+    auto exp = runSingle(ctx, isClass, /* maybeSharedExamplesName */ nullptr, send, insideDescribe,
+                         prevStat != nullptr && ASTUtil::castSig(*prevStat) != nullptr);
     if (exp != nullptr) {
         stats.emplace_back(std::move(exp));
     }

--- a/rewriter/Minitest.h
+++ b/rewriter/Minitest.h
@@ -32,7 +32,8 @@ namespace sorbet::rewriter {
  */
 class Minitest final {
 public:
-    static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, bool isClass, ast::Send *send);
+    static std::vector<ast::ExpressionPtr> run(core::MutableContext ctx, bool isClass, ast::Send *send,
+                                               const ast::ExpressionPtr *prevStat);
 
     Minitest() = delete;
 };

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -99,7 +99,7 @@ public:
                         return;
                     }
 
-                    nodes = Minitest::run(ctx, isClass, &send);
+                    nodes = Minitest::run(ctx, isClass, &send, prevStat);
                     if (!nodes.empty()) {
                         replaceNodes[stat.get()] = move(nodes);
                         return;

--- a/test/testdata/rewriter/minitest_sig.rb
+++ b/test/testdata/rewriter/minitest_sig.rb
@@ -4,7 +4,7 @@ module MustTestFoo
   extend T::Sig, T::Helpers
   abstract!
 
-  sig { abstract.void } # error: Unused type annotation. No method def before next annotation
+  sig { abstract.void }
   it "foo" do
   end
 end

--- a/test/testdata/rewriter/minitest_sig.rb
+++ b/test/testdata/rewriter/minitest_sig.rb
@@ -1,0 +1,17 @@
+# typed: strict
+
+module MustTestFoo
+  extend T::Sig, T::Helpers
+  abstract!
+
+  sig { abstract.void } # error: Unused type annotation. No method def before next annotation
+  it "foo" do
+  end
+end
+
+class A
+  include MustTestFoo
+
+  it "foo" do
+  end
+end

--- a/test/testdata/rewriter/minitest_sig.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_sig.rb.rewrite-tree.exp
@@ -1,0 +1,31 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module <emptyTree>::<C MustTestFoo><<C <todo sym>>> < ()
+    <self>.sig() do ||
+      <self>.abstract().void()
+    end
+
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.void()
+    end
+
+    def <it 'foo'><<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    <self>.extend(<emptyTree>::<C T>::<C Sig>, <emptyTree>::<C T>::<C Helpers>)
+
+    <self>.abstract!()
+  end
+
+  class <emptyTree>::<C A><<C <todo sym>>> < (::<todo sym>)
+    ::T::Sig::WithoutRuntime.sig() do ||
+      <self>.void()
+    end
+
+    def <it 'foo'><<todo method>>(&<blk>)
+      <emptyTree>
+    end
+
+    <self>.include(<emptyTree>::<C MustTestFoo>)
+  end
+end

--- a/test/testdata/rewriter/minitest_sig.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/minitest_sig.rb.rewrite-tree.exp
@@ -4,10 +4,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <self>.abstract().void()
     end
 
-    ::T::Sig::WithoutRuntime.sig() do ||
-      <self>.void()
-    end
-
     def <it 'foo'><<todo method>>(&<blk>)
       <emptyTree>
     end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'd like to allow people to make "abstract" tests in an interface, such that
tests would be required to implement them with an `it` block.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Going to have to see whether it's even possible to get this working in the runtime, before landing.