### PR TITLE
directly remove single-use writes in `findAllReadsAndWrites`

### DIFF
--- a/cfg/CFG.cc
+++ b/cfg/CFG.cc
@@ -172,17 +172,11 @@ CFG::ReadsAndWrites CFG::findAllReadsAndWrites(core::Context ctx) {
     {
         Timer timeit(ctx.state.tracer(), "privates2");
         auto local = 0;
-        vector<UIntSet> writesToRemove(maxBasicBlockId, UIntSet(numLocalVariables()));
         for (const auto &usages : usageCounts) {
             if (usages.first == 1) {
-                writesToRemove[usages.second].add(local);
+                target.writes[usages.second].remove(local);
             }
             local++;
-        }
-        auto blockId = 0;
-        for (const auto &blockWritesToRemove : writesToRemove) {
-            target.writes[blockId].remove(blockWritesToRemove);
-            blockId++;
         }
     }
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Claude identified this one by analyzing the code, and running with cachegrind says this is good for an ~0.3% reduction in instructions executed.  Probably more helpful on big functions, but I can't really imagine cases where it would be worse...?

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
