### PR TITLE
Allow "overwriting" a `final` method if it's an abstract method

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -272,7 +272,6 @@ module T::Private::Methods
           end
         end
 
-
         found_error = true
 
         final_sig = T::Private::Methods.signature_for_method(ancestor.instance_method(method_name))

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -267,7 +267,7 @@ module T::Private::Methods
           # but rather implementing an interface that would defer back
           # to this implementation.
           source_sig = T::Private::Methods.signature_for_method(source.instance_method(method_name))
-          if source_sig.mode == T::Private::Methods::Modes.abstract
+          if source_sig&.mode == T::Private::Methods::Modes.abstract
             next
           end
         end

--- a/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/_methods.rb
@@ -227,6 +227,7 @@ module T::Private::Methods
       source_ancestors = T.let(nil, T.nilable(T::Array[T::Module[T.anything]]))
       found_error = T.let(false, T::Boolean)
     end
+
     found_error = false
     # use reverse_each to check farther-up ancestors first, for better error messages.
     target.ancestors.reverse_each do |ancestor|
@@ -258,6 +259,19 @@ module T::Private::Methods
           end
           next if defining_ancestor_idx && source_ancestors[defining_ancestor_idx] == ancestor
         end
+
+        if source && T::AbstractUtils.abstract_module?(source)
+          # If the source is abstract, then it's possible that the
+          # method we're "redefining" was declared as abstract
+          # there. In that case, this may not be actually redefining,
+          # but rather implementing an interface that would defer back
+          # to this implementation.
+          source_sig = T::Private::Methods.signature_for_method(source.instance_method(method_name))
+          if source_sig.mode == T::Private::Methods::Modes.abstract
+            next
+          end
+        end
+
 
         found_error = true
 

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -600,8 +600,8 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   it 'allows final "overriding" when the override is abstract' do
     parent = Class.new do
       extend T::Sig
-      sig(:final) { void }
-      def foo = puts "hello"
+      sig(:final) { returns(String) }
+      def foo = "hello"
     end
 
     ifoo = Module.new do
@@ -609,7 +609,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
       extend T::Helpers
       abstract!
 
-      sig { abstract.void }
+      sig { abstract.returns(String) }
       def foo; end
     end
 
@@ -621,8 +621,8 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   it 'only allows "final overriding" if the method is actually abstract' do
     parent = Class.new do
       extend T::Sig
-      sig(:final) { void }
-      def foo = puts "hello"
+      sig(:final) { returns(String) }
+      def foo = "hello"
     end
 
     ifoo = Module.new do
@@ -644,7 +644,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   it 'doesnt let one "final override" stop us from finding another' do
     parent = Class.new do
       extend T::Sig
-      sig(:final) { void }
+      sig(:final) { returns(String) }
       def foo = puts "hello"
     end
 
@@ -653,7 +653,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
       extend T::Helpers
       abstract!
 
-      sig { abstract.void }
+      sig { abstract.returns(String) }
       def foo; end
     end
 
@@ -662,7 +662,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
       extend T::Helpers
       abstract!
 
-      sig { void }
+      sig { returns(String) }
       def foo = puts "goodbye"
     end
 

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -596,4 +596,81 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
   ensure
     T::Configuration.sig_validation_error_handler = nil
   end
+
+  it 'allows final "overriding" when the override is abstract' do
+    parent = Class.new do
+      extend T::Sig
+      sig(:final) { void }
+      def foo = puts "hello"
+    end
+
+    ifoo = Module.new do
+      extend T::Sig
+      extend T::Helpers
+      abstract!
+
+      sig { abstract.void }
+      def foo; end
+    end
+
+    Class.new(parent) do
+      include ifoo
+    end
+  end
+
+  it 'only allows "final overriding" if the method is actually abstract' do
+    parent = Class.new do
+      extend T::Sig
+      sig(:final) { void }
+      def foo = puts "hello"
+    end
+
+    ifoo = Module.new do
+      extend T::Sig
+      extend T::Helpers
+      abstract!
+
+      sig { void }
+      def foo; end
+    end
+
+    assert_raises(RuntimeError) do
+      Class.new(parent) do
+        include ifoo
+      end
+    end
+  end
+
+  it 'doesnt let one "final override" stop us from finding another' do
+    parent = Class.new do
+      extend T::Sig
+      sig(:final) { void }
+      def foo = puts "hello"
+    end
+
+    good_mod = Module.new do
+      extend T::Sig
+      extend T::Helpers
+      abstract!
+
+      sig { abstract.void }
+      def foo; end
+    end
+
+    bad_mod = Module.new do
+      extend T::Sig
+      extend T::Helpers
+      abstract!
+
+      sig { void }
+      def foo = puts "goodbye"
+    end
+
+    assert_raises(RuntimeError) do
+      Class.new(parent) do
+        include good_mod
+        include bad_mod
+      end
+    end
+  end
 end

--- a/gems/sorbet-runtime/test/types/final_method.rb
+++ b/gems/sorbet-runtime/test/types/final_method.rb
@@ -645,7 +645,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
     parent = Class.new do
       extend T::Sig
       sig(:final) { returns(String) }
-      def foo = puts "hello"
+      def foo = "hello"
     end
 
     good_mod = Module.new do
@@ -663,7 +663,7 @@ class Opus::Types::Test::FinalMethodTest < Critic::Unit::UnitTest
       abstract!
 
       sig { returns(String) }
-      def foo = puts "goodbye"
+      def foo = "goodbye"
     end
 
     assert_raises(RuntimeError) do


### PR DESCRIPTION
This change addresses an order-dependence that happens between `sig(:final)` methods and mixins by making the final machinery skip cases where the "override" is actually an abstract method which would defer to the final method.

### Motivation
Previously, if we had a final method already defined (e.g. from a parent class) and we included a mixin which defines that method, we'd raise an error. However, sometimes that method isn't actually overriding the real method, particularly when including an abstract module where that method had been defined as abstract: in that case, we'd still be calling the final method. This meant that certain patterns would have had surprising runtime failures despite being accepted statically. For example, this would fail at runtime:

```ruby
# typed: true

class Parent
  sig(:final) { void }
  def foo = puts 'Hello!'
end

module IFoo
  extend T::Helpers
  abstract!

  sig { abstract.void }
  def foo; end
end

class Child < Parent
  include IFoo # <- suceeds statically, fails at runtime
end
```
[-> sorbet.run link](https://sorbet.run/#%23%20typed%3A%20true%0A%0Aclass%20Parent%0A%20%20extend%20T%3A%3ASig%0A%0A%20%20sig%28%3Afinal%29%20%7B%20void%20%7D%0A%20%20def%20foo%20%3D%20puts%20'Hello!'%0Aend%0A%0Amodule%20IFoo%0A%20%20extend%20T%3A%3ASig%0A%20%20extend%20T%3A%3AHelpers%0A%20%20abstract!%0A%0A%20%20sig%20%7B%20abstract.void%20%7D%0A%20%20def%20foo%3B%20end%0Aend%0A%0Aclass%20Child%20%3C%20Parent%0A%20%20include%20IFoo%20%23%20%3C-%20suceeds%20statically%2C%20fails%20at%20runtime%0Aend%0A)

With this change, the above succeeds.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests. Added tests to exercise this case and show that it only happens when the "override" is happening from an abstract method.
