### PR TITLE
Put all the friend annotations at the beginning of the class

### DIFF
--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -29,6 +29,7 @@ public:
 
 class PackageDB final {
     friend class core::GlobalState;
+    friend class UnfreezePackages;
 
 public:
     static constexpr NameRef TEST_NAMESPACE = core::Names::Constants::Test();
@@ -156,8 +157,6 @@ private:
     std::thread::id writerThread;
 
     Condensation condensation_;
-
-    friend class UnfreezePackages;
 };
 
 } // namespace sorbet::core::packages


### PR DESCRIPTION

### Motivation
It's nice to have friend declarations grouped together.


### Test plan
No semantic changes.
