### PR TITLE
Fix the signature for Kernel#Array

### DIFF
--- a/rbi/core/kernel.rbi
+++ b/rbi/core/kernel.rbi
@@ -767,9 +767,7 @@ module Kernel
   sig { params(x: NilClass).returns(T::Array[T.untyped]) }
   sig do
     type_parameters(:Elem)
-      .params(
-        x: T.any(T::Enumerable[T.type_parameter(:Elem)], T.type_parameter(:Elem), T.nilable(T.type_parameter(:Elem)))
-      )
+      .params(x: T.any(T::Enumerable[T.type_parameter(:Elem)], NilClass, T.type_parameter(:Elem)))
       .returns(T::Array[T.type_parameter(:Elem)])
   end
   def Array(x); end


### PR DESCRIPTION
This PR simplifies the signatue for `Kernel#Array` a bit, by breaking the `Enumerable` and `T.nilable` cases into two separate overloads. This avoids any confusion from the sub-component of the `T.any` looking like `T.any(T.type_parameter(:Elem), T.nilable(T.type_parameter(:Elem)))`.

An alternate choice would be to remove the middle `T.type_parameter(:Elem)` on the second overload, as it should be redundant with the `T.nilable` argument.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
RBI fixes.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.
