### PR TITLE
Move "cannot be referenced in a non-test file" to reasons

### DIFF
--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -585,8 +585,8 @@ public:
             path = pkg.pathTo(ctx, thisPkg.mangledName());
             causesCycle = strictDepsLevel >= core::packages::StrictDependenciesLevel::LayeredDag && path.has_value();
         }
-        bool hasModularityError =
-            layeringViolation || strictDependenciesTooLow || causesCycle || badTestReference || causesVisibilityError || testNamespaceInProd;
+        bool hasModularityError = layeringViolation || strictDependenciesTooLow || causesCycle || badTestReference ||
+                                  causesVisibilityError || testNamespaceInProd;
         // visible_to errors are handled separately (by `updateVisibilityFor`),
         // so they're not included in this causesModularityError field of referencedPackages
         bool causesModularityError = hasModularityError && !causesVisibilityError;
@@ -628,11 +628,11 @@ public:
         } else {
             // TODO(neil): Provide actionable advice and/or link to a doc that would help the user resolve these
             // layering/strict_dependencies issues.
-            auto error = causesCycle         ? core::errors::Packager::StrictDependenciesViolation
-                         : layeringViolation ? core::errors::Packager::LayeringViolation
-                         : badTestReference  ? core::errors::Packager::TestImportMismatch
+            auto error = causesCycle           ? core::errors::Packager::StrictDependenciesViolation
+                         : layeringViolation   ? core::errors::Packager::LayeringViolation
+                         : badTestReference    ? core::errors::Packager::TestImportMismatch
                          : testNamespaceInProd ? core::errors::Packager::UsedTestOnlyName
-                                             : core::errors::Packager::StrictDependenciesViolation;
+                                               : core::errors::Packager::StrictDependenciesViolation;
             if (auto e = ctx.beginError(errLoc, error)) {
                 vector<string> reasons;
                 e.addErrorLine(thisPkg.declLoc(), "Enclosing package declared here");
@@ -720,11 +720,11 @@ public:
                 }
                 e.setHeader("`{}` cannot be referenced here because {}", litSymbol.show(ctx), reason);
                 if (!testNamespaceInProd) {
-                if (!wasImported) {
-                    e.addErrorNote("`{}`'s package is not imported", litSymbol.show(ctx));
-                } else if (testImportInProd || testUnitImportInHelper) {
-                    e.addErrorNote("`{}`'s package is imported as `{}`", litSymbol.show(ctx), "test_import");
-                }
+                    if (!wasImported) {
+                        e.addErrorNote("`{}`'s package is not imported", litSymbol.show(ctx));
+                    } else if (testImportInProd || testUnitImportInHelper) {
+                        e.addErrorNote("`{}`'s package is imported as `{}`", litSymbol.show(ctx), "test_import");
+                    }
                 }
             }
         }
@@ -766,7 +766,8 @@ public:
 
         // If the imported symbol comes from the test namespace, we must also be in the test namespace.
         // TODO(trevor): this check is redundant with import checking after the test-packages migration is complete.
-        bool testNamespaceInProd = !pkg.usesTestPackages &&
+        bool testNamespaceInProd =
+            !pkg.usesTestPackages &&
             (otherFile.data(ctx).isPackagedTestHelper() || otherFile.data(ctx).isPackagedTest()) &&
             !ctx.file.data(ctx).isPackagedTest();
 

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -552,7 +552,7 @@ public:
     static bool reportImportError(core::Context ctx, const core::packages::PackageInfo &thisPkg,
                                   const core::packages::PackageInfo &pkg, core::LocOffsets errLoc,
                                   core::SymbolRef litSymbol, core::FileRef otherFile, bool wasImported,
-                                  bool testImportInProd, bool testUnitImportInHelper) {
+                                  bool testImportInProd, bool testUnitImportInHelper, bool testNamespaceInProd) {
         auto &db = ctx.state.packageDB();
         auto otherPackage = pkg.mangledName();
         bool isTestImport = otherFile.data(ctx).isPackagedTestHelper() || ctx.file.data(ctx).isPackagedTest();
@@ -586,7 +586,7 @@ public:
             causesCycle = strictDepsLevel >= core::packages::StrictDependenciesLevel::LayeredDag && path.has_value();
         }
         bool hasModularityError =
-            layeringViolation || strictDependenciesTooLow || causesCycle || badTestReference || causesVisibilityError;
+            layeringViolation || strictDependenciesTooLow || causesCycle || badTestReference || causesVisibilityError || testNamespaceInProd;
         // visible_to errors are handled separately (by `updateVisibilityFor`),
         // so they're not included in this causesModularityError field of referencedPackages
         bool causesModularityError = hasModularityError && !causesVisibilityError;
@@ -631,6 +631,7 @@ public:
             auto error = causesCycle         ? core::errors::Packager::StrictDependenciesViolation
                          : layeringViolation ? core::errors::Packager::LayeringViolation
                          : badTestReference  ? core::errors::Packager::TestImportMismatch
+                         : testNamespaceInProd ? core::errors::Packager::UsedTestOnlyName
                                              : core::errors::Packager::StrictDependenciesViolation;
             if (auto e = ctx.beginError(errLoc, error)) {
                 vector<string> reasons;
@@ -649,6 +650,10 @@ public:
                     reasons.emplace_back(
                         core::ErrorColors::format("`{}` may not reference `{}` packages", thisPkg.show(ctx), "test!"));
                     e.addErrorLine(pkg.declLoc(), "Referenced `{}` package defined here", "test!");
+                }
+                if (testNamespaceInProd) {
+                    reasons.emplace_back(
+                        "it is defined in a test namespace and cannot be referenced in a non-test file");
                 }
                 if (causesCycle) {
                     reasons.emplace_back(core::ErrorColors::format("importing its package would put `{}` into a cycle",
@@ -707,14 +712,19 @@ public:
                 } else if (reasons.size() == 5) {
                     reason = fmt::format("{}, {}, {}, {}, and {}", reasons[0], reasons[1], reasons[2], reasons[3],
                                          reasons[4]);
+                } else if (reasons.size() == 6) {
+                    reason = fmt::format("{}, {}, {}, {}, {}, and {}", reasons[0], reasons[1], reasons[2], reasons[3],
+                                         reasons[4], reasons[5]);
                 } else {
-                    ENFORCE(false, "At most five reasons should be present");
+                    ENFORCE(false, "At most six reasons should be present");
                 }
                 e.setHeader("`{}` cannot be referenced here because {}", litSymbol.show(ctx), reason);
+                if (!testNamespaceInProd) {
                 if (!wasImported) {
                     e.addErrorNote("`{}`'s package is not imported", litSymbol.show(ctx));
                 } else if (testImportInProd || testUnitImportInHelper) {
                     e.addErrorNote("`{}`'s package is imported as `{}`", litSymbol.show(ctx), "test_import");
+                }
                 }
             }
         }
@@ -756,15 +766,9 @@ public:
 
         // If the imported symbol comes from the test namespace, we must also be in the test namespace.
         // TODO(trevor): this check is redundant with import checking after the test-packages migration is complete.
-        if (!pkg.usesTestPackages &&
+        bool testNamespaceInProd = !pkg.usesTestPackages &&
             (otherFile.data(ctx).isPackagedTestHelper() || otherFile.data(ctx).isPackagedTest()) &&
-            !ctx.file.data(ctx).isPackagedTest()) {
-            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
-                e.setHeader("`{}` is defined in a test namespace and cannot be referenced in a non-test file",
-                            litSymbol.show(ctx));
-            }
-            return;
-        }
+            !ctx.file.data(ctx).isPackagedTest();
 
         auto *import = this->package.importsPackage(otherPackage);
         auto wasImported = import != nullptr;
@@ -781,10 +785,10 @@ public:
         bool importNeeded = !wasImported || testImportInProd || testUnitImportInHelper;
         referencedPackages[otherPackage] = {.importNeeded = importNeeded, .causesModularityError = false};
 
-        if (importNeeded) {
+        if (importNeeded || testNamespaceInProd) {
             referencedPackages[otherPackage].causesModularityError =
                 reportImportError(ctx, this->package, pkg, lit.loc(), litSymbol, otherFile, wasImported,
-                                  testImportInProd, testUnitImportInHelper);
+                                  testImportInProd, testUnitImportInHelper, testNamespaceInProd);
             return;
         }
 

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -575,7 +575,7 @@ public:
         bool causesVisibilityError = !pkg.isVisibleTo(ctx, thisPkg, autocorrectedImportType);
         bool badTestReference = thisPkg.usesTestPackages && pkg.testPackage() && !thisPkg.testPackage();
         optional<string> path;
-        if (!isTestImport && db.enforceLayering()) {
+        if (!isTestImport && !testNamespaceInProd && db.enforceLayering()) {
             layeringViolation = strictDepsLevel > core::packages::StrictDependenciesLevel::False &&
                                 thisPkg.causesLayeringViolation(db, pkg);
             strictDependenciesTooLow = importStrictDepsLevel != core::packages::StrictDependenciesLevel::None &&

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -56,9 +56,12 @@ use_other_package/foo.rb:15: `Foo::Bar::OtherPackage::OtherClass` resolves but i
      7 |  strict_dependencies 'layered'
                                        ^
 
-use_other_package/foo.rb:18: `Test::Foo::Bar::OtherPackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+use_other_package/foo.rb:18: `Test::Foo::Bar::OtherPackage::TestUtil` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
     18 |  Test::Foo::Bar::OtherPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_other_package/__package.rb:5: Enclosing package declared here
+     5 |class Foo::MyPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 use_other_package/foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::OtherPackage::TestUtil
@@ -119,9 +122,12 @@ use_app_package/foo.rb:7: `Foo::Bar::AppPackageTest::OtherClass` cannot be refer
   Note:
     `Foo::Bar::AppPackageTest::OtherClass`'s package is imported as `test_import`
 
-use_app_package/foo.rb:13: `Test::Foo::Bar::AppPackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+use_app_package/foo.rb:13: `Test::Foo::Bar::AppPackage::TestUtil` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
     13 |  Test::Foo::Bar::AppPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_app_package/__package.rb:5: Enclosing package declared here
+     5 |class Foo::MyPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 use_app_package/foo.test.rb:6: `Foo::Bar::AppPackage::ImportMeTestOnly` resolves but its package is not imported https://srb.help/3718
      6 |  Foo::Bar::AppPackage::ImportMeTestOnly
@@ -171,9 +177,12 @@ use_false_package/foo.rb:7: `Foo::Bar::FalsePackageTest::OtherClass` cannot be r
   Note:
     `Foo::Bar::FalsePackageTest::OtherClass`'s package is imported as `test_import`
 
-use_false_package/foo.rb:13: `Test::Foo::Bar::FalsePackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+use_false_package/foo.rb:13: `Test::Foo::Bar::FalsePackage::TestUtil` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
     13 |  Test::Foo::Bar::FalsePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_false_package/__package.rb:5: Enclosing package declared here
+     5 |class Foo::MyPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 use_false_package/foo.test.rb:4: `Test::Foo::Bar::FalsePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalsePackage::TestUtil
@@ -229,9 +238,12 @@ use_false_and_app_package/foo.rb:7: `Foo::Bar::FalseAndAppPackageTest::OtherClas
   Note:
     `Foo::Bar::FalseAndAppPackageTest::OtherClass`'s package is imported as `test_import`
 
-use_false_and_app_package/foo.rb:13: `Test::Foo::Bar::FalseAndAppPackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+use_false_and_app_package/foo.rb:13: `Test::Foo::Bar::FalseAndAppPackage::TestUtil` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
     13 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_false_and_app_package/__package.rb:5: Enclosing package declared here
+     5 |class Foo::MyPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 use_false_and_app_package/foo.test.rb:4: `Test::Foo::Bar::FalseAndAppPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
@@ -291,9 +303,12 @@ use_cycle_package/foo.rb:7: `Foo::Bar::CyclePackageTest::OtherClass` cannot be r
   Note:
     `Foo::Bar::CyclePackageTest::OtherClass`'s package is imported as `test_import`
 
-use_cycle_package/foo.rb:13: `Test::Foo::Bar::CyclePackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+use_cycle_package/foo.rb:13: `Test::Foo::Bar::CyclePackage::TestUtil` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
     13 |  Test::Foo::Bar::CyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_cycle_package/__package.rb:5: Enclosing package declared here
+     5 |class Foo::MyPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 use_cycle_package/foo.test.rb:4: `Test::Foo::Bar::CyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::CyclePackage::TestUtil
@@ -359,9 +374,12 @@ use_app_cycle_package/foo.rb:7: `Foo::Bar::AppCyclePackageTest::OtherClass` cann
   Note:
     `Foo::Bar::AppCyclePackageTest::OtherClass`'s package is imported as `test_import`
 
-use_app_cycle_package/foo.rb:13: `Test::Foo::Bar::AppCyclePackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+use_app_cycle_package/foo.rb:13: `Test::Foo::Bar::AppCyclePackage::TestUtil` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
     13 |  Test::Foo::Bar::AppCyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_app_cycle_package/__package.rb:5: Enclosing package declared here
+     5 |class Foo::MyPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 use_app_cycle_package/foo.test.rb:4: `Test::Foo::Bar::AppCyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::AppCyclePackage::TestUtil
@@ -427,9 +445,12 @@ use_false_cycle_package/foo.rb:7: `Foo::Bar::FalseCyclePackageTest::OtherClass` 
   Note:
     `Foo::Bar::FalseCyclePackageTest::OtherClass`'s package is imported as `test_import`
 
-use_false_cycle_package/foo.rb:13: `Test::Foo::Bar::FalseCyclePackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+use_false_cycle_package/foo.rb:13: `Test::Foo::Bar::FalseCyclePackage::TestUtil` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
     13 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_false_cycle_package/__package.rb:5: Enclosing package declared here
+     5 |class Foo::MyPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 use_false_cycle_package/foo.test.rb:4: `Test::Foo::Bar::FalseCyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
@@ -501,9 +522,12 @@ use_app_false_cycle_package/foo.rb:7: `Foo::Bar::AppFalseCyclePackageTest::Other
   Note:
     `Foo::Bar::AppFalseCyclePackageTest::OtherClass`'s package is imported as `test_import`
 
-use_app_false_cycle_package/foo.rb:13: `Test::Foo::Bar::AppFalseCyclePackage::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+use_app_false_cycle_package/foo.rb:13: `Test::Foo::Bar::AppFalseCyclePackage::TestUtil` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
     13 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_app_false_cycle_package/__package.rb:5: Enclosing package declared here
+     5 |class Foo::MyPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 use_app_false_cycle_package/foo.test.rb:4: `Test::Foo::Bar::AppFalseCyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil

--- a/test/testdata/packager/export_for_test/foo/foo.rb
+++ b/test/testdata/packager/export_for_test/foo/foo.rb
@@ -18,12 +18,12 @@ module Opus::Foo
   # via import Opus::Foo::Bar
   Opus::Foo::Bar::BarClass
   Test::Opus::Foo::Bar::BarClassTest
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::Foo::Bar::BarClassTest` is defined in a test namespace
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::Foo::Bar::BarClassTest` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file
 
   # via import Opus::Util
   Opus::Util::UtilClass
   Test::Opus::Util::TestUtil
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::Util::TestUtil` is defined in a test namespace
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::Util::TestUtil` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file
 
   Opus::Util::Nesting::Public.public_method
 
@@ -36,7 +36,7 @@ module Opus::Foo
   Opus::TestImported::TIClass
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Used `test_import` constant `Opus::TestImported::TIClass` in non-test file
   Test::Opus::TestImported::TITestClass
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::TestImported::TITestClass` is defined in a test namespace
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::TestImported::TITestClass` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file
 
 
   # via export_for_test Opus::Foo::Private::ImplDetail

--- a/test/testdata/packager/lsp_features/family.rb
+++ b/test/testdata/packager/lsp_features/family.rb
@@ -41,7 +41,7 @@ module Simpsons
   end
 
   Test::Krabappel::Popquiz
-# ^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Krabappel::Popquiz` is defined in a test namespace
+# ^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Krabappel::Popquiz` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file
   #                ^^^^^^^ usage: popquiz
 # ^^^^^^^^^^^^^^^ importusage: krabappel-pkg
 

--- a/test/testdata/packager/simple_test_import/main_lib/lib.rb
+++ b/test/testdata/packager/simple_test_import/main_lib/lib.rb
@@ -9,8 +9,8 @@ class Project::MainLib::Lib
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Used `test_import` constant `Project::TestOnly::SomeHelper` in non-test file
 
   Test::Project::Util::UtilHelper
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::UtilHelper` is defined in a test namespace
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::UtilHelper` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file
 
   Test::Project::Util::Unexported
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::Unexported` is defined in a test namespace
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::Unexported` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Review by commit

This makes the handling of this part of `reportImportError` more uniform,
which makes it easier to use `reportImportError` for my work-in-progress
change to move visibility checking into resolver.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.