### PR TITLE
Attempted fix for `ErrorQueue::collected` race

### DIFF
--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1515,16 +1515,27 @@ void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> &&what, cons
         auto fileq = make_shared<ConcurrentBoundedQueue<ast::ParsedFile>>(what.size());
         auto outputq = make_shared<BlockingBoundedQueue<core::FileRef>>(what.size());
 
+        bool checkRelevantPackages = gs.packageDB().enabled() && relevantPackages != nullptr;
+        auto filesToTypecheck = make_shared<UnorderedSet<core::FileRef>>();
+        if (checkRelevantPackages) {
+            // ErrorQueue::flushErrorsForFile mutates the collected-errors map while workers run, so compute this
+            // before starting them rather than having shouldTypecheck read that map concurrently.
+            filesToTypecheck->reserve(what.size());
+            for (const auto &resolved : what) {
+                if (shouldTypecheck(gs, *relevantPackages, resolved.file)) {
+                    filesToTypecheck->insert(resolved.file);
+                }
+            }
+        }
+
         for (auto &resolved : what) {
             fileq->push(move(resolved), 1);
         }
 
-        bool checkRelevantPackages = gs.packageDB().enabled() && relevantPackages != nullptr;
-
         {
             ProgressIndicator cfgInferProgress(opts.showProgress, "CFG+Inference", what.size());
             workers.multiplexJob("typecheck", [&gs, &opts, epoch, &epochManager, &preemptionManager, fileq, outputq,
-                                               cancelable, relevantPackages, checkRelevantPackages,
+                                               cancelable, filesToTypecheck, checkRelevantPackages,
                                                intentionallyLeakASTs]() {
                 ast::ParsedFile job;
                 int processedByThread = 0;
@@ -1549,7 +1560,7 @@ void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> &&what, cons
                             const bool fileWasChanged = preemptionManager && job.file.data(gs).epoch > epoch;
                             if (!isCanceled && !fileWasChanged && gs.errorQueue->wouldFlushErrorsForFile(job.file)) {
                                 core::FileRef file = job.file;
-                                if (!checkRelevantPackages || shouldTypecheck(gs, *relevantPackages, file)) {
+                                if (!checkRelevantPackages || filesToTypecheck->contains(file)) {
                                     try {
                                         core::Context ctx(gs, core::Symbols::root(), file);
                                         typecheckOne(ctx, move(job), opts, intentionallyLeakASTs);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

It looks like [typechecking downstream packages](https://github.com/sorbet/sorbet/pull/10617) causes multithreaded_protocol_test to become racy. I'm seeing 15 of 100 runs of the test fail. Here's where it caused me to [have to rebuild](https://buildkite.com/sorbet/sorbet/builds/44336#01a06583-1bd7-4b4b-a9df-85d773dee47a) to merge my PR.

It seems to introduce a data race on `ErrorQueue::collected`, which makes sense given that we were noticing earlier today that `ErrorQueue` was playing fast and loose with concurrency.

Typecheck workers read that field through `hasCollectedErrors`, while the main typecheck thread concurrently mutates it in `flushErrorsForFile` via `collectAllInternal` and `collected[file]`.

Concurrent reads and writes can rehash the map, invalidating worker reads. This manifests as ASan buffer overflows/use-after-free errors or Abseil’s “hash table was modified unexpectedly” assertion.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.