### PR TITLE
speedup `UIntSet::forEach` with `__builtin_ctz`

### DIFF
--- a/common/UIntSetForEach.h
+++ b/common/UIntSetForEach.h
@@ -5,24 +5,14 @@
 
 namespace sorbet {
 template <typename F> void UIntSet::forEach(F each) const {
-    uint32_t id = 0;
+    uint32_t base = 0;
     for (auto entry : _members) {
-        uint32_t startIdForNextU4 = id + 32;
         while (entry != 0) {
-            uint32_t startIdForNextU1 = id + 8;
-            // Process 1 byte at a time so we can check 8 places at once.
-            uint32_t byte = entry & 0xFF;
-            while (byte != 0) {
-                if ((byte & 0x1) == 1) {
-                    each(id);
-                }
-                byte >>= 1;
-                id++;
-            }
-            entry >>= 8;
-            id = startIdForNextU1;
+            uint32_t bit = __builtin_ctz(entry);
+            each(base + bit);
+            entry &= entry - 1; // clear lowest set bit
         }
-        id = startIdForNextU4;
+        base += 32;
     }
 }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Profiling with callgrind says that this change reduces the overall number of instructions executed (in a fully-cached run) by ~0.5% (!).  Not just in typechecking, for the entire Sorbet run.

I don't really expect this to show up in typechecking numbers, but I do appreciate a good use of `ctz`.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests, especially #10607.
