### PR TITLE
LSP: Re-drive the diagnostics when a preempt fast makes a slow path stale

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -113,6 +113,22 @@ public:
     }
 };
 
+// Collects the names of the constants an indexed (pre-namer) tree assigns: static fields, type aliases, class aliases
+// and type members alike are all `Constant = ...` at this stage. The incremental namer deletes and re-enters those
+// symbols when it re-processes the file, so this is the set of names whose old symbols other trees may still hold.
+class ConstantDefinitionNames {
+    vector<core::WithoutUniqueNameHash> &names;
+
+public:
+    ConstantDefinitionNames(vector<core::WithoutUniqueNameHash> &names) : names(names) {}
+
+    void postTransformAssign(core::Context ctx, const ast::Assign &assign) {
+        if (auto lhs = ast::cast_tree<ast::UnresolvedConstantLit>(assign.lhs)) {
+            names.emplace_back(ctx.state, lhs->cnst);
+        }
+    }
+};
+
 } // namespace
 
 LSPTypechecker::LSPTypechecker(shared_ptr<const LSPConfiguration> config,
@@ -402,6 +418,19 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
         }
     }
 
+    const auto isPreemption = gs->epochManager->getStatus().slowPathRunning;
+    if (shouldRunIncrementalNamer && isPreemption) {
+        // The incremental namer is about to delete and re-enter every symbol these files define. The slow path we are
+        // preempting resolved its trees before that, so the ones mentioning these constants point at the symbols we
+        // are deleting; it re-derives those files' diagnostics once it is done typechecking (see
+        // `rederiveAfterPreemption`).
+        ConstantDefinitionNames collector(this->constantsRedefinedByPreemption);
+        for (auto &tree : updatedIndexed) {
+            core::Context ctx(*gs, core::Symbols::root(), tree.file);
+            ast::ConstTreeWalk::apply(ctx, collector, tree.tree);
+        }
+    }
+
     ENFORCE(gs->lspQuery.isEmpty());
     auto resolved = shouldRunIncrementalNamer
                         ? pipeline::incrementalResolve(*gs, move(updatedIndexed), std::move(oldFoundHashesForFiles),
@@ -426,7 +455,6 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
     } else {
         files = "...";
     }
-    auto isPreemption = gs->epochManager->getStatus().slowPathRunning;
     config->logger->debug(
         "Running fast path over num_files={} incrementalNamer={} preemption={} duration={} files=[{}]",
         toTypecheck.size(), shouldRunIncrementalNamer, isPreemption, duration.usec, files);
@@ -899,8 +927,15 @@ pair<bool, core::packages::Stratum> LSPTypechecker::runSlowPath(LSPFileUpdates &
             Exception::raise("Slow path failed to handle all expected preemptions");
         }
 
+        if (!this->constantsRedefinedByPreemption.empty() && !epochManager.wasTypecheckingCanceled()) {
+            this->rederiveAfterPreemption(epoch, workers, errorFlusher);
+        }
+
         return this->lastStratum;
     });
+
+    // Whether the slow path committed or was canceled, the trees it resolved are gone with it.
+    this->constantsRedefinedByPreemption.clear();
 
     if (mode == SlowPathMode::Init) {
         // TODO: if we start supporting preemption in the init path, we'll need to rethink what this boolean means.
@@ -928,6 +963,52 @@ pair<bool, core::packages::Stratum> LSPTypechecker::runSlowPath(LSPFileUpdates &
     }
 
     return {committed, startingStratum};
+}
+
+void LSPTypechecker::rederiveAfterPreemption(uint32_t epoch, WorkerPool &workers,
+                                             shared_ptr<core::ErrorFlusher> errorFlusher) {
+    ENFORCE(this_thread::get_id() == typecheckerThreadId, "Typechecker can only be used from the typechecker thread.");
+    Timer timeit(config->logger, "slow_path.rederive_after_preemption");
+
+    auto &names = this->constantsRedefinedByPreemption;
+    core::WithoutUniqueNameHash::sortAndDedupe(names);
+
+    vector<core::FileRef> stale;
+    for (auto fref : this->workspaceFiles) {
+        const auto &file = fref.data(*gs);
+        if (file.isPayload()) {
+            continue;
+        }
+
+        // Files the preempting fast path typechecked itself were reported under its (later) epoch and hold current
+        // symbols; the slow path would not report them either way.
+        if (!errorReporter->wouldReportForFile(epoch, fref)) {
+            continue;
+        }
+
+        const auto &hash = file.getFileHash();
+        if (hash == nullptr) {
+            continue;
+        }
+
+        if (core::WithoutUniqueNameHash::sortedIntersects(names, hash->usages.nameHashes)) {
+            stale.emplace_back(fref);
+        }
+    }
+
+    config->logger->debug("Re-deriving diagnostics for {} files whose trees may point at symbols a preempting fast "
+                          "path redefined ({} constant names)",
+                          stale.size(), names.size());
+    if (stale.empty()) {
+        return;
+    }
+
+    // A no-op update re-indexes and re-resolves these files against the symbol table as it stands now, and reports
+    // them under the slow path's own epoch, replacing whatever the stale trees produced.
+    auto noop = getNoopUpdate(stale);
+    const bool isNoopUpdateForRetypecheck = true;
+    runFastPath(*noop, workers, errorFlusher, isNoopUpdateForRetypecheck);
+    prodCounterAdd("lsp.slow_path.rederived_after_preemption", stale.size());
 }
 
 void LSPTypechecker::cacheUpdatedFiles(absl::Span<const ast::ParsedFile> indexed,

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -115,11 +115,11 @@ public:
 
 // Before namer runs, a static field, type alias, class alias and type member are all `Constant = ...`, which is
 // exactly the set the incremental namer deletes and re-enters.
-class ConstantDefinitionNames {
+class ConstantDefinitionFinder {
     vector<core::WithoutUniqueNameHash> &names;
 
 public:
-    ConstantDefinitionNames(vector<core::WithoutUniqueNameHash> &names) : names(names) {}
+    ConstantDefinitionFinder(vector<core::WithoutUniqueNameHash> &names) : names(names) {}
 
     void postTransformAssign(core::Context ctx, const ast::Assign &assign) {
         if (auto lhs = ast::cast_tree<ast::UnresolvedConstantLit>(assign.lhs)) {
@@ -418,14 +418,14 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
         }
     }
 
-    const auto isPreemption = gs->epochManager->getStatus().slowPathRunning;
+    auto isPreemption = gs->epochManager->getStatus().slowPathRunning;
     vector<core::WithoutUniqueNameHash> constantsRedefined;
     if (shouldRunIncrementalNamer && isPreemption) {
         // Collected before incrementalResolve deletes the old symbols, while the trees still name them.
-        ConstantDefinitionNames collector(constantsRedefined);
+        ConstantDefinitionFinder finder(constantsRedefined);
         for (auto &tree : updatedIndexed) {
             core::Context ctx(*gs, core::Symbols::root(), tree.file);
-            ast::ConstTreeWalk::apply(ctx, collector, tree.tree);
+            ast::ConstTreeWalk::apply(ctx, finder, tree.tree);
         }
     }
 
@@ -1001,7 +1001,7 @@ void LSPTypechecker::rederiveAfterPreemption(uint32_t epoch, WorkerPool &workers
 
     // A no-op update re-indexes and re-resolves against the symbol table as it now stands.
     auto noop = getNoopUpdate(stale);
-    const bool isNoopUpdateForRetypecheck = true;
+    bool isNoopUpdateForRetypecheck = true;
     runFastPath(*noop, workers, errorFlusher, isNoopUpdateForRetypecheck);
     prodCounterAdd("lsp.slow_path.rederived_after_preemption", stale.size());
 }

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -113,9 +113,8 @@ public:
     }
 };
 
-// Collects the names of the constants an indexed (pre-namer) tree assigns: static fields, type aliases, class aliases
-// and type members alike are all `Constant = ...` at this stage. The incremental namer deletes and re-enters those
-// symbols when it re-processes the file, so this is the set of names whose old symbols other trees may still hold.
+// Before namer runs, a static field, type alias, class alias and type member are all `Constant = ...`, which is
+// exactly the set the incremental namer deletes and re-enters.
 class ConstantDefinitionNames {
     vector<core::WithoutUniqueNameHash> &names;
 
@@ -234,6 +233,7 @@ bool LSPTypechecker::typecheck(unique_ptr<LSPFileUpdates> updates, WorkerPool &w
             auto result = runFastPath(*updates, workers, errorFlusher, isNoopUpdateForRetypecheck);
 
             filesTypechecked = move(result.filesTypechecked);
+            absl::c_move(result.constantsRedefined, back_inserter(this->constantsRedefinedByPreemption));
 
             ENFORCE(updates->updatedFiles.empty());
             ENFORCE(updates->updatedFileRefs.empty());
@@ -419,12 +419,10 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
     }
 
     const auto isPreemption = gs->epochManager->getStatus().slowPathRunning;
+    vector<core::WithoutUniqueNameHash> constantsRedefined;
     if (shouldRunIncrementalNamer && isPreemption) {
-        // The incremental namer is about to delete and re-enter every symbol these files define. The slow path we are
-        // preempting resolved its trees before that, so the ones mentioning these constants point at the symbols we
-        // are deleting; it re-derives those files' diagnostics once it is done typechecking (see
-        // `rederiveAfterPreemption`).
-        ConstantDefinitionNames collector(this->constantsRedefinedByPreemption);
+        // Collected before incrementalResolve deletes the old symbols, while the trees still name them.
+        ConstantDefinitionNames collector(constantsRedefined);
         for (auto &tree : updatedIndexed) {
             core::Context ctx(*gs, core::Symbols::root(), tree.file);
             ast::ConstTreeWalk::apply(ctx, collector, tree.tree);
@@ -459,7 +457,7 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
         "Running fast path over num_files={} incrementalNamer={} preemption={} duration={} files=[{}]",
         toTypecheck.size(), shouldRunIncrementalNamer, isPreemption, duration.usec, files);
 
-    return FastPathResult{move(toTypecheck), move(toCache)};
+    return FastPathResult{move(toTypecheck), move(toCache), move(constantsRedefined)};
 }
 
 namespace {
@@ -934,7 +932,7 @@ pair<bool, core::packages::Stratum> LSPTypechecker::runSlowPath(LSPFileUpdates &
         return this->lastStratum;
     });
 
-    // Whether the slow path committed or was canceled, the trees it resolved are gone with it.
+    // Cleared on cancellation too: the next slow path re-resolves from scratch.
     this->constantsRedefinedByPreemption.clear();
 
     if (mode == SlowPathMode::Init) {
@@ -980,8 +978,7 @@ void LSPTypechecker::rederiveAfterPreemption(uint32_t epoch, WorkerPool &workers
             continue;
         }
 
-        // Files the preempting fast path typechecked itself were reported under its (later) epoch and hold current
-        // symbols; the slow path would not report them either way.
+        // The preempting fast path reported its own files under a later epoch, and they hold current symbols.
         if (!errorReporter->wouldReportForFile(epoch, fref)) {
             continue;
         }
@@ -996,15 +993,13 @@ void LSPTypechecker::rederiveAfterPreemption(uint32_t epoch, WorkerPool &workers
         }
     }
 
-    config->logger->debug("Re-deriving diagnostics for {} files whose trees may point at symbols a preempting fast "
-                          "path redefined ({} constant names)",
-                          stale.size(), names.size());
+    config->logger->debug("Re-deriving diagnostics for {} files over {} redefined constants", stale.size(),
+                          names.size());
     if (stale.empty()) {
         return;
     }
 
-    // A no-op update re-indexes and re-resolves these files against the symbol table as it stands now, and reports
-    // them under the slow path's own epoch, replacing whatever the stale trees produced.
+    // A no-op update re-indexes and re-resolves against the symbol table as it now stands.
     auto noop = getNoopUpdate(stale);
     const bool isNoopUpdateForRetypecheck = true;
     runFastPath(*noop, workers, errorFlusher, isNoopUpdateForRetypecheck);

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -107,13 +107,10 @@ class LSPTypechecker final {
     core::packages::Stratum lastStratum;
 
     /**
-     * Names of the constants (static fields, type aliases, type members) that fast paths preempting the running slow
-     * path deleted and re-entered through the incremental namer. The slow path resolves a whole stratum before it
-     * typechecks any of it, so trees it resolved before such a preemption still point at the deleted symbols; the files
-     * that mention these names get their diagnostics re-derived from freshly resolved trees before the slow path
-     * commits. Mutable because runFastPath is const.
+     * Constants that fast paths preempting the running slow path have re-entered, so that the trees the slow path
+     * resolved earlier still point at the symbols they replaced. Emptied by the slow path that consumes it.
      */
-    mutable std::vector<core::WithoutUniqueNameHash> constantsRedefinedByPreemption;
+    std::vector<core::WithoutUniqueNameHash> constantsRedefinedByPreemption;
 
     enum class SlowPathMode {
         Init,
@@ -121,9 +118,8 @@ class LSPTypechecker final {
     };
 
     /**
-     * Retypechecks, from freshly indexed and resolved trees, every file whose usages mention a constant in
-     * `constantsRedefinedByPreemption`, reporting under the slow path's `epoch`. Files a later epoch already reported
-     * (the preempting fast path's own files) are left alone.
+     * Retypechecks every file whose usages mention `constantsRedefinedByPreemption` from freshly resolved trees,
+     * reporting under the slow path's `epoch`. Files a later epoch already reported are left alone.
      */
     void rederiveAfterPreemption(uint32_t epoch, WorkerPool &workers, std::shared_ptr<core::ErrorFlusher> errorFlusher);
 
@@ -140,6 +136,9 @@ class LSPTypechecker final {
 
         // Copies of the indexed trees that were updated during the fast path, for updating the cache of open files.
         std::vector<ast::ParsedFile> indexedTrees;
+
+        // Non-empty only when this run preempted a slow path and re-entered constants out from under its trees.
+        std::vector<core::WithoutUniqueNameHash> constantsRedefined;
     };
 
     /** Runs incremental typechecking on the provided updates. Returns the final list of files typechecked. */

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -107,8 +107,8 @@ class LSPTypechecker final {
     core::packages::Stratum lastStratum;
 
     /**
-     * Constants that fast paths preempting the running slow path have re-entered, so that the trees the slow path
-     * resolved earlier still point at the symbols they replaced. Emptied by the slow path that consumes it.
+     * Constants that fast paths preempting the running slow path have deleted and re-entered. The trees the slow path
+     * resolved earlier still point at the deleted symbols. Emptied by the slow path that consumes it.
      */
     std::vector<core::WithoutUniqueNameHash> constantsRedefinedByPreemption;
 
@@ -117,18 +117,18 @@ class LSPTypechecker final {
         Cancelable,
     };
 
-    /**
-     * Retypechecks every file whose usages mention `constantsRedefinedByPreemption` from freshly resolved trees,
-     * reporting under the slow path's `epoch`. Files a later epoch already reported are left alone.
-     */
-    void rederiveAfterPreemption(uint32_t epoch, WorkerPool &workers, std::shared_ptr<core::ErrorFlusher> errorFlusher);
-
     /** Conservatively reruns entire pipeline without caching any trees. Returns 'true' if committed, 'false' if
      * canceled. */
     std::pair<bool, core::packages::Stratum> runSlowPath(LSPFileUpdates &updates, KVStoreStrategy &kvstore,
                                                          WorkerPool &workers,
                                                          std::shared_ptr<core::ErrorFlusher> errorFlusher,
                                                          SlowPathMode mode);
+
+    /**
+     * Retypechecks every file whose usages mention `constantsRedefinedByPreemption` from freshly resolved trees,
+     * reporting under the slow path's `epoch`.
+     */
+    void rederiveAfterPreemption(uint32_t epoch, WorkerPool &workers, std::shared_ptr<core::ErrorFlusher> errorFlusher);
 
     struct FastPathResult {
         // All of the files that we typechecked during the fast path.

--- a/main/lsp/LSPTypechecker.h
+++ b/main/lsp/LSPTypechecker.h
@@ -106,10 +106,26 @@ class LSPTypechecker final {
 
     core::packages::Stratum lastStratum;
 
+    /**
+     * Names of the constants (static fields, type aliases, type members) that fast paths preempting the running slow
+     * path deleted and re-entered through the incremental namer. The slow path resolves a whole stratum before it
+     * typechecks any of it, so trees it resolved before such a preemption still point at the deleted symbols; the files
+     * that mention these names get their diagnostics re-derived from freshly resolved trees before the slow path
+     * commits. Mutable because runFastPath is const.
+     */
+    mutable std::vector<core::WithoutUniqueNameHash> constantsRedefinedByPreemption;
+
     enum class SlowPathMode {
         Init,
         Cancelable,
     };
+
+    /**
+     * Retypechecks, from freshly indexed and resolved trees, every file whose usages mention a constant in
+     * `constantsRedefinedByPreemption`, reporting under the slow path's `epoch`. Files a later epoch already reported
+     * (the preempting fast path's own files) are left alone.
+     */
+    void rederiveAfterPreemption(uint32_t epoch, WorkerPool &workers, std::shared_ptr<core::ErrorFlusher> errorFlusher);
 
     /** Conservatively reruns entire pipeline without caching any trees. Returns 'true' if committed, 'false' if
      * canceled. */

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -707,6 +707,66 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanPreemptSlowPathWithFastPathAndB
                          /* assertUniqueStartTimes */ false);
 }
 
+TEST_CASE_FIXTURE(MultithreadedProtocolTest, "PreemptingFastPathWithIncrementalNamerDoesNotLeaveSlowPathPhantoms") {
+    auto initOptions = make_unique<SorbetInitializationOptions>();
+    initOptions->enableTypecheckInfo = true;
+    assertErrorDiagnostics(
+        initializeLSP(true /* supportsMarkdown */, true /* supportsCodeActionResolve */, move(initOptions)), {});
+
+    // foo.rb defines a constant and a method. bar.rb reads the constant but never mentions the method's name, so a
+    // change to the method's signature does not make bar.rb one of the fast path's extra files.
+    assertErrorDiagnostics(send(*openFile("foo.rb", "# typed: true\n"
+                                                    "class Foo\n"
+                                                    "  extend T::Sig\n"
+                                                    "  CONST = T.let(1, T.nilable(Integer))\n"
+                                                    "  sig {returns(Integer)}\n"
+                                                    "  def method_only_in_foo\n"
+                                                    "    1\n"
+                                                    "  end\n"
+                                                    "end\n")),
+                           {});
+    assertErrorDiagnostics(send(*openFile("bar.rb", "# typed: strict\n"
+                                                    "class Bar\n"
+                                                    "  extend T::Sig\n"
+                                                    "  sig {returns(Integer)}\n"
+                                                    "  def use_const\n"
+                                                    "    T.must(Foo::CONST)\n"
+                                                    "  end\n"
+                                                    "end\n")),
+                           {});
+    assertErrorDiagnostics(send(*openFile("baz.rb", "# typed: true\nclass Baz\nend\n")), {});
+
+    // Slow path: baz.rb gains a class. The slow path resolves every file (bar.rb's tree now points at the
+    // `Foo::CONST` symbol) and then waits for one preemption before typechecking.
+    sendAsync(*changeFile("baz.rb", "# typed: true\nclass Baz\nend\nclass Qux\nend\n", 2, false, 1));
+
+    // Wait for typechecking to begin to avoid races.
+    {
+        auto status = getTypecheckRunStatus(*readAsync());
+        REQUIRE(status.has_value());
+        REQUIRE_EQ(*status, SorbetTypecheckRunStatus::Started);
+    }
+
+    // Fast path [preempt]: change the signature of Foo#method_only_in_foo. This runs the incremental namer, which
+    // deletes and re-enters every symbol foo.rb defines -- including `Foo::CONST`, whose old symbol is what bar.rb's
+    // already-resolved tree refers to.
+    sendAsync(*changeFile("foo.rb",
+                          "# typed: true\n"
+                          "class Foo\n"
+                          "  extend T::Sig\n"
+                          "  CONST = T.let(1, T.nilable(Integer))\n"
+                          "  sig {returns(String)}\n"
+                          "  def method_only_in_foo\n"
+                          "    'one'\n"
+                          "  end\n"
+                          "end\n",
+                          3));
+
+    // When the slow path resumes and typechecks bar.rb, `Foo::CONST` must still be `T.nilable(Integer)`; a stale
+    // symbol would make it `T.untyped` and produce a `T.must` is redundant error out of thin air.
+    assertErrorDiagnostics(send(LSPMessage(make_unique<NotificationMessage>("2.0", LSPMethod::SorbetFence, 20))), {});
+}
+
 TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanCancelSlowPathWithFastPathThatReintroducesOldError") {
     auto initOptions = make_unique<SorbetInitializationOptions>();
     initOptions->enableTypecheckInfo = true;

--- a/test/lsp/multithreaded_protocol_test_corpus.cc
+++ b/test/lsp/multithreaded_protocol_test_corpus.cc
@@ -707,14 +707,14 @@ TEST_CASE_FIXTURE(MultithreadedProtocolTest, "CanPreemptSlowPathWithFastPathAndB
                          /* assertUniqueStartTimes */ false);
 }
 
-TEST_CASE_FIXTURE(MultithreadedProtocolTest, "PreemptingFastPathWithIncrementalNamerDoesNotLeaveSlowPathPhantoms") {
+TEST_CASE_FIXTURE(MultithreadedProtocolTest, "PreemptingFastPathWithIncrementalNamerDoesNotReportStaleErrors") {
     auto initOptions = make_unique<SorbetInitializationOptions>();
     initOptions->enableTypecheckInfo = true;
     assertErrorDiagnostics(
         initializeLSP(true /* supportsMarkdown */, true /* supportsCodeActionResolve */, move(initOptions)), {});
 
-    // foo.rb defines a constant and a method. bar.rb reads the constant but never mentions the method's name, so a
-    // change to the method's signature does not make bar.rb one of the fast path's extra files.
+    // bar.rb reads `Foo::CONST` but never mentions `method_only_in_foo`, so changing that method's sig does not make
+    // bar.rb one of the fast path's extra files.
     assertErrorDiagnostics(send(*openFile("foo.rb", "# typed: true\n"
                                                     "class Foo\n"
                                                     "  extend T::Sig\n"


### PR DESCRIPTION
### Summary
r?

A preempted slow path can publish diagnostics for files which nobody edited, and they don't actually get retracted. At least in the case I ran into it, it showed up as things like a `T.must` being flagged as incorrect when it wasn't.

The slow path resolves a set before typechecking, and a fast path can preempt between that. If the preemption edit changes a method sig (or anything else that runs an incremental pass), then the namer deletes and re-enters every symbol in the files it renames, including constants which weren't touched.

Nothing would re-drive a file in those cases, since they are not part of the preempting edit's extra files, and a later watchman would drop it as a no-op edit which was due to #10606 fixing other bugs. Sorry @elliottt  😅 

The change is to have `runFastPath` record when it preempts a slow path with the files it re-names. After the slow path finishes, `rederiveAfterPreemption` re-indexes/resolves all the remaining workspace files from the premption pass.

It looks like this is a fairly rare occurrence, about 1 out of 115 other preemptions I had logged but also seems worth fixing since the only way to resolve it is to restart the LSP.

Fleet extent was one occurrence across 115 other preempted epochs, so this is real but rare. It is worth fixing rather than tolerating because the phantom persists until the affected file is edited, and the only reliable clearing action a developer has is a full cold reboot of the language server.
