### PR TITLE
Rewrite Struct.new assignments inside blocks

### DIFF
--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -1,4 +1,5 @@
 #include "rewriter/rewriter.h"
+#include "ast/Helpers.h"
 #include "ast/treemap/treemap.h"
 #include "ast/verifier/verifier.h"
 #include "common/typecase.h"
@@ -38,7 +39,40 @@ namespace sorbet::rewriter {
 class Rewriterer {
     friend class Rewriter;
 
+    int blockDepth = 0;
+
 public:
+    void preTransformBlock(core::MutableContext ctx, ast::ExpressionPtr &tree) {
+        blockDepth++;
+    }
+
+    void postTransformAssign(core::MutableContext ctx, ast::ExpressionPtr &tree) {
+        if (blockDepth == 0) {
+            return;
+        }
+
+        auto assign = ast::cast_tree<ast::Assign>(tree);
+        auto nodes = Struct::run(ctx, assign);
+        if (nodes.empty()) {
+            return;
+        }
+
+        auto loc = assign->loc;
+        auto expr = std::move(nodes.back());
+        nodes.pop_back();
+
+        ast::InsSeq::STATS_store stats;
+        stats.reserve(nodes.size());
+        for (auto &node : nodes) {
+            stats.emplace_back(std::move(node));
+        }
+        tree = ast::MK::InsSeq(loc, std::move(stats), std::move(expr));
+    }
+
+    void postTransformBlock(core::MutableContext ctx, ast::ExpressionPtr &tree) {
+        blockDepth--;
+    }
+
     void postTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr &tree) {
         auto classDef = ast::cast_tree<ast::ClassDef>(tree);
 

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -40,14 +40,19 @@ class Rewriterer {
     friend class Rewriter;
 
     int blockDepth = 0;
+    vector<int> classBlockDepths;
 
 public:
+    void preTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr &tree) {
+        classBlockDepths.emplace_back(blockDepth);
+    }
+
     void preTransformBlock(core::MutableContext ctx, ast::ExpressionPtr &tree) {
         blockDepth++;
     }
 
     void postTransformAssign(core::MutableContext ctx, ast::ExpressionPtr &tree) {
-        if (blockDepth == 0) {
+        if (classBlockDepths.empty() || blockDepth <= classBlockDepths.back()) {
             return;
         }
 
@@ -74,6 +79,9 @@ public:
     }
 
     void postTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr &tree) {
+        ENFORCE(!classBlockDepths.empty());
+        classBlockDepths.pop_back();
+
         auto classDef = ast::cast_tree<ast::ClassDef>(tree);
 
         auto isClass = classDef->kind == ast::ClassDef::Kind::Class;

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -39,51 +39,32 @@ namespace sorbet::rewriter {
 class Rewriterer {
     friend class Rewriter;
 
-    int blockDepth = 0;
-    vector<int> classBlockDepths;
+    // Direct class-body assignments were already expanded into multiple statements. Track Struct replacements so the
+    // class rewriter below can preserve that AST shape.
+    UnorderedSet<void *> structRewrites;
 
 public:
-    void preTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr &tree) {
-        classBlockDepths.emplace_back(blockDepth);
-    }
-
-    void preTransformBlock(core::MutableContext ctx, ast::ExpressionPtr &tree) {
-        blockDepth++;
-    }
-
     void postTransformAssign(core::MutableContext ctx, ast::ExpressionPtr &tree) {
-        if (classBlockDepths.empty() || blockDepth <= classBlockDepths.back()) {
-            return;
-        }
-
         auto assign = ast::cast_tree<ast::Assign>(tree);
-        if (!ast::isa_tree<ast::UnresolvedConstantLit>(assign->lhs)) {
-            return;
-        }
-
-        auto result = assign->lhs.deepCopy();
         auto nodes = Struct::run(ctx, assign);
         if (nodes.empty()) {
             return;
         }
 
         auto loc = assign->loc;
+        auto expr = std::move(nodes.back());
+        nodes.pop_back();
+
         ast::InsSeq::STATS_store stats;
         stats.reserve(nodes.size());
         for (auto &node : nodes) {
             stats.emplace_back(std::move(node));
         }
-        tree = ast::MK::InsSeq(loc, std::move(stats), std::move(result));
-    }
-
-    void postTransformBlock(core::MutableContext ctx, ast::ExpressionPtr &tree) {
-        blockDepth--;
+        tree = ast::MK::InsSeq(loc, std::move(stats), std::move(expr));
+        structRewrites.emplace(tree.get());
     }
 
     void postTransformClassDef(core::MutableContext ctx, ast::ExpressionPtr &tree) {
-        ENFORCE(!classBlockDepths.empty());
-        classBlockDepths.pop_back();
-
         auto classDef = ast::cast_tree<ast::ClassDef>(tree);
 
         auto isClass = classDef->kind == ast::ClassDef::Kind::Class;
@@ -107,16 +88,24 @@ public:
         UnorderedMap<void *, vector<ast::ExpressionPtr>> replaceNodes;
         UnorderedMap<void *, vector<ast::ExpressionPtr>> insertNodes;
         for (auto &stat : classDef->rhs) {
+            if (structRewrites.erase(stat.get()) != 0) {
+                auto &insSeq = ast::cast_tree_nonnull<ast::InsSeq>(stat);
+
+                vector<ast::ExpressionPtr> nodes;
+                nodes.reserve(insSeq.stats.size() + 1);
+                for (auto &node : insSeq.stats) {
+                    nodes.emplace_back(std::move(node));
+                }
+                nodes.emplace_back(std::move(insSeq.expr));
+                replaceNodes[stat.get()] = std::move(nodes);
+                prevStat = &stat;
+                continue;
+            }
+
             typecase(
                 stat,
                 [&](ast::Assign &assign) {
                     vector<ast::ExpressionPtr> nodes;
-
-                    nodes = Struct::run(ctx, &assign);
-                    if (!nodes.empty()) {
-                        replaceNodes[stat.get()] = std::move(nodes);
-                        return;
-                    }
 
                     nodes = Data::run(ctx, &assign);
                     if (!nodes.empty()) {

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -57,21 +57,23 @@ public:
         }
 
         auto assign = ast::cast_tree<ast::Assign>(tree);
+        if (!ast::isa_tree<ast::UnresolvedConstantLit>(assign->lhs)) {
+            return;
+        }
+
+        auto result = assign->lhs.deepCopy();
         auto nodes = Struct::run(ctx, assign);
         if (nodes.empty()) {
             return;
         }
 
         auto loc = assign->loc;
-        auto expr = std::move(nodes.back());
-        nodes.pop_back();
-
         ast::InsSeq::STATS_store stats;
         stats.reserve(nodes.size());
         for (auto &node : nodes) {
             stats.emplace_back(std::move(node));
         }
-        tree = ast::MK::InsSeq(loc, std::move(stats), std::move(expr));
+        tree = ast::MK::InsSeq(loc, std::move(stats), std::move(result));
     }
 
     void postTransformBlock(core::MutableContext ctx, ast::ExpressionPtr &tree) {

--- a/rewriter/rewriter.cc
+++ b/rewriter/rewriter.cc
@@ -36,6 +36,30 @@ using namespace std;
 
 namespace sorbet::rewriter {
 
+namespace {
+
+ast::ExpressionPtr copyConstantReference(const ast::ExpressionPtr &constant) {
+    if (ast::isa_tree<ast::EmptyTree>(constant)) {
+        return ast::MK::EmptyTree();
+    }
+    if (ast::isa_tree<ast::Self>(constant)) {
+        // Sorbet treats `self::Foo` as a dynamic constant when it is read, so use the equivalent lexical reference.
+        return ast::MK::EmptyTree();
+    }
+    if (auto resolved = ast::cast_tree<ast::ConstantLit>(constant)) {
+        return ast::MK::Constant(resolved->loc(), resolved->symbol());
+    }
+    if (auto unresolved = ast::cast_tree<ast::UnresolvedConstantLit>(constant)) {
+        auto scope = copyConstantReference(unresolved->scope);
+        if (scope != nullptr) {
+            return ast::MK::UnresolvedConstant(unresolved->loc, std::move(scope), unresolved->cnst);
+        }
+    }
+    return nullptr;
+}
+
+} // namespace
+
 class Rewriterer {
     friend class Rewriter;
 
@@ -46,21 +70,23 @@ class Rewriterer {
 public:
     void postTransformAssign(core::MutableContext ctx, ast::ExpressionPtr &tree) {
         auto assign = ast::cast_tree<ast::Assign>(tree);
+        auto result = copyConstantReference(assign->lhs);
+        if (result == nullptr) {
+            return;
+        }
+
         auto nodes = Struct::run(ctx, assign);
         if (nodes.empty()) {
             return;
         }
 
         auto loc = assign->loc;
-        auto expr = std::move(nodes.back());
-        nodes.pop_back();
-
         ast::InsSeq::STATS_store stats;
         stats.reserve(nodes.size());
         for (auto &node : nodes) {
             stats.emplace_back(std::move(node));
         }
-        tree = ast::MK::InsSeq(loc, std::move(stats), std::move(expr));
+        tree = ast::MK::InsSeq(loc, std::move(stats), std::move(result));
         structRewrites.emplace(tree.get());
     }
 
@@ -92,11 +118,10 @@ public:
                 auto &insSeq = ast::cast_tree_nonnull<ast::InsSeq>(stat);
 
                 vector<ast::ExpressionPtr> nodes;
-                nodes.reserve(insSeq.stats.size() + 1);
+                nodes.reserve(insSeq.stats.size());
                 for (auto &node : insSeq.stats) {
                     nodes.emplace_back(std::move(node));
                 }
-                nodes.emplace_back(std::move(insSeq.expr));
                 replaceNodes[stat.get()] = std::move(nodes);
                 prevStat = &stat;
                 continue;

--- a/test/testdata/rewriter/struct_nested_block.rb
+++ b/test/testdata/rewriter/struct_nested_block.rb
@@ -22,3 +22,11 @@ class StructInNestedBlock
     end
   end
 end
+
+class ClassInBlock
+  1.times do
+    class Inner
+      Duplicate = Struct.new(:value, :value) # error: Duplicate member `value` in Struct definition
+    end
+  end
+end

--- a/test/testdata/rewriter/struct_nested_block.rb
+++ b/test/testdata/rewriter/struct_nested_block.rb
@@ -30,3 +30,11 @@ class ClassInBlock
     end
   end
 end
+
+class StructAsBlockValue
+  result = [nil].map do
+    Generated = Struct.new(:value)
+  end
+
+  T.assert_type!(result, T::Array[T.class_of(Generated)])
+end

--- a/test/testdata/rewriter/struct_nested_block.rb
+++ b/test/testdata/rewriter/struct_nested_block.rb
@@ -31,10 +31,11 @@ class ClassInBlock
   end
 end
 
-class StructAsBlockValue
-  result = [nil].map do
+class StructInConditional
+  if Kernel.rand > 0.5
     Generated = Struct.new(:value)
   end
 
-  T.assert_type!(result, T::Array[T.class_of(Generated)])
+  T.assert_type!(Generated.new(1), Generated)
+  Generated.new(1).value
 end

--- a/test/testdata/rewriter/struct_nested_block.rb
+++ b/test/testdata/rewriter/struct_nested_block.rb
@@ -1,0 +1,24 @@
+# typed: strict
+
+class StructInBlock
+  1.times do
+    Generated = Struct.new(:value)
+  end
+
+  T.assert_type!(Generated.new(1), Generated)
+  Generated.new(1).value
+end
+
+class StructInNestedBlock
+  1.times do
+    local_struct = Struct.new(:value)
+    T.assert_type!(local_struct, Struct)
+
+    1.times do
+      Generated = Struct.new(:value)
+
+      T.assert_type!(Generated.new(1), Generated)
+      Generated.new(1).value
+    end
+  end
+end

--- a/test/testdata/rewriter/struct_nested_block.rb
+++ b/test/testdata/rewriter/struct_nested_block.rb
@@ -39,3 +39,17 @@ class StructInConditional
   T.assert_type!(Generated.new(1), Generated)
   Generated.new(1).value
 end
+
+class StructAsBlockValue
+  result = [nil].map do
+    Generated = Struct.new(:value)
+  end
+
+  T.assert_type!(result, T::Array[T.class_of(Generated)])
+
+  self_qualified_result = [nil].map do
+    self::SelfQualified = Struct.new(:value)
+  end
+
+  T.assert_type!(self_qualified_result, T::Array[T.class_of(SelfQualified)])
+end

--- a/test/testdata/rewriter/struct_nested_block.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct_nested_block.rb.rewrite-tree.exp
@@ -42,7 +42,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
             {:fixed => ::T.untyped()}
           end
         end
-        <emptyTree>::<C Generated>
       end
     end
 
@@ -99,7 +98,6 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
                   {:fixed => ::T.untyped()}
                 end
               end
-              <emptyTree>::<C Generated>
             end
             <cast:assert_type!>(<emptyTree>::<C Generated>.new(1), <todo sym>, <emptyTree>::<C Generated>)
             <emptyTree>::<C Generated>.new(1).value()
@@ -117,8 +115,8 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     end
   end
 
-  class <emptyTree>::<C StructAsBlockValue><<C <todo sym>>> < (::<todo sym>)
-    result = [nil].map() do ||
+  class <emptyTree>::<C StructInConditional><<C <todo sym>>> < (::<todo sym>)
+    if <emptyTree>::<C Kernel>.rand().>(0.500000)
       begin
         class <emptyTree>::<C Generated$1><<C <todo sym>>> < (::<root>::<C Struct>)
           ::T::Sig::WithoutRuntime.sig() do ||
@@ -160,10 +158,13 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
             {:fixed => ::T.untyped()}
           end
         end
-        <emptyTree>::<C Generated>
       end
+    else
+      <emptyTree>
     end
 
-    <cast:assert_type!>(result, <todo sym>, <emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C T>.class_of(<emptyTree>::<C Generated>)))
+    <cast:assert_type!>(<emptyTree>::<C Generated>.new(1), <todo sym>, <emptyTree>::<C Generated>)
+
+    <emptyTree>::<C Generated>.new(1).value()
   end
 end

--- a/test/testdata/rewriter/struct_nested_block.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct_nested_block.rb.rewrite-tree.exp
@@ -1,0 +1,109 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class <emptyTree>::<C StructInBlock><<C <todo sym>>> < (::<todo sym>)
+    1.times() do ||
+      begin
+        class <emptyTree>::<C Generated$1><<C <todo sym>>> < (::<root>::<C Struct>)
+          ::T::Sig::WithoutRuntime.sig() do ||
+            <self>.returns(::T.untyped())
+          end
+
+          def value<<todo method>>(&<blk>)
+            ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+          end
+
+          ::T::Sig::WithoutRuntime.sig() do ||
+            <self>.params(:value, ::T.untyped()).returns(::T.untyped())
+          end
+
+          def value=<<todo method>>(value, &<blk>)
+            ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+          end
+
+          ::T::Sig::WithoutRuntime.sig() do ||
+            <self>.params(:value, ::BasicObject).void()
+          end
+
+          def initialize<<todo method>>(value = nil, &<blk>)
+            ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+          end
+
+          <runtime method definition of value>
+
+          <runtime method definition of value=>
+
+          <emptyTree>::<C Elem> = <self>.type_member() do ||
+            {:fixed => ::T.untyped()}
+          end
+
+          <runtime method definition of initialize>
+        end
+        class <emptyTree>::<C Generated><<C <todo sym>>> < (<emptyTree>::<C Generated$1>)
+          <emptyTree>::<C Elem> = <self>.type_member() do ||
+            {:fixed => ::T.untyped()}
+          end
+        end
+      end
+    end
+
+    <cast:assert_type!>(<emptyTree>::<C Generated>.new(1), <todo sym>, <emptyTree>::<C Generated>)
+
+    <emptyTree>::<C Generated>.new(1).value()
+  end
+
+  class <emptyTree>::<C StructInNestedBlock><<C <todo sym>>> < (::<todo sym>)
+    1.times() do ||
+      begin
+        local_struct = <emptyTree>::<C Struct>.new(:value)
+        <cast:assert_type!>(local_struct, <todo sym>, <emptyTree>::<C Struct>)
+        1.times() do ||
+          begin
+            begin
+              class <emptyTree>::<C Generated$1><<C <todo sym>>> < (::<root>::<C Struct>)
+                ::T::Sig::WithoutRuntime.sig() do ||
+                  <self>.returns(::T.untyped())
+                end
+
+                def value<<todo method>>(&<blk>)
+                  ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+                end
+
+                ::T::Sig::WithoutRuntime.sig() do ||
+                  <self>.params(:value, ::T.untyped()).returns(::T.untyped())
+                end
+
+                def value=<<todo method>>(value, &<blk>)
+                  ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+                end
+
+                ::T::Sig::WithoutRuntime.sig() do ||
+                  <self>.params(:value, ::BasicObject).void()
+                end
+
+                def initialize<<todo method>>(value = nil, &<blk>)
+                  ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+                end
+
+                <runtime method definition of value>
+
+                <runtime method definition of value=>
+
+                <emptyTree>::<C Elem> = <self>.type_member() do ||
+                  {:fixed => ::T.untyped()}
+                end
+
+                <runtime method definition of initialize>
+              end
+              class <emptyTree>::<C Generated><<C <todo sym>>> < (<emptyTree>::<C Generated$1>)
+                <emptyTree>::<C Elem> = <self>.type_member() do ||
+                  {:fixed => ::T.untyped()}
+                end
+              end
+            end
+            <cast:assert_type!>(<emptyTree>::<C Generated>.new(1), <todo sym>, <emptyTree>::<C Generated>)
+            <emptyTree>::<C Generated>.new(1).value()
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/testdata/rewriter/struct_nested_block.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct_nested_block.rb.rewrite-tree.exp
@@ -106,4 +106,12 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
       end
     end
   end
+
+  class <emptyTree>::<C ClassInBlock><<C <todo sym>>> < (::<todo sym>)
+    1.times() do ||
+      class <emptyTree>::<C Inner><<C <todo sym>>> < (::<todo sym>)
+        <emptyTree>::<C Duplicate> = <cast:<assume type>>(<emptyTree>::<C Struct>.new(:value, :value), <todo sym>, <emptyTree>::<C Struct>)
+      end
+    end
+  end
 end

--- a/test/testdata/rewriter/struct_nested_block.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct_nested_block.rb.rewrite-tree.exp
@@ -42,6 +42,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
             {:fixed => ::T.untyped()}
           end
         end
+        <emptyTree>::<C Generated>
       end
     end
 
@@ -98,6 +99,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
                   {:fixed => ::T.untyped()}
                 end
               end
+              <emptyTree>::<C Generated>
             end
             <cast:assert_type!>(<emptyTree>::<C Generated>.new(1), <todo sym>, <emptyTree>::<C Generated>)
             <emptyTree>::<C Generated>.new(1).value()
@@ -113,5 +115,55 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
         <emptyTree>::<C Duplicate> = <cast:<assume type>>(<emptyTree>::<C Struct>.new(:value, :value), <todo sym>, <emptyTree>::<C Struct>)
       end
     end
+  end
+
+  class <emptyTree>::<C StructAsBlockValue><<C <todo sym>>> < (::<todo sym>)
+    result = [nil].map() do ||
+      begin
+        class <emptyTree>::<C Generated$1><<C <todo sym>>> < (::<root>::<C Struct>)
+          ::T::Sig::WithoutRuntime.sig() do ||
+            <self>.returns(::T.untyped())
+          end
+
+          def value<<todo method>>(&<blk>)
+            ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+          end
+
+          ::T::Sig::WithoutRuntime.sig() do ||
+            <self>.params(:value, ::T.untyped()).returns(::T.untyped())
+          end
+
+          def value=<<todo method>>(value, &<blk>)
+            ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+          end
+
+          ::T::Sig::WithoutRuntime.sig() do ||
+            <self>.params(:value, ::BasicObject).void()
+          end
+
+          def initialize<<todo method>>(value = nil, &<blk>)
+            ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+          end
+
+          <runtime method definition of value>
+
+          <runtime method definition of value=>
+
+          <emptyTree>::<C Elem> = <self>.type_member() do ||
+            {:fixed => ::T.untyped()}
+          end
+
+          <runtime method definition of initialize>
+        end
+        class <emptyTree>::<C Generated><<C <todo sym>>> < (<emptyTree>::<C Generated$1>)
+          <emptyTree>::<C Elem> = <self>.type_member() do ||
+            {:fixed => ::T.untyped()}
+          end
+        end
+        <emptyTree>::<C Generated>
+      end
+    end
+
+    <cast:assert_type!>(result, <todo sym>, <emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C T>.class_of(<emptyTree>::<C Generated>)))
   end
 end

--- a/test/testdata/rewriter/struct_nested_block.rb.rewrite-tree.exp
+++ b/test/testdata/rewriter/struct_nested_block.rb.rewrite-tree.exp
@@ -42,6 +42,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
             {:fixed => ::T.untyped()}
           end
         end
+        <emptyTree>::<C Generated>
       end
     end
 
@@ -98,6 +99,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
                   {:fixed => ::T.untyped()}
                 end
               end
+              <emptyTree>::<C Generated>
             end
             <cast:assert_type!>(<emptyTree>::<C Generated>.new(1), <todo sym>, <emptyTree>::<C Generated>)
             <emptyTree>::<C Generated>.new(1).value()
@@ -158,6 +160,7 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
             {:fixed => ::T.untyped()}
           end
         end
+        <emptyTree>::<C Generated>
       end
     else
       <emptyTree>
@@ -166,5 +169,103 @@ class <emptyTree><<C <root>>> < (::<todo sym>)
     <cast:assert_type!>(<emptyTree>::<C Generated>.new(1), <todo sym>, <emptyTree>::<C Generated>)
 
     <emptyTree>::<C Generated>.new(1).value()
+  end
+
+  class <emptyTree>::<C StructAsBlockValue><<C <todo sym>>> < (::<todo sym>)
+    result = [nil].map() do ||
+      begin
+        class <emptyTree>::<C Generated$1><<C <todo sym>>> < (::<root>::<C Struct>)
+          ::T::Sig::WithoutRuntime.sig() do ||
+            <self>.returns(::T.untyped())
+          end
+
+          def value<<todo method>>(&<blk>)
+            ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+          end
+
+          ::T::Sig::WithoutRuntime.sig() do ||
+            <self>.params(:value, ::T.untyped()).returns(::T.untyped())
+          end
+
+          def value=<<todo method>>(value, &<blk>)
+            ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+          end
+
+          ::T::Sig::WithoutRuntime.sig() do ||
+            <self>.params(:value, ::BasicObject).void()
+          end
+
+          def initialize<<todo method>>(value = nil, &<blk>)
+            ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+          end
+
+          <runtime method definition of value>
+
+          <runtime method definition of value=>
+
+          <emptyTree>::<C Elem> = <self>.type_member() do ||
+            {:fixed => ::T.untyped()}
+          end
+
+          <runtime method definition of initialize>
+        end
+        class <emptyTree>::<C Generated><<C <todo sym>>> < (<emptyTree>::<C Generated$1>)
+          <emptyTree>::<C Elem> = <self>.type_member() do ||
+            {:fixed => ::T.untyped()}
+          end
+        end
+        <emptyTree>::<C Generated>
+      end
+    end
+
+    <cast:assert_type!>(result, <todo sym>, <emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C T>.class_of(<emptyTree>::<C Generated>)))
+
+    self_qualified_result = [nil].map() do ||
+      begin
+        class <self>::<C SelfQualified$1><<C <todo sym>>> < (::<root>::<C Struct>)
+          ::T::Sig::WithoutRuntime.sig() do ||
+            <self>.returns(::T.untyped())
+          end
+
+          def value<<todo method>>(&<blk>)
+            ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+          end
+
+          ::T::Sig::WithoutRuntime.sig() do ||
+            <self>.params(:value, ::T.untyped()).returns(::T.untyped())
+          end
+
+          def value=<<todo method>>(value, &<blk>)
+            ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+          end
+
+          ::T::Sig::WithoutRuntime.sig() do ||
+            <self>.params(:value, ::BasicObject).void()
+          end
+
+          def initialize<<todo method>>(value = nil, &<blk>)
+            ::Kernel.raise("Sorbet rewriter pass partially unimplemented")
+          end
+
+          <runtime method definition of value>
+
+          <runtime method definition of value=>
+
+          <emptyTree>::<C Elem> = <self>.type_member() do ||
+            {:fixed => ::T.untyped()}
+          end
+
+          <runtime method definition of initialize>
+        end
+        class <self>::<C SelfQualified><<C <todo sym>>> < (<emptyTree>::<C SelfQualified$1>)
+          <emptyTree>::<C Elem> = <self>.type_member() do ||
+            {:fixed => ::T.untyped()}
+          end
+        end
+        <emptyTree>::<C SelfQualified>
+      end
+    end
+
+    <cast:assert_type!>(self_qualified_result, <todo sym>, <emptyTree>::<C T>::<C Array>.[](<emptyTree>::<C T>.class_of(<emptyTree>::<C SelfQualified>)))
   end
 end


### PR DESCRIPTION
### Motivation

Fixes #10631.

Constant assignments such as `Generated = Struct.new(:value)` normally go through the Struct rewriter, which gives the generated class its members and constructor type. The old entry point only considered direct class-body statements, so assignments nested under another expression skipped the rewrite and strict files received error 7027 with a `T.let(..., Struct)` autocorrect that fails at runtime.

This change invokes the existing Struct rewriter from `postTransformAssign`, allowing the tree walk to handle matching assignments wherever they occur in the AST. It does not special-case blocks. For assignments whose value is used, the generated classes are emitted as `InsSeq` statements and a rebuilt reference to the target constant remains as the result, preserving Ruby assignment-expression semantics. The reference builder handles lexical, root-qualified, relative-qualified, and `self::` paths without adding a generic AST `deepCopy`.

Direct class-body replacements are still spliced into the class RHS to preserve the existing AST shape. Local-variable `Struct.new` calls remain unchanged because they do not match the Struct rewriter's constant-lhs requirement.

The regression fixture covers direct and nested blocks, immediate use of the generated class, an unchanged local-variable path, a class nested inside a block, a conditional assignment outside a block, and assignment values returned from blocks, including a `self::`-qualified target. The rewrite-tree snapshot also verifies that direct class-body assignments are not rewritten twice.

### Test plan

- [x] `tools/scripts/format_cxx.sh -t rewriter/rewriter.cc`
- [x] Legacy and Prism positive tests for `struct_nested_block`
- [x] Legacy and Prism LSP tests for `struct_nested_block`
- [x] All 304 Legacy and Prism `test_PosTests/testdata/rewriter/*` targets
- [x] `git diff --check`

Prepared with OpenAI Codex assistance.
