### PR TITLE
Do not ignore constant references for include/extend sends in method bodies

### DIFF
--- a/main/autogen/autogen.cc
+++ b/main/autogen/autogen.cc
@@ -33,7 +33,7 @@ class AutogenWalk {
     vector<NestingStackEntry> nestingStack;
     const AutogenConfig *autogenCfg;
 
-    enum class ScopeType { Class, Block };
+    enum class ScopeType { Class, Block, Method };
     vector<const ast::Send *> ignoring;
     vector<ScopeType> scopeTypes;
 
@@ -197,6 +197,14 @@ public:
 
         // remove the stuff added to handle the class scope here
         nestingStack.pop_back();
+        scopeTypes.pop_back();
+    }
+
+    void preTransformMethodDef(core::Context ctx, const ast::MethodDef &original) {
+        scopeTypes.emplace_back(ScopeType::Method);
+    }
+
+    void postTransformMethodDef(core::Context ctx, const ast::MethodDef &original) {
         scopeTypes.pop_back();
     }
 
@@ -378,10 +386,11 @@ public:
 
     void preTransformSend(core::Context ctx, const ast::Send &original) {
         bool inBlock = !scopeTypes.empty() && scopeTypes.back() == ScopeType::Block;
+        bool inMethod = !scopeTypes.empty() && scopeTypes.back() == ScopeType::Method;
         // Ignore include/extend sends iff they are directly at the class/module level.
         // These cases are handled in `preTransformClassDef`.
         // Do not ignore in block scope so that we a ref to the included module is still rendered.
-        if (!inBlock && original.recv.isSelfReference() &&
+        if (!inBlock && !inMethod && original.recv.isSelfReference() &&
             (original.fun == core::Names::include() || original.fun == core::Names::extend())) {
             ignoring.emplace_back(&original);
         }

--- a/test/testdata/autogen/hidden_include.rb.autogen.exp
+++ b/test/testdata/autogen/hidden_include.rb.autogen.exp
@@ -30,3 +30,10 @@ requires: []
  resolved=[B]
  loc=test/testdata/autogen/hidden_include.rb:5
  is_defining_ref=1
+[ref id=2]
+ scope=[B]
+ name=[A]
+ nesting=[[B]]
+ resolved=[A]
+ loc=test/testdata/autogen/hidden_include.rb:7
+ is_defining_ref=0


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
The DependencyDB is not reporting references to constants from `include`/`extend` calls inside method bodies. However, we currently do include them for blocks. This PR fixes that by copying how we track block scopes, but doing it for method bodies too. Then, we also do not ignore constant references if we are currently in a method body.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
This is a problem because our internal scripts end up with missing references.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

```
./bazel test //test:test_PosTests/testdata/autogen/hidden_include
```