### PR TITLE
Traverse all updated files when determining the maximum prefix

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -458,31 +458,27 @@ core::packages::Stratum determineMaximumPrefix(const core::GlobalState &gs,
 
         // If this is a new file, we can still copy a prefix if we can determine what package it would belong to.
         if (fref.id() >= fileToStratum.size()) {
-            // We can't keep any part of the symbol table if we see a new package file
-            if (file->hasPackageRbPath()) {
-                return core::packages::Stratum(0);
-            }
-
             auto pkg = gs.packageDB().findPackageByPath(gs, *file);
-            if (!pkg.exists()) {
-                return core::packages::Stratum(0);
+
+            // We can't keep any part of the symbol table if we see a new package file, or can't determine what
+            // package the file might belong to.
+            if (file->hasPackageRbPath() || !pkg.exists()) {
+                fileStratum = core::packages::Stratum(0);
+            } else {
+                auto &info = gs.packageDB().getPackageInfo(pkg);
+                ENFORCE(info.exists());
+
+                // We have already checked for new package files above, so this should always be true.
+                ENFORCE(info.file.id() < fileToStratum.size());
+                fileStratum = fileToStratum[info.file.id()];
             }
-
-            auto &info = gs.packageDB().getPackageInfo(pkg);
-            ENFORCE(info.exists());
-
-            // We have already checked for new package files above, so this should always be true.
-            ENFORCE(info.file.id() < fileToStratum.size());
-            fileStratum = fileToStratum[info.file.id()];
         } else {
-            // We can't keep any part of the symbol table if the package file has changed. The byte-for-byte comparison
-            // is a little expensive here, but we could refactor LSPIndexer::getTypecheckingPathInternal to cache the
-            // results of this check on the LSPFileUpdates so that we could avoid the additional check here.
+            // We can't keep any part of the symbol table if a package file has changed.
             if (file->hasPackageRbPath() && fref.data(gs).sourceHash() != file->sourceHash()) {
-                return core::packages::Stratum(0);
+                fileStratum = core::packages::Stratum(0);
+            } else {
+                fileStratum = fileToStratum[fref.id()];
             }
-
-            fileStratum = fileToStratum[fref.id()];
         }
 
         // We need to find the earliest stratum involved in this edit to know what prefix of the symbol table will not


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Instead of exiting early when we encounter a package file, treat it as a file that occurs at stratum `0` and continue the loop. This has the same behavior that we have now, but makes the loop more amenable to also collecting the set of affected packages, as prework for landing #10417.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
Refactoring, to simplify #10417.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No changes expected, pure refactoring.
