### PR TITLE
Add a note about error queue management in the fast path

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -272,6 +272,9 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
     }
 
     // Replace error queue with one that is owned by this thread.
+    // NOTE: If the fast path is running in a preemption context, the `errorQueue` of the running slow path will be
+    // saved in the preemption manager; it's always fine at this point to replace the queue, as we will either be
+    // replacing an inactive queue from the idle state, or a dummy queue from the preemption manager.
     gs->errorQueue = make_shared<core::ErrorQueue>(gs->errorQueue->logger, gs->errorQueue->tracer, errorFlusher);
 
     vector<core::FileRef> toTypecheck;


### PR DESCRIPTION

Add a note about why it's always safe to replace the `errorQueue` on the fast path, so that I don't have to rediscover why in the future.

### Motivation
Documentation.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Comment-only change
