### PR TITLE
Require `raise_on_nil_write: true` be used on `T.nilable` prop

### DIFF
--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -290,7 +290,15 @@ module T::Props::Serializable::DecoratorMethods
     end
 
     if rules[:raise_on_nil_write] && !rules[:_tnilable]
-      raise ArgumentError.new("`raise_on_nil_write` requires that the type of `#{name}` be `T.nilable(...)` (given: #{type})")
+      is_nilclass_parent = type.is_a?(T::Types::Simple) &&
+                           (type.raw_type.equal?(Object) || type.raw_type.equal?(BasicObject))
+      # Use `instance_of?` because modules can be mixed into NilClass, but classes cannot.
+      is_module = type.is_a?(T::Types::Simple) && type.raw_type.instance_of?(Module)
+      underspecified_type = type.equal?(T.untyped) || is_nilclass_parent || is_module
+
+      unless underspecified_type
+        raise ArgumentError.new("`raise_on_nil_write` requires that the type of `#{name}` be `T.nilable(...)` (given: #{type})")
+      end
     end
 
     result

--- a/gems/sorbet-runtime/lib/types/props/serializable.rb
+++ b/gems/sorbet-runtime/lib/types/props/serializable.rb
@@ -289,6 +289,10 @@ module T::Props::Serializable::DecoratorMethods
       raise ArgumentError.new("The value of `raise_on_nil_write` if specified must be `true` (given: #{rules[:raise_on_nil_write]}).")
     end
 
+    if rules[:raise_on_nil_write] && !rules[:_tnilable]
+      raise ArgumentError.new("`raise_on_nil_write` requires that the type of `#{name}` be `T.nilable(...)` (given: #{type})")
+    end
+
     result
   end
 

--- a/gems/sorbet-runtime/test/types/props/constructor.rb
+++ b/gems/sorbet-runtime/test/types/props/constructor.rb
@@ -478,7 +478,7 @@ class Opus::Types::Test::Props::ConstructorTest < Critic::Unit::UnitTest
   class NilFieldStruct < T::Struct
     prop :foo, T.nilable(Integer), raise_on_nil_write: true
     prop :bar, T.nilable(String), raise_on_nil_write: true
-    prop :required, String, raise_on_nil_write: true
+    prop :required, String
   end
 
   class UntypedStruct < T::Struct

--- a/gems/sorbet-runtime/test/types/props/serializable.rb
+++ b/gems/sorbet-runtime/test/types/props/serializable.rb
@@ -390,6 +390,26 @@ class Opus::Types::Test::Props::SerializableTest < Critic::Unit::UnitTest
       end
     end
 
+    it 'requires the prop type to be nilable' do
+      assert_prop_error(/requires that the type of `foo` be `T.nilable\(\.\.\.\)` \(given: String\)/) do
+        prop :foo, String, raise_on_nil_write: true
+      end
+
+      assert_prop_error(/requires that the type of `foo` be `T.nilable\(\.\.\.\)` \(given: NilClass\)/) do
+        prop :foo, NilClass, raise_on_nil_write: true
+      end
+    end
+
+    it 'allows underspecified prop types' do
+      Class.new do
+        include T::Props::Serializable
+        prop :untyped, T.untyped, raise_on_nil_write: true
+        prop :object, Object, raise_on_nil_write: true
+        prop :basic_object, BasicObject, raise_on_nil_write: true
+        prop :interface, Kernel, raise_on_nil_write: true
+      end
+    end
+
     it 'forbids nil in setter' do
       struct = NilFieldStruct.new(foo: 1, bar: 'something')
       ex = assert_raises(TypeError) do


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We have a wholesome test for this property at Stripe, which requires looping over all subclasses of `Serializable`. We shouldn't need that test—we can check this property at prop definition time more cheaply.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.