### PR TITLE
Add some tests, prep for import-aware resolver

### DIFF
--- a/test/cli/package-did-you-mean-filtering/__package.rb
+++ b/test/cli/package-did-you-mean-filtering/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# enable-packager: true
+
+class Project < PackageSpec
+  import Project::SomePkg1
+end

--- a/test/cli/package-did-you-mean-filtering/root.rb
+++ b/test/cli/package-did-you-mean-filtering/root.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module Project
+  SomePkg
+end

--- a/test/cli/package-did-you-mean-filtering/some_pkg1/__package.rb
+++ b/test/cli/package-did-you-mean-filtering/some_pkg1/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Project::SomePkg1 < PackageSpec
+  export Project::SomePkg1::Helper
+end

--- a/test/cli/package-did-you-mean-filtering/some_pkg1/helper.rb
+++ b/test/cli/package-did-you-mean-filtering/some_pkg1/helper.rb
@@ -1,0 +1,3 @@
+# typed: strict
+
+class Project::SomePkg1::Helper; end

--- a/test/cli/package-did-you-mean-filtering/some_pkg2/__package.rb
+++ b/test/cli/package-did-you-mean-filtering/some_pkg2/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Project::SomePkg2 < PackageSpec
+  export Project::SomePkg2::Helper
+end

--- a/test/cli/package-did-you-mean-filtering/some_pkg2/helper.rb
+++ b/test/cli/package-did-you-mean-filtering/some_pkg2/helper.rb
@@ -1,0 +1,3 @@
+# typed: strict
+
+class Project::SomePkg2::Helper; end

--- a/test/cli/package-did-you-mean-filtering/test.out
+++ b/test/cli/package-did-you-mean-filtering/test.out
@@ -1,0 +1,18 @@
+root.rb:4: Unable to resolve constant `SomePkg` https://srb.help/5002
+     4 |  SomePkg
+          ^^^^^^^
+  Did you mean `Project::SomePkg1`? Use `-a` to autocorrect
+    root.rb:4: Replace with `Project::SomePkg1`
+     4 |  SomePkg
+          ^^^^^^^
+    some_pkg1/helper.rb:3: `Project::SomePkg1` defined here
+     3 |class Project::SomePkg1::Helper; end
+              ^^^^^^^^^^^^^^^^^
+  Did you mean `Project::SomePkg2`? Use `-a` to autocorrect
+    root.rb:4: Replace with `Project::SomePkg2`
+     4 |  SomePkg
+          ^^^^^^^
+    some_pkg2/helper.rb:3: `Project::SomePkg2` defined here
+     3 |class Project::SomePkg2::Helper; end
+              ^^^^^^^^^^^^^^^^^
+Errors: 1

--- a/test/cli/package-did-you-mean-filtering/test.sh
+++ b/test/cli/package-did-you-mean-filtering/test.sh
@@ -1,0 +1,3 @@
+cd test/cli/package-did-you-mean-filtering || exit 1
+
+../../../main/sorbet --silence-dev-message --sorbet-packages --max-threads=0 . 2>&1

--- a/test/testdata/packager/import_nonexistent_package/__package.rb
+++ b/test/testdata/packager/import_nonexistent_package/__package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+# enable-packager: true
+
+class Root < PackageSpec
+  import NonExistent
+  #      ^^^^^^^^^^^ error: Unable to resolve constant `NonExistent`
+  import Root::B
+end

--- a/test/testdata/packager/import_nonexistent_package/a/__package.rb
+++ b/test/testdata/packager/import_nonexistent_package/a/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Root::A < PackageSpec
+end

--- a/test/testdata/packager/import_nonexistent_package/a/foo.rb
+++ b/test/testdata/packager/import_nonexistent_package/a/foo.rb
@@ -1,0 +1,3 @@
+# typed: strict
+
+class Root::A::Foo; end

--- a/test/testdata/packager/import_nonexistent_package/b/__package.rb
+++ b/test/testdata/packager/import_nonexistent_package/b/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Root::B < PackageSpec
+  import Root::A
+end

--- a/test/testdata/packager/import_nonexistent_package/root.rb
+++ b/test/testdata/packager/import_nonexistent_package/root.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+module Root
+  Root::A::Foo
+# ^^^^^^^^^^^^ error: `Root::A::Foo` resolves but its package is not imported
+end

--- a/test/testdata/packager/prefix_of_imported/__package.rb
+++ b/test/testdata/packager/prefix_of_imported/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+
+class Opus::Main < PackageSpec
+  import Opus::OuterPackage::InnerPackage
+end

--- a/test/testdata/packager/prefix_of_imported/main.rb
+++ b/test/testdata/packager/prefix_of_imported/main.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+# typed: strict
+
+module Opus::Main
+  p(Opus::OuterPackage)
+  # ^^^^^^^^^^^^^^^^^^ error: `Opus::OuterPackage` resolves but its package is not imported
+
+  p(Opus::OuterPackage::InnerPackage)
+
+  p(Opus::OuterPackage::InnerPackage::SomeClass)
+
+  p(Opus::OuterPackage::DoesNotExist)
+  # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `DoesNotExist`
+end

--- a/test/testdata/packager/prefix_of_imported/outer_package/__package.rb
+++ b/test/testdata/packager/prefix_of_imported/outer_package/__package.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Opus::OuterPackage < PackageSpec
+end

--- a/test/testdata/packager/prefix_of_imported/outer_package/inner_package/__package.rb
+++ b/test/testdata/packager/prefix_of_imported/outer_package/inner_package/__package.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Opus::OuterPackage::InnerPackage < PackageSpec
+  export Opus::OuterPackage::InnerPackage::SomeClass
+end

--- a/test/testdata/packager/prefix_of_imported/outer_package/inner_package/some_class.rb
+++ b/test/testdata/packager/prefix_of_imported/outer_package/inner_package/some_class.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+
+module Opus::OuterPackage::InnerPackage
+  class SomeClass
+  end
+end


### PR DESCRIPTION
1.  The `prefix_of_imported` test captures the current (pre-change) behavior
    for the case where a package imports Opus::OuterPackage::InnerPackage but
    not Opus::OuterPackage itself. The test shows:

    - Opus::OuterPackage resolves but fires VisibilityChecker error
    - Opus::OuterPackage::InnerPackage resolves fine (imported)
    - Opus::OuterPackage::InnerPackage::SomeClass resolves fine (exported)
    - Opus::OuterPackage::DoesNotExist fails with "Unable to resolve"

    In the follow-up PR, we'll move the package check into the resolver so
    that Opus::OuterPackage fails to resolve (not just fires a
    VisibilityChecker error), and Opus::OuterPackage::DoesNotExist blames
    OuterPackage rather than DoesNotExist.

1.  The import_nonexistent_package test is a regression test against the case
    where we scan imports to see whether the reference should be allowed as
    something that's a prefix of an import, but one of the imports is for a
    non-existent package.

1.  The package-did-you-mean-filtering test is for an upcoming change to limit
    "Did you mean:" suggestions to only those packages which have been imported.


<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I've had these tests written on a WIP branch for a while, but I figure I should
just commit them so that I don't have to keep rebasing it.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

test-only change