### PR TITLE
Remove `prelude_package` support in favor of `prelude!`

### DIFF
--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -798,7 +798,7 @@ std::string PackageInfo::renderPackageRbContents(
     fmt::memory_buffer result;
 
     if (isPreludePackage()) {
-        fmt::format_to(std::back_inserter(result), "  prelude_package\n\n");
+        fmt::format_to(std::back_inserter(result), "  prelude!\n\n");
     }
 
     for (auto &directive : extraDirectives_) {

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -168,7 +168,7 @@ public:
         // Set to non-none loc when this package is marked `test!`
         core::LocOffsets testPackage;
 
-        // Set to non-none loc when this package is marked `prelude_package`
+        // Set to non-none loc when this package is marked `prelude!`
         core::LocOffsets preludePackage;
     } locs;
 
@@ -293,7 +293,7 @@ public:
     // looks at non-test imports.
     std::optional<std::string> pathTo(const core::GlobalState &gs, const MangledName dest) const;
 
-    // True when the package is marked with a `prelude_package` annotation. This requires that the package only import
+    // True when the package is marked with a `prelude!` annotation. This requires that the package only import
     // other prelude packages and markes it as an implicit dependency of all non-prelude packages.
     bool isPreludePackage() const {
         return this->locs.preludePackage.exists();

--- a/core/tools/generate_names.cc
+++ b/core/tools/generate_names.cc
@@ -505,7 +505,6 @@ NameDef names[] = {
     {"PackageSpecRegistry", "<PackageSpecRegistry>", true},
     {"only"},
     {"testRb", "test_rb"},
-    {"preludePackage", "prelude_package"},
     {"prelude_bang", "prelude!"},
     {"test_bang", "test!"},
     {"usesInternals", "uses_internals"},

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -2255,9 +2255,9 @@ public:
                         e.addErrorLine(ownerPackage.declLoc(), "Owning package defined here", ctx.owner.show(ctx));
                     } else {
                         e.addErrorLine(filePackageInfo.declLoc(), "Package containing the `{}` is not a `{}`",
-                                       isTypeTemplate ? "type_template" : "type_member", "prelude_package");
+                                       isTypeTemplate ? "type_template" : "type_member", "prelude!");
                         e.addErrorNote("`{}` is unpackaged, and may be reopened from a package marked `{}`",
-                                       ctx.owner.show(ctx), "prelude_package");
+                                       ctx.owner.show(ctx), "prelude!");
                     }
                 }
                 return ignoreBadTypeMember(ctx, move(tree));

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -601,8 +601,7 @@ struct PackageSpecBodyWalk {
             if (send.numPosArgs() == 0) {
                 info.locs.exportAll = send.loc;
             }
-        } else if ((send.fun == core::Names::preludePackage() || send.fun == core::Names::prelude_bang()) &&
-                   !send.hasBlock() && !send.hasNonBlockArgs()) {
+        } else if (send.fun == core::Names::prelude_bang() && !send.hasBlock() && !send.hasNonBlockArgs()) {
             info.locs.preludePackage = send.loc;
         } else if (send.fun == core::Names::visibleTo()) {
             if (send.numPosArgs() == 1) {
@@ -883,7 +882,6 @@ struct PackageSpecBodyWalk {
             case core::Names::export_().rawId():
             case core::Names::visibleTo().rawId():
             case core::Names::exportAll().rawId():
-            case core::Names::preludePackage().rawId():
             case core::Names::prelude_bang().rawId():
             case core::Names::testImport().rawId():
             case core::Names::test_bang().rawId():

--- a/rbi/sorbet/packages.rbi
+++ b/rbi/sorbet/packages.rbi
@@ -25,9 +25,6 @@ class Sorbet::Private::Static::PackageSpec
   def self.sorbet(min_typed_level:, tests_min_typed_level: nil); end
 
   sig { void }
-  def self.prelude_package; end
-
-  sig { void }
   def self.prelude!; end
 
   sig { void }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -855,10 +855,10 @@ private:
                                 e.addErrorLine(ownerPackage.declLoc(), "Package where `{}` is defined",
                                                job.klass.show(ctx));
                             } else {
-                                e.addErrorLine(filePackageInfo.declLoc(), "Package defined here is not a `{}`",
-                                               "prelude_package");
+                                e.addErrorLine(filePackageInfo.declLoc(), "Package defined here is not marked `{}`",
+                                               "prelude!");
                                 e.addErrorNote("`{}` is unpackaged, and may be reopened from a package marked `{}`",
-                                               job.klass.show(ctx), "prelude_package");
+                                               job.klass.show(ctx), "prelude!");
                             }
                         }
                     }
@@ -926,10 +926,10 @@ private:
                                 e.addErrorLine(ownerPackage.declLoc(), "Package where `{}` is defined",
                                                job.klass.show(ctx));
                             } else {
-                                e.addErrorLine(filePackageInfo.declLoc(), "Package defined here is not a `{}`",
-                                               "prelude_package");
+                                e.addErrorLine(filePackageInfo.declLoc(), "Package defined here is not marked `{}`",
+                                               "prelude!");
                                 e.addErrorNote("`{}` is unpackaged, and may be reopened from a package marked `{}`",
-                                               job.klass.show(ctx), "prelude_package");
+                                               job.klass.show(ctx), "prelude!");
                             }
                         }
                     }

--- a/test/cli/condensation-package-reopen/prelude/__package.rb
+++ b/test/cli/condensation-package-reopen/prelude/__package.rb
@@ -1,7 +1,7 @@
 # typed: strict
 
 class Prelude < PackageSpec
-  prelude_package
+  prelude!
 
   export Prelude::A
 end

--- a/test/cli/condensation-package-reopen/test.out
+++ b/test/cli/condensation-package-reopen/test.out
@@ -29,7 +29,7 @@ bad_test/a.rb:15: `include` may only be used on constants in the package that ow
     bad_test/subpackage/foo.rb:3: Symbol originally defined here
      3 |module Test::BadTest
         ^^^^^^^^^^^^^^^^^^^^
-    bad_test/__package.rb:3: Package defined here is not a `prelude!`
+    bad_test/__package.rb:3: Package defined here is not marked `prelude!`
      3 |class Test::BadTest < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
@@ -41,7 +41,7 @@ bad_test/a.rb:12: `extend` may only be used on constants in the package that own
     bad_test/subpackage/foo.rb:3: Symbol originally defined here
      3 |module Test::BadTest
         ^^^^^^^^^^^^^^^^^^^^
-    bad_test/__package.rb:3: Package defined here is not a `prelude!`
+    bad_test/__package.rb:3: Package defined here is not marked `prelude!`
      3 |class Test::BadTest < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:

--- a/test/cli/condensation-package-reopen/test.out
+++ b/test/cli/condensation-package-reopen/test.out
@@ -1,20 +1,20 @@
 bad_test/a.rb:17: `type_member` may only be used on constants in the package that owns them https://srb.help/4028
     17 |  X = type_member
               ^^^^^^^^^^^
-    bad_test/__package.rb:3: Package containing the `type_member` is not a `prelude_package`
+    bad_test/__package.rb:3: Package containing the `type_member` is not a `prelude!`
      3 |class Test::BadTest < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
-    `Test::BadTest` is unpackaged, and may be reopened from a package marked `prelude_package`
+    `Test::BadTest` is unpackaged, and may be reopened from a package marked `prelude!`
 
 bad_test/a.rb:19: `type_template` may only be used on constants in the package that owns them https://srb.help/4028
     19 |  Y = type_template
               ^^^^^^^^^^^^^
-    bad_test/__package.rb:3: Package containing the `type_template` is not a `prelude_package`
+    bad_test/__package.rb:3: Package containing the `type_template` is not a `prelude!`
      3 |class Test::BadTest < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
-    `Test::BadTest` is unpackaged, and may be reopened from a package marked `prelude_package`
+    `Test::BadTest` is unpackaged, and may be reopened from a package marked `prelude!`
 
 bad_test/a.rb:3: File belongs to package `Test::BadTest` but defines a constant that does not match this namespace https://srb.help/3713
      3 |module Test::BadTest
@@ -29,11 +29,11 @@ bad_test/a.rb:15: `include` may only be used on constants in the package that ow
     bad_test/subpackage/foo.rb:3: Symbol originally defined here
      3 |module Test::BadTest
         ^^^^^^^^^^^^^^^^^^^^
-    bad_test/__package.rb:3: Package defined here is not a `prelude_package`
+    bad_test/__package.rb:3: Package defined here is not a `prelude!`
      3 |class Test::BadTest < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
-    `Test::BadTest` is unpackaged, and may be reopened from a package marked `prelude_package`
+    `Test::BadTest` is unpackaged, and may be reopened from a package marked `prelude!`
 
 bad_test/a.rb:12: `extend` may only be used on constants in the package that owns them https://srb.help/5084
     12 |  extend ClassMethods
@@ -41,11 +41,11 @@ bad_test/a.rb:12: `extend` may only be used on constants in the package that own
     bad_test/subpackage/foo.rb:3: Symbol originally defined here
      3 |module Test::BadTest
         ^^^^^^^^^^^^^^^^^^^^
-    bad_test/__package.rb:3: Package defined here is not a `prelude_package`
+    bad_test/__package.rb:3: Package defined here is not a `prelude!`
      3 |class Test::BadTest < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
-    `T.class_of(Test::BadTest)` is unpackaged, and may be reopened from a package marked `prelude_package`
+    `T.class_of(Test::BadTest)` is unpackaged, and may be reopened from a package marked `prelude!`
 
 bad_test/subpackage/foo.rb:3: File belongs to package `Test::BadTest::Subpackage` but defines a constant that does not match this namespace https://srb.help/3713
      3 |module Test::BadTest
@@ -68,20 +68,20 @@ bad_test/__package.rb:4: Unable to resolve constant `Root` https://srb.help/5002
 bad_test/a.rbi:4: `type_member` may only be used on constants in the package that owns them https://srb.help/4028
      4 |  X = type_member
               ^^^^^^^^^^^
-    bad_test/__package.rb:3: Package containing the `type_member` is not a `prelude_package`
+    bad_test/__package.rb:3: Package containing the `type_member` is not a `prelude!`
      3 |class Test::BadTest < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
-    `Test::BadTest` is unpackaged, and may be reopened from a package marked `prelude_package`
+    `Test::BadTest` is unpackaged, and may be reopened from a package marked `prelude!`
 
 bad_test/a.rbi:5: `type_template` may only be used on constants in the package that owns them https://srb.help/4028
      5 |  Y = type_template
               ^^^^^^^^^^^^^
-    bad_test/__package.rb:3: Package containing the `type_template` is not a `prelude_package`
+    bad_test/__package.rb:3: Package containing the `type_template` is not a `prelude!`
      3 |class Test::BadTest < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
-    `Test::BadTest` is unpackaged, and may be reopened from a package marked `prelude_package`
+    `Test::BadTest` is unpackaged, and may be reopened from a package marked `prelude!`
 
 bad_test/a.rbi:3: File belongs to package `Test::BadTest` but defines a constant that does not match this namespace https://srb.help/3713
      3 |module Test::BadTest

--- a/test/cli/package-gen-packages-strict/prelude/__package.rb
+++ b/test/cli/package-gen-packages-strict/prelude/__package.rb
@@ -1,7 +1,7 @@
 # typed: strict
 
 class Prelude < PackageSpec
-  prelude_package
+  prelude!
 
   layer 'app'
   strict_dependencies 'dag'

--- a/test/cli/package-non-prefix-collision/other/__package.rb
+++ b/test/cli/package-non-prefix-collision/other/__package.rb
@@ -1,5 +1,5 @@
 # typed: strict
 
 class Other < PackageSpec
-  prelude_package
+  prelude!
 end

--- a/test/cli/package-prefix-enforcement/test.out
+++ b/test/cli/package-prefix-enforcement/test.out
@@ -288,7 +288,7 @@ extend_sig.rb:4: `include` may only be used on constants in the package that own
     https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Symbol originally defined here
     NN |class Module < Object
         ^^^^^^^^^^^^^^^^^^^^^
-    __package.rb:3: Package defined here is not a `prelude!`
+    __package.rb:3: Package defined here is not marked `prelude!`
      3 |class Root < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^
   Note:

--- a/test/cli/package-prefix-enforcement/test.out
+++ b/test/cli/package-prefix-enforcement/test.out
@@ -288,9 +288,9 @@ extend_sig.rb:4: `include` may only be used on constants in the package that own
     https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Symbol originally defined here
     NN |class Module < Object
         ^^^^^^^^^^^^^^^^^^^^^
-    __package.rb:3: Package defined here is not a `prelude_package`
+    __package.rb:3: Package defined here is not a `prelude!`
      3 |class Root < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
-    `Module` is unpackaged, and may be reopened from a package marked `prelude_package`
+    `Module` is unpackaged, and may be reopened from a package marked `prelude!`
 Errors: 29

--- a/test/cli/package-private/test.out
+++ b/test/cli/package-private/test.out
@@ -44,7 +44,7 @@ a/a.rb:23: `extend` may only be used on constants in the package that owns them 
     a/a.rb:22: Symbol originally defined here
     22 |  class ::Global
           ^^^^^^^^^^^^^^
-    a/__package.rb:3: Package defined here is not a `prelude!`
+    a/__package.rb:3: Package defined here is not marked `prelude!`
      3 |class A < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Note:
@@ -164,7 +164,7 @@ a/a.rbi:3: Superclasses may only be set on constants in the package that owns th
     https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Symbol originally defined here
     NN |class Module < Object
         ^^^^^^^^^^^^^^^^^^^^^
-    a/__package.rb:3: Package defined here is not a `prelude!`
+    a/__package.rb:3: Package defined here is not marked `prelude!`
      3 |class A < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Note:

--- a/test/cli/package-private/test.out
+++ b/test/cli/package-private/test.out
@@ -44,11 +44,11 @@ a/a.rb:23: `extend` may only be used on constants in the package that owns them 
     a/a.rb:22: Symbol originally defined here
     22 |  class ::Global
           ^^^^^^^^^^^^^^
-    a/__package.rb:3: Package defined here is not a `prelude_package`
+    a/__package.rb:3: Package defined here is not a `prelude!`
      3 |class A < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Note:
-    `T.class_of(Global)` is unpackaged, and may be reopened from a package marked `prelude_package`
+    `T.class_of(Global)` is unpackaged, and may be reopened from a package marked `prelude!`
 
 a/a.rb:24: Method `sig` does not exist on `T.class_of(Global)` https://srb.help/7003
     24 |    sig { void }
@@ -164,11 +164,11 @@ a/a.rbi:3: Superclasses may only be set on constants in the package that owns th
     https://github.com/sorbet/sorbet/tree/master/rbi/core/module.rbi#LCENSORED: Symbol originally defined here
     NN |class Module < Object
         ^^^^^^^^^^^^^^^^^^^^^
-    a/__package.rb:3: Package defined here is not a `prelude_package`
+    a/__package.rb:3: Package defined here is not a `prelude!`
      3 |class A < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Note:
-    `Module` is unpackaged, and may be reopened from a package marked `prelude_package`
+    `Module` is unpackaged, and may be reopened from a package marked `prelude!`
 
 b/b.rb:8: Method `foo` on `T.class_of(A)` is package-private and cannot be called from package `B` https://srb.help/7036
      8 |    A.foo

--- a/test/helpers/packages.cc
+++ b/test/helpers/packages.cc
@@ -24,7 +24,7 @@ string PackageTextBuilder::build() {
     string out = fmt::format("# typed: strict\n\nclass {} < PackageSpec\n", this->name);
 
     if (this->preludePackage) {
-        fmt::format_to(back_inserter(out), "  prelude_package\n");
+        fmt::format_to(back_inserter(out), "  prelude!\n");
     }
 
     if (!this->strictDeps.empty()) {

--- a/test/testdata/packager/directed-prelude/a/__package.rb
+++ b/test/testdata/packager/directed-prelude/a/__package.rb
@@ -7,5 +7,5 @@
 # stratum: 0
 
 class A < PackageSpec
-  prelude_package
+  prelude!
 end

--- a/test/testdata/packager/directed-prelude/c/__package.rb
+++ b/test/testdata/packager/directed-prelude/c/__package.rb
@@ -5,6 +5,6 @@
 # stratum: 0
 
 class C < PackageSpec
-  prelude_package
+  prelude!
   import A
 end

--- a/test/testdata/packager/invalid_package_control_flow/__package.rb
+++ b/test/testdata/packager/invalid_package_control_flow/__package.rb
@@ -8,7 +8,7 @@ SomeConstant = PackageSpec # error: Invalid expression in package: `Assign`
 
 class MyPackage < PackageSpec
   # Mark this as a prelude package so that it's allowed to reopen PackageSpec
-  prelude_package
+  prelude!
 
   extend T::Helpers # error: Invalid expression in package: `extend` is not allowed
   include T::Helpers # error: Invalid expression in package: `include` is not allowed

--- a/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
+++ b/test/testdata/packager/invalid_package_control_flow/pass.package-tree.exp
@@ -19,7 +19,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       <emptyTree>
     end
 
-    <self>.prelude_package()
+    <self>.prelude!()
 
     <self>.extend(<emptyTree>::<C T>::<C Helpers>)
 

--- a/test/testdata/packager/package-prefix-enforcement/__package.rb
+++ b/test/testdata/packager/package-prefix-enforcement/__package.rb
@@ -3,5 +3,5 @@
 # enable-packager: true
 
 class Root < PackageSpec
-  prelude_package
+  prelude!
 end

--- a/test/testdata/packager/prelude_packages_cycle/prelude/first/__package.rb
+++ b/test/testdata/packager/prelude_packages_cycle/prelude/first/__package.rb
@@ -4,7 +4,7 @@
 # packager-layers: a
 
 class Prelude::First < PackageSpec
-  prelude_package
+  prelude!
 
   layer 'a'
   strict_dependencies 'layered'

--- a/test/testdata/packager/prelude_packages_cycle/prelude/second/__package.rb
+++ b/test/testdata/packager/prelude_packages_cycle/prelude/second/__package.rb
@@ -2,7 +2,7 @@
 # typed: strict
 
 class Prelude::Second < PackageSpec
-  prelude_package
+  prelude!
 
   layer 'a'
   strict_dependencies 'layered'

--- a/test/testdata/packager/prelude_packages_explicit_imports/prelude/first/__package.rb
+++ b/test/testdata/packager/prelude_packages_explicit_imports/prelude/first/__package.rb
@@ -3,7 +3,7 @@
 # enable-packager: true
 
 class Prelude::First < PackageSpec
-  prelude_package
+  prelude!
 
   export Prelude::First::A
 end

--- a/test/testdata/packager/prelude_packages_explicit_imports/prelude/second/__package.rb
+++ b/test/testdata/packager/prelude_packages_explicit_imports/prelude/second/__package.rb
@@ -3,7 +3,7 @@
 # enable-packager: true
 
 class Prelude::Second < PackageSpec
-  prelude_package
+  prelude!
 
   export Prelude::Second::B
 end

--- a/test/testdata/packager/prelude_packages_imports/prelude/first/__package.rb
+++ b/test/testdata/packager/prelude_packages_imports/prelude/first/__package.rb
@@ -3,7 +3,7 @@
 # enable-packager: true
 
 class Prelude::First < PackageSpec
-  prelude_package
+  prelude!
 
   export Prelude::First::A
 end

--- a/test/testdata/packager/prelude_packages_imports/prelude/second/__package.rb
+++ b/test/testdata/packager/prelude_packages_imports/prelude/second/__package.rb
@@ -3,7 +3,7 @@
 # enable-packager: true
 
 class Prelude::Second < PackageSpec
-  prelude_package
+  prelude!
 
   export Prelude::Second::B
 end

--- a/test/testdata/packager/prelude_packages_layers/prelude/first/__package.rb
+++ b/test/testdata/packager/prelude_packages_layers/prelude/first/__package.rb
@@ -4,7 +4,7 @@
 # packager-layers: utility, product
 
 class Prelude::First < PackageSpec
-  prelude_package
+  prelude!
 
   layer "product"
   strict_dependencies "dag"

--- a/test/testdata/packager/prelude_packages_layers/prelude/second/__package.rb
+++ b/test/testdata/packager/prelude_packages_layers/prelude/second/__package.rb
@@ -3,7 +3,7 @@
 # enable-packager: true
 
 class Prelude::Second < PackageSpec
-  prelude_package
+  prelude!
 
   layer "utility"
   strict_dependencies "dag"

--- a/test/testdata/packager/prelude_packages_non_prelude_import/prelude/__package.rb
+++ b/test/testdata/packager/prelude_packages_non_prelude_import/prelude/__package.rb
@@ -3,7 +3,7 @@
 # enable-packager: true
 
 class Prelude < PackageSpec
-  prelude_package
+  prelude!
 
   import Application # error: `Prelude` may not `import` non-prelude package `Application`
   test_import Application # error: `Prelude` may not `test_import` non-prelude package `Application`

--- a/test/testdata/packager/prelude_packages_visible_to/prelude/__package.rb
+++ b/test/testdata/packager/prelude_packages_visible_to/prelude/__package.rb
@@ -3,7 +3,7 @@
 # enable-packager: true
 
 class Prelude < PackageSpec
-  prelude_package
+  prelude!
 
   visible_to Application::A
 

--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -913,16 +913,16 @@ The `sorbet` directive in `__package.rb` specifies what the minimum sigil must b
 
 > This error is specific to Stripe's custom `--sorbet-packages` mode. If you are at Stripe, please see [go/modularity](http://go/modularity) and [go/strict-dependencies](http://go/strict-dependencies) for more.
 
-If a package is marked with `prelude_package`, it is restricted to only importing other packages marked as `prelude_package`. This error indicates that a `prelude_package` is importing a non-prelude package.
+If a package is marked with `prelude!`, it is restricted to only importing other packages marked as `prelude!`. This error indicates that a prelude package is importing a non-prelude package.
 
 ```ruby
 class A < PackageSpec
 end
 
 class B < PackageSpec
-  prelude_package
+  prelude!
 
-  import A # error: Importing A, which is not marked as `prelude_package`
+  import A # error: Importing A, which is not marked as `prelude!`
 end
 ```
 
@@ -1347,7 +1347,7 @@ Each package must have only one definition. A package definition is the place wh
 
 > This error is specific to Stripe's custom `--sorbet-packages` mode. If you are at Stripe, please see [go/modularity](http://go/modularity) for more.
 
-If your package reopens constants from the stdlib or gems to add type members, your package must be marked as a `prelude_package`. This is to ensure that the constant remains in a consistent state throughout typechecking, even when checking in package dependency order. If we allowed type members to be added on stdlib/gem constants in any package, two parts of the codebase may see the constant with or without that type member present--before or after the type member declaration on the reopened constant.
+If your package reopens constants from the stdlib or gems to add type members, your package must be marked with `prelude!`. This is to ensure that the constant remains in a consistent state throughout typechecking, even when checking in package dependency order. If we allowed type members to be added on stdlib/gem constants in any package, two parts of the codebase may see the constant with or without that type member present--before or after the type member declaration on the reopened constant.
 
 ## 4029
 
@@ -2975,7 +2975,7 @@ end
 
 > This error is specific to Stripe's custom `--sorbet-packages` mode. If you are at Stripe, please see [go/modularity](http://go/modularity) for more.
 
-If your package reopens constants from the stdlib or gems to add mixins, your package must be must be marked as a `prelude_package`. This ensures that the constant remains consistent throughout type checking, even when checking in package dependency order. If we allowed mixins on stdlib/gem constants to be added in any package, two parts of the codebase may see that constant in different states--before and after the mixin was applied.
+If your package reopens constants from the stdlib or gems to add mixins, your package must be must be marked with `prelude!`. This ensures that the constant remains consistent throughout type checking, even when checking in package dependency order. If we allowed mixins on stdlib/gem constants to be added in any package, two parts of the codebase may see that constant in different states--before and after the mixin was applied.
 
 ## 5085
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Follow up from #9915.




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

Pending changes on Stripe's codebase