### PR TITLE
Track the stratum of all files in the fast-path edit

### DIFF
--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -328,7 +328,11 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
     // Remember where in the package graph we're making this change, as that will determine how much we can copy on the
     // next slow path. We consider all parts of the edit, not just changed files, as running the fast path will mutate
     // the symbols of the stratum the files belong to.
-    gs->reopenStratum(this->getFileStratumMapping().getStratumForFiles(toTypecheck));
+    auto editStratum = this->lastStratum;
+    for (auto fref : toTypecheck) {
+        editStratum = std::min(editStratum, this->fileToStratum[fref.id()]);
+    }
+    gs->reopenStratum(editStratum);
 
     if (shouldRunIncrementalNamer && gs->packageDB().enabled()) {
         vector<core::FileRef> packageFiles;

--- a/main/lsp/LSPTypechecker.cc
+++ b/main/lsp/LSPTypechecker.cc
@@ -288,7 +288,6 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
     }
 
     config->logger->debug("Added {} files that were not part of the edit to the update set", toTypecheck.size());
-    auto editStratum = this->lastStratum;
     UnorderedMap<core::FileRef, shared_ptr<const core::FileHash>> oldFoundHashesForFiles;
     auto ix = -1;
     for (auto &file : updates.updatedFiles) {
@@ -297,7 +296,6 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
         ENFORCE(fref.exists(), "New files are not supported in the fast path");
         ENFORCE(fref == gs->findFileByPath(file->path()));
 
-        auto newHash = file->sourceHash();
         auto oldFile = gs->replaceFile(fref, std::move(file));
 
         if (shouldRunIncrementalNamer) {
@@ -318,13 +316,6 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
             oldFoundHashesForFiles.emplace(fref, oldFile->getFileHash());
         }
 
-        // We track the edit stratum for all files that were updated by the edit, if their source hashes differ. This
-        // will avoid bumping the reopened stratum down when the file was opened by a query like go-to-definition,
-        // but is still fairly coarse grained, as any change will mark the package as needing to be re-typechecked.
-        if (oldFile->sourceHash() != newHash) {
-            editStratum = std::min(this->fileToStratum[fref.id()], editStratum);
-        }
-
         // If file doesn't have a typed: sigil, then we need to ensure it's typechecked using typed: false.
         fref.data(*gs).strictLevel = pipeline::decideStrictLevel(*gs, fref, config->opts);
 
@@ -334,9 +325,10 @@ LSPTypechecker::FastPathResult LSPTypechecker::runFastPath(LSPFileUpdates &updat
     updates.updatedFiles.clear();
     updates.updatedFileRefs.clear();
 
-    // Remember where in the package graph we're making this change, as that will determine how much we can
-    // copy on the next slow path.
-    gs->reopenStratum(editStratum);
+    // Remember where in the package graph we're making this change, as that will determine how much we can copy on the
+    // next slow path. We consider all parts of the edit, not just changed files, as running the fast path will mutate
+    // the symbols of the stratum the files belong to.
+    gs->reopenStratum(this->getFileStratumMapping().getStratumForFiles(toTypecheck));
 
     if (shouldRunIncrementalNamer && gs->packageDB().enabled()) {
         vector<core::FileRef> packageFiles;

--- a/test/lsp/protocol_test_corpus.cc
+++ b/test/lsp/protocol_test_corpus.cc
@@ -1637,9 +1637,8 @@ TEST_CASE_FIXTURE(ProtocolTest, "ErrorsRemainAfterSlowPathRestart") {
     }
 }
 
-// Tests that no-op fast path edits don't push the fastPathEditStratum down, affecting where we can start the next slow
-// path from.
-TEST_CASE_FIXTURE(ProtocolTest, "ViewingFilesDoesntAffectFastPathEditStratum") {
+// Show that no-op fast path edits still shrink the copyable prefix of the symbol table.
+TEST_CASE_FIXTURE(ProtocolTest, "ViewingFilesAffectsFastPathEditStratum") {
     auto initOpts = make_shared<realmain::options::Options>();
     initOpts->cacheSensitiveOptions.sorbetPackages = true;
     initOpts->packageDirected = true;
@@ -1680,7 +1679,7 @@ TEST_CASE_FIXTURE(ProtocolTest, "ViewingFilesDoesntAffectFastPathEditStratum") {
     // The initial slow path.
     assertErrorDiagnostics(initializeLSP(supportsMarkdown, supportsCodeActionResolve, move(opts)), {});
 
-    // Only open a.rb, to test that we skip this stratum on the next slow path
+    // Only open a.rb, which will reset the editable prefix to stratum `0`.
     assertErrorDiagnostics(send(*openFile(files[1].first, files[1].second)), {});
 
     // Make a slow path edit to Root::Foo::A
@@ -1719,8 +1718,52 @@ TEST_CASE_FIXTURE(ProtocolTest, "ViewingFilesDoesntAffectFastPathEditStratum") {
             CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
             CHECK_EQ(params->status, SorbetTypecheckRunStatus::Ended);
 
-            // We're modifying package `Root::Foo`, after a no-op edit to `Root`. As a result, we should restart at
-            // stratum 1.
+            // We're modifying package `Root::Foo`, after a no-op edit to `Root`. However, as fast-path edits will
+            // always shrink the copyable prefix of the symbol table, we restart at stratum `0`.
+            CHECK_EQ(params->startingStratum, 0);
+        }
+
+        assertErrorDiagnostics(move(resps), {{files[3].first, 7, "Method `+` does not exist"}});
+    }
+
+    // Make another slow path edit to Root::Foo::A
+    {
+        assertErrorDiagnostics(send(*openFile(files[3].first, files[3].second)), {});
+
+        // Make a slow path modification to an existing file.
+        auto resps = send(*changeFile(files[3].first,
+                                      "# typed: true\n"
+                                      "module Root::Foo\n"
+                                      "  class A\n"
+                                      "    module Foo2\n"
+                                      "    end\n"
+                                      "\n"
+                                      "    def foo\n"
+                                      "      Root::A.new() + :type_error\n"
+                                      "    end\n"
+                                      "  end\n"
+                                      "end\n",
+                                      2));
+
+        // We should see at a minimum the start/end typechecking messages.
+        REQUIRE(resps.size() >= 2);
+
+        // We should see a starting and ending slow path message, with errors between. The error message between is the
+        // error on `Root::Foo::A`.
+        CHECK_EQ(resps.size(), 3);
+        {
+            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps.front()->asNotification().params);
+            CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
+            CHECK_EQ(params->status, SorbetTypecheckRunStatus::Started);
+        }
+
+        {
+            auto &params = get<unique_ptr<SorbetTypecheckRunInfo>>(resps.back()->asNotification().params);
+            CHECK_EQ(params->typecheckingPath, TypecheckingPath::Slow);
+            CHECK_EQ(params->status, SorbetTypecheckRunStatus::Ended);
+
+            // We're modifying package `Root::Foo` from a fresh state, so the next slow path should start at the stratum
+            // that defines `Root::Foo`.
             CHECK_EQ(params->startingStratum, 1);
         }
 


### PR DESCRIPTION
As the fast path will mutate the symbols of the stratum their package belongs to, even if their source is the same, we must push the copyable prefix down to the stratum of any file in the fast-path edit.

### Motivation
Stabilizing package-directed sorbet.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
