### PR TITLE
Edge case test for "cannot be referenced in a non-test file" error

### DIFF
--- a/test/testdata/packager/test_constant_outside_test_namespace_referenced/consumer/__package.rb
+++ b/test/testdata/packager/test_constant_outside_test_namespace_referenced/consumer/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Consumer < PackageSpec
+  import Target
+end

--- a/test/testdata/packager/test_constant_outside_test_namespace_referenced/consumer/__package.rb
+++ b/test/testdata/packager/test_constant_outside_test_namespace_referenced/consumer/__package.rb
@@ -1,4 +1,5 @@
 # typed: strict
+# enable-packager: true
 
 class Consumer < PackageSpec
   import Target

--- a/test/testdata/packager/test_constant_outside_test_namespace_referenced/consumer/use.rb
+++ b/test/testdata/packager/test_constant_outside_test_namespace_referenced/consumer/use.rb
@@ -1,0 +1,3 @@
+# typed: strict
+
+Target::TestOnlyThing # error: `Target::TestOnlyThing` is defined in a test namespace and cannot be referenced in a non-test file

--- a/test/testdata/packager/test_constant_outside_test_namespace_referenced/consumer/use.rb
+++ b/test/testdata/packager/test_constant_outside_test_namespace_referenced/consumer/use.rb
@@ -1,3 +1,3 @@
 # typed: strict
 
-Target::TestOnlyThing # error: `Target::TestOnlyThing` is defined in a test namespace and cannot be referenced in a non-test file
+Target::TestOnlyThing # error: `Target::TestOnlyThing` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file

--- a/test/testdata/packager/test_constant_outside_test_namespace_referenced/target/__package.rb
+++ b/test/testdata/packager/test_constant_outside_test_namespace_referenced/target/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Target < PackageSpec
+  export_all!
+end

--- a/test/testdata/packager/test_constant_outside_test_namespace_referenced/target/thing.test.rb
+++ b/test/testdata/packager/test_constant_outside_test_namespace_referenced/target/thing.test.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Target::TestOnlyThing # error: Tests in the `Target` package must define tests in the `Test::Target` namespace
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm considering deleting this error after the package-aware constant
resolution changes, because it mostly won't be reachable.

There's a slight edge case where it will be reachable, which relies on
referencing a constant defined in a test file but not defined in the
`Test::` namespace.

Luckily, that behavior is already banned, because the namespace doesn't
match the required namespace.

I want to land this test early to show that it's just capturing the
current behavior. It will change ~soon.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

test-only change