### PR TITLE
Skip no-op file updates in LSP

### DIFF
--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -489,20 +489,9 @@ bool LSPIndexer::wouldUpdateFileTable(const core::File &newer) const {
     }
 
     auto &existing = this->getFile(fref);
-
-    if (existing.sourceType != core::File::Type::Normal) {
-        return true;
-    }
-
-    if (newer.sourceType != existing.sourceType) {
-        return true;
-    }
-
-    if (newer.isOpenInClient() != existing.isOpenInClient()) {
-        return true;
-    }
-
-    return newer.source().size() != existing.source().size() || newer.sourceHash() != existing.sourceHash();
+    return existing.sourceType != core::File::Type::Normal || existing.sourceType != newer.sourceType ||
+           existing.isOpenInClient() != newer.isOpenInClient() || existing.source().size() != newer.source().size() ||
+           existing.sourceHash() != newer.sourceHash();
 }
 
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -482,4 +482,27 @@ bool LSPIndexer::preemptionPossible(const TaskQueue::QueueType &tasks) const {
     return true;
 }
 
+bool LSPIndexer::wouldUpdateFileTable(const core::File &newer) const {
+    auto fref = this->gs->findFileByPath(newer.path());
+    if (!fref.exists()) {
+        return true;
+    }
+
+    auto &existing = this->getFile(fref);
+
+    if (existing.sourceType != core::File::Type::Normal) {
+        return true;
+    }
+
+    if (newer.sourceType != existing.sourceType) {
+        return true;
+    }
+
+    if (newer.isOpenInClient() != existing.isOpenInClient()) {
+        return true;
+    }
+
+    return newer.source().size() != existing.source().size() || newer.sourceHash() != existing.sourceHash();
+}
+
 } // namespace sorbet::realmain::lsp

--- a/main/lsp/LSPIndexer.h
+++ b/main/lsp/LSPIndexer.h
@@ -104,6 +104,11 @@ public:
     const core::File &getFile(core::FileRef fref) const;
 
     /**
+     * Given a File, return true if it is new, or differs from the version currently in the indexer's file table.
+     */
+    bool wouldUpdateFileTable(const core::File &file) const;
+
+    /**
      * Given a reference to the InitializedTask, transfer ownership of the global state out for initialization in the
      * typechecker thread. The task argument is unused, and is present only to make it difficult to get the global state
      * out in a context that's not the InitializedTask's index function.

--- a/main/lsp/notifications/sorbet_workspace_edit.cc
+++ b/main/lsp/notifications/sorbet_workspace_edit.cc
@@ -57,6 +57,15 @@ void SorbetWorkspaceEditTask::preprocess(LSPPreprocessor &preprocessor) {
 }
 
 void SorbetWorkspaceEditTask::index(LSPIndexer &indexer) {
+    // This is the first time that we're able to compare the files in the update set to
+    // the indexer's file table. We should determine if any of the updates we've received
+    // are no-ops from background notifications, and filter them out to not artificially
+    // inflate the number of files that are actually making changes.
+    std::erase_if(this->params->updates, [&indexer](auto &file) {
+        ENFORCE(file != nullptr);
+        return !indexer.wouldUpdateFileTable(*file);
+    });
+
     if (params->updates.size() <= config.opts.lspMaxFilesOnFastPath) {
         updates = indexer.commitEdit(*params);
     } else {

--- a/test/BUILD
+++ b/test/BUILD
@@ -481,6 +481,7 @@ pipeline_tests(
             "testdata/lsp/fast_path/alias_stub_module__*.rb",
             "testdata/lsp/fast_path/not_enough_files/not_enough_files__*.rb",
             "testdata/lsp/fast_path/too_many_files/too_many_files__*.rb",
+            "testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__*.rb",
             "testdata/lsp/ripper_parse_error_formatting.rb",
             "testdata/lsp/successful_formatting.rb",
             "testdata/lsp/syntax_error_formatting.rb",

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -874,6 +874,44 @@ TEST_CASE_FIXTURE(ProtocolTest, "ReportsSyntaxErrors") {
     CHECK_EQ(counters.getCategoryCounter("lsp.slow_path_reason", "changed_definition"), 0);
 }
 
+TEST_CASE_FIXTURE(ProtocolTest, "HandlesEmptyUpdates") {
+    assertErrorDiagnostics(initializeLSP(), {});
+
+    // Create a new file.
+    assertErrorDiagnostics(send(*openFile("foo.rb", "# typed: true\n"
+                                                    "class A\n"
+                                                    "def foo; end\n"
+                                                    "end\n"
+                                                    "\n")),
+                           {});
+
+    // clear counters
+    {
+        auto counters = getCounters();
+        CHECK_EQ(counters.getCategoryCounter("lsp.updates", "fastpath"), 0);
+
+        // Initialization, and the new file makes two slow path updates
+        CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 2);
+    }
+
+    // Send the exact same file as a change, to exercise the behavior where we prune the file when indexing the
+    // workspace edit.
+    assertErrorDiagnostics(send(*changeFile("foo.rb",
+                                            "# typed: true\n"
+                                            "class A\n"
+                                            "def foo; end\n"
+                                            "end\n"
+                                            "\n",
+                                            2)),
+                           {});
+
+    {
+        auto counters = getCounters();
+        CHECK_EQ(counters.getCategoryCounter("lsp.updates", "fastpath"), 1);
+        CHECK_EQ(counters.getCategoryCounter("lsp.updates", "slowpath"), 0);
+    }
+}
+
 TEST_CASE_FIXTURE(ProtocolTest, "DidChangeConfigurationNotificationUpdatesHighlightUntypedSetting") {
     assertErrorDiagnostics(initializeLSP(), {});
 

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__2.1.rbupdate
@@ -1,1 +1,2 @@
 # typed: strict
+# updated

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__3.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__3.1.rbupdate
@@ -1,1 +1,2 @@
 # typed: strict
+# updated

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__4.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__4.1.rbupdate
@@ -1,1 +1,2 @@
 # typed: strict
+# updated

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__5.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__5.1.rbupdate
@@ -1,1 +1,2 @@
 # typed: strict
+# updated

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__6.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__6.1.rbupdate
@@ -1,1 +1,2 @@
 # typed: strict
+# updated

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__7.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__7.1.rbupdate
@@ -1,1 +1,2 @@
 # typed: strict
+# updated

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__8.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__8.1.rbupdate
@@ -1,1 +1,2 @@
 # typed: strict
+# updated

--- a/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__9.1.rbupdate
+++ b/test/testdata/lsp/fast_path/not_enough_files/not_enough_files__9.1.rbupdate
@@ -1,1 +1,2 @@
 # typed: strict
+# updated

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__1.1.rbupdate
@@ -1,1 +1,2 @@
 # typed: strict
+# updated

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__10.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__10.1.rbupdate
@@ -1,1 +1,2 @@
 # typed: strict
+# updated

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__2.1.rbupdate
@@ -1,1 +1,2 @@
 # typed: strict
+# updated

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__3.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__3.1.rbupdate
@@ -1,1 +1,2 @@
 # typed: strict
+# updated

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__4.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__4.1.rbupdate
@@ -1,1 +1,2 @@
 # typed: strict
+# updated

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__5.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__5.1.rbupdate
@@ -1,1 +1,2 @@
 # typed: strict
+# updated

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__6.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__6.1.rbupdate
@@ -1,1 +1,2 @@
 # typed: strict
+# updated

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__7.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__7.1.rbupdate
@@ -1,1 +1,2 @@
 # typed: strict
+# updated

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__8.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__8.1.rbupdate
@@ -1,1 +1,2 @@
 # typed: strict
+# updated

--- a/test/testdata/lsp/fast_path/too_many_files/too_many_files__9.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files/too_many_files__9.1.rbupdate
@@ -1,1 +1,2 @@
 # typed: strict
+# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__1.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__1.1.rbupdate
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__1.rb
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__1.rb
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__10.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__10.1.rbupdate
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__10.rb
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__10.rb
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__2.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__2.1.rbupdate
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__2.rb
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__2.rb
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__3.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__3.1.rbupdate
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__3.rb
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__3.rb
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__4.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__4.1.rbupdate
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__4.rb
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__4.rb
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__5.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__5.1.rbupdate
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__5.rb
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__5.rb
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__6.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__6.1.rbupdate
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__6.rb
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__6.rb
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__7.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__7.1.rbupdate
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__7.rb
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__7.rb
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__8.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__8.1.rbupdate
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__8.rb
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__8.rb
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__9.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__9.1.rbupdate
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__9.rb
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__9.rb
@@ -1,2 +1,1 @@
 # typed: strict
-# updated

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__main.1.rbupdate
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__main.1.rbupdate
@@ -1,0 +1,8 @@
+# typed: true
+# assert-slow-path: false
+
+class MyClass
+  def my_method
+    a = T.let(10, Float) # error: Argument does not have asserted type `Float`
+  end
+end

--- a/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__main.rb
+++ b/test/testdata/lsp/fast_path/too_many_files_no_op/too_many_files_no_op__main.rb
@@ -1,0 +1,13 @@
+# typed: true
+
+# This test shows off an exception to our slow path decision logic: when we receive
+# a lot of updates that don't actually change the state of the indexer's file table,
+# we skip applying those updates to shrink the edit down. The result is that we may
+# still be able to take the fast path, despite seeing a large number of change
+# notifications.
+
+class MyClass
+  def my_method
+    a = T.let(10, String) # error: Argument does not have asserted type `String`
+  end
+end

--- a/test/testdata/packager/incremental_fast_path_exported/lib/_impl.1.rbupdate
+++ b/test/testdata/packager/incremental_fast_path_exported/lib/_impl.1.rbupdate
@@ -1,5 +1,5 @@
 # typed: strict
-# assert-fast-path: lib/_impl.rb,main.rb
+# assert-fast-path: lib/_impl.rb
 
 module Lib
   MyStaticField = 1


### PR DESCRIPTION
This is a smaller version of #10603.

For codebases that have generated code, watchman will generate update events when generated files get written out even if their content hasn't changed as a result. We can detect this case in Sorbet's workspace edit task, removing files from the update set that we know have not changed, and lowering the possibility that a slow path will be triggered by events like this.

### Motivation
LSP performance, avoiding the slow path when possible.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

This PR changes behavior for tests that previously would use no-op `.rbupdate` files to exercise the limit where we would switch over to the slow path. As a result, I've updated those cases to emit actual updates, so that they don't get lost.
