### PR TITLE
Return a set of files that raised errors from `collectAll`

### DIFF
--- a/core/ErrorQueue.cc
+++ b/core/ErrorQueue.cc
@@ -18,10 +18,17 @@ void ErrorQueue::collectAllInternal() {
     }
 }
 
-bool ErrorQueue::hasCollectedErrors(core::FileRef file) const {
-    // NOTE: we only check for membership in collected here: flushing moves the error list out, but that doesn't mean
-    // that there weren't errors present for `file` for the lifetime of this queue.
-    return this->collected.contains(file);
+UnorderedSet<FileRef> ErrorQueue::collectAll() {
+    checkOwned();
+
+    this->collectAllInternal();
+
+    UnorderedSet<FileRef> hasErrors;
+    for (auto &entry : this->collected) {
+        hasErrors.insert(entry.first);
+    }
+
+    return hasErrors;
 }
 
 void ErrorQueue::flushAllErrors(const GlobalState &gs) {

--- a/core/ErrorQueue.h
+++ b/core/ErrorQueue.h
@@ -38,17 +38,8 @@ public:
     void pushQueryResponse(core::FileRef fromFile, std::unique_ptr<lsp::QueryResponse> response);
     bool isEmpty();
 
-    /** Collect all errors in the queue, so that we have an accurate picture of what files have raised errors. */
-    void collectAll() {
-        this->checkOwned();
-        this->collectAllInternal();
-    }
-
-    /**
-     * Checks if file currently has errors cached in the queue. This is only as up-to-date as the last call to
-     * this->collectAll().
-     */
-    bool hasCollectedErrors(core::FileRef file) const;
+    /** Collect all errors in the queue, returning a set of files that recorded errors at this point in time. */
+    UnorderedSet<FileRef> collectAll();
 
     void flushAllErrors(const GlobalState &gs);
     void flushErrorsForFile(const GlobalState &gs, FileRef file);

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -1482,14 +1482,14 @@ void typecheckOne(core::Context ctx, ast::ParsedFile resolved, const options::Op
 }
 
 bool shouldTypecheck(const core::GlobalState &gs, const UnorderedSet<core::packages::MangledName> &relevantPackages,
-                     core::FileRef file) {
+                     const UnorderedSet<core::FileRef> hadErrors, core::FileRef file) {
     auto pkg = gs.packageDB().getPackageNameForFile(file);
     if (!pkg.exists()) {
         return true;
     }
 
     // We override any potential skipping decision if the file has already had other errors raised.
-    if (gs.errorQueue->hasCollectedErrors(file)) {
+    if (hadErrors.contains(file)) {
         return true;
     }
 
@@ -1508,7 +1508,7 @@ void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> &&what, cons
 
     // Collect all outstanding errors eagerly, so that we have an up-to-date picture of what files have had errors
     // aready.
-    gs.errorQueue->collectAll();
+    auto recordedErrors = gs.errorQueue->collectAll();
 
     const auto &epochManager = *gs.epochManager;
     // Record epoch at start of typechecking before any preemption occurs.
@@ -1532,8 +1532,8 @@ void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> &&what, cons
 
         {
             ProgressIndicator cfgInferProgress(opts.showProgress, "CFG+Inference", what.size());
-            workers.multiplexJob("typecheck", [&gs, &opts, epoch, &epochManager, &preemptionManager, fileq, outputq,
-                                               cancelable, relevantPackages, checkRelevantPackages,
+            workers.multiplexJob("typecheck", [&gs, &opts, epoch, &epochManager, &preemptionManager, &recordedErrors,
+                                               fileq, outputq, cancelable, relevantPackages, checkRelevantPackages,
                                                intentionallyLeakASTs]() {
                 ast::ParsedFile job;
                 int processedByThread = 0;
@@ -1558,7 +1558,8 @@ void typecheck(const core::GlobalState &gs, vector<ast::ParsedFile> &&what, cons
                             const bool fileWasChanged = preemptionManager && job.file.data(gs).epoch > epoch;
                             if (!isCanceled && !fileWasChanged && gs.errorQueue->wouldFlushErrorsForFile(job.file)) {
                                 core::FileRef file = job.file;
-                                if (!checkRelevantPackages || shouldTypecheck(gs, *relevantPackages, file)) {
+                                if (!checkRelevantPackages ||
+                                    shouldTypecheck(gs, *relevantPackages, recordedErrors, file)) {
                                     try {
                                         core::Context ctx(gs, core::Symbols::root(), file);
                                         typecheckOne(ctx, move(job), opts, intentionallyLeakASTs);


### PR DESCRIPTION
To avoid looking into the `ErrorQueue::collected` map from worker threads, return a set of all files that were in the error queue when `ErrorQueue::collectAll` is called.


### Motivation
Avoiding concurrency issues in the `ErrorQueue`.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests, the multithreaded_protocol_test_corpus should be more stable now.
