### PR TITLE
Additional performance improvements to LSP paths

### DIFF
--- a/main/lsp/BUILD
+++ b/main/lsp/BUILD
@@ -174,6 +174,24 @@ cc_test(
 )
 
 cc_test(
+    name = "undo_state_test",
+    size = "small",
+    srcs = ["test/undo_state_test.cc"],
+    linkstatic = select({
+        "//tools/config:linkshared": 0,
+        "//conditions:default": 1,
+    }),
+    visibility = ["//tools:__pkg__"],
+    deps = [
+        "lsp",
+        "//payload",
+        "//test/helpers",
+        "@doctest//doctest",
+        "@doctest//doctest:main",
+    ],
+)
+
+cc_test(
     name = "lsp_file_updates_test",
     size = "small",
     srcs = ["test/lsp_file_updates_test.cc"],

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -1,5 +1,6 @@
 #include "main/lsp/LSPIndexer.h"
 #include "LSPFileUpdates.h"
+#include "absl/algorithm/container.h"
 #include "common/concurrency/ConcurrentQueue.h"
 #include "core/ErrorQueue.h"
 #include "core/FileHash.h"
@@ -15,6 +16,7 @@
 #include "main/lsp/notifications/sorbet_workspace_edit.h"
 #include "main/pipeline/pipeline.h"
 #include "payload/payload.h"
+#include <algorithm>
 
 using namespace std;
 
@@ -252,8 +254,27 @@ LSPIndexer::getTypecheckingPath(LSPFileUpdates &edit,
     return path;
 }
 
-TypecheckingPath LSPIndexer::getTypecheckingPath(const vector<shared_ptr<core::File>> &changedFiles) const {
+bool LSPIndexer::fileIsUnchanged(const core::File &file) const {
+    auto fref = gs->findFileByPath(file.path());
+    if (!fref.exists()) {
+        return false;
+    }
+    const auto &current = fref.data(*gs);
+    return current.sourceType == core::File::Type::Normal && file.sourceType == core::File::Type::Normal &&
+           current.isOpenInClient() == file.isOpenInClient() && current.sourceHash() == file.sourceHash();
+}
+
+size_t LSPIndexer::countChangedFiles(const vector<shared_ptr<core::File>> &files) const {
+    return absl::c_count_if(files, [this](const auto &file) { return !fileIsUnchanged(*file); });
+}
+
+TypecheckingPath LSPIndexer::getTypecheckingPath(const vector<shared_ptr<core::File>> &files) const {
     static UnorderedMap<core::FileRef, shared_ptr<core::File>> emptyMap;
+
+    // Files that did not change need no typechecking, so they must not count against the fast path's file budget.
+    vector<shared_ptr<core::File>> changedFiles;
+    changedFiles.reserve(files.size());
+    absl::c_copy_if(files, back_inserter(changedFiles), [this](const auto &file) { return !fileIsUnchanged(*file); });
 
     // Avoid expensively computing file hashes if there are too many files and it's likely that we'd
     // do a lot of hashing just to realize that something changed, requiring a slowpath anyways.
@@ -331,6 +352,19 @@ unique_ptr<LSPFileUpdates> LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edi
     update.epoch = edit.epoch;
     update.editCount = edit.mergeCount + 1;
     update.updatedFiles = move(edit.updates);
+    {
+        // Watchman reports every write, and tools like autogen, `git checkout` or a build regenerating its outputs
+        // rewrite many files byte-for-byte. Those files have nothing to typecheck; dropping them here keeps them from
+        // being re-indexed and, above all, from counting against `lspMaxFilesOnFastPath` and forcing a slow path.
+        auto unchanged = update.updatedFiles.size() - countChangedFiles(update.updatedFiles);
+        if (unchanged > 0) {
+            update.updatedFiles.erase(remove_if(update.updatedFiles.begin(), update.updatedFiles.end(),
+                                                [this](const auto &file) { return fileIsUnchanged(*file); }),
+                                      update.updatedFiles.end());
+            config->logger->debug("Dropped {} unchanged file(s) from the edit", unchanged);
+            prodCounterAdd("lsp.edit.unchanged_files_dropped", unchanged);
+        }
+    }
     update.cancellationExpected = edit.sorbetCancellationExpected;
     update.preemptionsExpected = edit.sorbetPreemptionsExpected;
     // _Wait_ to compute `getTypecheckingPath` until after we compute hashes.
@@ -431,7 +465,7 @@ unique_ptr<LSPFileUpdates> LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edi
 }
 
 unique_ptr<LSPFileUpdates> LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edit) {
-    ENFORCE(edit.updates.size() <= config->opts.lspMaxFilesOnFastPath, "Too many files to index serially");
+    ENFORCE(countChangedFiles(edit.updates) <= config->opts.lspMaxFilesOnFastPath, "Too many files to index serially");
     return commitEdit(edit, *emptyWorkers);
 }
 

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -90,6 +90,14 @@ LSPIndexer::getTypecheckingPathInternal(const vector<shared_ptr<core::File>> &ch
     Timer timeit(config->logger, "fast_path_decision");
     auto &logger = *config->logger;
     logger.debug("Trying to see if fast path is available after {} file changes", changedFiles.size());
+    if (changedFiles.empty()) {
+        // Nothing to typecheck (every file in the edit was unchanged): a no-op fast path, regardless of
+        // `disableFastPath` -- the slow path requires at least one file.
+        logger.debug("Taking fast path because no files changed");
+        result.path = TypecheckingPath::Fast;
+        timeit.setTag("path_chosen", "fast");
+        return result;
+    }
     if (config->disableFastPath) {
         logger.debug("Taking slow path because fast path is disabled.");
         prodCategoryCounterInc("lsp.slow_path_reason", "fast_path_disabled");
@@ -356,11 +364,11 @@ unique_ptr<LSPFileUpdates> LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edi
         // Watchman reports every write, and tools like autogen, `git checkout` or a build regenerating its outputs
         // rewrite many files byte-for-byte. Those files have nothing to typecheck; dropping them here keeps them from
         // being re-indexed and, above all, from counting against `lspMaxFilesOnFastPath` and forcing a slow path.
-        auto unchanged = update.updatedFiles.size() - countChangedFiles(update.updatedFiles);
+        auto changedEnd = remove_if(update.updatedFiles.begin(), update.updatedFiles.end(),
+                                    [this](const auto &file) { return fileIsUnchanged(*file); });
+        auto unchanged = distance(changedEnd, update.updatedFiles.end());
         if (unchanged > 0) {
-            update.updatedFiles.erase(remove_if(update.updatedFiles.begin(), update.updatedFiles.end(),
-                                                [this](const auto &file) { return fileIsUnchanged(*file); }),
-                                      update.updatedFiles.end());
+            update.updatedFiles.erase(changedEnd, update.updatedFiles.end());
             config->logger->debug("Dropped {} unchanged file(s) from the edit", unchanged);
             prodCounterAdd("lsp.edit.unchanged_files_dropped", unchanged);
         }

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -364,11 +364,8 @@ unique_ptr<LSPFileUpdates> LSPIndexer::commitEdit(SorbetWorkspaceEditParams &edi
         // Watchman reports every write, and tools like autogen, `git checkout` or a build regenerating its outputs
         // rewrite many files byte-for-byte. Those files have nothing to typecheck; dropping them here keeps them from
         // being re-indexed and, above all, from counting against `lspMaxFilesOnFastPath` and forcing a slow path.
-        auto changedEnd = remove_if(update.updatedFiles.begin(), update.updatedFiles.end(),
-                                    [this](const auto &file) { return fileIsUnchanged(*file); });
-        auto unchanged = distance(changedEnd, update.updatedFiles.end());
+        auto unchanged = erase_if(update.updatedFiles, [this](const auto &file) { return fileIsUnchanged(*file); });
         if (unchanged > 0) {
-            update.updatedFiles.erase(changedEnd, update.updatedFiles.end());
             config->logger->debug("Dropped {} unchanged file(s) from the edit", unchanged);
             prodCounterAdd("lsp.edit.unchanged_files_dropped", unchanged);
         }

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -75,6 +75,17 @@ public:
      * Determines if the given files can take the fast path relative to the latest committed edit.
      */
     TypecheckingPath getTypecheckingPath(const std::vector<std::shared_ptr<core::File>> &changedFiles) const;
+    /**
+     * Whether `file` is identical to the version of that file already committed to the indexer (same content, same
+     * editor-open status). Watchman reports every write, and tools like autogen, `git checkout` or a build regenerating
+     * its outputs rewrite many files byte-for-byte; such files need no typechecking and must not count against
+     * `lspMaxFilesOnFastPath`.
+     */
+    bool fileIsUnchanged(const core::File &file) const;
+    /**
+     * The number of `files` that are not `fileIsUnchanged`.
+     */
+    size_t countChangedFiles(const std::vector<std::shared_ptr<core::File>> &files) const;
 
     /**
      * Computes state hashes for the given set of files. Is a no-op if the provided files all have hashes.

--- a/main/lsp/UndoState.cc
+++ b/main/lsp/UndoState.cc
@@ -1,10 +1,10 @@
 #include "main/lsp/UndoState.h"
 #include "common/sort/sort.h"
+#include "common/timers/Timer.h"
 #include "main/lsp/LSPConfiguration.h"
 #include "main/lsp/LSPMessage.h"
 #include "main/lsp/LSPOutput.h"
 #include "main/lsp/json_types.h"
-#include <algorithm>
 
 using namespace std;
 
@@ -19,6 +19,7 @@ UndoState::UndoState(unique_ptr<core::GlobalState> evictedGs, UnorderedMap<int, 
 void UndoState::restore(unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast::ParsedFile> &indexedFinalGS,
                         vector<core::packages::Stratum> &fileToStratum, core::packages::Stratum &lastStratum,
                         vector<core::FileRef> &workspaceFiles) {
+    Timer timeit(evictedGs->tracer(), "undo_state.restore");
     indexedFinalGS = std::move(evictedIndexedFinalGS);
     gs = move(evictedGs);
 
@@ -29,9 +30,7 @@ void UndoState::restore(unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast
     // wherever the slow path's in-place partitioning of `workspaceFiles` moved them. Truncating to the old size instead
     // would drop whichever pre-existing files the partition displaced past it.
     auto usedFiles = gs->filesUsed();
-    workspaceFiles.erase(
-        remove_if(workspaceFiles.begin(), workspaceFiles.end(), [usedFiles](auto f) { return f.id() >= usedFiles; }),
-        workspaceFiles.end());
+    erase_if(workspaceFiles, [usedFiles](auto f) { return f.id() >= usedFiles; });
     ENFORCE(workspaceFiles.size() == this->initialWorkspaceFilesSize);
 }
 

--- a/main/lsp/UndoState.cc
+++ b/main/lsp/UndoState.cc
@@ -12,8 +12,7 @@ UndoState::UndoState(unique_ptr<core::GlobalState> evictedGs, UnorderedMap<int, 
                      vector<core::packages::Stratum> fileToStratum, core::packages::Stratum lastStratum,
                      const vector<core::FileRef> &workspaceFiles, uint32_t epoch)
     : evictedGs(move(evictedGs)), evictedIndexedFinalGS(std::move(evictedIndexedFinalGS)),
-      fileToStratum{move(fileToStratum)}, lastStratum{lastStratum}, initialWorkspaceFilesSize{workspaceFiles.size()},
-      epoch(epoch) {}
+      fileToStratum{move(fileToStratum)}, lastStratum{lastStratum}, savedWorkspaceFiles(workspaceFiles), epoch(epoch) {}
 
 void UndoState::restore(unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast::ParsedFile> &indexedFinalGS,
                         vector<core::packages::Stratum> &fileToStratum, core::packages::Stratum &lastStratum,
@@ -24,9 +23,10 @@ void UndoState::restore(unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast
     fileToStratum = move(this->fileToStratum);
     lastStratum = this->lastStratum;
 
-    if (workspaceFiles.size() != this->initialWorkspaceFilesSize) {
-        workspaceFiles.erase(workspaceFiles.begin() + this->initialWorkspaceFilesSize, workspaceFiles.end());
-    }
+    // Restore the snapshot wholesale. The slow path appends new files to the live vector and then permutes it in place
+    // (partitionPackageFiles), so rolling back by truncating to the old size would erase whatever ended up at the tail,
+    // not the new files.
+    workspaceFiles = std::move(this->savedWorkspaceFiles);
 }
 
 const unique_ptr<core::GlobalState> &UndoState::getEvictedGs() {

--- a/main/lsp/UndoState.cc
+++ b/main/lsp/UndoState.cc
@@ -4,6 +4,7 @@
 #include "main/lsp/LSPMessage.h"
 #include "main/lsp/LSPOutput.h"
 #include "main/lsp/json_types.h"
+#include <algorithm>
 
 using namespace std;
 
@@ -12,7 +13,8 @@ UndoState::UndoState(unique_ptr<core::GlobalState> evictedGs, UnorderedMap<int, 
                      vector<core::packages::Stratum> fileToStratum, core::packages::Stratum lastStratum,
                      const vector<core::FileRef> &workspaceFiles, uint32_t epoch)
     : evictedGs(move(evictedGs)), evictedIndexedFinalGS(std::move(evictedIndexedFinalGS)),
-      fileToStratum{move(fileToStratum)}, lastStratum{lastStratum}, savedWorkspaceFiles(workspaceFiles), epoch(epoch) {}
+      fileToStratum{move(fileToStratum)}, lastStratum{lastStratum}, initialWorkspaceFilesSize{workspaceFiles.size()},
+      epoch(epoch) {}
 
 void UndoState::restore(unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast::ParsedFile> &indexedFinalGS,
                         vector<core::packages::Stratum> &fileToStratum, core::packages::Stratum &lastStratum,
@@ -23,10 +25,14 @@ void UndoState::restore(unique_ptr<core::GlobalState> &gs, UnorderedMap<int, ast
     fileToStratum = move(this->fileToStratum);
     lastStratum = this->lastStratum;
 
-    // Restore the snapshot wholesale. The slow path appends new files to the live vector and then permutes it in place
-    // (partitionPackageFiles), so rolling back by truncating to the old size would erase whatever ended up at the tail,
-    // not the new files.
-    workspaceFiles = std::move(this->savedWorkspaceFiles);
+    // Drop the files that the canceled edit added: exactly the files the restored file table does not know about,
+    // wherever the slow path's in-place partitioning of `workspaceFiles` moved them. Truncating to the old size instead
+    // would drop whichever pre-existing files the partition displaced past it.
+    auto usedFiles = gs->filesUsed();
+    workspaceFiles.erase(
+        remove_if(workspaceFiles.begin(), workspaceFiles.end(), [usedFiles](auto f) { return f.id() >= usedFiles; }),
+        workspaceFiles.end());
+    ENFORCE(workspaceFiles.size() == this->initialWorkspaceFilesSize);
 }
 
 const unique_ptr<core::GlobalState> &UndoState::getEvictedGs() {

--- a/main/lsp/UndoState.h
+++ b/main/lsp/UndoState.h
@@ -25,9 +25,10 @@ class UndoState final {
     // The id of the last stratum in the previous slow path.
     const core::packages::Stratum lastStratum;
 
-    // The size of the workspaceFiles vector when the slow path started. Tracked so that we can roll back additions to
-    // the vector from new files added in the canceled edit.
-    const size_t initialWorkspaceFilesSize;
+    // The workspaceFiles vector as it was when the slow path started. The slow path appends new files to the live
+    // vector and then permutes it in place (partitionPackageFiles), so rolling back by truncating to the old size
+    // would erase whatever ended up at the tail rather than the new files; restoring the snapshot is order-independent.
+    std::vector<core::FileRef> savedWorkspaceFiles;
 
 public:
     // Epoch of the running slow path

--- a/main/lsp/UndoState.h
+++ b/main/lsp/UndoState.h
@@ -25,10 +25,9 @@ class UndoState final {
     // The id of the last stratum in the previous slow path.
     const core::packages::Stratum lastStratum;
 
-    // The workspaceFiles vector as it was when the slow path started. The slow path appends new files to the live
-    // vector and then permutes it in place (partitionPackageFiles), so rolling back by truncating to the old size
-    // would erase whatever ended up at the tail rather than the new files; restoring the snapshot is order-independent.
-    std::vector<core::FileRef> savedWorkspaceFiles;
+    // The size of the workspaceFiles vector when the slow path started, so that `restore` can check it removed exactly
+    // the files the canceled edit added.
+    const size_t initialWorkspaceFilesSize;
 
 public:
     // Epoch of the running slow path

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -57,7 +57,8 @@ void SorbetWorkspaceEditTask::preprocess(LSPPreprocessor &preprocessor) {
 }
 
 void SorbetWorkspaceEditTask::index(LSPIndexer &indexer) {
-    if (params->updates.size() <= config.opts.lspMaxFilesOnFastPath) {
+    // Only files whose content actually changed count: the indexer drops the others from the edit.
+    if (indexer.countChangedFiles(params->updates) <= config.opts.lspMaxFilesOnFastPath) {
         updates = indexer.commitEdit(*params);
     } else {
         // HACK: Too many files to `commitEdit` serially. Index in `runSpecial`.

--- a/main/lsp/test/undo_state_test.cc
+++ b/main/lsp/test/undo_state_test.cc
@@ -2,6 +2,7 @@
 // has to go first as it violates our requirements
 
 #include "ast/ast.h"
+#include "common/sort/sort.h"
 #include "core/ErrorQueue.h"
 #include "core/GlobalState.h"
 #include "core/Unfreeze.h"
@@ -23,12 +24,14 @@ unique_ptr<core::GlobalState> makeGlobalState() {
     return gs;
 }
 
-vector<uint32_t> ids(const vector<core::FileRef> &files) {
+// The ids in `files`, sorted: `restore` guarantees membership, not order (the slow path reorders the live vector).
+vector<uint32_t> sortedIds(const vector<core::FileRef> &files) {
     vector<uint32_t> result;
     result.reserve(files.size());
     for (auto file : files) {
         result.emplace_back(file.id());
     }
+    fast_sort(result);
     return result;
 }
 
@@ -55,53 +58,32 @@ struct Fixture {
     }
 
     // What the slow path does to `workspaceFiles` after the snapshot: applyFileTableUpdates appends the edit's new
-    // files, then partitionPackageFiles moves package files to the front with an unstable partition, which swaps an
-    // appended `__package.rb` with the first non-package file.
+    // files, then partitionPackageFiles moves package files to the front without preserving order, so an appended
+    // `__package.rb` ends up in the front block and a pre-existing source file is displaced past the old size.
     void appendNewFilesAndPartition(vector<core::FileRef> &files, vector<core::FileRef> &newFiles) {
         core::UnfreezeFileTable unfreeze(*gs);
         newFiles.emplace_back(gs->enterFile("foo/__package.rb", ""));
         newFiles.emplace_back(gs->enterFile("foo/c.rb", ""));
         files.insert(files.end(), newFiles.begin(), newFiles.end());
-        // a.rb (index 1, first non-package file) <-> foo/__package.rb (index 3, appended package file)
         swap(files[1], files[3]);
     }
 };
 } // namespace
 
-TEST_CASE_FIXTURE(Fixture, "RestoreReturnsTheExactPreSlowPathWorkspaceFiles") {
-    auto expected = ids(workspaceFiles);
+TEST_CASE_FIXTURE(Fixture, "RestoreRemovesExactlyTheFilesTheCanceledEditAdded") {
+    auto expected = sortedIds(workspaceFiles);
     auto undoState = snapshot(/* epoch */ 7);
 
     vector<core::FileRef> newFiles;
     appendNewFilesAndPartition(workspaceFiles, newFiles);
     REQUIRE_EQ(workspaceFiles.size(), expected.size() + newFiles.size());
-    // Precondition of the regression: a pre-existing file now sits in the region that size-based truncation would
-    // have erased, and an appended file sits in the region it would have kept.
+    // A pre-existing file now sits past the old size, and an appended file sits below it.
     REQUIRE_EQ(workspaceFiles[1].id(), newFiles[0].id());
     REQUIRE_EQ(workspaceFiles[3].id(), expected[1]);
 
     undoState.restore(gs, indexedFinalGS, fileToStratum, lastStratum, workspaceFiles);
 
-    CHECK_EQ(ids(workspaceFiles), expected);
-    // None of the files appended during the canceled slow path survive in the restored workspace.
-    for (auto newFile : newFiles) {
-        for (auto file : workspaceFiles) {
-            CHECK_NE(file.id(), newFile.id());
-        }
-    }
-}
-
-TEST_CASE_FIXTURE(Fixture, "RestoreUndoesAReorderingEvenWhenNoFilesWereAdded") {
-    auto expected = ids(workspaceFiles);
-    auto undoState = snapshot(/* epoch */ 8);
-
-    // A slow path with no new files still partitions `workspaceFiles` in place.
-    swap(workspaceFiles[1], workspaceFiles[2]);
-    REQUIRE_NE(ids(workspaceFiles), expected);
-
-    undoState.restore(gs, indexedFinalGS, fileToStratum, lastStratum, workspaceFiles);
-
-    CHECK_EQ(ids(workspaceFiles), expected);
+    CHECK_EQ(sortedIds(workspaceFiles), expected);
 }
 
 TEST_CASE_FIXTURE(Fixture, "RestoreBringsBackTheEvictedGlobalStateAndStrata") {

--- a/main/lsp/test/undo_state_test.cc
+++ b/main/lsp/test/undo_state_test.cc
@@ -18,94 +18,49 @@ namespace {
 auto logger = spdlog::stderr_color_mt("undo_state_test");
 auto errorQueue = make_shared<core::ErrorQueue>(*logger, *logger);
 
-unique_ptr<core::GlobalState> makeGlobalState() {
-    auto gs = make_unique<core::GlobalState>(errorQueue);
-    gs->initEmpty();
-    return gs;
-}
-
-// The ids in `files`, sorted: `restore` guarantees membership, not order (the slow path reorders the live vector).
+// `restore` guarantees which files are in `workspaceFiles`, not their order: the slow path reorders the live vector.
 vector<uint32_t> sortedIds(const vector<core::FileRef> &files) {
     vector<uint32_t> result;
-    result.reserve(files.size());
     for (auto file : files) {
         result.emplace_back(file.id());
     }
     fast_sort(result);
     return result;
 }
-
-struct Fixture {
-    unique_ptr<core::GlobalState> gs = makeGlobalState();
-    vector<core::FileRef> workspaceFiles;
-    UnorderedMap<int, ast::ParsedFile> indexedFinalGS;
-    vector<core::packages::Stratum> fileToStratum;
-    core::packages::Stratum lastStratum{0};
-
-    Fixture() {
-        core::UnfreezeFileTable unfreeze(*gs);
-        // A package file followed by two source files, i.e. already in the order that partitionPackageFiles leaves
-        // behind (package files first).
-        workspaceFiles.emplace_back(gs->enterFile("__package.rb", ""));
-        workspaceFiles.emplace_back(gs->enterFile("a.rb", ""));
-        workspaceFiles.emplace_back(gs->enterFile("b.rb", ""));
-        fileToStratum.assign(gs->filesUsed(), core::packages::Stratum(0));
-    }
-
-    UndoState snapshot(uint32_t epoch) {
-        auto evictedGs = gs->deepCopyGlobalState();
-        return UndoState(move(evictedGs), move(indexedFinalGS), fileToStratum, lastStratum, workspaceFiles, epoch);
-    }
-
-    // What the slow path does to `workspaceFiles` after the snapshot: applyFileTableUpdates appends the edit's new
-    // files, then partitionPackageFiles moves package files to the front without preserving order, so an appended
-    // `__package.rb` ends up in the front block and a pre-existing source file is displaced past the old size.
-    void appendNewFilesAndPartition(vector<core::FileRef> &files, vector<core::FileRef> &newFiles) {
-        core::UnfreezeFileTable unfreeze(*gs);
-        newFiles.emplace_back(gs->enterFile("foo/__package.rb", ""));
-        newFiles.emplace_back(gs->enterFile("foo/c.rb", ""));
-        files.insert(files.end(), newFiles.begin(), newFiles.end());
-        swap(files[1], files[3]);
-    }
-};
 } // namespace
 
-TEST_CASE_FIXTURE(Fixture, "RestoreRemovesExactlyTheFilesTheCanceledEditAdded") {
-    auto expected = sortedIds(workspaceFiles);
-    auto undoState = snapshot(/* epoch */ 7);
+TEST_CASE("UndoStateRestoreRemovesExactlyTheFilesTheCanceledEditAdded") {
+    auto gs = make_unique<core::GlobalState>(errorQueue);
+    gs->initEmpty();
 
-    vector<core::FileRef> newFiles;
-    appendNewFilesAndPartition(workspaceFiles, newFiles);
-    REQUIRE_EQ(workspaceFiles.size(), expected.size() + newFiles.size());
-    // A pre-existing file now sits past the old size, and an appended file sits below it.
-    REQUIRE_EQ(workspaceFiles[1].id(), newFiles[0].id());
+    vector<core::FileRef> workspaceFiles;
+    {
+        core::UnfreezeFileTable unfreeze(*gs);
+        for (auto path : {"__package.rb", "a.rb", "b.rb"}) {
+            workspaceFiles.emplace_back(gs->enterFile(path, ""));
+        }
+    }
+    auto expected = sortedIds(workspaceFiles);
+
+    UnorderedMap<int, ast::ParsedFile> indexedFinalGS;
+    vector<core::packages::Stratum> fileToStratum(gs->filesUsed(), core::packages::Stratum(0));
+    core::packages::Stratum lastStratum(0);
+    UndoState undoState(gs->deepCopyGlobalState(), move(indexedFinalGS), fileToStratum, lastStratum, workspaceFiles,
+                        /* epoch */ 7);
+
+    // The canceled edit adds a package file and a source file; partitionPackageFiles then moves the package file to
+    // the front, displacing `a.rb` past the old size.
+    {
+        core::UnfreezeFileTable unfreeze(*gs);
+        workspaceFiles.emplace_back(gs->enterFile("foo/__package.rb", ""));
+        workspaceFiles.emplace_back(gs->enterFile("foo/c.rb", ""));
+    }
+    swap(workspaceFiles[1], workspaceFiles[3]);
     REQUIRE_EQ(workspaceFiles[3].id(), expected[1]);
 
     undoState.restore(gs, indexedFinalGS, fileToStratum, lastStratum, workspaceFiles);
 
     CHECK_EQ(sortedIds(workspaceFiles), expected);
-}
-
-TEST_CASE_FIXTURE(Fixture, "RestoreBringsBackTheEvictedGlobalStateAndStrata") {
-    auto filesBefore = gs->filesUsed();
-    fileToStratum.assign(gs->filesUsed(), core::packages::Stratum(3));
-    lastStratum = core::packages::Stratum(3);
-    auto undoState = snapshot(/* epoch */ 9);
-
-    // The slow path grows the file table and recomputes strata before it is canceled.
-    {
-        core::UnfreezeFileTable unfreeze(*gs);
-        workspaceFiles.emplace_back(gs->enterFile("new.rb", ""));
-    }
-    fileToStratum.assign(gs->filesUsed(), core::packages::Stratum(0));
-    lastStratum = core::packages::Stratum(0);
-
-    undoState.restore(gs, indexedFinalGS, fileToStratum, lastStratum, workspaceFiles);
-
-    CHECK_EQ(gs->filesUsed(), filesBefore);
-    CHECK_EQ(fileToStratum.size(), filesBefore);
-    CHECK(lastStratum == core::packages::Stratum(3));
-    CHECK_EQ(workspaceFiles.size(), 3);
 }
 
 } // namespace sorbet::realmain::lsp::test

--- a/main/lsp/test/undo_state_test.cc
+++ b/main/lsp/test/undo_state_test.cc
@@ -1,0 +1,129 @@
+#include "doctest/doctest.h"
+// has to go first as it violates our requirements
+
+#include "ast/ast.h"
+#include "core/ErrorQueue.h"
+#include "core/GlobalState.h"
+#include "core/Unfreeze.h"
+#include "core/packages/Stratum.h"
+#include "main/lsp/UndoState.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
+#include "spdlog/spdlog.h"
+
+namespace sorbet::realmain::lsp::test {
+using namespace std;
+
+namespace {
+auto logger = spdlog::stderr_color_mt("undo_state_test");
+auto errorQueue = make_shared<core::ErrorQueue>(*logger, *logger);
+
+unique_ptr<core::GlobalState> makeGlobalState() {
+    auto gs = make_unique<core::GlobalState>(errorQueue);
+    gs->initEmpty();
+    return gs;
+}
+
+vector<uint32_t> ids(const vector<core::FileRef> &files) {
+    vector<uint32_t> result;
+    result.reserve(files.size());
+    for (auto file : files) {
+        result.emplace_back(file.id());
+    }
+    return result;
+}
+
+struct Fixture {
+    unique_ptr<core::GlobalState> gs = makeGlobalState();
+    vector<core::FileRef> workspaceFiles;
+    UnorderedMap<int, ast::ParsedFile> indexedFinalGS;
+    vector<core::packages::Stratum> fileToStratum;
+    core::packages::Stratum lastStratum{0};
+
+    Fixture() {
+        core::UnfreezeFileTable unfreeze(*gs);
+        // A package file followed by two source files, i.e. already in the order that partitionPackageFiles leaves
+        // behind (package files first).
+        workspaceFiles.emplace_back(gs->enterFile("__package.rb", ""));
+        workspaceFiles.emplace_back(gs->enterFile("a.rb", ""));
+        workspaceFiles.emplace_back(gs->enterFile("b.rb", ""));
+        fileToStratum.assign(gs->filesUsed(), core::packages::Stratum(0));
+    }
+
+    UndoState snapshot(uint32_t epoch) {
+        auto evictedGs = gs->deepCopyGlobalState();
+        return UndoState(move(evictedGs), move(indexedFinalGS), fileToStratum, lastStratum, workspaceFiles, epoch);
+    }
+
+    // What the slow path does to `workspaceFiles` after the snapshot: applyFileTableUpdates appends the edit's new
+    // files, then partitionPackageFiles moves package files to the front with an unstable partition, which swaps an
+    // appended `__package.rb` with the first non-package file.
+    void appendNewFilesAndPartition(vector<core::FileRef> &files, vector<core::FileRef> &newFiles) {
+        core::UnfreezeFileTable unfreeze(*gs);
+        newFiles.emplace_back(gs->enterFile("foo/__package.rb", ""));
+        newFiles.emplace_back(gs->enterFile("foo/c.rb", ""));
+        files.insert(files.end(), newFiles.begin(), newFiles.end());
+        // a.rb (index 1, first non-package file) <-> foo/__package.rb (index 3, appended package file)
+        swap(files[1], files[3]);
+    }
+};
+} // namespace
+
+TEST_CASE_FIXTURE(Fixture, "RestoreReturnsTheExactPreSlowPathWorkspaceFiles") {
+    auto expected = ids(workspaceFiles);
+    auto undoState = snapshot(/* epoch */ 7);
+
+    vector<core::FileRef> newFiles;
+    appendNewFilesAndPartition(workspaceFiles, newFiles);
+    REQUIRE_EQ(workspaceFiles.size(), expected.size() + newFiles.size());
+    // Precondition of the regression: a pre-existing file now sits in the region that size-based truncation would
+    // have erased, and an appended file sits in the region it would have kept.
+    REQUIRE_EQ(workspaceFiles[1].id(), newFiles[0].id());
+    REQUIRE_EQ(workspaceFiles[3].id(), expected[1]);
+
+    undoState.restore(gs, indexedFinalGS, fileToStratum, lastStratum, workspaceFiles);
+
+    CHECK_EQ(ids(workspaceFiles), expected);
+    // None of the files appended during the canceled slow path survive in the restored workspace.
+    for (auto newFile : newFiles) {
+        for (auto file : workspaceFiles) {
+            CHECK_NE(file.id(), newFile.id());
+        }
+    }
+}
+
+TEST_CASE_FIXTURE(Fixture, "RestoreUndoesAReorderingEvenWhenNoFilesWereAdded") {
+    auto expected = ids(workspaceFiles);
+    auto undoState = snapshot(/* epoch */ 8);
+
+    // A slow path with no new files still partitions `workspaceFiles` in place.
+    swap(workspaceFiles[1], workspaceFiles[2]);
+    REQUIRE_NE(ids(workspaceFiles), expected);
+
+    undoState.restore(gs, indexedFinalGS, fileToStratum, lastStratum, workspaceFiles);
+
+    CHECK_EQ(ids(workspaceFiles), expected);
+}
+
+TEST_CASE_FIXTURE(Fixture, "RestoreBringsBackTheEvictedGlobalStateAndStrata") {
+    auto filesBefore = gs->filesUsed();
+    fileToStratum.assign(gs->filesUsed(), core::packages::Stratum(3));
+    lastStratum = core::packages::Stratum(3);
+    auto undoState = snapshot(/* epoch */ 9);
+
+    // The slow path grows the file table and recomputes strata before it is canceled.
+    {
+        core::UnfreezeFileTable unfreeze(*gs);
+        workspaceFiles.emplace_back(gs->enterFile("new.rb", ""));
+    }
+    fileToStratum.assign(gs->filesUsed(), core::packages::Stratum(0));
+    lastStratum = core::packages::Stratum(0);
+
+    undoState.restore(gs, indexedFinalGS, fileToStratum, lastStratum, workspaceFiles);
+
+    CHECK_EQ(gs->filesUsed(), filesBefore);
+    CHECK_EQ(fileToStratum.size(), filesBefore);
+    CHECK(lastStratum == core::packages::Stratum(3));
+    CHECK_EQ(workspaceFiles.size(), 3);
+}
+
+} // namespace sorbet::realmain::lsp::test

--- a/test/lsp/ProtocolTest.cc
+++ b/test/lsp/ProtocolTest.cc
@@ -19,7 +19,7 @@ bool isTypecheckRun(const LSPMessage &msg) {
 }
 } // namespace
 
-void ProtocolTest::resetState(shared_ptr<realmain::options::Options> opts) {
+void ProtocolTest::resetState(shared_ptr<realmain::options::Options> opts, bool disableFastPath) {
     fs = make_shared<MockFileSystem>(rootPath);
     diagnostics.clear();
     sourceFileContents.clear();
@@ -36,9 +36,9 @@ void ProtocolTest::resetState(shared_ptr<realmain::options::Options> opts) {
     }
 
     if (useMultithreading) {
-        lspWrapper = MultiThreadedLSPWrapper::create(rootPath, opts);
+        lspWrapper = MultiThreadedLSPWrapper::create(rootPath, opts, disableFastPath);
     } else {
-        lspWrapper = SingleThreadedLSPWrapper::create(rootPath, opts);
+        lspWrapper = SingleThreadedLSPWrapper::create(rootPath, opts, disableFastPath);
     }
     lspWrapper->opts->fs = fs;
     lspWrapper->enableAllExperimentalFeatures();

--- a/test/lsp/ProtocolTest.h
+++ b/test/lsp/ProtocolTest.h
@@ -47,7 +47,7 @@ protected:
     ~ProtocolTest();
 
     /** Reset lspWrapper and other internal state. */
-    void resetState(std::shared_ptr<sorbet::realmain::options::Options> opts = nullptr);
+    void resetState(std::shared_ptr<sorbet::realmain::options::Options> opts = nullptr, bool disableFastPath = false);
 
     /** Get an absolute file URI for the given relative file path. */
     std::string getUri(std::string_view filePath);

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -911,6 +911,44 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest,
     CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath_canceled"), 1);
 }
 
+TEST_CASE_FIXTURE(MultithreadedProtocolTest, "UnchangedDuplicateFileUpdateDuringSlowPathIsDroppedAndHarmless") {
+    // A watchman event that re-reports a file with the content the indexer already holds is dropped from the edit; if
+    // it arrives while a slow path is in flight, the resulting zero-file fast path preempts that slow path and must
+    // leave its result intact.
+    auto initOptions = make_unique<SorbetInitializationOptions>();
+    initOptions->enableTypecheckInfo = true;
+    assertErrorDiagnostics(
+        initializeLSP(true /* supportsMarkdown */, true /* supportsCodeActionResolve */, move(initOptions)), {});
+
+    writeFilesToFS({{"bar.rb", "# typed: true\nclass Bar\nend\n"}});
+    assertErrorDiagnostics(send(*watchmanFileUpdate({"bar.rb"})), {});
+    assertErrorDiagnostics(send(*openFile("foo.rb", "")), {});
+    getCounters();
+
+    // Slow path: a new class with an error, expecting one preemption.
+    sendAsync(*changeFile("foo.rb",
+                          "# typed: true\nclass Foo\nextend T::Sig\nsig{returns(String)}\ndef bar\n3\nend\nend\n", 2,
+                          false, 1));
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // Duplicate: bar.rb re-reported with the content Sorbet already has.
+    sendAsync(*watchmanFileUpdate({"bar.rb"}));
+
+    // Send a fence to clear out the pipeline. The slow path's error is reported; nothing else changed.
+    assertErrorDiagnostics(send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20))),
+                           {{"foo.rb", 5, "Expected `String` but found `Integer(3)` for method result type"}});
+
+    auto counters = getCounters();
+    CHECK_EQ(counters.getCounter("lsp.edit.unchanged_files_dropped"), 1);
+    CHECK_EQ(counters.getCategoryCounter("lsp.updates", "fastpath"), 1);
+    CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 1);
+    CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath_canceled"), 0);
+}
+
 TEST_CASE_FIXTURE(MultithreadedProtocolTest, "SlowFooThenFastBarThenUndoSlowFoo") {
     auto initOptions = make_unique<SorbetInitializationOptions>();
     initOptions->enableTypecheckInfo = true;

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -769,27 +769,15 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanCancelSlowPathEvenIfAddsFile") 
 }
 
 TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CancelingSlowPathThatAddsPackageFileKeepsExistingWorkspaceFiles") {
-    // Regression test for a slow-path cancellation bug in package mode. `UndoState` used to roll back
-    // `LSPTypechecker::workspaceFiles` by truncating it to its pre-edit size, which assumed that the canceled slow path
-    // had only *appended* the edit's new files. But the slow path also partitions the vector in place (package files
-    // first, with an unstable partition), so when one of the appended new files is a `__package.rb`, the partition
-    // swaps it with the first non-package file. Truncating then erased that pre-existing file from the workspace for
-    // the life of the process: it was never indexed again, every reference to its definitions became an unresolved
-    // constant, and only a restart brought it back.
-    bool packageDirected = false;
-    SUBCASE("package-directed typechecking off") {}
-    SUBCASE("package-directed typechecking on") {
-        packageDirected = true;
-    }
-
+    // Canceling a slow path must leave `LSPTypechecker::workspaceFiles` with exactly its pre-edit membership. The slow
+    // path appends the edit's new files and then partitions the vector in place (package files first, order not
+    // preserved), so when a new file is a `__package.rb` a pre-existing source file is displaced past the old size; a
+    // rollback that truncated to the old size dropped that file from the workspace for good.
     auto opts = make_shared<realmain::options::Options>();
     opts->cacheSensitiveOptions.sorbetPackages = true;
-    opts->packageDirected = packageDirected;
     resetState(opts);
 
-    // The order is significant: `__package.rb` comes first so that `a.rb` is the first non-package file after the
-    // partition, i.e. the file that a newly appended package file gets swapped with. `a.rb` and `b.rb` reference each
-    // other so that losing either one of them shows up as an unresolved constant in the other.
+    // `a.rb` and `b.rb` reference each other so that losing either shows up as an unresolved constant in the other.
     vector<pair<string, string>> files = {
         {"__package.rb", PackageTextBuilder().withName("Root").withExports({"Root::A", "Root::B"}).build()},
         {"a.rb", "# typed: true\n"
@@ -821,15 +809,11 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CancelingSlowPathThatAddsPackageFi
     assertErrorDiagnostics(
         initializeLSP(true /* supportsMarkdown */, true /* supportsCodeActionResolve */, move(initOptions)), {});
 
-    // Open the two source files so that we can query definitions in them afterwards.
-    assertErrorDiagnostics(send(*openFile("a.rb", files[1].second)), {});
-    assertErrorDiagnostics(send(*openFile("b.rb", files[2].second)), {});
-
     // Clear counters so that the assertions below only see the edits.
     getCounters();
 
-    // Slow path 1: a brand-new `__package.rb` (so a new file that is a package file). `cancellationExpected` makes
-    // the slow path wait for its cancellation only once it has already partitioned `workspaceFiles`.
+    // Slow path 1: a brand-new `__package.rb`. `cancellationExpected` makes the slow path wait for its cancellation
+    // only once it has already partitioned `workspaceFiles`.
     sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::PAUSE, nullopt)));
     sendAsync(*openFile("foo/__package.rb", ""));
     sendAsync(*changeFile("foo/__package.rb", PackageTextBuilder().withName("Root::Foo").withImports({"Root"}).build(),
@@ -865,11 +849,6 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CancelingSlowPathThatAddsPackageFi
     // Send a fence to clear out the pipeline. Every file is still part of the workspace, so nothing is unresolved.
     assertErrorDiagnostics(send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20))), {});
 
-    // And the definitions in the files that sat next to the partition boundary are still reachable.
-    auto definitions = getDefinitions("b.rb", 4, 6);
-    REQUIRE_EQ(definitions.size(), 1);
-    CHECK_EQ(definitions[0]->uri, getUri("a.rb"));
-
     auto counters = getCounters();
     CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 1);
     CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath_canceled"), 1);
@@ -877,10 +856,9 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CancelingSlowPathThatAddsPackageFi
 
 TEST_CASE_FIXTURE(MultithreadedProtocolTest,
                   "CancelingPackageDirectedSlowPathThatAddsLowStratumFileKeepsExistingWorkspaceFiles") {
-    // Companion to the previous test for package-directed typechecking, where computePackageStrata additionally sorts
-    // the non-package files of `workspaceFiles` in place by (stratum, id). A new file in a low stratum therefore sorts
-    // ahead of pre-existing files of higher strata, pushing the last of them into the region that a size-based rollback
-    // would have erased -- without any new package file being involved.
+    // Same invariant as the previous test, for the second way the slow path reorders `workspaceFiles`: with
+    // package-directed typechecking, computePackageStrata sorts the non-package files in place by (stratum, id), so a
+    // new low-stratum file displaces the last high-stratum file past the old size -- no new package file involved.
     auto opts = make_shared<realmain::options::Options>();
     opts->cacheSensitiveOptions.sorbetPackages = true;
     opts->packageDirected = true;
@@ -929,15 +907,6 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest,
     assertErrorDiagnostics(
         initializeLSP(true /* supportsMarkdown */, true /* supportsCodeActionResolve */, move(initOptions)), {});
 
-    // The class defined in the file that will sit at the end of the sorted workspace is known to the symbol table.
-    {
-        auto responses = send(*workspaceSymbol("Root::Bar::C"));
-        REQUIRE_EQ(responses.size(), 1);
-        auto &result = get<variant<JSONNullObject, vector<unique_ptr<SymbolInformation>>>>(
-            responses[0]->asResponse().result.value());
-        REQUIRE_EQ(get<vector<unique_ptr<SymbolInformation>>>(result).size(), 1);
-    }
-
     // Clear counters so that the assertions below only see the edits.
     getCounters();
 
@@ -978,7 +947,7 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest,
     // Send a fence to clear out the pipeline. Nothing was lost, so nothing is unresolved ...
     assertErrorDiagnostics(send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20))), {});
 
-    // ... and the file at the end of the sorted workspace is still part of it.
+    // ... and the file at the end of the sorted workspace is still part of it (its class is in the symbol table).
     {
         auto responses = send(*workspaceSymbol("Root::Bar::C"));
         REQUIRE_EQ(responses.size(), 1);

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -55,6 +55,51 @@ public:
         REQUIRE(msg == nullptr);
         setSlowPathBlocked(false);
     }
+
+    // Initializes Sorbet in package mode over `files` (written to the workspace, in this order) and clears the
+    // counters.
+    void initializePackagedWorkspace(bool packageDirected, const vector<pair<string, string>> &files) {
+        auto opts = make_shared<realmain::options::Options>();
+        opts->cacheSensitiveOptions.sorbetPackages = true;
+        opts->packageDirected = packageDirected;
+        resetState(opts);
+
+        writeFilesToFS(files);
+        for (auto &[path, _] : files) {
+            lspWrapper->opts->inputFileNames.emplace_back(fmt::format("{}/{}", rootPath, path));
+        }
+
+        auto initOptions = make_unique<SorbetInitializationOptions>();
+        initOptions->enableTypecheckInfo = true;
+        assertErrorDiagnostics(
+            initializeLSP(true /* supportsMarkdown */, true /* supportsCodeActionResolve */, move(initOptions)), {});
+        getCounters();
+    }
+
+    // Starts a slow path by creating `newFile`, cancels it by creating `cancelFile` once it has started, and returns
+    // the messages of a fence sent afterwards. `cancellationExpected` on the first edit makes the slow path wait for
+    // the cancellation only once it has rearranged `workspaceFiles`.
+    vector<unique_ptr<LSPMessage>> cancelSlowPathWithNewFile(const pair<string, string> &newFile,
+                                                             const pair<string, string> &cancelFile) {
+        sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::PAUSE, nullopt)));
+        sendAsync(*openFile(newFile.first, ""));
+        sendAsync(*changeFile(newFile.first, newFile.second, 2, /* cancellationExpected */ true));
+        sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::RESUME, nullopt)));
+        {
+            auto status = getTypecheckRunStatus(*readAsync());
+            REQUIRE(status.has_value());
+            REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+        }
+
+        sendAsync(*openFile(cancelFile.first, cancelFile.second));
+        {
+            auto status = getTypecheckRunStatus(*readAsync());
+            REQUIRE(status.has_value());
+            REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Cancelled);
+        }
+
+        return send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20)));
+    }
 };
 
 } // namespace
@@ -769,85 +814,48 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanCancelSlowPathEvenIfAddsFile") 
 }
 
 TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CancelingSlowPathThatAddsPackageFileKeepsExistingWorkspaceFiles") {
-    // Canceling a slow path must leave `LSPTypechecker::workspaceFiles` with exactly its pre-edit membership. The slow
-    // path appends the edit's new files and then partitions the vector in place (package files first, order not
-    // preserved), so when a new file is a `__package.rb` a pre-existing source file is displaced past the old size; a
-    // rollback that truncated to the old size dropped that file from the workspace for good.
-    auto opts = make_shared<realmain::options::Options>();
-    opts->cacheSensitiveOptions.sorbetPackages = true;
-    resetState(opts);
+    // Canceling a slow path must leave `LSPTypechecker::workspaceFiles` with its pre-edit membership. The slow path
+    // appends the edit's new files and then partitions the vector in place (package files first, order not preserved),
+    // so a new `__package.rb` displaces a pre-existing source file past the old size; a rollback that truncated to the
+    // old size dropped that file from the workspace for good.
+    initializePackagedWorkspace(
+        /* packageDirected */ false,
+        {
+            {"__package.rb", PackageTextBuilder().withName("Root").withExports({"Root::A", "Root::B"}).build()},
+            // `a.rb` and `b.rb` reference each other, so losing either is an unresolved
+            // constant in the other.
+            {"a.rb", "# typed: true\n"
+                     "module Root\n"
+                     "  class A\n"
+                     "    def fun\n"
+                     "      B.new.bar\n"
+                     "    end\n"
+                     "  end\n"
+                     "end\n"},
+            {"b.rb", "# typed: true\n"
+                     "module Root\n"
+                     "  class B\n"
+                     "    def bar\n"
+                     "      A.new.fun\n"
+                     "    end\n"
+                     "  end\n"
+                     "end\n"},
+        });
 
-    // `a.rb` and `b.rb` reference each other so that losing either shows up as an unresolved constant in the other.
-    vector<pair<string, string>> files = {
-        {"__package.rb", PackageTextBuilder().withName("Root").withExports({"Root::A", "Root::B"}).build()},
-        {"a.rb", "# typed: true\n"
-                 "module Root\n"
-                 "  class A\n"
-                 "    def fun\n"
-                 "      B.new.bar\n"
-                 "    end\n"
-                 "  end\n"
-                 "end\n"},
-        {"b.rb", "# typed: true\n"
-                 "module Root\n"
-                 "  class B\n"
-                 "    def bar\n"
-                 "      A.new.fun\n"
-                 "    end\n"
-                 "  end\n"
-                 "end\n"},
-    };
-
-    writeFilesToFS(files);
-
-    for (auto &[path, _] : files) {
-        this->lspWrapper->opts->inputFileNames.emplace_back(fmt::format("{}/{}", this->rootPath, path));
-    }
-
-    auto initOptions = make_unique<SorbetInitializationOptions>();
-    initOptions->enableTypecheckInfo = true;
+    // The canceling edit lives in the new package and uses the root package's exports, so it only typechecks cleanly
+    // if nothing was lost along the way.
     assertErrorDiagnostics(
-        initializeLSP(true /* supportsMarkdown */, true /* supportsCodeActionResolve */, move(initOptions)), {});
-
-    // Clear counters so that the assertions below only see the edits.
-    getCounters();
-
-    // Slow path 1: a brand-new `__package.rb`. `cancellationExpected` makes the slow path wait for its cancellation
-    // only once it has already partitioned `workspaceFiles`.
-    sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::PAUSE, nullopt)));
-    sendAsync(*openFile("foo/__package.rb", ""));
-    sendAsync(*changeFile("foo/__package.rb", PackageTextBuilder().withName("Root::Foo").withImports({"Root"}).build(),
-                          2,
-                          /* cancellationExpected */ true));
-    sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::RESUME, nullopt)));
-
-    // Wait for typechecking to begin to avoid races.
-    {
-        auto status = getTypecheckRunStatus(*readAsync());
-        REQUIRE(status.has_value());
-        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
-    }
-
-    // Slow path 2: another new file, which cancels slow path 1. It lives in the new package and uses the exports of
-    // the root package, so it only typechecks cleanly if nothing was lost along the way.
-    sendAsync(*openFile("foo/c.rb", "# typed: true\n"
-                                    "module Root::Foo\n"
-                                    "  class C\n"
-                                    "    def c\n"
-                                    "      Root::A.new.fun\n"
-                                    "    end\n"
-                                    "  end\n"
-                                    "end\n"));
-
-    // Wait for the first typecheck run to get canceled.
-    {
-        auto status = getTypecheckRunStatus(*readAsync());
-        REQUIRE(status.has_value());
-        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Cancelled);
-    }
-
-    // Send a fence to clear out the pipeline. Every file is still part of the workspace, so nothing is unresolved.
-    assertErrorDiagnostics(send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20))), {});
+        cancelSlowPathWithNewFile(
+            {"foo/__package.rb", PackageTextBuilder().withName("Root::Foo").withImports({"Root"}).build()},
+            {"foo/c.rb", "# typed: true\n"
+                         "module Root::Foo\n"
+                         "  class C\n"
+                         "    def c\n"
+                         "      Root::A.new.fun\n"
+                         "    end\n"
+                         "  end\n"
+                         "end\n"}),
+        {});
 
     auto counters = getCounters();
     CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 1);
@@ -856,105 +864,47 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CancelingSlowPathThatAddsPackageFi
 
 TEST_CASE_FIXTURE(MultithreadedProtocolTest,
                   "CancelingPackageDirectedSlowPathThatAddsLowStratumFileKeepsExistingWorkspaceFiles") {
-    // Same invariant as the previous test, for the second way the slow path reorders `workspaceFiles`: with
-    // package-directed typechecking, computePackageStrata sorts the non-package files in place by (stratum, id), so a
-    // new low-stratum file displaces the last high-stratum file past the old size -- no new package file involved.
-    auto opts = make_shared<realmain::options::Options>();
-    opts->cacheSensitiveOptions.sorbetPackages = true;
-    opts->packageDirected = true;
-    resetState(opts);
-
-    // Three packages in a chain, so that the strata are Root (0) < Root::Foo (1) < Root::Bar (2) and `bar/c.rb` is the
-    // last non-package file after the stratum sort.
-    vector<pair<string, string>> files = {
-        {"__package.rb", PackageTextBuilder().withName("Root").withExports({"Root::A"}).build()},
-        {"a.rb", "# typed: true\n"
-                 "module Root\n"
-                 "  class A\n"
-                 "    def fun\n"
-                 "    end\n"
-                 "  end\n"
-                 "end\n"},
-        {"foo/__package.rb",
-         PackageTextBuilder().withName("Root::Foo").withImports({"Root"}).withExports({"Root::Foo::B"}).build()},
-        {"foo/b.rb", "# typed: true\n"
-                     "module Root::Foo\n"
-                     "  class B\n"
-                     "    def bar\n"
-                     "      Root::A.new.fun\n"
-                     "    end\n"
+    // Same invariant for the second way the slow path reorders `workspaceFiles`: with package-directed typechecking,
+    // computePackageStrata sorts the non-package files in place by (stratum, id), so a new low-stratum file displaces
+    // the last high-stratum file past the old size -- no new package file involved.
+    initializePackagedWorkspace(
+        /* packageDirected */ true,
+        {
+            {"__package.rb", PackageTextBuilder().withName("Root").withExports({"Root::A"}).build()},
+            {"a.rb", "# typed: true\n"
+                     "module Root\n"
+                     "  class A\n"
                      "  end\n"
                      "end\n"},
-        {"bar/__package.rb", PackageTextBuilder().withName("Root::Bar").withImports({"Root::Foo"}).build()},
-        {"bar/c.rb", "# typed: true\n"
-                     "module Root::Bar\n"
-                     "  class C\n"
-                     "    def c\n"
-                     "      Root::Foo::B.new.bar\n"
-                     "    end\n"
-                     "  end\n"
-                     "end\n"},
-    };
+            {"foo/__package.rb",
+             PackageTextBuilder().withName("Root::Foo").withImports({"Root"}).withExports({"Root::Foo::B"}).build()},
+            // Root::Foo depends on Root, so `foo/b.rb` is the last file after the stratum
+            // sort and the one a new file in Root displaces.
+            {"foo/b.rb", "# typed: true\n"
+                         "module Root::Foo\n"
+                         "  class B\n"
+                         "  end\n"
+                         "end\n"},
+        });
 
-    writeFilesToFS(files);
+    assertErrorDiagnostics(cancelSlowPathWithNewFile({"d.rb", "# typed: true\n"
+                                                              "module Root\n"
+                                                              "  class D\n"
+                                                              "  end\n"
+                                                              "end\n"},
+                                                     {"e.rb", "# typed: true\n"
+                                                              "module Root\n"
+                                                              "  class E\n"
+                                                              "  end\n"
+                                                              "end\n"}),
+                           {});
 
-    for (auto &[path, _] : files) {
-        this->lspWrapper->opts->inputFileNames.emplace_back(fmt::format("{}/{}", this->rootPath, path));
-    }
-
-    auto initOptions = make_unique<SorbetInitializationOptions>();
-    initOptions->enableTypecheckInfo = true;
-    assertErrorDiagnostics(
-        initializeLSP(true /* supportsMarkdown */, true /* supportsCodeActionResolve */, move(initOptions)), {});
-
-    // Clear counters so that the assertions below only see the edits.
-    getCounters();
-
-    // Slow path 1: a brand-new source file in the lowest stratum (the root package). `cancellationExpected` makes the
-    // slow path wait for its cancellation only once `workspaceFiles` has been partitioned and sorted.
-    sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::PAUSE, nullopt)));
-    sendAsync(*openFile("d.rb", ""));
-    sendAsync(*changeFile("d.rb",
-                          "# typed: true\n"
-                          "module Root\n"
-                          "  class D\n"
-                          "  end\n"
-                          "end\n",
-                          2, /* cancellationExpected */ true));
-    sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::RESUME, nullopt)));
-
-    // Wait for typechecking to begin to avoid races.
-    {
-        auto status = getTypecheckRunStatus(*readAsync());
-        REQUIRE(status.has_value());
-        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
-    }
-
-    // Slow path 2: another new file, which cancels slow path 1.
-    sendAsync(*openFile("e.rb", "# typed: true\n"
-                                "module Root\n"
-                                "  class E\n"
-                                "  end\n"
-                                "end\n"));
-
-    // Wait for the first typecheck run to get canceled.
-    {
-        auto status = getTypecheckRunStatus(*readAsync());
-        REQUIRE(status.has_value());
-        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Cancelled);
-    }
-
-    // Send a fence to clear out the pipeline. Nothing was lost, so nothing is unresolved ...
-    assertErrorDiagnostics(send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20))), {});
-
-    // ... and the file at the end of the sorted workspace is still part of it (its class is in the symbol table).
-    {
-        auto responses = send(*workspaceSymbol("Root::Bar::C"));
-        REQUIRE_EQ(responses.size(), 1);
-        auto &result = get<variant<JSONNullObject, vector<unique_ptr<SymbolInformation>>>>(
-            responses[0]->asResponse().result.value());
-        REQUIRE_EQ(get<vector<unique_ptr<SymbolInformation>>>(result).size(), 1);
-    }
+    // `foo/b.rb` is still part of the workspace: its class is in the symbol table.
+    auto responses = send(*workspaceSymbol("Root::Foo::B"));
+    REQUIRE_EQ(responses.size(), 1);
+    auto &result =
+        get<variant<JSONNullObject, vector<unique_ptr<SymbolInformation>>>>(responses[0]->asResponse().result.value());
+    CHECK_EQ(get<vector<unique_ptr<SymbolInformation>>>(result).size(), 1);
 
     auto counters = getCounters();
     CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 1);

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -768,6 +768,230 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanCancelSlowPathEvenIfAddsFile") 
                          /* assertUniqueStartTimes */ false);
 }
 
+TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CancelingSlowPathThatAddsPackageFileKeepsExistingWorkspaceFiles") {
+    // Regression test for a slow-path cancellation bug in package mode. `UndoState` used to roll back
+    // `LSPTypechecker::workspaceFiles` by truncating it to its pre-edit size, which assumed that the canceled slow path
+    // had only *appended* the edit's new files. But the slow path also partitions the vector in place (package files
+    // first, with an unstable partition), so when one of the appended new files is a `__package.rb`, the partition
+    // swaps it with the first non-package file. Truncating then erased that pre-existing file from the workspace for
+    // the life of the process: it was never indexed again, every reference to its definitions became an unresolved
+    // constant, and only a restart brought it back.
+    bool packageDirected = false;
+    SUBCASE("package-directed typechecking off") {}
+    SUBCASE("package-directed typechecking on") {
+        packageDirected = true;
+    }
+
+    auto opts = make_shared<realmain::options::Options>();
+    opts->cacheSensitiveOptions.sorbetPackages = true;
+    opts->packageDirected = packageDirected;
+    resetState(opts);
+
+    // The order is significant: `__package.rb` comes first so that `a.rb` is the first non-package file after the
+    // partition, i.e. the file that a newly appended package file gets swapped with. `a.rb` and `b.rb` reference each
+    // other so that losing either one of them shows up as an unresolved constant in the other.
+    vector<pair<string, string>> files = {
+        {"__package.rb", PackageTextBuilder().withName("Root").withExports({"Root::A", "Root::B"}).build()},
+        {"a.rb", "# typed: true\n"
+                 "module Root\n"
+                 "  class A\n"
+                 "    def fun\n"
+                 "      B.new.bar\n"
+                 "    end\n"
+                 "  end\n"
+                 "end\n"},
+        {"b.rb", "# typed: true\n"
+                 "module Root\n"
+                 "  class B\n"
+                 "    def bar\n"
+                 "      A.new.fun\n"
+                 "    end\n"
+                 "  end\n"
+                 "end\n"},
+    };
+
+    writeFilesToFS(files);
+
+    for (auto &[path, _] : files) {
+        this->lspWrapper->opts->inputFileNames.emplace_back(fmt::format("{}/{}", this->rootPath, path));
+    }
+
+    auto initOptions = make_unique<SorbetInitializationOptions>();
+    initOptions->enableTypecheckInfo = true;
+    assertErrorDiagnostics(
+        initializeLSP(true /* supportsMarkdown */, true /* supportsCodeActionResolve */, move(initOptions)), {});
+
+    // Open the two source files so that we can query definitions in them afterwards.
+    assertErrorDiagnostics(send(*openFile("a.rb", files[1].second)), {});
+    assertErrorDiagnostics(send(*openFile("b.rb", files[2].second)), {});
+
+    // Clear counters so that the assertions below only see the edits.
+    getCounters();
+
+    // Slow path 1: a brand-new `__package.rb` (so a new file that is a package file). `cancellationExpected` makes
+    // the slow path wait for its cancellation only once it has already partitioned `workspaceFiles`.
+    sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::PAUSE, nullopt)));
+    sendAsync(*openFile("foo/__package.rb", ""));
+    sendAsync(*changeFile("foo/__package.rb", PackageTextBuilder().withName("Root::Foo").withImports({"Root"}).build(),
+                          2,
+                          /* cancellationExpected */ true));
+    sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::RESUME, nullopt)));
+
+    // Wait for typechecking to begin to avoid races.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // Slow path 2: another new file, which cancels slow path 1. It lives in the new package and uses the exports of
+    // the root package, so it only typechecks cleanly if nothing was lost along the way.
+    sendAsync(*openFile("foo/c.rb", "# typed: true\n"
+                                    "module Root::Foo\n"
+                                    "  class C\n"
+                                    "    def c\n"
+                                    "      Root::A.new.fun\n"
+                                    "    end\n"
+                                    "  end\n"
+                                    "end\n"));
+
+    // Wait for the first typecheck run to get canceled.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Cancelled);
+    }
+
+    // Send a fence to clear out the pipeline. Every file is still part of the workspace, so nothing is unresolved.
+    assertErrorDiagnostics(send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20))), {});
+
+    // And the definitions in the files that sat next to the partition boundary are still reachable.
+    auto definitions = getDefinitions("b.rb", 4, 6);
+    REQUIRE_EQ(definitions.size(), 1);
+    CHECK_EQ(definitions[0]->uri, getUri("a.rb"));
+
+    auto counters = getCounters();
+    CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 1);
+    CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath_canceled"), 1);
+}
+
+TEST_CASE_FIXTURE(MultithreadedProtocolTest,
+                  "CancelingPackageDirectedSlowPathThatAddsLowStratumFileKeepsExistingWorkspaceFiles") {
+    // Companion to the previous test for package-directed typechecking, where computePackageStrata additionally sorts
+    // the non-package files of `workspaceFiles` in place by (stratum, id). A new file in a low stratum therefore sorts
+    // ahead of pre-existing files of higher strata, pushing the last of them into the region that a size-based rollback
+    // would have erased -- without any new package file being involved.
+    auto opts = make_shared<realmain::options::Options>();
+    opts->cacheSensitiveOptions.sorbetPackages = true;
+    opts->packageDirected = true;
+    resetState(opts);
+
+    // Three packages in a chain, so that the strata are Root (0) < Root::Foo (1) < Root::Bar (2) and `bar/c.rb` is the
+    // last non-package file after the stratum sort.
+    vector<pair<string, string>> files = {
+        {"__package.rb", PackageTextBuilder().withName("Root").withExports({"Root::A"}).build()},
+        {"a.rb", "# typed: true\n"
+                 "module Root\n"
+                 "  class A\n"
+                 "    def fun\n"
+                 "    end\n"
+                 "  end\n"
+                 "end\n"},
+        {"foo/__package.rb",
+         PackageTextBuilder().withName("Root::Foo").withImports({"Root"}).withExports({"Root::Foo::B"}).build()},
+        {"foo/b.rb", "# typed: true\n"
+                     "module Root::Foo\n"
+                     "  class B\n"
+                     "    def bar\n"
+                     "      Root::A.new.fun\n"
+                     "    end\n"
+                     "  end\n"
+                     "end\n"},
+        {"bar/__package.rb", PackageTextBuilder().withName("Root::Bar").withImports({"Root::Foo"}).build()},
+        {"bar/c.rb", "# typed: true\n"
+                     "module Root::Bar\n"
+                     "  class C\n"
+                     "    def c\n"
+                     "      Root::Foo::B.new.bar\n"
+                     "    end\n"
+                     "  end\n"
+                     "end\n"},
+    };
+
+    writeFilesToFS(files);
+
+    for (auto &[path, _] : files) {
+        this->lspWrapper->opts->inputFileNames.emplace_back(fmt::format("{}/{}", this->rootPath, path));
+    }
+
+    auto initOptions = make_unique<SorbetInitializationOptions>();
+    initOptions->enableTypecheckInfo = true;
+    assertErrorDiagnostics(
+        initializeLSP(true /* supportsMarkdown */, true /* supportsCodeActionResolve */, move(initOptions)), {});
+
+    // The class defined in the file that will sit at the end of the sorted workspace is known to the symbol table.
+    {
+        auto responses = send(*workspaceSymbol("Root::Bar::C"));
+        REQUIRE_EQ(responses.size(), 1);
+        auto &result = get<variant<JSONNullObject, vector<unique_ptr<SymbolInformation>>>>(
+            responses[0]->asResponse().result.value());
+        REQUIRE_EQ(get<vector<unique_ptr<SymbolInformation>>>(result).size(), 1);
+    }
+
+    // Clear counters so that the assertions below only see the edits.
+    getCounters();
+
+    // Slow path 1: a brand-new source file in the lowest stratum (the root package). `cancellationExpected` makes the
+    // slow path wait for its cancellation only once `workspaceFiles` has been partitioned and sorted.
+    sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::PAUSE, nullopt)));
+    sendAsync(*openFile("d.rb", ""));
+    sendAsync(*changeFile("d.rb",
+                          "# typed: true\n"
+                          "module Root\n"
+                          "  class D\n"
+                          "  end\n"
+                          "end\n",
+                          2, /* cancellationExpected */ true));
+    sendAsync(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::RESUME, nullopt)));
+
+    // Wait for typechecking to begin to avoid races.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // Slow path 2: another new file, which cancels slow path 1.
+    sendAsync(*openFile("e.rb", "# typed: true\n"
+                                "module Root\n"
+                                "  class E\n"
+                                "  end\n"
+                                "end\n"));
+
+    // Wait for the first typecheck run to get canceled.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Cancelled);
+    }
+
+    // Send a fence to clear out the pipeline. Nothing was lost, so nothing is unresolved ...
+    assertErrorDiagnostics(send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20))), {});
+
+    // ... and the file at the end of the sorted workspace is still part of it.
+    {
+        auto responses = send(*workspaceSymbol("Root::Bar::C"));
+        REQUIRE_EQ(responses.size(), 1);
+        auto &result = get<variant<JSONNullObject, vector<unique_ptr<SymbolInformation>>>>(
+            responses[0]->asResponse().result.value());
+        REQUIRE_EQ(get<vector<unique_ptr<SymbolInformation>>>(result).size(), 1);
+    }
+
+    auto counters = getCounters();
+    CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 1);
+    CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath_canceled"), 1);
+}
+
 TEST_CASE_FIXTURE(MultithreadedProtocolTest, "SlowFooThenFastBarThenUndoSlowFoo") {
     auto initOptions = make_unique<SorbetInitializationOptions>();
     initOptions->enableTypecheckInfo = true;

--- a/test/lsp/watchman_test_corpus.cc
+++ b/test/lsp/watchman_test_corpus.cc
@@ -37,13 +37,14 @@ TEST_CASE_FIXTURE(ProtocolTest, "UnchangedFilesDoNotCountTowardsTheSlowPath") {
     assertErrorDiagnostics(initializeLSP(), {});
     getCounters();
 
-    // All five files rewritten byte-for-byte: nothing to typecheck, and in particular no slow path.
+    // All five files rewritten byte-for-byte: nothing to typecheck, so a fast path over no files and no slow path.
     writeFilesToFS(files);
     assertErrorDiagnostics(send(*watchmanFileUpdate(paths)), {});
     {
         auto counters = getCounters();
         CHECK_EQ(counters.getCounter("lsp.edit.unchanged_files_dropped"), 5);
         CHECK_EQ(counters.getCategoryCounter("lsp.slow_path_reason", "too_many_files"), 0);
+        CHECK_EQ(counters.getCategoryCounter("lsp.updates", "fastpath"), 1);
         CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 0);
     }
 
@@ -57,6 +58,49 @@ TEST_CASE_FIXTURE(ProtocolTest, "UnchangedFilesDoNotCountTowardsTheSlowPath") {
         CHECK_EQ(counters.getCategoryCounter("lsp.updates", "fastpath"), 1);
         CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 0);
     }
+}
+
+// With the fast path disabled, an edit whose files are all unchanged still has nothing to typecheck: it must not be
+// sent down the slow path (which requires at least one file).
+TEST_CASE_FIXTURE(ProtocolTest, "UnchangedFilesAreANoOpEvenWhenTheFastPathIsDisabled") {
+    auto opts = make_shared<realmain::options::Options>();
+    resetState(opts, /* disableFastPath */ true);
+
+    vector<pair<string, string>> files = {{"foo.rb", "# typed: true\nclass Foo\n  def foo\n    1\n  end\nend\n"}};
+    writeFilesToFS(files);
+    this->lspWrapper->opts->inputFileNames.emplace_back(fmt::format("{}/foo.rb", this->rootPath));
+    assertErrorDiagnostics(initializeLSP(), {});
+    getCounters();
+
+    writeFilesToFS(files);
+    assertErrorDiagnostics(send(*watchmanFileUpdate({"foo.rb"})), {});
+    {
+        auto counters = getCounters();
+        CHECK_EQ(counters.getCounter("lsp.edit.unchanged_files_dropped"), 1);
+        CHECK_EQ(counters.getCategoryCounter("lsp.updates", "fastpath"), 1);
+        CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 0);
+    }
+
+    // A real change takes the slow path, as the option demands.
+    writeFilesToFS({{"foo.rb", "# typed: true\nclass Foo\n  def foo\n    1 + \"stuff\"\n  end\nend\n"}});
+    assertErrorDiagnostics(send(*watchmanFileUpdate({"foo.rb"})), {{"foo.rb", 3, "Expected `Integer`"}});
+    CHECK_EQ(getCounters().getCategoryCounter("lsp.updates", "slowpath"), 1);
+}
+
+// Opening or closing a file whose editor text equals the text on disk changes its editor-open status, so it is an
+// edit Sorbet must process, not an unchanged file.
+TEST_CASE_FIXTURE(ProtocolTest, "IdenticalTextOpenAndCloseAreNotUnchangedFiles") {
+    string contents = "# typed: true\nclass Foo\n  def foo\n    1\n  end\nend\n";
+    writeFilesToFS({{"foo.rb", contents}});
+    this->lspWrapper->opts->inputFileNames.emplace_back(fmt::format("{}/foo.rb", this->rootPath));
+    assertErrorDiagnostics(initializeLSP(), {});
+    getCounters();
+
+    assertErrorDiagnostics(send(*openFile("foo.rb", contents)), {});
+    assertErrorDiagnostics(send(*closeFile("foo.rb")), {});
+    auto counters = getCounters();
+    CHECK_EQ(counters.getCounter("lsp.edit.unchanged_files_dropped"), 0);
+    CHECK_EQ(counters.getCategoryCounter("lsp.updates", "fastpath"), 2);
 }
 
 // Creates an empty file and deletes it.

--- a/test/lsp/watchman_test_corpus.cc
+++ b/test/lsp/watchman_test_corpus.cc
@@ -17,6 +17,48 @@ TEST_CASE_FIXTURE(ProtocolTest, "UpdateFileOnFileSystem") {
     assertErrorDiagnostics(send(*watchmanFileUpdate({"foo.rb"})), {d});
 }
 
+// Watchman reports every write, and tools like autogen or `git checkout` rewrite many files without changing them.
+// Such files must not count against lspMaxFilesOnFastPath: a batch of unchanged files takes no slow path, and a real
+// change hidden among them still takes the fast path.
+TEST_CASE_FIXTURE(ProtocolTest, "UnchangedFilesDoNotCountTowardsTheSlowPath") {
+    auto opts = make_shared<realmain::options::Options>();
+    opts->lspMaxFilesOnFastPath = 2;
+    resetState(opts);
+
+    vector<pair<string, string>> files;
+    vector<string> paths;
+    for (int i = 0; i < 5; i++) {
+        auto path = fmt::format("foo{}.rb", i);
+        files.emplace_back(path, fmt::format("# typed: true\nclass Foo{}\n  def foo\n    1\n  end\nend\n", i));
+        paths.emplace_back(path);
+        this->lspWrapper->opts->inputFileNames.emplace_back(fmt::format("{}/{}", this->rootPath, path));
+    }
+    writeFilesToFS(files);
+    assertErrorDiagnostics(initializeLSP(), {});
+    getCounters();
+
+    // All five files rewritten byte-for-byte: nothing to typecheck, and in particular no slow path.
+    writeFilesToFS(files);
+    assertErrorDiagnostics(send(*watchmanFileUpdate(paths)), {});
+    {
+        auto counters = getCounters();
+        CHECK_EQ(counters.getCounter("lsp.edit.unchanged_files_dropped"), 5);
+        CHECK_EQ(counters.getCategoryCounter("lsp.slow_path_reason", "too_many_files"), 0);
+        CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 0);
+    }
+
+    // One real change among the five takes the fast path.
+    files[2].second = "# typed: true\nclass Foo2\n  def foo\n    1 + \"stuff\"\n  end\nend\n";
+    writeFilesToFS({files[2]});
+    assertErrorDiagnostics(send(*watchmanFileUpdate(paths)), {{"foo2.rb", 3, "Expected `Integer`"}});
+    {
+        auto counters = getCounters();
+        CHECK_EQ(counters.getCounter("lsp.edit.unchanged_files_dropped"), 4);
+        CHECK_EQ(counters.getCategoryCounter("lsp.updates", "fastpath"), 1);
+        CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 0);
+    }
+}
+
 // Creates an empty file and deletes it.
 TEST_CASE_FIXTURE(ProtocolTest, "CreateAndDeleteEmptyFile") {
     assertErrorDiagnostics(initializeLSP(), {});

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__1.1.rbupdate
@@ -1,1 +1,3 @@
 # typed: strict
+
+# Changed on purpose: an update whose contents are identical to the file's does not count as a changed file.

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__2.1.rbupdate
@@ -1,1 +1,3 @@
 # typed: strict
+
+# Changed on purpose: an update whose contents are identical to the file's does not count as a changed file.

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__3.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__3.1.rbupdate
@@ -1,1 +1,3 @@
 # typed: strict
+
+# Changed on purpose: an update whose contents are identical to the file's does not count as a changed file.

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__4.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__4.1.rbupdate
@@ -1,1 +1,3 @@
 # typed: strict
+
+# Changed on purpose: an update whose contents are identical to the file's does not count as a changed file.

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__5.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__5.1.rbupdate
@@ -1,1 +1,3 @@
 # typed: strict
+
+# Changed on purpose: an update whose contents are identical to the file's does not count as a changed file.

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__6.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__6.1.rbupdate
@@ -1,1 +1,3 @@
 # typed: strict
+
+# Changed on purpose: an update whose contents are identical to the file's does not count as a changed file.

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__7.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__7.1.rbupdate
@@ -1,1 +1,3 @@
 # typed: strict
+
+# Changed on purpose: an update whose contents are identical to the file's does not count as a changed file.

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__8.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__8.1.rbupdate
@@ -1,1 +1,3 @@
 # typed: strict
+
+# Changed on purpose: an update whose contents are identical to the file's does not count as a changed file.

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__9.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__9.1.rbupdate
@@ -1,1 +1,3 @@
 # typed: strict
+
+# Changed on purpose: an update whose contents are identical to the file's does not count as a changed file.

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__1.1.rbupdate
@@ -1,1 +1,3 @@
 # typed: strict
+
+# Changed on purpose: an update whose contents are identical to the file's does not count as a changed file.

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__10.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__10.1.rbupdate
@@ -1,1 +1,3 @@
 # typed: strict
+
+# Changed on purpose: an update whose contents are identical to the file's does not count as a changed file.

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__2.1.rbupdate
@@ -1,1 +1,3 @@
 # typed: strict
+
+# Changed on purpose: an update whose contents are identical to the file's does not count as a changed file.

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__3.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__3.1.rbupdate
@@ -1,1 +1,3 @@
 # typed: strict
+
+# Changed on purpose: an update whose contents are identical to the file's does not count as a changed file.

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__4.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__4.1.rbupdate
@@ -1,1 +1,3 @@
 # typed: strict
+
+# Changed on purpose: an update whose contents are identical to the file's does not count as a changed file.

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__5.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__5.1.rbupdate
@@ -1,1 +1,3 @@
 # typed: strict
+
+# Changed on purpose: an update whose contents are identical to the file's does not count as a changed file.

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__6.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__6.1.rbupdate
@@ -1,1 +1,3 @@
 # typed: strict
+
+# Changed on purpose: an update whose contents are identical to the file's does not count as a changed file.

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__7.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__7.1.rbupdate
@@ -1,1 +1,3 @@
 # typed: strict
+
+# Changed on purpose: an update whose contents are identical to the file's does not count as a changed file.

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__8.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__8.1.rbupdate
@@ -1,1 +1,3 @@
 # typed: strict
+
+# Changed on purpose: an update whose contents are identical to the file's does not count as a changed file.

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__9.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__9.1.rbupdate
@@ -1,1 +1,3 @@
 # typed: strict
+
+# Changed on purpose: an update whose contents are identical to the file's does not count as a changed file.

--- a/test/testdata/packager/incremental_fast_path_exported/main.1.rbupdate
+++ b/test/testdata/packager/incremental_fast_path_exported/main.1.rbupdate
@@ -1,5 +1,6 @@
 # typed: strict
 # spacer for exclude-from-file-update
+# Changed on purpose: an update identical to the file's contents does not count as a changed file.
 
 module Root
   class Main

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -76,6 +76,7 @@ compilation_database(
         "//main/lsp:lsp_file_updates_test",
         "//main/lsp:lsp_preprocessor_test",
         "//main/lsp:lsp_test",
+        "//main/lsp:undo_state_test",
         "//main/lsp:watchman_shutdown_test",
         "//main/minimize:minimize",
         "//main/options:options",


### PR DESCRIPTION
### Motivation
r? @elliottt 

Second bit of areas I found having an agent sit and poke at LSP for bugs. Basically, anytime a file was touched, even if it didn't change, we would factor it as a changed file.  That matters because if we count too many files as changing, we won't hit the fast path and then that turns into a slow path.

Because autogen and internal processes do a lot of writing identical byte contents, we end up being forced into the slow path more often.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
