### PR TITLE
avoid allocating in the common case of no extra props

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -78,16 +78,22 @@ module T::Props::Serializable
 
     if hash.size > hash_keys_matching_props
       serialized_forms = self.class.decorator.prop_by_serialized_forms
-      extra = hash.reject { |k, _| serialized_forms.key?(k) }
+      # `any?` is specialized for Hash and therefore faster than the
+      # generic `Enumerator#all?`.  We expect the common case to not require
+      # the construction of `extra` below.
+      has_extra_keys = hash.any? { |k, _| !serialized_forms.key?(k) }
+
+      return unless has_extra_keys
 
       # `extra` could still be empty here if the input matches a `dont_store` prop;
       # historically, we just ignore those
-      if !extra.empty?
-        if strict
-          raise "Unknown properties for #{self.class.name}: #{extra.keys.inspect}"
-        else
-          @_extra_props = extra
-        end
+      extra = hash.reject { |k, _| serialized_forms.key?(k) }
+      return if extra.empty?
+
+      if strict
+        raise "Unknown properties for #{self.class.name}: #{extra.keys.inspect}"
+      else
+        @_extra_props = extra
       end
     end
   end

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -81,15 +81,17 @@ module T::Props::Serializable
       # `any?` is specialized for Hash and therefore faster than the
       # generic `Enumerator#all?`.  We expect the common case to not require
       # the construction of `extra` below.
+      #
+      # It's possible to get to this line and still have `has_extra_keys` be
+      # false if we have a `:dont_store` prop in the class definition and that
+      # prop appears in the input we were asked to deserialize.  We will pass
+      # over that prop during deserialization, and so `hash_keys_matching_props`
+      # will be less than the hash's size.  Historically, we have ignored this
+      # case.
       has_extra_keys = hash.any? { |k, _| !serialized_forms.key?(k) }
-
       return unless has_extra_keys
 
-      # `extra` could still be empty here if the input matches a `dont_store` prop;
-      # historically, we just ignore those
       extra = hash.reject { |k, _| serialized_forms.key?(k) }
-      return if extra.empty?
-
       if strict
         raise "Unknown properties for #{self.class.name}: #{extra.keys.inspect}"
       else


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

cc @zanker-stripe 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I noticed this `reject` showing up on allocation profiles.  My belief is that the overwhelmingly common case is that we don't have extra props to save, so we should be able to make the common case not allocate.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests...and this probably needs a test run on Stripe's codebase.
