### PR TITLE
Split `findMemberFuzzyMatch` → constants, methods

### DIFF
--- a/core/Symbols.cc
+++ b/core/Symbols.cc
@@ -774,7 +774,7 @@ SymbolRef ClassOrModule::findMemberTransitiveInternal(const GlobalState &gs, Nam
     return findParentMemberTransitiveInternal(gs, name, maxDepth, dealias);
 }
 
-vector<ClassOrModule::FuzzySearchResult> ClassOrModule::findMemberFuzzyMatch(const GlobalState &gs, NameRef name,
+vector<ClassOrModule::FuzzySearchResult> ClassOrModule::findMethodFuzzyMatch(const GlobalState &gs, NameRef name,
                                                                              int betterThan) const {
     vector<ClassOrModule::FuzzySearchResult> res;
     // Don't run under the fuzzer, as otherwise fuzzy match dominates runtime.
@@ -786,7 +786,7 @@ vector<ClassOrModule::FuzzySearchResult> ClassOrModule::findMemberFuzzyMatch(con
 
     if (name.kind() == NameKind::UTF8) {
         Levenstein levenstein;
-        auto sym = findMemberFuzzyMatchUTF8(gs, name, levenstein, betterThan);
+        auto sym = findMethodFuzzyMatchUTF8(gs, name, levenstein, betterThan);
         if (sym.symbol.exists()) {
             res.emplace_back(sym);
         } else {
@@ -794,7 +794,7 @@ vector<ClassOrModule::FuzzySearchResult> ClassOrModule::findMemberFuzzyMatch(con
             // singleton one
             auto singleton = lookupSingletonClass(gs);
             if (singleton.exists()) {
-                sym = singleton.data(gs)->findMemberFuzzyMatchUTF8(gs, name, levenstein, betterThan);
+                sym = singleton.data(gs)->findMethodFuzzyMatchUTF8(gs, name, levenstein, betterThan);
                 if (sym.symbol.exists()) {
                     res.emplace_back(sym);
                 }
@@ -802,30 +802,26 @@ vector<ClassOrModule::FuzzySearchResult> ClassOrModule::findMemberFuzzyMatch(con
                 // For the error when you use a singleton method but wanted the
                 // instance one
                 auto attached = attachedClass(gs);
-                sym = attached.data(gs)->findMemberFuzzyMatchUTF8(gs, name, levenstein, betterThan);
+                sym = attached.data(gs)->findMethodFuzzyMatchUTF8(gs, name, levenstein, betterThan);
                 if (sym.symbol.exists()) {
                     res.emplace_back(sym);
                 }
             }
         }
-        auto shortName = name.shortName(gs);
-        if (!shortName.empty() && std::isupper(shortName.front())) {
-            vector<ClassOrModule::FuzzySearchResult> constant_matches =
-                findMemberFuzzyMatchConstant(gs, name, betterThan);
-            res.insert(res.end(), constant_matches.begin(), constant_matches.end());
-        }
-    } else if (name.kind() == NameKind::CONSTANT) {
-        res = findMemberFuzzyMatchConstant(gs, name, betterThan);
     }
     return res;
 }
 
-vector<ClassOrModule::FuzzySearchResult>
-ClassOrModule::findMemberFuzzyMatchConstant(const GlobalState &gs, NameRef name, int betterThan) const {
+vector<ClassOrModule::FuzzySearchResult> ClassOrModule::findConstantFuzzyMatch(const GlobalState &gs, NameRef name,
+                                                                               int betterThan) const {
+    vector<ClassOrModule::FuzzySearchResult> result;
+    // Don't run under the fuzzer, as otherwise fuzzy match dominates runtime.
+    if constexpr (fuzz_mode) {
+        return result;
+    }
+
     // This function is somewhat expensive, as it will crawl all owners to determine if there's a reasonable match for
     // `name`.
-    vector<ClassOrModule::FuzzySearchResult> result;
-
     FuzzySearchResult best;
     best.symbol = Symbols::noSymbol();
     best.name = NameRef::noName();
@@ -922,7 +918,7 @@ ClassOrModule::findMemberFuzzyMatchConstant(const GlobalState &gs, NameRef name,
     return result;
 }
 
-ClassOrModule::FuzzySearchResult ClassOrModule::findMemberFuzzyMatchUTF8(const GlobalState &gs, NameRef name,
+ClassOrModule::FuzzySearchResult ClassOrModule::findMethodFuzzyMatchUTF8(const GlobalState &gs, NameRef name,
                                                                          Levenstein &levenstein, int betterThan) const {
     FuzzySearchResult result;
     result.symbol = Symbols::noSymbol();
@@ -936,7 +932,7 @@ ClassOrModule::FuzzySearchResult ClassOrModule::findMemberFuzzyMatchUTF8(const G
 
     for (auto pair : members()) {
         auto thisName = pair.first;
-        if (thisName.kind() != NameKind::UTF8) {
+        if (thisName.kind() != NameKind::UTF8 || !pair.second.isMethod()) {
             continue;
         }
         auto utf8 = thisName.dataUtf8(gs)->utf8;
@@ -952,7 +948,7 @@ ClassOrModule::FuzzySearchResult ClassOrModule::findMemberFuzzyMatchUTF8(const G
     for (auto it = this->mixins().rbegin(); it != this->mixins().rend(); ++it) {
         ENFORCE(it->exists());
 
-        auto subResult = it->data(gs)->findMemberFuzzyMatchUTF8(gs, name, levenstein, result.distance);
+        auto subResult = it->data(gs)->findMethodFuzzyMatchUTF8(gs, name, levenstein, result.distance);
         if (subResult.symbol.exists()) {
             ENFORCE(subResult.name.exists());
             ENFORCE(subResult.name.kind() == NameKind::UTF8);
@@ -960,7 +956,7 @@ ClassOrModule::FuzzySearchResult ClassOrModule::findMemberFuzzyMatchUTF8(const G
         }
     }
     if (this->superClass().exists()) {
-        auto subResult = this->superClass().data(gs)->findMemberFuzzyMatchUTF8(gs, name, levenstein, result.distance);
+        auto subResult = this->superClass().data(gs)->findMethodFuzzyMatchUTF8(gs, name, levenstein, result.distance);
         if (subResult.symbol.exists()) {
             ENFORCE(subResult.name.exists());
             ENFORCE(subResult.name.kind() == NameKind::UTF8);

--- a/core/Symbols.h
+++ b/core/Symbols.h
@@ -561,7 +561,7 @@ public:
     MethodRef findParentMethodTransitive(const GlobalState &gs, NameRef name) const;
     MethodRef findConcreteMethodTransitive(const GlobalState &gs, NameRef name) const;
 
-    /* transitively finds a member with the most similar name */
+    /* transitively finds methods or constants with the most similar name */
 
     struct FuzzySearchResult {
         SymbolRef symbol;
@@ -569,7 +569,9 @@ public:
         int distance;
     };
 
-    std::vector<FuzzySearchResult> findMemberFuzzyMatch(const GlobalState &gs, NameRef name, int betterThan = -1) const;
+    std::vector<FuzzySearchResult> findMethodFuzzyMatch(const GlobalState &gs, NameRef name, int betterThan = -1) const;
+    std::vector<FuzzySearchResult> findConstantFuzzyMatch(const GlobalState &gs, NameRef name,
+                                                          int betterThan = -1) const;
 
     // Returns true if the symbol or any of its children are not in the symbol table. False otherwise.
     bool isPrintable(const GlobalState &gs) const;
@@ -723,10 +725,8 @@ private:
     friend class serialize::SerializerImpl;
     friend class GlobalState;
 
-    FuzzySearchResult findMemberFuzzyMatchUTF8(const GlobalState &gs, NameRef name, Levenstein &levenstein,
+    FuzzySearchResult findMethodFuzzyMatchUTF8(const GlobalState &gs, NameRef name, Levenstein &levenstein,
                                                int betterThan = -1) const;
-    std::vector<FuzzySearchResult> findMemberFuzzyMatchConstant(const GlobalState &gs, NameRef name,
-                                                                int betterThan = -1) const;
 
     /*
      * mixins and superclasses: `superClass` is *not* included in the

--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -934,7 +934,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                     // - It has to be aware of the `<root>` / `Object` distinction at the top-level
                     // - It ignores the syntactic scope and always does a transitive lookup (even
                     //   when Sorbet would otherwise ban that)
-                    // but it lets us avoid the findMemberFuzzyMatch call below.
+                    // but it lets us avoid the findMethodFuzzyMatch call below.
                     auto constantScope = symbol == Symbols::root() ? symbol : symbol.data(gs)->attachedClass(gs);
                     NameRef constantName;
                     if (constantScope.exists() && (constantName = gs.lookupNameConstant(targetName)).exists()) {
@@ -958,7 +958,7 @@ DispatchResult dispatchCallSymbol(const GlobalState &gs, const DispatchArgs &arg
                 }
 
                 if (!canSkipFuzzyMatch) {
-                    auto alternatives = symbol.data(gs)->findMemberFuzzyMatch(gs, targetName);
+                    auto alternatives = symbol.data(gs)->findMethodFuzzyMatch(gs, targetName);
                     for (auto alternative : alternatives) {
                         auto possibleSymbol = alternative.symbol;
                         if (!possibleSymbol.isMethod()) {

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -527,7 +527,7 @@ private:
                     suggestionCount++;
 
                     auto suggested =
-                        suggestScope.asClassOrModuleRef().data(ctx)->findMemberFuzzyMatch(ctx, original.cnst);
+                        suggestScope.asClassOrModuleRef().data(ctx)->findConstantFuzzyMatch(ctx, original.cnst);
 
                     if (isExport) {
                         // If the resolution error is for an export, suggestions must be restricted to within the


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Now that we're only looking at the constants in resolver and the methods
in calls.cc, we can have two public entrypoints.

We already had a private/internal helper each, so this mostly amounts to
promoting those to the public API.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.