### PR TITLE
Only do the export autocorrect if it was imported

### DIFF
--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -724,12 +724,12 @@ public:
                     bool definesBehavior = !litSymbol.isClassOrModule() ||
                                            litSymbol.asClassOrModuleRef().data(ctx)->flags.isBehaviorDefining;
                     std::optional<core::AutocorrectSuggestion> exportAutocorrect;
-                    auto symToExport = litSymbol;
-                    auto enumClass = getEnumClassForEnumValue(ctx.state, symToExport);
-                    if (enumClass.exists()) {
-                        symToExport = enumClass;
-                    }
                     if (definesBehavior) {
+                        auto symToExport = litSymbol;
+                        auto enumClass = getEnumClassForEnumValue(ctx.state, symToExport);
+                        if (enumClass.exists()) {
+                            symToExport = enumClass;
+                        }
                         // For compatibility with gen-packages, we do _not_ add an export if it doesn't define
                         // behavior. This is mostly because it's easier to get Sorbet to behave like gen-packages
                         // than the other way around.

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -709,34 +709,35 @@ public:
                         importAutocorrect.emplace(exp.value());
                     }
 
-                if (!wasImported) {
-                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
-                        e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
-                        e.addErrorLine(pkg.declLoc(), "Package defined here");
-                        addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
+                    if (!wasImported) {
+                        if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
+                            e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
+                            e.addErrorLine(pkg.declLoc(), "Package defined here");
+                            addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
+                        }
+                    } else if (testImportInProd) {
+                        ENFORCE(!isTestImport);
+                        ENFORCE(!this->package.usesTestPackages, "test_import found in --test-packages mode");
+                        if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
+                            e.setHeader("Used `{}` constant `{}` in non-test file", "test_import", litSymbol.show(ctx));
+                            e.addErrorLine(pkg.declLoc(), "Defined here");
+                            addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
+                        }
+                    } else if (testUnitImportInHelper) {
+                        ENFORCE(!this->package.usesTestPackages, "test_import found in --test-packages mode");
+                        if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
+                            e.setHeader("The `{}` constant `{}` can only be used in `{}` files", "test_import",
+                                        litSymbol.show(ctx), ".test.rb");
+                            e.addErrorLine(pkg.declLoc(), "Defined here");
+                            e.addErrorNote(
+                                "This is because this `{}` is declared with `{}`, which means the constant can "
+                                "only be used in `{}` files.",
+                                "test_import", "only: 'test_rb'", ".test.rb");
+                            addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
+                        }
+                    } else {
+                        ENFORCE(false);
                     }
-                } else if (testImportInProd) {
-                    ENFORCE(!isTestImport);
-                    ENFORCE(!this->package.usesTestPackages, "test_import found in --test-packages mode");
-                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
-                        e.setHeader("Used `{}` constant `{}` in non-test file", "test_import", litSymbol.show(ctx));
-                        e.addErrorLine(pkg.declLoc(), "Defined here");
-                        addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
-                    }
-                } else if (testUnitImportInHelper) {
-                    ENFORCE(!this->package.usesTestPackages, "test_import found in --test-packages mode");
-                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
-                        e.setHeader("The `{}` constant `{}` can only be used in `{}` files", "test_import",
-                                    litSymbol.show(ctx), ".test.rb");
-                        e.addErrorLine(pkg.declLoc(), "Defined here");
-                        e.addErrorNote("This is because this `{}` is declared with `{}`, which means the constant can "
-                                       "only be used in `{}` files.",
-                                       "test_import", "only: 'test_rb'", ".test.rb");
-                        addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
-                    }
-                } else {
-                    ENFORCE(false);
-                }
                 } else {
                     auto symToExport = litSymbol;
                     auto enumClass = getEnumClassForEnumValue(ctx.state, symToExport);
@@ -840,11 +841,11 @@ public:
                     }
                     e.setHeader("`{}` cannot be referenced here because {}", lit.symbol().show(ctx), reason);
                     if (importNeeded) {
-                    if (!wasImported) {
-                        e.addErrorNote("`{}`'s package is not imported", lit.symbol().show(ctx));
-                    } else if (testImportInProd || testUnitImportInHelper) {
-                        e.addErrorNote("`{}`'s package is imported as `{}`", lit.symbol().show(ctx), "test_import");
-                    }
+                        if (!wasImported) {
+                            e.addErrorNote("`{}`'s package is not imported", lit.symbol().show(ctx));
+                        } else if (testImportInProd || testUnitImportInHelper) {
+                            e.addErrorNote("`{}`'s package is imported as `{}`", lit.symbol().show(ctx), "test_import");
+                        }
                     } else {
                         ENFORCE(!isExported);
                         e.addErrorNote("`{}` is not exported", lit.symbol().show(ctx));

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -688,37 +688,36 @@ public:
                     return;
                 }
 
-                    auto importAutocorrect = this->package.addImport(ctx, pkg, autocorrectedImportType);
+                auto importAutocorrect = this->package.addImport(ctx, pkg, autocorrectedImportType);
 
-                    if (!wasImported) {
-                        if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
-                            e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
-                            e.addErrorLine(pkg.declLoc(), "Package defined here");
-                            addAutocorrect(ctx, e, move(importAutocorrect));
-                        }
-                    } else if (testImportInProd) {
-                        ENFORCE(!isTestImport);
-                        ENFORCE(!this->package.usesTestPackages, "test_import found in --test-packages mode");
-                        if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
-                            e.setHeader("Used `{}` constant `{}` in non-test file", "test_import", litSymbol.show(ctx));
-                            e.addErrorLine(pkg.declLoc(), "Defined here");
-                            addAutocorrect(ctx, e, move(importAutocorrect));
-                        }
-                    } else if (testUnitImportInHelper) {
-                        ENFORCE(!this->package.usesTestPackages, "test_import found in --test-packages mode");
-                        if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
-                            e.setHeader("The `{}` constant `{}` can only be used in `{}` files", "test_import",
-                                        litSymbol.show(ctx), ".test.rb");
-                            e.addErrorLine(pkg.declLoc(), "Defined here");
-                            e.addErrorNote(
-                                "This is because this `{}` is declared with `{}`, which means the constant can "
-                                "only be used in `{}` files.",
-                                "test_import", "only: 'test_rb'", ".test.rb");
-                            addAutocorrect(ctx, e, move(importAutocorrect));
-                        }
-                    } else {
-                        ENFORCE(false);
+                if (!wasImported) {
+                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
+                        e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
+                        e.addErrorLine(pkg.declLoc(), "Package defined here");
+                        addAutocorrect(ctx, e, move(importAutocorrect));
                     }
+                } else if (testImportInProd) {
+                    ENFORCE(!isTestImport);
+                    ENFORCE(!this->package.usesTestPackages, "test_import found in --test-packages mode");
+                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
+                        e.setHeader("Used `{}` constant `{}` in non-test file", "test_import", litSymbol.show(ctx));
+                        e.addErrorLine(pkg.declLoc(), "Defined here");
+                        addAutocorrect(ctx, e, move(importAutocorrect));
+                    }
+                } else if (testUnitImportInHelper) {
+                    ENFORCE(!this->package.usesTestPackages, "test_import found in --test-packages mode");
+                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
+                        e.setHeader("The `{}` constant `{}` can only be used in `{}` files", "test_import",
+                                    litSymbol.show(ctx), ".test.rb");
+                        e.addErrorLine(pkg.declLoc(), "Defined here");
+                        e.addErrorNote("This is because this `{}` is declared with `{}`, which means the constant can "
+                                       "only be used in `{}` files.",
+                                       "test_import", "only: 'test_rb'", ".test.rb");
+                        addAutocorrect(ctx, e, move(importAutocorrect));
+                    }
+                } else {
+                    ENFORCE(false);
+                }
             }
 
             // We should only report a visibility error if we're not going to add a visible_to to the package
@@ -797,43 +796,43 @@ public:
                         ENFORCE(false, "At most three reasons should be present");
                     }
                     e.setHeader("`{}` cannot be referenced here because {}", lit.symbol().show(ctx), reason);
-                        if (!wasImported) {
-                            e.addErrorNote("`{}`'s package is not imported", lit.symbol().show(ctx));
-                        } else if (testImportInProd || testUnitImportInHelper) {
-                            e.addErrorNote("`{}`'s package is imported as `{}`", lit.symbol().show(ctx), "test_import");
+                    if (!wasImported) {
+                        e.addErrorNote("`{}`'s package is not imported", lit.symbol().show(ctx));
+                    } else if (testImportInProd || testUnitImportInHelper) {
+                        e.addErrorNote("`{}`'s package is imported as `{}`", lit.symbol().show(ctx), "test_import");
                     }
                 }
             }
         } else if (!isExported) {
-                    if (db.genPackagesMode() != core::packages::GenPackagesMode::Disabled) {
-                        return;
-                    }
+            if (db.genPackagesMode() != core::packages::GenPackagesMode::Disabled) {
+                return;
+            }
 
-                    bool definesBehavior = !litSymbol.isClassOrModule() ||
-                                           litSymbol.asClassOrModuleRef().data(ctx)->flags.isBehaviorDefining;
-                    std::optional<core::AutocorrectSuggestion> exportAutocorrect;
-                    if (definesBehavior) {
-                        auto symToExport = litSymbol;
-                        auto enumClass = getEnumClassForEnumValue(ctx.state, symToExport);
-                        if (enumClass.exists()) {
-                            symToExport = enumClass;
-                        }
-                        // For compatibility with gen-packages, we do _not_ add an export if it doesn't define
-                        // behavior. This is mostly because it's easier to get Sorbet to behave like gen-packages
-                        // than the other way around.
-                        //
-                        // If we move to a world where all __package.rb edits are done via Sorbet autocorrects,
-                        // we could make this addExport call unconditional.
-                        if (auto exp = pkg.addExport(ctx, symToExport)) {
-                            exportAutocorrect.emplace(exp.value());
-                        }
-                    }
-                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedPackagePrivateName)) {
-                        e.setHeader("`{}` resolves but is not exported from `{}`", litSymbol.show(ctx), pkg.show(ctx));
-                        addExportInfo(ctx, e, litSymbol, definesBehavior);
+            bool definesBehavior =
+                !litSymbol.isClassOrModule() || litSymbol.asClassOrModuleRef().data(ctx)->flags.isBehaviorDefining;
+            std::optional<core::AutocorrectSuggestion> exportAutocorrect;
+            if (definesBehavior) {
+                auto symToExport = litSymbol;
+                auto enumClass = getEnumClassForEnumValue(ctx.state, symToExport);
+                if (enumClass.exists()) {
+                    symToExport = enumClass;
+                }
+                // For compatibility with gen-packages, we do _not_ add an export if it doesn't define
+                // behavior. This is mostly because it's easier to get Sorbet to behave like gen-packages
+                // than the other way around.
+                //
+                // If we move to a world where all __package.rb edits are done via Sorbet autocorrects,
+                // we could make this addExport call unconditional.
+                if (auto exp = pkg.addExport(ctx, symToExport)) {
+                    exportAutocorrect.emplace(exp.value());
+                }
+            }
+            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedPackagePrivateName)) {
+                e.setHeader("`{}` resolves but is not exported from `{}`", litSymbol.show(ctx), pkg.show(ctx));
+                addExportInfo(ctx, e, litSymbol, definesBehavior);
 
-                        addAutocorrect(ctx, e, move(exportAutocorrect));
-                    }
+                addAutocorrect(ctx, e, move(exportAutocorrect));
+            }
         }
     }
 

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -650,7 +650,7 @@ public:
         bool importNeeded = !wasImported || testImportInProd || testUnitImportInHelper;
         referencedPackages[otherPackage] = {.importNeeded = importNeeded, .causesModularityError = false};
 
-        if (importNeeded || !isExported) {
+        if (importNeeded) {
             bool isTestImport = otherFile.data(ctx).isPackagedTestHelper() || this->fileType != FileType::ProdFile;
             if (this->package.usesTestPackages) {
                 isTestImport = false;
@@ -688,7 +688,6 @@ public:
                     return;
                 }
 
-                if (importNeeded) {
                     auto importAutocorrect = this->package.addImport(ctx, pkg, autocorrectedImportType);
 
                     if (!wasImported) {
@@ -720,33 +719,6 @@ public:
                     } else {
                         ENFORCE(false);
                     }
-                } else {
-                    bool definesBehavior = !litSymbol.isClassOrModule() ||
-                                           litSymbol.asClassOrModuleRef().data(ctx)->flags.isBehaviorDefining;
-                    std::optional<core::AutocorrectSuggestion> exportAutocorrect;
-                    if (definesBehavior) {
-                        auto symToExport = litSymbol;
-                        auto enumClass = getEnumClassForEnumValue(ctx.state, symToExport);
-                        if (enumClass.exists()) {
-                            symToExport = enumClass;
-                        }
-                        // For compatibility with gen-packages, we do _not_ add an export if it doesn't define
-                        // behavior. This is mostly because it's easier to get Sorbet to behave like gen-packages
-                        // than the other way around.
-                        //
-                        // If we move to a world where all __package.rb edits are done via Sorbet autocorrects,
-                        // we could make this addExport call unconditional.
-                        if (auto exp = pkg.addExport(ctx, symToExport)) {
-                            exportAutocorrect.emplace(exp.value());
-                        }
-                    }
-                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedPackagePrivateName)) {
-                        e.setHeader("`{}` resolves but is not exported from `{}`", litSymbol.show(ctx), pkg.show(ctx));
-                        addExportInfo(ctx, e, litSymbol, definesBehavior);
-
-                        addAutocorrect(ctx, e, move(exportAutocorrect));
-                    }
-                }
             }
 
             // We should only report a visibility error if we're not going to add a visible_to to the package
@@ -825,18 +797,43 @@ public:
                         ENFORCE(false, "At most three reasons should be present");
                     }
                     e.setHeader("`{}` cannot be referenced here because {}", lit.symbol().show(ctx), reason);
-                    if (importNeeded) {
                         if (!wasImported) {
                             e.addErrorNote("`{}`'s package is not imported", lit.symbol().show(ctx));
                         } else if (testImportInProd || testUnitImportInHelper) {
                             e.addErrorNote("`{}`'s package is imported as `{}`", lit.symbol().show(ctx), "test_import");
-                        }
-                    } else {
-                        ENFORCE(!isExported);
-                        e.addErrorNote("`{}` is not exported", lit.symbol().show(ctx));
                     }
                 }
             }
+        } else if (!isExported) {
+                    if (db.genPackagesMode() != core::packages::GenPackagesMode::Disabled) {
+                        return;
+                    }
+
+                    bool definesBehavior = !litSymbol.isClassOrModule() ||
+                                           litSymbol.asClassOrModuleRef().data(ctx)->flags.isBehaviorDefining;
+                    std::optional<core::AutocorrectSuggestion> exportAutocorrect;
+                    if (definesBehavior) {
+                        auto symToExport = litSymbol;
+                        auto enumClass = getEnumClassForEnumValue(ctx.state, symToExport);
+                        if (enumClass.exists()) {
+                            symToExport = enumClass;
+                        }
+                        // For compatibility with gen-packages, we do _not_ add an export if it doesn't define
+                        // behavior. This is mostly because it's easier to get Sorbet to behave like gen-packages
+                        // than the other way around.
+                        //
+                        // If we move to a world where all __package.rb edits are done via Sorbet autocorrects,
+                        // we could make this addExport call unconditional.
+                        if (auto exp = pkg.addExport(ctx, symToExport)) {
+                            exportAutocorrect.emplace(exp.value());
+                        }
+                    }
+                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedPackagePrivateName)) {
+                        e.setHeader("`{}` resolves but is not exported from `{}`", litSymbol.show(ctx), pkg.show(ctx));
+                        addExportInfo(ctx, e, litSymbol, definesBehavior);
+
+                        addAutocorrect(ctx, e, move(exportAutocorrect));
+                    }
         }
     }
 

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -703,68 +703,16 @@ public:
                 }
 
                 std::optional<core::AutocorrectSuggestion> importAutocorrect;
+                std::optional<core::AutocorrectSuggestion> exportAutocorrect;
                 if (importNeeded) {
                     if (auto exp = this->package.addImport(ctx, pkg, autocorrectedImportType)) {
                         importAutocorrect.emplace(exp.value());
                     }
-                }
-                std::optional<core::AutocorrectSuggestion> exportAutocorrect;
-                if (!isExported) {
-                    auto symToExport = litSymbol;
-                    auto enumClass = getEnumClassForEnumValue(ctx.state, symToExport);
-                    if (enumClass.exists()) {
-                        symToExport = enumClass;
-                    }
-                    if (definesBehavior) {
-                        // For compatibility with gen-packages, we do _not_ add an export if it doesn't define
-                        // behavior. This is mostly because it's easier to get Sorbet to behave like gen-packages
-                        // than the other way around.
-                        //
-                        // If we move to a world where all __package.rb edits are done via Sorbet autocorrects,
-                        // we could make this addExport call unconditional.
-                        if (auto exp = pkg.addExport(ctx, symToExport)) {
-                            exportAutocorrect.emplace(exp.value());
-                        }
-                    }
-                }
 
-                if (!isExported && !wasImported) {
-                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
-                        e.setHeader("`{}` resolves but is not exported from `{}` and `{}` is not imported",
-                                    litSymbol.show(ctx), pkg.show(ctx), pkg.show(ctx));
-                        addExportInfo(ctx, e, litSymbol, definesBehavior);
-                        addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
-                    }
-                } else if (!isExported && testImportInProd) {
-                    ENFORCE(!this->package.usesTestPackages, "test_import found in --test-packages mode");
-                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
-                        e.setHeader("`{}` resolves but is not exported from `{}` and `{}` is `{}`ed",
-                                    litSymbol.show(ctx), pkg.show(ctx), pkg.show(ctx), "test_import");
-                        addExportInfo(ctx, e, litSymbol, definesBehavior);
-                        addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
-                    }
-                } else if (!isExported && testUnitImportInHelper) {
-                    ENFORCE(!this->package.usesTestPackages, "test_import found in --test-packages mode");
-                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
-                        e.setHeader("`{}` resolves but is not exported from `{}` and `{}` is `{}`ed for only {} files",
-                                    litSymbol.show(ctx), pkg.show(ctx), pkg.show(ctx), "test_import", ".test.rb");
-                        e.addErrorNote("This is because this `{}` is declared with `{}`, which means the constant can "
-                                       "only be used in `{}` files.",
-                                       "test_import", "only: 'test_rb'", ".test.rb");
-                        addExportInfo(ctx, e, litSymbol, definesBehavior);
-                        addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
-                    }
-                } else if (!isExported) {
-                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedPackagePrivateName)) {
-                        e.setHeader("`{}` resolves but is not exported from `{}`", litSymbol.show(ctx), pkg.show(ctx));
-                        addExportInfo(ctx, e, litSymbol, definesBehavior);
-
-                        addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
-                    }
-                } else if (!wasImported) {
+                if (!wasImported) {
                     if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
                         e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
-                        e.addErrorLine(pkg.declLoc(), "Exported from package here");
+                        e.addErrorLine(pkg.declLoc(), "Package defined here");
                         addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
                     }
                 } else if (testImportInProd) {
@@ -788,6 +736,30 @@ public:
                     }
                 } else {
                     ENFORCE(false);
+                }
+                } else {
+                    auto symToExport = litSymbol;
+                    auto enumClass = getEnumClassForEnumValue(ctx.state, symToExport);
+                    if (enumClass.exists()) {
+                        symToExport = enumClass;
+                    }
+                    if (definesBehavior) {
+                        // For compatibility with gen-packages, we do _not_ add an export if it doesn't define
+                        // behavior. This is mostly because it's easier to get Sorbet to behave like gen-packages
+                        // than the other way around.
+                        //
+                        // If we move to a world where all __package.rb edits are done via Sorbet autocorrects,
+                        // we could make this addExport call unconditional.
+                        if (auto exp = pkg.addExport(ctx, symToExport)) {
+                            exportAutocorrect.emplace(exp.value());
+                        }
+                    }
+                    if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedPackagePrivateName)) {
+                        e.setHeader("`{}` resolves but is not exported from `{}`", litSymbol.show(ctx), pkg.show(ctx));
+                        addExportInfo(ctx, e, litSymbol, definesBehavior);
+
+                        addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
+                    }
                 }
             }
 
@@ -867,14 +839,15 @@ public:
                         ENFORCE(false, "At most three reasons should be present");
                     }
                     e.setHeader("`{}` cannot be referenced here because {}", lit.symbol().show(ctx), reason);
-                    if (!isExported) {
-                        e.addErrorNote("`{}` is not exported", lit.symbol().show(ctx));
-                    } else if (!wasImported) {
+                    if (importNeeded) {
+                    if (!wasImported) {
                         e.addErrorNote("`{}`'s package is not imported", lit.symbol().show(ctx));
                     } else if (testImportInProd || testUnitImportInHelper) {
                         e.addErrorNote("`{}`'s package is imported as `{}`", lit.symbol().show(ctx), "test_import");
+                    }
                     } else {
-                        ENFORCE(false);
+                        ENFORCE(!isExported);
+                        e.addErrorNote("`{}` is not exported", lit.symbol().show(ctx));
                     }
                 }
             }

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -631,8 +631,6 @@ public:
             isExported = isExported || litSymbol.asFieldRef().data(ctx)->flags.isExported;
         }
         isExported = isExported || db.allowRelaxedPackagerChecksFor(this->package.mangledName());
-        bool definesBehavior =
-            !litSymbol.isClassOrModule() || litSymbol.asClassOrModuleRef().data(ctx)->flags.isBehaviorDefining;
         auto *import = this->package.importsPackage(otherPackage);
         auto wasImported = import != nullptr;
         if (this->package.usesTestPackages) {
@@ -723,6 +721,8 @@ public:
                         ENFORCE(false);
                     }
                 } else {
+                    bool definesBehavior = !litSymbol.isClassOrModule() ||
+                                           litSymbol.asClassOrModuleRef().data(ctx)->flags.isBehaviorDefining;
                     std::optional<core::AutocorrectSuggestion> exportAutocorrect;
                     auto symToExport = litSymbol;
                     auto enumClass = getEnumClassForEnumValue(ctx.state, symToExport);

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -630,17 +630,6 @@ public:
             ENFORCE(import->type == core::packages::ImportType::Normal, "test_import found in --test-packages mode");
         }
 
-        bool isExported = pkg.locs.exportAll.exists();
-        if (litSymbol.isClassOrModule()) {
-            isExported = isExported || litSymbol.asClassOrModuleRef().data(ctx)->flags.isExported;
-        } else if (litSymbol.isFieldOrStaticField()) {
-            isExported = isExported || litSymbol.asFieldRef().data(ctx)->flags.isExported;
-        }
-        isExported = isExported || db.allowRelaxedPackagerChecksFor(this->package.mangledName());
-        if (this->package.usesTestPackages) {
-            isExported = isExported || (wasImported && import->usesInternals);
-        }
-
         // Is this a test import (whether test helper or not) used in a production context?
         auto testImportInProd =
             wasImported && import->type != core::packages::ImportType::Normal && this->fileType == FileType::ProdFile;
@@ -803,7 +792,21 @@ public:
                     }
                 }
             }
-        } else if (!isExported) {
+            return;
+        }
+
+        bool isExported = pkg.locs.exportAll.exists();
+        if (litSymbol.isClassOrModule()) {
+            isExported = isExported || litSymbol.asClassOrModuleRef().data(ctx)->flags.isExported;
+        } else if (litSymbol.isFieldOrStaticField()) {
+            isExported = isExported || litSymbol.asFieldRef().data(ctx)->flags.isExported;
+        }
+        isExported = isExported || db.allowRelaxedPackagerChecksFor(this->package.mangledName());
+        if (this->package.usesTestPackages) {
+            isExported = isExported || (wasImported && import->usesInternals);
+        }
+
+        if (!isExported) {
             if (db.genPackagesMode() != core::packages::GenPackagesMode::Disabled) {
                 return;
             }

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -614,16 +614,6 @@ public:
             return;
         }
 
-        if (this->package.usesTestPackages) {
-            if (pkg.testPackage() && !this->package.testPackage()) {
-                if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::TestImportMismatch)) {
-                    e.setHeader("Package `{}` may not reference `{}` packages", this->package.show(ctx), "test!");
-                    e.addErrorLine(this->package.declLoc(), "Defined here");
-                    e.addErrorLine(pkg.declLoc(), "Referenced `{}` package defined here", "test!");
-                }
-            }
-        }
-
         auto *import = this->package.importsPackage(otherPackage);
         auto wasImported = import != nullptr;
         if (wasImported && this->package.usesTestPackages) {
@@ -658,6 +648,7 @@ public:
             bool strictDependenciesTooLow = false;
             bool causesCycle = false;
             bool causesVisibilityError = !pkg.isVisibleTo(ctx, this->package, autocorrectedImportType);
+            bool badTestReference = this->package.usesTestPackages && pkg.testPackage() && !this->package.testPackage();
             optional<string> path;
             if (!isTestImport && db.enforceLayering()) {
                 layeringViolation = strictDepsLevel > core::packages::StrictDependenciesLevel::False &&
@@ -670,7 +661,7 @@ public:
                 causesCycle =
                     strictDepsLevel >= core::packages::StrictDependenciesLevel::LayeredDag && path.has_value();
             }
-            bool hasModularityError = layeringViolation || strictDependenciesTooLow || causesCycle;
+            bool hasModularityError = layeringViolation || strictDependenciesTooLow || causesCycle || badTestReference;
             referencedPackages[otherPackage].causesModularityError = hasModularityError;
             if (!hasModularityError && !causesVisibilityError) {
                 if (db.genPackagesMode() != core::packages::GenPackagesMode::Disabled) {
@@ -723,13 +714,18 @@ public:
             if (hasModularityError) {
                 // TODO(neil): Provide actionable advice and/or link to a doc that would help the user resolve these
                 // layering/strict_dependencies issues.
-                core::ErrorClass error =
-                    causesCycle ? core::errors::Packager::StrictDependenciesViolation
-                                : (layeringViolation ? core::errors::Packager::LayeringViolation
-                                                     : core::errors::Packager::StrictDependenciesViolation);
+                auto error = causesCycle         ? core::errors::Packager::StrictDependenciesViolation
+                             : layeringViolation ? core::errors::Packager::LayeringViolation
+                             : badTestReference  ? core::errors::Packager::TestImportMismatch
+                                                 : core::errors::Packager::StrictDependenciesViolation;
                 if (auto e = ctx.beginError(lit.loc(), error)) {
                     vector<string> reasons;
                     e.addErrorLine(this->package.declLoc(), "Enclosing package declared here");
+                    if (badTestReference) {
+                        reasons.emplace_back(core::ErrorColors::format("`{}` may not reference `{}` packages",
+                                                                       this->package.show(ctx), "test!"));
+                        e.addErrorLine(pkg.declLoc(), "Referenced `{}` package defined here", "test!");
+                    }
                     if (causesCycle) {
                         reasons.emplace_back(core::ErrorColors::format(
                             "importing its package would put `{}` into a cycle", this->package.show(ctx)));
@@ -781,8 +777,10 @@ public:
                         reason = fmt::format("{}, and {}", reasons[0], reasons[1]);
                     } else if (reasons.size() == 3) {
                         reason = fmt::format("{}, {}, and {}", reasons[0], reasons[1], reasons[2]);
+                    } else if (reasons.size() == 4) {
+                        reason = fmt::format("{}, {}, {}, and {}", reasons[0], reasons[1], reasons[2], reasons[3]);
                     } else {
-                        ENFORCE(false, "At most three reasons should be present");
+                        ENFORCE(false, "At most four reasons should be present");
                     }
                     e.setHeader("`{}` cannot be referenced here because {}", lit.symbol().show(ctx), reason);
                     if (!wasImported) {

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -524,24 +524,12 @@ class VisibilityCheckerPass final {
         }
     }
 
-    void addImportExportAutocorrect(core::Context ctx, core::ErrorBuilder &e,
-                                    optional<core::AutocorrectSuggestion> &&importAutocorrect,
-                                    optional<core::AutocorrectSuggestion> &&exportAutocorrect) {
+    void addAutocorrect(core::Context ctx, core::ErrorBuilder &e, optional<core::AutocorrectSuggestion> &&autocorrect) {
         auto &db = ctx.state.packageDB();
-        auto hasAutocorrect = importAutocorrect.has_value() || exportAutocorrect.has_value();
+        auto hasAutocorrect = autocorrect.has_value();
 
-        if (importAutocorrect.has_value() && exportAutocorrect.has_value()) {
-            auto combinedTitle = fmt::format("{} and {}", importAutocorrect->title, exportAutocorrect->title);
-            importAutocorrect->edits.insert(importAutocorrect->edits.end(),
-                                            make_move_iterator(exportAutocorrect->edits.begin()),
-                                            make_move_iterator(exportAutocorrect->edits.end()));
-            e.addAutocorrect(core::AutocorrectSuggestion{combinedTitle, move(importAutocorrect->edits),
-                                                         false /* isDidYouMean */, false /* hideEdit */,
-                                                         /* shouldSkipWhenAggregated */ true});
-        } else if (importAutocorrect.has_value()) {
-            e.addAutocorrect(std::move(importAutocorrect.value()));
-        } else if (exportAutocorrect.has_value()) {
-            e.addAutocorrect(std::move(exportAutocorrect.value()));
+        if (autocorrect.has_value()) {
+            e.addAutocorrect(std::move(autocorrect.value()));
         }
 
         if (hasAutocorrect && !db.errorHint().empty()) {
@@ -713,7 +701,7 @@ public:
                         if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
                             e.setHeader("`{}` resolves but its package is not imported", lit.symbol().show(ctx));
                             e.addErrorLine(pkg.declLoc(), "Package defined here");
-                            addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
+                            addAutocorrect(ctx, e, move(importAutocorrect));
                         }
                     } else if (testImportInProd) {
                         ENFORCE(!isTestImport);
@@ -721,7 +709,7 @@ public:
                         if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
                             e.setHeader("Used `{}` constant `{}` in non-test file", "test_import", litSymbol.show(ctx));
                             e.addErrorLine(pkg.declLoc(), "Defined here");
-                            addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
+                            addAutocorrect(ctx, e, move(importAutocorrect));
                         }
                     } else if (testUnitImportInHelper) {
                         ENFORCE(!this->package.usesTestPackages, "test_import found in --test-packages mode");
@@ -733,7 +721,7 @@ public:
                                 "This is because this `{}` is declared with `{}`, which means the constant can "
                                 "only be used in `{}` files.",
                                 "test_import", "only: 'test_rb'", ".test.rb");
-                            addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
+                            addAutocorrect(ctx, e, move(importAutocorrect));
                         }
                     } else {
                         ENFORCE(false);
@@ -759,7 +747,7 @@ public:
                         e.setHeader("`{}` resolves but is not exported from `{}`", litSymbol.show(ctx), pkg.show(ctx));
                         addExportInfo(ctx, e, litSymbol, definesBehavior);
 
-                        addImportExportAutocorrect(ctx, e, move(importAutocorrect), move(exportAutocorrect));
+                        addAutocorrect(ctx, e, move(exportAutocorrect));
                     }
                 }
             }

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -624,6 +624,12 @@ public:
             }
         }
 
+        auto *import = this->package.importsPackage(otherPackage);
+        auto wasImported = import != nullptr;
+        if (wasImported && this->package.usesTestPackages) {
+            ENFORCE(import->type == core::packages::ImportType::Normal, "test_import found in --test-packages mode");
+        }
+
         bool isExported = pkg.locs.exportAll.exists();
         if (litSymbol.isClassOrModule()) {
             isExported = isExported || litSymbol.asClassOrModuleRef().data(ctx)->flags.isExported;
@@ -631,14 +637,8 @@ public:
             isExported = isExported || litSymbol.asFieldRef().data(ctx)->flags.isExported;
         }
         isExported = isExported || db.allowRelaxedPackagerChecksFor(this->package.mangledName());
-        auto *import = this->package.importsPackage(otherPackage);
-        auto wasImported = import != nullptr;
         if (this->package.usesTestPackages) {
             isExported = isExported || (wasImported && import->usesInternals);
-            if (wasImported) {
-                ENFORCE(import->type == core::packages::ImportType::Normal,
-                        "test_import found in --test-packages mode");
-            }
         }
 
         // Is this a test import (whether test helper or not) used in a production context?

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -712,15 +712,16 @@ public:
                     vector<string> reasons;
                     e.addErrorLine(this->package.declLoc(), "Enclosing package declared here");
 
-            // We should only report a visibility error if we're not going to add a visible_to to the package
-            // Otherwise the error is pointless since it'll go away after the new visible_to is added
-            if (causesVisibilityError && !ctx.state.packageDB().updateVisibilityFor(otherPackage)) {
-                reasons.emplace_back(core::ErrorColors::format(
-                    "package `{}` includes explicit visibility modifiers and cannot be imported from `{}`",
-                                pkg.show(ctx), this->package.show(ctx)));
-                    e.addErrorNote("Please consult with the owning team before adding a `{}` line to the package `{}`",
-                                   "visible_to", pkg.show(ctx));
-            }
+                    // We should only report a visibility error if we're not going to add a visible_to to the package
+                    // Otherwise the error is pointless since it'll go away after the new visible_to is added
+                    if (causesVisibilityError && !ctx.state.packageDB().updateVisibilityFor(otherPackage)) {
+                        reasons.emplace_back(core::ErrorColors::format(
+                            "package `{}` includes explicit visibility modifiers and cannot be imported from `{}`",
+                            pkg.show(ctx), this->package.show(ctx)));
+                        e.addErrorNote(
+                            "Please consult with the owning team before adding a `{}` line to the package `{}`",
+                            "visible_to", pkg.show(ctx));
+                    }
                     if (badTestReference) {
                         reasons.emplace_back(core::ErrorColors::format("`{}` may not reference `{}` packages",
                                                                        this->package.show(ctx), "test!"));

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -690,12 +690,8 @@ public:
                     return;
                 }
 
-                std::optional<core::AutocorrectSuggestion> importAutocorrect;
-                std::optional<core::AutocorrectSuggestion> exportAutocorrect;
                 if (importNeeded) {
-                    if (auto exp = this->package.addImport(ctx, pkg, autocorrectedImportType)) {
-                        importAutocorrect.emplace(exp.value());
-                    }
+                    auto importAutocorrect = this->package.addImport(ctx, pkg, autocorrectedImportType);
 
                     if (!wasImported) {
                         if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::MissingImport)) {
@@ -727,6 +723,7 @@ public:
                         ENFORCE(false);
                     }
                 } else {
+                    std::optional<core::AutocorrectSuggestion> exportAutocorrect;
                     auto symToExport = litSymbol;
                     auto enumClass = getEnumClassForEnumValue(ctx.state, symToExport);
                     if (enumClass.exists()) {

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -661,9 +661,12 @@ public:
                 causesCycle =
                     strictDepsLevel >= core::packages::StrictDependenciesLevel::LayeredDag && path.has_value();
             }
-            bool hasModularityError = layeringViolation || strictDependenciesTooLow || causesCycle || badTestReference;
-            referencedPackages[otherPackage].causesModularityError = hasModularityError;
-            if (!hasModularityError && !causesVisibilityError) {
+            bool hasModularityError = layeringViolation || strictDependenciesTooLow || causesCycle ||
+                                      badTestReference || causesVisibilityError;
+            // visible_to errors are handled separately (by `updateVisibilityFor`),
+            // so they're not included in this causesModularityError field of referencedPackages
+            referencedPackages[otherPackage].causesModularityError = hasModularityError && !causesVisibilityError;
+            if (!hasModularityError) {
                 if (db.genPackagesMode() != core::packages::GenPackagesMode::Disabled) {
                     return;
                 }
@@ -698,20 +701,7 @@ public:
                 } else {
                     ENFORCE(false);
                 }
-            }
-
-            // We should only report a visibility error if we're not going to add a visible_to to the package
-            // Otherwise the error is pointless since it'll go away after the new visible_to is added
-            if (causesVisibilityError && !ctx.state.packageDB().updateVisibilityFor(otherPackage)) {
-                if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::ImportNotVisible)) {
-                    e.setHeader("Package `{}` includes explicit visibility modifiers and cannot be imported from `{}`",
-                                pkg.show(ctx), this->package.show(ctx));
-                    e.addErrorNote("Please consult with the owning team before adding a `{}` line to the package `{}`",
-                                   "visible_to", pkg.show(ctx));
-                }
-            }
-
-            if (hasModularityError) {
+            } else {
                 // TODO(neil): Provide actionable advice and/or link to a doc that would help the user resolve these
                 // layering/strict_dependencies issues.
                 auto error = causesCycle         ? core::errors::Packager::StrictDependenciesViolation
@@ -721,6 +711,16 @@ public:
                 if (auto e = ctx.beginError(lit.loc(), error)) {
                     vector<string> reasons;
                     e.addErrorLine(this->package.declLoc(), "Enclosing package declared here");
+
+            // We should only report a visibility error if we're not going to add a visible_to to the package
+            // Otherwise the error is pointless since it'll go away after the new visible_to is added
+            if (causesVisibilityError && !ctx.state.packageDB().updateVisibilityFor(otherPackage)) {
+                reasons.emplace_back(core::ErrorColors::format(
+                    "package `{}` includes explicit visibility modifiers and cannot be imported from `{}`",
+                                pkg.show(ctx), this->package.show(ctx)));
+                    e.addErrorNote("Please consult with the owning team before adding a `{}` line to the package `{}`",
+                                   "visible_to", pkg.show(ctx));
+            }
                     if (badTestReference) {
                         reasons.emplace_back(core::ErrorColors::format("`{}` may not reference `{}` packages",
                                                                        this->package.show(ctx), "test!"));
@@ -769,6 +769,13 @@ public:
                                        requiredStrictDepsLevel, currentStrictDepsLevel);
                     }
 
+                    if (reasons.empty() && causesVisibilityError &&
+                        ctx.state.packageDB().updateVisibilityFor(otherPackage)) {
+                        // Force the error to build here, so that we don't report an error
+                        e.build();
+                        return;
+                    }
+
                     ENFORCE(!reasons.empty(), "At least one reason should be present");
                     string reason;
                     if (reasons.size() == 1) {
@@ -779,8 +786,11 @@ public:
                         reason = fmt::format("{}, {}, and {}", reasons[0], reasons[1], reasons[2]);
                     } else if (reasons.size() == 4) {
                         reason = fmt::format("{}, {}, {}, and {}", reasons[0], reasons[1], reasons[2], reasons[3]);
+                    } else if (reasons.size() == 5) {
+                        reason = fmt::format("{}, {}, {}, {}, and {}", reasons[0], reasons[1], reasons[2], reasons[3],
+                                             reasons[4]);
                     } else {
-                        ENFORCE(false, "At most four reasons should be present");
+                        ENFORCE(false, "At most five reasons should be present");
                     }
                     e.setHeader("`{}` cannot be referenced here because {}", lit.symbol().show(ctx), reason);
                     if (!wasImported) {

--- a/test/cli/autocorrect-package-import/test.out
+++ b/test/cli/autocorrect-package-import/test.out
@@ -1,7 +1,7 @@
 a/foo.rb:4: `B::Foo` resolves but its package is not imported https://srb.help/3718
      4 |  B::Foo.new
           ^^^^^^
-    b/__package.rb:3: Exported from package here
+    b/__package.rb:3: Package defined here
      3 |class B < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done

--- a/test/cli/condensation-package-autocorrect-missing-import/test.out
+++ b/test/cli/condensation-package-autocorrect-missing-import/test.out
@@ -30,7 +30,7 @@ use_other_package/foo.rb:18: Unable to resolve constant `Test` https://srb.help/
 use_other_package/foo.rb:7: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
      7 |      Foo::Bar::OtherPackage::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Exported from package here
+    other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -41,7 +41,7 @@ use_other_package/foo.rb:7: `Foo::Bar::OtherPackage::OtherClass` resolves but it
 use_other_package/foo.rb:8: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
      8 |      Bar::OtherPackage::OtherClass # resolves via `module Foo`
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Exported from package here
+    other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -66,7 +66,7 @@ use_other_package/foo.rb:9: Used `test_import` constant `Foo::Bar::OtherPackageT
 use_other_package/foo.rb:15: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
     15 |  Foo::Bar::OtherPackage::OtherClass # resolves via root
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Exported from package here
+    other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -77,7 +77,7 @@ use_other_package/foo.rb:15: `Foo::Bar::OtherPackage::OtherClass` resolves but i
 use_other_package/foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::OtherPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Exported from package here
+    other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -88,7 +88,7 @@ use_other_package/foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolv
 use_other_package/foo.test.rb:6: `Foo::Bar::OtherPackage::ImportMeTestOnly` resolves but its package is not imported https://srb.help/3718
      6 |  Foo::Bar::OtherPackage::ImportMeTestOnly
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Exported from package here
+    other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -154,7 +154,7 @@ use_app_package/foo.rb:7: `Foo::Bar::AppPackageTest::OtherClass` cannot be refer
 use_app_package/foo.test.rb:6: `Foo::Bar::AppPackage::ImportMeTestOnly` resolves but its package is not imported https://srb.help/3718
      6 |  Foo::Bar::AppPackage::ImportMeTestOnly
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    app_package/__package.rb:3: Exported from package here
+    app_package/__package.rb:3: Package defined here
      3 |class Foo::Bar::AppPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -220,7 +220,7 @@ use_false_package/foo.rb:7: `Foo::Bar::FalsePackageTest::OtherClass` cannot be r
 use_false_package/foo.test.rb:4: `Test::Foo::Bar::FalsePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalsePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    false_package/__package.rb:3: Exported from package here
+    false_package/__package.rb:3: Package defined here
      3 |class Foo::Bar::FalsePackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -292,7 +292,7 @@ use_false_and_app_package/foo.rb:7: `Foo::Bar::FalseAndAppPackageTest::OtherClas
 use_false_and_app_package/foo.test.rb:4: `Test::Foo::Bar::FalseAndAppPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    false_and_app_package/__package.rb:3: Exported from package here
+    false_and_app_package/__package.rb:3: Package defined here
      3 |class Foo::Bar::FalseAndAppPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done

--- a/test/cli/package-attributed-errors/test.out
+++ b/test/cli/package-attributed-errors/test.out
@@ -1,16 +1,13 @@
-[App] app/main.rb:5: `Lib::Nested::SomeClass` resolves but is not exported from `Lib::Nested` and `Lib::Nested` is not imported https://srb.help/3718
+[App] app/main.rb:5: `Lib::Nested::SomeClass` resolves but its package is not imported https://srb.help/3718
      5 |    Lib::Nested::SomeClass
             ^^^^^^^^^^^^^^^^^^^^^^
-    lib/nested/some_class.rb:3: Defined here
-     3 |class Lib::Nested::SomeClass
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    lib/nested/__package.rb:3: Package defined here
+     3 |class Lib::Nested < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     app/__package.rb:3: Insert `import Lib::Nested`
      3 |class App < PackageSpec
                                ^
-    lib/nested/__package.rb:4: Insert `export Lib::Nested::SomeClass`
-     4 |  bad
-             ^
 
 [Lib::Nested] lib/nested/some_class.rb:4: The method `foo` does not have a `sig` https://srb.help/7017
      4 |  def foo; end

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -529,11 +529,16 @@ end
 
 --------------------------------------------------------------------------
 
-use_visible_to_package/foo.rb:6: Package `Foo::Bar::OtherPackage` includes explicit visibility modifiers and cannot be imported from `Foo::MyPackage` https://srb.help/3723
+use_visible_to_package/foo.rb:6: `Foo::Bar::OtherPackage::OtherClass` cannot be referenced here because package `Foo::Bar::OtherPackage` includes explicit visibility modifiers and cannot be imported from `Foo::MyPackage` https://srb.help/3727
      6 |      Foo::Bar::OtherPackage::OtherClass
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_visible_to_package/__package.rb:5: Enclosing package declared here
+     5 |class Foo::MyPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `Foo::Bar::OtherPackage`
+  Note:
+    `Foo::Bar::OtherPackage::OtherClass`'s package is imported as `test_import`
 Errors: 1
 # frozen_string_literal: true
 # typed: strict

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -12,7 +12,7 @@ use_other_package/foo.rb:16: Unable to resolve constant `MyClass` https://srb.he
 use_other_package/foo.rb:7: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
      7 |      Foo::Bar::OtherPackage::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Exported from package here
+    other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -23,7 +23,7 @@ use_other_package/foo.rb:7: `Foo::Bar::OtherPackage::OtherClass` resolves but it
 use_other_package/foo.rb:8: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
      8 |      Bar::OtherPackage::OtherClass # resolves via `module Foo`
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Exported from package here
+    other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -48,7 +48,7 @@ use_other_package/foo.rb:9: Used `test_import` constant `Foo::Bar::OtherPackageT
 use_other_package/foo.rb:15: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
     15 |  Foo::Bar::OtherPackage::OtherClass # resolves via root
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Exported from package here
+    other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -63,7 +63,7 @@ use_other_package/foo.rb:18: `Test::Foo::Bar::OtherPackage::TestUtil` is defined
 use_other_package/foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::OtherPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Exported from package here
+    other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -74,7 +74,7 @@ use_other_package/foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolv
 use_other_package/foo.test.rb:6: `Foo::Bar::OtherPackage::ImportMeTestOnly` resolves but its package is not imported https://srb.help/3718
      6 |  Foo::Bar::OtherPackage::ImportMeTestOnly
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Exported from package here
+    other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -126,7 +126,7 @@ use_app_package/foo.rb:13: `Test::Foo::Bar::AppPackage::TestUtil` is defined in 
 use_app_package/foo.test.rb:6: `Foo::Bar::AppPackage::ImportMeTestOnly` resolves but its package is not imported https://srb.help/3718
      6 |  Foo::Bar::AppPackage::ImportMeTestOnly
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    app_package/__package.rb:3: Exported from package here
+    app_package/__package.rb:3: Package defined here
      3 |class Foo::Bar::AppPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -178,7 +178,7 @@ use_false_package/foo.rb:13: `Test::Foo::Bar::FalsePackage::TestUtil` is defined
 use_false_package/foo.test.rb:4: `Test::Foo::Bar::FalsePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalsePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    false_package/__package.rb:3: Exported from package here
+    false_package/__package.rb:3: Package defined here
      3 |class Foo::Bar::FalsePackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -236,7 +236,7 @@ use_false_and_app_package/foo.rb:13: `Test::Foo::Bar::FalseAndAppPackage::TestUt
 use_false_and_app_package/foo.test.rb:4: `Test::Foo::Bar::FalseAndAppPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    false_and_app_package/__package.rb:3: Exported from package here
+    false_and_app_package/__package.rb:3: Package defined here
      3 |class Foo::Bar::FalseAndAppPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -298,7 +298,7 @@ use_cycle_package/foo.rb:13: `Test::Foo::Bar::CyclePackage::TestUtil` is defined
 use_cycle_package/foo.test.rb:4: `Test::Foo::Bar::CyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::CyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    cycle_package/__package.rb:5: Exported from package here
+    cycle_package/__package.rb:5: Package defined here
      5 |class Foo::Bar::CyclePackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -366,7 +366,7 @@ use_app_cycle_package/foo.rb:13: `Test::Foo::Bar::AppCyclePackage::TestUtil` is 
 use_app_cycle_package/foo.test.rb:4: `Test::Foo::Bar::AppCyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::AppCyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    app_cycle_package/__package.rb:5: Exported from package here
+    app_cycle_package/__package.rb:5: Package defined here
      5 |class Foo::Bar::AppCyclePackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -434,7 +434,7 @@ use_false_cycle_package/foo.rb:13: `Test::Foo::Bar::FalseCyclePackage::TestUtil`
 use_false_cycle_package/foo.test.rb:4: `Test::Foo::Bar::FalseCyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    false_cycle_package/__package.rb:5: Exported from package here
+    false_cycle_package/__package.rb:5: Package defined here
      5 |class Foo::Bar::FalseCyclePackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
@@ -508,7 +508,7 @@ use_app_false_cycle_package/foo.rb:13: `Test::Foo::Bar::AppFalseCyclePackage::Te
 use_app_false_cycle_package/foo.test.rb:4: `Test::Foo::Bar::AppFalseCyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    app_false_cycle_package/__package.rb:5: Exported from package here
+    app_false_cycle_package/__package.rb:5: Package defined here
      5 |class Foo::Bar::AppFalseCyclePackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done

--- a/test/cli/package-error-missing-export-import/test.out
+++ b/test/cli/package-error-missing-export-import/test.out
@@ -1,25 +1,22 @@
-missing_import/foo_class.rb:5: `Other::OtherClass` resolves but is not exported from `Other` and `Other` is not imported https://srb.help/3718
+missing_import/foo_class.rb:5: `Other::OtherClass` resolves but its package is not imported https://srb.help/3718
      5 |    Other::OtherClass
             ^^^^^^^^^^^^^^^^^
-    other/other_class.rb:4: Defined here
-     4 |  class OtherClass
-          ^^^^^^^^^^^^^^^^
+    other/__package.rb:3: Package defined here
+     3 |class Other < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     missing_import/__package.rb:3: Insert `import Other`
      3 |class Foo::MissingImport < PackageSpec
                                               ^
-    other/__package.rb:3: Insert `export Other::OtherClass`
-     3 |class Other < PackageSpec
-                                 ^
   Note:
     Try running generate-packages.sh
 Errors: 1
-imported_as_test/foo_class.rb:5: `Other::OtherClass` resolves but is not exported from `Other` and `Other` is `test_import`ed https://srb.help/3720
+imported_as_test/foo_class.rb:5: Used `test_import` constant `Other::OtherClass` in non-test file https://srb.help/3720
      5 |    Other::OtherClass
             ^^^^^^^^^^^^^^^^^
-    other/other_class.rb:4: Defined here
-     4 |  class OtherClass
-          ^^^^^^^^^^^^^^^^
+    other/__package.rb:3: Defined here
+     3 |class Other < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     imported_as_test/__package.rb:3: Insert `import Other`
      3 |class Foo::MissingImport < PackageSpec
@@ -27,20 +24,17 @@ imported_as_test/foo_class.rb:5: `Other::OtherClass` resolves but is not exporte
     imported_as_test/__package.rb:4: Delete
      4 |  test_import Other
         ^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Insert `export Other::OtherClass`
-     3 |class Other < PackageSpec
-                                 ^
   Note:
     Try running generate-packages.sh
 Errors: 1
-imported_as_test_unit/test/foo_class.rb:5: `Other::OtherClass` resolves but is not exported from `Other` and `Other` is `test_import`ed for only .test.rb files https://srb.help/3720
+imported_as_test_unit/test/foo_class.rb:5: The `test_import` constant `Other::OtherClass` can only be used in `.test.rb` files https://srb.help/3720
      5 |    Other::OtherClass
             ^^^^^^^^^^^^^^^^^
+    other/__package.rb:3: Defined here
+     3 |class Other < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
     This is because this `test_import` is declared with `only: 'test_rb'`, which means the constant can only be used in `.test.rb` files.
-    other/other_class.rb:4: Defined here
-     4 |  class OtherClass
-          ^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     imported_as_test_unit/__package.rb:3: Insert `test_import Other`
      3 |class Foo::MissingImport < PackageSpec
@@ -48,9 +42,6 @@ imported_as_test_unit/test/foo_class.rb:5: `Other::OtherClass` resolves but is n
     imported_as_test_unit/__package.rb:4: Delete
      4 |  test_import Other, only: "test_rb"
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Insert `export Other::OtherClass`
-     3 |class Other < PackageSpec
-                                 ^
   Note:
     Try running generate-packages.sh
 Errors: 1

--- a/test/cli/package-error-missing-export/test.out
+++ b/test/cli/package-error-missing-export/test.out
@@ -71,5 +71,5 @@ use_app_false_cycle_package/foo.rb:6: `Foo::Bar::AppFalseCyclePackage::OtherClas
      7 |  strict_dependencies 'false'
                               ^^^^^^^
   Note:
-    `Foo::Bar::AppFalseCyclePackage::OtherClass` is not exported
+    `Foo::Bar::AppFalseCyclePackage::OtherClass`'s package is not imported
 Errors: 1

--- a/test/cli/package-error-missing-import/test.out
+++ b/test/cli/package-error-missing-import/test.out
@@ -1,7 +1,7 @@
 foo_class.rb:7: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
      7 |      Foo::Bar::OtherPackage::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Exported from package here
+    other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
@@ -14,7 +14,7 @@ foo_class.rb:7: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is
 foo_class.rb:8: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
      8 |      Bar::OtherPackage::OtherClass # resolves via `module Foo`
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Exported from package here
+    other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
@@ -27,7 +27,7 @@ foo_class.rb:8: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is
 foo_class.rb:14: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
     14 |  Foo::Bar::OtherPackage::OtherClass # resolves via root
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Exported from package here
+    other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
@@ -40,7 +40,7 @@ foo_class.rb:14: `Foo::Bar::OtherPackage::OtherClass` resolves but its package i
 foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::OtherPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Exported from package here
+    other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect

--- a/test/cli/package-gen-packages-test-packages/test.out
+++ b/test/cli/package-gen-packages-test-packages/test.out
@@ -131,11 +131,16 @@ C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_d
   Note:
     `F::CONSTANT_FROM_F`'s package is not imported
 
-C/app.rb:9: Package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3723
+C/app.rb:9: `G::CONSTANT_FROM_G` cannot be referenced here because package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3727
      9 |      puts G::CONSTANT_FROM_G
                    ^^^^^^^^^^^^^^^^^^
+    C/__package.rb:3: Enclosing package declared here
+     3 |class C < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
+  Note:
+    `G::CONSTANT_FROM_G`'s package is not imported
 Errors: 12
 
 ###### cat B/__package.rb ######
@@ -352,11 +357,16 @@ C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_d
   Note:
     `F::CONSTANT_FROM_F`'s package is not imported
 
-C/app.rb:9: Package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3723
+C/app.rb:9: `G::CONSTANT_FROM_G` cannot be referenced here because package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3727
      9 |      puts G::CONSTANT_FROM_G
                    ^^^^^^^^^^^^^^^^^^
+    C/__package.rb:3: Enclosing package declared here
+     3 |class C < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
+  Note:
+    `G::CONSTANT_FROM_G`'s package is not imported
 Errors: 11
 
 ###### cat B/__package.rb ######

--- a/test/cli/package-gen-packages/test.out
+++ b/test/cli/package-gen-packages/test.out
@@ -126,11 +126,16 @@ C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_d
   Note:
     `F::CONSTANT_FROM_F`'s package is not imported
 
-C/app.rb:9: Package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3723
+C/app.rb:9: `G::CONSTANT_FROM_G` cannot be referenced here because package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3727
      9 |      puts G::CONSTANT_FROM_G
                    ^^^^^^^^^^^^^^^^^^
+    C/__package.rb:3: Enclosing package declared here
+     3 |class C < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
+  Note:
+    `G::CONSTANT_FROM_G`'s package is not imported
 Errors: 11
 
 ###### cat B/__package.rb ######
@@ -336,11 +341,16 @@ C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_d
   Note:
     `F::CONSTANT_FROM_F`'s package is not imported
 
-C/app.rb:9: Package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3723
+C/app.rb:9: `G::CONSTANT_FROM_G` cannot be referenced here because package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3727
      9 |      puts G::CONSTANT_FROM_G
                    ^^^^^^^^^^^^^^^^^^
+    C/__package.rb:3: Enclosing package declared here
+     3 |class C < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
+  Note:
+    `G::CONSTANT_FROM_G`'s package is not imported
 Errors: 10
 
 ###### cat B/__package.rb ######

--- a/test/cli/package-strict-dependencies-show-cycle/test.out
+++ b/test/cli/package-strict-dependencies-show-cycle/test.out
@@ -15,7 +15,7 @@ a/__package.rb:7: Strict dependencies violation: importing `B` will put `A` into
 a/foo.rb:5: `Y::Foo` resolves but its package is not imported https://srb.help/3718
      5 |    Y::Foo.new
             ^^^^^^
-    y/__package.rb:3: Exported from package here
+    y/__package.rb:3: Package defined here
      3 |class Y < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect

--- a/test/cli/package-top-level-inheritance/test.out
+++ b/test/cli/package-top-level-inheritance/test.out
@@ -1,7 +1,7 @@
 a/foo.rb:5: `Main::B` resolves but its package is not imported https://srb.help/3718
      5 |    class Foo < Main::B
                         ^^^^^^^
-    __package.rb:3: Exported from package here
+    __package.rb:3: Package defined here
      3 |class Main < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect

--- a/test/cli/packager_suggest_nested_crash/test.out
+++ b/test/cli/packager_suggest_nested_crash/test.out
@@ -1,14 +1,11 @@
-consumer_auth/data/identifier_struct.rb:6: `Project::ConsumerAuth::IdentifierType` resolves but is not exported from `Project::ConsumerAuth` and `Project::ConsumerAuth` is not imported https://srb.help/3718
+consumer_auth/data/identifier_struct.rb:6: `Project::ConsumerAuth::IdentifierType` resolves but its package is not imported https://srb.help/3718
      6 |    puts(Project::ConsumerAuth::IdentifierType)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    consumer_auth/identity_type.rb:5: Defined here
-     5 |  class IdentifierType
-          ^^^^^^^^^^^^^^^^^^^^
+    consumer_auth/__package.rb:5: Package defined here
+     5 |class Project::ConsumerAuth < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Use `-a` to autocorrect
     consumer_auth/data/__package.rb:4: Insert `import Project::ConsumerAuth`
      4 |class Project::ConsumerAuth::Data < PackageSpec
                                                        ^
-    consumer_auth/__package.rb:6: Insert `export Project::ConsumerAuth::IdentifierType`
-     6 |  import Project::ConsumerAuth::Data
-                                            ^
 Errors: 1

--- a/test/lsp/watchman_test_corpus.cc
+++ b/test/lsp/watchman_test_corpus.cc
@@ -197,8 +197,8 @@ TEST_CASE_FIXTURE(ProtocolTest, "ZeroingOutPackageFiles") {
     requests.push_back(watchmanFileUpdate({"c/__package.rb", "c/impl.rb"}));
     assertErrorDiagnostics(send(move(requests)), {
                                                      {"b/__package.rb", 4, "Unable to resolve constant"},
-                                                     {"b/impl.rb", 5, "resolves but is not exported"},
-                                                     {"b/impl.rb", 7, "resolves but is not exported"},
+                                                     {"b/impl.rb", 5, "resolves but its package is not imported"},
+                                                     {"b/impl.rb", 7, "resolves but its package is not imported"},
                                                      {"c/__package.rb", 0, "must contain a package definition"},
                                                  });
 }

--- a/test/testdata/packager/package-prefix-enforcement/nested/nested.rb
+++ b/test/testdata/packager/package-prefix-enforcement/nested/nested.rb
@@ -39,7 +39,7 @@ module Root
     sig { void }
     def example
       NOT_IN_PACKAGE
-    # ^^^^^^^^^^^^^^ error: `Root::NOT_IN_PACKAGE` resolves but is not exported from `Root` and `Root` is not imported
+    # ^^^^^^^^^^^^^^ error: `Root::NOT_IN_PACKAGE` resolves but its package is not imported
     end
   end
 end

--- a/test/testdata/packager/test_helper_import/b/thing.rb
+++ b/test/testdata/packager/test_helper_import/b/thing.rb
@@ -3,4 +3,7 @@
 module B
   module Thing
   end
+
+  module PrivateThing
+  end
 end

--- a/test/testdata/packager/test_helper_import/c/thing.rb
+++ b/test/testdata/packager/test_helper_import/c/thing.rb
@@ -3,4 +3,7 @@
 module C
   module Thing
   end
+
+  module PrivateThing
+  end
 end

--- a/test/testdata/packager/test_helper_import/root_stuff.rb
+++ b/test/testdata/packager/test_helper_import/root_stuff.rb
@@ -7,11 +7,11 @@ module RootPkg
     B::Thing # not allowed---test import
   # ^^^^^^^^ error: Used `test_import` constant `B::Thing` in non-test file
     B::PrivateThing
-  # ^^^^^^^^^^^^^^^ error: `B::PrivateThing` resolves but is not exported from `B` and `B` is `test_import`ed
+  # ^^^^^^^^^^^^^^^ error: Used `test_import` constant `B::PrivateThing` in non-test file
 
     C::Thing # not allowed---test import
   # ^^^^^^^^ error: Used `test_import` constant `C::Thing` in non-test file
     C::PrivateThing
-  # ^^^^^^^^^^^^^^^ error: `C::PrivateThing` resolves but is not exported from `C` and `C` is `test_import`ed
+  # ^^^^^^^^^^^^^^^ error: Used `test_import` constant `C::PrivateThing` in non-test file
   end
 end

--- a/test/testdata/packager/test_helper_import/root_stuff.rb
+++ b/test/testdata/packager/test_helper_import/root_stuff.rb
@@ -6,8 +6,12 @@ module RootPkg
 
     B::Thing # not allowed---test import
   # ^^^^^^^^ error: Used `test_import` constant `B::Thing` in non-test file
+    B::PrivateThing
+  # ^^^^^^^^^^^^^^^ error: `B::PrivateThing` resolves but is not exported from `B` and `B` is `test_import`ed
 
     C::Thing # not allowed---test import
   # ^^^^^^^^ error: Used `test_import` constant `C::Thing` in non-test file
+    C::PrivateThing
+  # ^^^^^^^^^^^^^^^ error: `C::PrivateThing` resolves but is not exported from `C` and `C` is `test_import`ed
   end
 end

--- a/test/testdata/packager/test_helper_import/test/test_helper.rb
+++ b/test/testdata/packager/test_helper_import/test/test_helper.rb
@@ -11,6 +11,6 @@ module Test::RootPkg
     C::Thing # not allowed---test-only import
   # ^^^^^^^^ error: The `test_import` constant `C::Thing` can only be used in `.test.rb` files
     C::PrivateThing
-  # ^^^^^^^^^^^^^^^ error: `C::PrivateThing` resolves but is not exported from `C` and `C` is `test_import`ed for only .test.rb files
+  # ^^^^^^^^^^^^^^^ error: The `test_import` constant `C::PrivateThing` can only be used in `.test.rb` files
   end
 end

--- a/test/testdata/packager/test_helper_import/test/test_helper.rb
+++ b/test/testdata/packager/test_helper_import/test/test_helper.rb
@@ -5,8 +5,12 @@ module Test::RootPkg
     A::Thing # allowed
 
     B::Thing # allowed---test helper import
+    B::PrivateThing
+  # ^^^^^^^^^^^^^^^ error: `B::PrivateThing` resolves but is not exported from `B`
 
     C::Thing # not allowed---test-only import
   # ^^^^^^^^ error: The `test_import` constant `C::Thing` can only be used in `.test.rb` files
+    C::PrivateThing
+  # ^^^^^^^^^^^^^^^ error: `C::PrivateThing` resolves but is not exported from `C` and `C` is `test_import`ed for only .test.rb files
   end
 end

--- a/test/testdata/packager/unimported_namespace/aaa/a_class.rb
+++ b/test/testdata/packager/unimported_namespace/aaa/a_class.rb
@@ -3,7 +3,7 @@
 
 class AAA::AClass
   BBB
-# ^^^ error: `BBB` resolves but is not exported from `BBB` and `BBB` is not imported
+# ^^^ error: `BBB` resolves but its package is not imported
 
   CCC
 # ^^^ error: Unable to resolve constant `CCC`


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This aligns the behavior more closely with the soon-to-come package-aware
constant resolution, where we will not be able to report that a constant
for sure exists if its package was not imported.

Review by commit. The diff looks large but looks a lot better if you look at it
with `diff.colorMoved` in the command line. The core change is in the second
commit, and everything after that is random simplifications and cleanups that we
can make.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.