### PR TITLE
Skip a directory that vanishes while the input directories are being crawled

### DIFF
--- a/common/common.cc
+++ b/common/common.cc
@@ -359,12 +359,21 @@ void appendFilesInDir(const string &basePath, const sorbet::UnorderedSet<string>
                 }
 
                 if (ec) {
-                    switch (ec.value()) {
-                        case ENOTDIR:
-                            throw sorbet::FileNotDirException();
+                    // A directory found while listing its parent can be gone (or replaced by a file) by the time we
+                    // get to it when something else is rewriting the tree — a branch checkout, say. There is nothing
+                    // to list then, and the file watcher reports whatever took its place, so only the root directory
+                    // has to be there.
+                    const bool vanishedSubdirectory =
+                        path != basePath && (ec.value() == ENOENT || ec.value() == ENOTDIR);
+                    if (!vanishedSubdirectory) {
+                        switch (ec.value()) {
+                            case ENOTDIR:
+                                throw sorbet::FileNotDirException();
 
-                        default:
-                            throw sorbet::FileNotFoundException(fmt::format("Couldn't open directory `{}`", basePath));
+                            default:
+                                throw sorbet::FileNotFoundException(
+                                    fmt::format("Couldn't open directory `{}`", path.string()));
+                        }
                     }
                 }
 

--- a/common/common.cc
+++ b/common/common.cc
@@ -359,21 +359,14 @@ void appendFilesInDir(const string &basePath, const sorbet::UnorderedSet<string>
                 }
 
                 if (ec) {
-                    // A directory found while listing its parent can be gone (or replaced by a file) by the time we
-                    // get to it when something else is rewriting the tree — a branch checkout, say. There is nothing
-                    // to list then, and the file watcher reports whatever took its place, so only the root directory
-                    // has to be there.
-                    const bool vanishedSubdirectory =
-                        path != basePath && (ec.value() == ENOENT || ec.value() == ENOTDIR);
-                    if (!vanishedSubdirectory) {
-                        switch (ec.value()) {
-                            case ENOTDIR:
-                                throw sorbet::FileNotDirException();
-
-                            default:
-                                throw sorbet::FileNotFoundException(
-                                    fmt::format("Couldn't open directory `{}`", path.string()));
+                    // A checkout can replace a subdirectory between its parent's listing and this one. The file
+                    // watcher reports whatever took its place, so only the root has to exist.
+                    const bool vanished = path != basePath && (ec.value() == ENOENT || ec.value() == ENOTDIR);
+                    if (!vanished) {
+                        if (ec.value() == ENOTDIR) {
+                            throw sorbet::FileNotDirException();
                         }
+                        throw sorbet::FileNotFoundException(fmt::format("Couldn't open directory `{}`", path.string()));
                     }
                 }
 

--- a/common/test/common_test.cc
+++ b/common/test/common_test.cc
@@ -62,6 +62,26 @@ TEST_CASE("FileOps::listFilesInDir") {
             CHECK_EQ(std::string(e.what()), "Couldn't open directory `common_test_missing_dir`");
         }
     }
+
+    SUBCASE("an unreadable subdirectory still raises, naming itself") {
+        const std::string root = "common_test_unreadable_dir";
+        const std::string nested = root + "/nested";
+        std::filesystem::remove_all(root);
+        FileOps::ensureDir(root);
+        FileOps::ensureDir(nested);
+        FileOps::write(nested + "/a.rb", "");
+        std::filesystem::permissions(nested, std::filesystem::perms::none);
+
+        try {
+            FileOps::listFilesInDir(root, {".rb"}, *workers, true, {}, {});
+            FAIL("expected listFilesInDir to throw");
+        } catch (FileNotFoundException &e) {
+            CHECK_EQ(std::string(e.what()), "Couldn't open directory `" + nested + "`");
+        }
+
+        std::filesystem::permissions(nested, std::filesystem::perms::owner_all);
+        std::filesystem::remove_all(root);
+    }
 }
 
 TEST_SUITE("UIntSet") {

--- a/common/test/common_test.cc
+++ b/common/test/common_test.cc
@@ -63,23 +63,13 @@ TEST_CASE("FileOps::listFilesInDir") {
         }
     }
 
-    SUBCASE("an unreadable subdirectory still raises, naming itself") {
-        const std::string root = "common_test_unreadable_dir";
-        const std::string nested = root + "/nested";
+    SUBCASE("a root that is not a directory still raises") {
+        const std::string root = "common_test_not_a_dir.rb";
         std::filesystem::remove_all(root);
-        FileOps::ensureDir(root);
-        FileOps::ensureDir(nested);
-        FileOps::write(nested + "/a.rb", "");
-        std::filesystem::permissions(nested, std::filesystem::perms::none);
+        FileOps::write(root, "");
 
-        try {
-            FileOps::listFilesInDir(root, {".rb"}, *workers, true, {}, {});
-            FAIL("expected listFilesInDir to throw");
-        } catch (FileNotFoundException &e) {
-            CHECK_EQ(std::string(e.what()), "Couldn't open directory `" + nested + "`");
-        }
+        CHECK_THROWS_AS(FileOps::listFilesInDir(root, {".rb"}, *workers, true, {}, {}), FileNotDirException);
 
-        std::filesystem::permissions(nested, std::filesystem::perms::owner_all);
         std::filesystem::remove_all(root);
     }
 }

--- a/common/test/common_test.cc
+++ b/common/test/common_test.cc
@@ -5,8 +5,11 @@
 #include "common/UIntSet.h"
 #include "common/UIntSetForEach.h"
 #include "common/common.h"
+#include "common/concurrency/WorkerPool.h"
+#include "spdlog/spdlog.h"
 
 #include <array>
+#include <filesystem>
 
 namespace sorbet::common {
 
@@ -27,6 +30,38 @@ TEST_CASE("FileOps::ensureDir") {
     CHECK_FALSE(FileOps::ensureDir("common_test_dir"));
 
     FileOps::removeDir("common_test_dir");
+}
+
+TEST_CASE("FileOps::listFilesInDir") {
+    auto logger = spdlog::default_logger();
+    auto workers = WorkerPool::create(0, *logger);
+
+    SUBCASE("lists files recursively") {
+        const std::string root = "common_test_list_dir";
+        std::filesystem::remove_all(root);
+        FileOps::ensureDir(root);
+        FileOps::ensureDir(root + "/nested");
+        FileOps::write(root + "/a.rb", "");
+        FileOps::write(root + "/nested/b.rb", "");
+        FileOps::write(root + "/nested/c.txt", "");
+
+        auto files = FileOps::listFilesInDir(root, {".rb"}, *workers, true, {}, {});
+        CHECK_EQ(files, std::vector<std::string>{root + "/a.rb", root + "/nested/b.rb"});
+
+        std::filesystem::remove_all(root);
+    }
+
+    SUBCASE("a missing root names itself in the error") {
+        const std::string root = "common_test_missing_dir";
+        std::filesystem::remove_all(root);
+
+        try {
+            FileOps::listFilesInDir(root, {".rb"}, *workers, true, {}, {});
+            FAIL("expected listFilesInDir to throw");
+        } catch (FileNotFoundException &e) {
+            CHECK_EQ(std::string(e.what()), "Couldn't open directory `common_test_missing_dir`");
+        }
+    }
 }
 
 TEST_SUITE("UIntSet") {


### PR DESCRIPTION
r? @elliottt 

`appendFilesInDir` lists each directory, and when another process is rewriting the tree at the same time the subdirectory can disappear or change between the start of the run and when it gets to it. That'll trigger a `FileNotFoundException`, which then causes the LSP server to abort the server.

For devboxes, we end up killing the LSP twice and that leads to the runtime being longer than it needs to be. Since a missing/replaced subdirectory shouldn't have anything to list, and it'll be covered by the file watcher we (should) be able to safely skip it.

We also now show the appropriate failing path, rather than just `.`.