### PR TITLE
Prohibit using T as RBS type parameter name

### DIFF
--- a/rbs/TypeParamsToParserNodes.cc
+++ b/rbs/TypeParamsToParserNodes.cc
@@ -29,7 +29,7 @@ vector<pm_node_t *> TypeParamsToParserNodes::typeParams(const rbs_node_list_t *r
 
             if (auto e = ctx.beginIndexerError(nameLoc, core::errors::Rewriter::RBSUnsupported)) {
                 e.setHeader("`{}` is not a valid type parameter name", nameStr);
-                e.addErrorNote("It may conflict with Sorbet's own namespace");
+                e.addErrorNote("It conflicts with Sorbet's own namespace");
             }
         }
 

--- a/rbs/TypeParamsToParserNodes.cc
+++ b/rbs/TypeParamsToParserNodes.cc
@@ -24,6 +24,15 @@ vector<pm_node_t *> TypeParamsToParserNodes::typeParams(const rbs_node_list_t *r
 
         auto nameStr = parser.resolveConstant(rbsTypeParam->name);
 
+        if (nameStr == core::Names::Constants::T().shortName(ctx.state)) {
+            auto nameLoc = declaration.typeLocFromRange(rbsTypeParam->name_range);
+
+            if (auto e = ctx.beginIndexerError(nameLoc, core::errors::Rewriter::RBSUnsupported)) {
+                e.setHeader("`{}` is not a valid type parameter name", nameStr);
+                e.addErrorNote("It may conflict with Sorbet's own namespace");
+            }
+        }
+
         absl::InlinedVector<pm_node_t *, 1> args{};
         if (rbsTypeParam->variance) {
             auto variance = rbsTypeParam->variance;

--- a/test/testdata/rbs/signatures_generics.rb
+++ b/test/testdata/rbs/signatures_generics.rb
@@ -27,7 +27,7 @@ module Errors
   end
 
   #: [T]
-  #   ^ error: `T` is not a valid type parameter name as it may conflict with Sorbet's own namespace
+  #   ^ error: `T` is not a valid type parameter name. It conflicts with Sorbet's own namespace
   class UnsupportedTypeParamName
   end
 end

--- a/test/testdata/rbs/signatures_generics.rb
+++ b/test/testdata/rbs/signatures_generics.rb
@@ -18,12 +18,17 @@ module Errors
   # ^^^ error: Failed to parse RBS type parameters (expected ',' or ']' after type parameter, got pEOF)
   class ParseError4; end
 
-  #: [unchecked T]
+  #: [unchecked A]
   #   ^^^^^^^^^^^ error: `unchecked` type parameters are not supported by Sorbet
   class UnsupportedError1; end
 
   class UselessSignature1 #: [U]
   #                       ^^^^^^ error: Unexpected RBS assertion comment found after `class` declaration
+  end
+
+  #: [T]
+  #   ^ error: `T` is not a valid type parameter name as it may conflict with Sorbet's own namespace
+  class UnsupportedTypeParamName
   end
 end
 
@@ -216,7 +221,7 @@ g16 = G14.new #: G14[MyModule::MyClass]
 T.reveal_type(g16) # error: Revealed type: `G14[MyModule::MyClass]`
 
 # Test deep copy with type parameter references
-#: [T, U]
+#: [A, U]
 class G17; end
 
 #: [X] (X) -> G17[X, X]

--- a/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
+++ b/test/testdata/rbs/signatures_generics.rb.rewrite-tree.exp
@@ -45,10 +45,14 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
 
     class <emptyTree>::<C UnsupportedError1><<C <todo sym>>> < (::<todo sym>)
-      <emptyTree>::<C T> = ::Sorbet::Private::Static.type_member()
+      <emptyTree>::<C A> = ::Sorbet::Private::Static.type_member()
     end
 
     class <emptyTree>::<C UselessSignature1><<C <todo sym>>> < (::<todo sym>)
+    end
+
+    class <emptyTree>::<C UnsupportedTypeParamName><<C <todo sym>>> < (::<todo sym>)
+      <emptyTree>::<C T> = ::Sorbet::Private::Static.type_member()
     end
   end
 
@@ -326,7 +330,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
   <emptyTree>::<C T>.reveal_type(g16)
 
   class <emptyTree>::<C G17><<C <todo sym>>> < (::<todo sym>)
-    <emptyTree>::<C T> = ::Sorbet::Private::Static.type_member()
+    <emptyTree>::<C A> = ::Sorbet::Private::Static.type_member()
 
     <emptyTree>::<C U> = ::Sorbet::Private::Static.type_member()
   end


### PR DESCRIPTION
Make `T` an invalid name for RBS generic type parameters.

### Motivation

When someone uses `T`, Tapioca will translate those into `T = type_member`, which then makes any references to `T` resolve to that member rather than Sorbet's module, causing incorrect RBI generation.

This is already [the recommendation](https://sorbet.org/docs/rbs-support#type-members:~:text=Note%3A%20do%20not%20name%20the%20type%20member%20T%20to%20avoid%20confusion%20with%20the%20T%20module%20from%20Sorbet), but without enforcement there's always a way to introduce it in the code that propagates errors in other places.

### Test plan

Added a new assertion for this.