### PR TITLE
Populate `exports_` in packager.cc, not VisibilityChecker.cc

### DIFF
--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -52,6 +52,7 @@ core::ClassOrModuleRef getScopeForPackage(const core::GlobalState &gs, absl::Spa
 // For each __package.rb file, traverse the resolved tree and apply the visibility annotations to the symbols.
 class PropagateVisibility final {
     core::packages::PackageInfo &package;
+    vector<core::LocOffsets> exportsInCurrentAST;
 
     // Blames which location (export) caused a symbol to first be marked exported.
     struct ExportBlame {
@@ -367,7 +368,12 @@ public:
         // that doesn't matter: the rest of the pipeline depends on being able to see the `export`
         // lines locations for the purposes of autocorrects, so let's at least record that there is
         // an export here.
-        this->package.exports_.emplace_back(send.loc);
+        //
+        // TODO(jez) Delete this once `test!` packages is the default (SEO: `--test-packages`)
+        // We populate `exports_` in `packager.cc` now, but we still need to track a file-local
+        // version of it here, to handle the test and non-test `__package.rb` split.
+        // After `--test-packages`, PackageInfo::exports_ should be our only source of truth.
+        this->exportsInCurrentAST.emplace_back(send.loc);
 
         if (lit->symbol() == core::Symbols::StubModule()) {
             // Don't attempt to export a symbol that doesn't exist. Resolver reported an error already.
@@ -457,14 +463,14 @@ public:
         ast::ConstTreeWalk::apply(ctx, pass, f.tree);
 
         auto exportAll = package->locs.exportAll;
-        if (exportAll.exists() && !package->exports_.empty()) {
+        if (exportAll.exists() && !pass.exportsInCurrentAST.empty()) {
             if (auto e = ctx.beginError(exportAll, core::errors::Packager::ExportConflict)) {
                 e.setHeader("Package `{}` declares `{}` and therefore should not use explicit exports",
                             package->mangledName().owner.show(ctx), "export_all!");
 
                 auto edits = vector<core::AutocorrectSuggestion::Edit>{};
-                for (const auto &export_ : package->exports_) {
-                    auto replaceLoc = ctx.locAt(export_.loc);
+                for (const auto exportLoc : pass.exportsInCurrentAST) {
+                    auto replaceLoc = ctx.locAt(exportLoc);
                     auto [indentedStart, numSpaces] = replaceLoc.findStartOfIndentation(ctx);
                     // Remove leading whitespace
                     replaceLoc = replaceLoc.adjust(ctx, -1 * numSpaces, 0);

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -523,8 +523,12 @@ struct PackageSpecBodyWalk {
 
         if (send.fun == core::Names::export_()) {
             if (send.numPosArgs() == 1) {
-                // null indicates an invalid export.
-                verifyConstant(ctx, core::Names::export_(), send.getPosArg(0));
+                // Record every syntactically valid export. verifyConstant only checks that the argument is a constant
+                // path, so this also records constants that will fail to resolve later. The rest of the pipeline uses
+                // these locations for autocorrects.
+                if (verifyConstant(ctx, core::Names::export_(), send.getPosArg(0)) != nullptr) {
+                    info.exports_.emplace_back(send.loc);
+                }
             }
         } else if ((send.fun == core::Names::import() || send.fun == core::Names::testImport())) {
             if (send.numPosArgs() == 1) {
@@ -1012,6 +1016,7 @@ void rewritePackageSpec(const core::GlobalState &gs, ast::ParsedFile &package, P
     PackageSpecBodyWalk bodyWalk(info);
     core::Context ctx(gs, core::Symbols::root(), package.file);
     ast::TreeWalk::apply(ctx, bodyWalk, package.tree);
+
     if (gs.packageDB().enforceLayering()) {
         if (!bodyWalk.foundLayerDeclaration) {
             if (auto e = gs.beginError(info.declLoc(), core::errors::Packager::InvalidLayer)) {

--- a/test/testdata/packager/directed-export_all_in_test/__package.rb
+++ b/test/testdata/packager/directed-export_all_in_test/__package.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# typed: strict
+# enable-packager: true
+# enable-package-directed: true
+
+class Foo::Bar < PackageSpec
+  export_all!
+# ^^^^^^^^^^^ error: Package `Foo::Bar` declares `export_all!` and therefore should not use explicit exports
+
+  export Test::Foo::Bar::Thing
+
+end

--- a/test/testdata/packager/directed-export_all_in_test/other/__package.rb
+++ b/test/testdata/packager/directed-export_all_in_test/other/__package.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Other < PackageSpec
+  test_import Foo::Bar
+  test_import Typical
+end

--- a/test/testdata/packager/directed-export_all_in_test/other/test/other.test.rb
+++ b/test/testdata/packager/directed-export_all_in_test/other/test/other.test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Test::Other::OtherClass
+  Test::Foo::Bar::Thing.hello # This ref still works
+  Test::Foo::Bar::OtherThing # anything from the package should be fine
+
+  Test::Typical::Example # packages that don't use `export_all` are not affected
+  Test::Typical::NonExported # packages that don't use `export_all` are not affected
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Typical::NonExported` resolves but is not exported
+end

--- a/test/testdata/packager/directed-export_all_in_test/test/foo_bar.test.rb
+++ b/test/testdata/packager/directed-export_all_in_test/test/foo_bar.test.rb
@@ -1,0 +1,13 @@
+# typed: strict
+
+module Test::Foo::Bar
+  class Thing
+    extend T::Sig
+
+    sig {void}
+    def self.hello; end
+  end
+
+  class OtherThing
+  end
+end

--- a/test/testdata/packager/directed-export_all_in_test/typical/__package.rb
+++ b/test/testdata/packager/directed-export_all_in_test/typical/__package.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# typed: strict
+
+class Typical < PackageSpec
+  export Test::Typical::Example
+end

--- a/test/testdata/packager/directed-export_all_in_test/typical/test/typical.test.rb
+++ b/test/testdata/packager/directed-export_all_in_test/typical/test/typical.test.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+module Test::Typical
+  class Example; end
+  class NonExported; end
+end


### PR DESCRIPTION

<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I want to be able to access the contents of `exports_` in `resolver.cc`
for the package-aware resolver changes, but I can't safely do that right
now--since the exports are not populated until later, it looks like
`exports_` is always empty in `resolver.cc`.

There's some subtlety with the `export_all!` "no duplicates" error and
the `package-directed` mode, because we duplicate + stripe exports for
the test and non-test version of a `__package.rb`. The easiest way
around that for now is to continue to track what the `exports_` vector
would have tracked, but keep it local to the file. We can delete that
once we've gotten rid of test packages, and let `packager.cc` be the
sole source of truth.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I added an `# enable-package-directed: true` test for the `export_all!` changes,
which would have failed had it not existed and I had done the naive change to
only move the `export_ = ...` line, without also pulling the `export_all!` line
into packager.cc.

Check the first commit's message to see that the new test is identical to an
existing test, except that it has `# enable-package-directed: true` in it.

- - - - -

It's kind of ironic that we need this, because in some ways it's a revert of this change:

https://github.com/sorbet/sorbet/pull/9342

which first moved `export_` parsing into `VisibilityChecker`. We're moving it back to `packager.cc`, but we're not bringing back the logic which required tracking a `vector<vector<NameRef>>` for each exported constant.