### PR TITLE
Support forcing test packages on

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -2110,7 +2110,8 @@ unique_ptr<GlobalState> GlobalState::copyForIndexThread(
     const vector<string> &extraPackageFilesDirectorySlashPrefixes,
     const vector<string> &packageSkipRBIExportEnforcementDirs, const vector<string> &allowRelaxedPackagerChecksFor,
     const vector<string> &updateVisibilityFor, const vector<string> &packagerLayers, string errorHint,
-    packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility, bool packageAttributedErrors) const {
+    packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility, bool packageAttributedErrors,
+    bool testPackages) const {
     ENFORCE(fileTableFrozen);
     auto result = make_unique<GlobalState>(this->errorQueue, this->epochManager);
 
@@ -2132,7 +2133,7 @@ unique_ptr<GlobalState> GlobalState::copyForIndexThread(
                                    extraPackageFilesDirectorySlashDeprecatedPrefixes,
                                    extraPackageFilesDirectorySlashPrefixes, packageSkipRBIExportEnforcementDirs,
                                    allowRelaxedPackagerChecksFor, updateVisibilityFor, packagerLayers, errorHint,
-                                   genPackagesMode, allowRelaxingTestVisibility, packageAttributedErrors);
+                                   genPackagesMode, allowRelaxingTestVisibility, packageAttributedErrors, testPackages);
     }
 
     return result;
@@ -2144,7 +2145,7 @@ unique_ptr<GlobalState> GlobalState::copyForLSPTypechecker(
     const vector<string> &extraPackageFilesDirectorySlashPrefixes,
     const vector<string> &packageSkipRBIExportEnforcementDirs, const vector<string> &allowRelaxedPackagerChecksFor,
     const vector<string> &updateVisibilityFor, const vector<string> &packagerLayers, string errorHint,
-    packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility) const {
+    packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility, bool testPackages) const {
     auto result = make_unique<GlobalState>(this->errorQueue, this->epochManager);
 
     result->initEmpty();
@@ -2165,7 +2166,7 @@ unique_ptr<GlobalState> GlobalState::copyForLSPTypechecker(
                                    extraPackageFilesDirectorySlashDeprecatedPrefixes,
                                    extraPackageFilesDirectorySlashPrefixes, packageSkipRBIExportEnforcementDirs,
                                    allowRelaxedPackagerChecksFor, updateVisibilityFor, packagerLayers, errorHint,
-                                   genPackagesMode, allowRelaxingTestVisibility, packageAttributedErrors);
+                                   genPackagesMode, allowRelaxingTestVisibility, packageAttributedErrors, testPackages);
     }
 
     return result;
@@ -2178,7 +2179,7 @@ unique_ptr<GlobalState> GlobalState::copyForSlowPath(
     const vector<string> &packageSkipRBIExportEnforcementDirs, const vector<string> &allowRelaxedPackagerChecksFor,
     const vector<string> &updateVisibilityFor, const vector<string> &packagerLayers, string errorHint,
     packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility, bool packageAttributedErrors,
-    core::packages::Stratum toStratum) const {
+    bool testPackages, core::packages::Stratum toStratum) const {
     auto result = make_unique<GlobalState>(this->errorQueue, this->epochManager);
 
     // We omit a call to `initEmpty` here, as the only intended use of this function is to have its symbol table
@@ -2209,11 +2210,11 @@ unique_ptr<GlobalState> GlobalState::copyForSlowPath(
         {
             core::UnfreezeNameTable unfreezeToEnterPackagerOptionsGS(*result);
             core::packages::UnfreezePackages unfreezeToEnterPackagerOptionsPackageDB = result->unfreezePackages();
-            result->setPackagerOptions(extraPackageFilesDirectoryUnderscorePrefixes,
-                                       extraPackageFilesDirectorySlashDeprecatedPrefixes,
-                                       extraPackageFilesDirectorySlashPrefixes, packageSkipRBIExportEnforcementDirs,
-                                       allowRelaxedPackagerChecksFor, updateVisibilityFor, packagerLayers, errorHint,
-                                       genPackagesMode, allowRelaxingTestVisibility, packageAttributedErrors);
+            result->setPackagerOptions(
+                extraPackageFilesDirectoryUnderscorePrefixes, extraPackageFilesDirectorySlashDeprecatedPrefixes,
+                extraPackageFilesDirectorySlashPrefixes, packageSkipRBIExportEnforcementDirs,
+                allowRelaxedPackagerChecksFor, updateVisibilityFor, packagerLayers, errorHint, genPackagesMode,
+                allowRelaxingTestVisibility, packageAttributedErrors, testPackages);
         }
 
         result->copySymbolTableFrom(*this, toStratum);
@@ -2461,7 +2462,8 @@ void GlobalState::setPackagerOptions(const vector<string> &extraPackageFilesDire
                                      const vector<string> &allowRelaxedPackagerChecksFor,
                                      const vector<string> &updateVisibilityFor, const vector<string> &packagerLayers,
                                      string errorHint, packages::GenPackagesMode genPackagesMode,
-                                     bool allowRelaxingTestVisibility, bool packageAttributedErrors) {
+                                     bool allowRelaxingTestVisibility, bool packageAttributedErrors,
+                                     bool testPackages) {
     ENFORCE_NO_TIMER(!packageDB_.frozen);
 
     packageDB_.enabled_ = true;
@@ -2477,6 +2479,7 @@ void GlobalState::setPackagerOptions(const vector<string> &extraPackageFilesDire
     absl::c_transform(packagerLayers, std::back_inserter(packageDB_.layers_),
                       [this](const auto &layer) { return enterNameUTF8(layer); });
     packageDB_.errorHint_ = errorHint;
+    packageDB_.testPackages_ = testPackages;
 }
 
 packages::UnfreezePackages GlobalState::unfreezePackages() {

--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1191,7 +1191,8 @@ ClassOrModuleRef GlobalState::enterClassOrModuleSymbol(Loc loc, ClassOrModuleRef
     }
 
     // TODO(trevor) remove this once we've fully migrated to test-packages
-    if (owner == Symbols::root() && name == packages::PackageDB::TEST_NAMESPACE) {
+    if (owner == Symbols::root() &&
+        (!this->packageDB().testPackages() && name == packages::PackageDB::TEST_NAMESPACE)) {
         // Leave packageRegistryOwner as `<PackageSpecRegistry>` (essentially, skip over `Test` when
         // searching for package names). Leave `package` as the non-existent package name.
         return ret;

--- a/core/GlobalState.h
+++ b/core/GlobalState.h
@@ -441,7 +441,7 @@ public:
                             const std::vector<std::string> &updateVisibilityFor,
                             const std::vector<std::string> &packagerLayers, std::string errorHint,
                             packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility,
-                            bool packageAttributedErrors);
+                            bool packageAttributedErrors, bool testPackages);
     packages::UnfreezePackages unfreezePackages();
 
     NameRef nextMangledName(ClassOrModuleRef owner, NameRef origName);
@@ -566,7 +566,7 @@ public:
         const std::vector<std::string> &allowRelaxedPackagerChecksFor,
         const std::vector<std::string> &updateVisibilityFor, const std::vector<std::string> &packagerLayers,
         std::string errorHint, packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility,
-        bool packageAttributedErrors) const;
+        bool packageAttributedErrors, bool testPackages) const;
 
     // Minimally copy the global state, including the file table, to initialize the LSPTypechecker.
     // NOTE: this very intentionally will not copy the symbol or name tables. The symbol tables aren't used or populated
@@ -578,7 +578,8 @@ public:
         const std::vector<std::string> &packageSkipRBIExportEnforcementDirs,
         const std::vector<std::string> &allowRelaxedPackagerChecksFor,
         const std::vector<std::string> &updateVisibilityFor, const std::vector<std::string> &packagerLayers,
-        std::string errorHint, packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility) const;
+        std::string errorHint, packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility,
+        bool testPackages) const;
 
     // Copy the name table, file table and other parts of GlobalState that are required to start the slow path. If the
     // `toStratum` value is passed as something other than the `0` stratum, the prefix of the symbol table leading up to
@@ -591,7 +592,7 @@ public:
                     const std::vector<std::string> &allowRelaxedPackagerChecksFor,
                     const std::vector<std::string> &updateVisibilityFor, const std::vector<std::string> &packagerLayers,
                     std::string errorHint, packages::GenPackagesMode genPackagesMode, bool allowRelaxingTestVisibility,
-                    bool packageAttributedErrors, core::packages::Stratum toStratum) const;
+                    bool packageAttributedErrors, bool testPackages, core::packages::Stratum toStratum) const;
 
     // Contains a path prefix that should be stripped from all printed paths.
     std::string pathPrefix;

--- a/core/packages/PackageDB.h
+++ b/core/packages/PackageDB.h
@@ -71,6 +71,12 @@ public:
         return this->enabled_;
     }
 
+    // Whether the --experimental-test-packages mode is active. This controls whether all packages are treated as having
+    // been migrated to `test!` packages; if this returns `false` there still may be test packages present.
+    bool testPackages() const {
+        return this->testPackages_;
+    }
+
     GenPackagesMode genPackagesMode() const {
         return this->genPackagesMode_;
     }
@@ -154,6 +160,8 @@ private:
 
     bool frozen = true;
     std::thread::id writerThread;
+
+    bool testPackages_ = false;
 
     Condensation condensation_;
 

--- a/core/test/core_test.cc
+++ b/core/test/core_test.cc
@@ -441,7 +441,7 @@ TEST_CASE("isPackageSpecSymbol") {
 
     {
         auto unfrezePackages = gs.packageDB().unfreeze();
-        gs.setPackagerOptions({}, {}, {}, {}, {}, {}, {}, "", packages::GenPackagesMode::Disabled, false, false);
+        gs.setPackagerOptions({}, {}, {}, {}, {}, {}, {}, "", packages::GenPackagesMode::Disabled, false, false, false);
     }
 
     CHECK_FALSE(Symbols::root().isPackageSpecSymbol(gs));

--- a/main/lsp/LSPIndexer.cc
+++ b/main/lsp/LSPIndexer.cc
@@ -277,16 +277,17 @@ void LSPIndexer::transferInitializeState(InitializedTask &task) {
     // indexer and typechecker's file tables will almost immediately diverge, but that's not an issue as we don't share
     // `core::FileRef` values between the two.
     auto enableGenPackagesAllowRelaxingTestVisibility = false;
-    auto typecheckerGS = std::exchange(
-        this->gs, this->gs->copyForLSPTypechecker(
-                      this->config->opts.cacheSensitiveOptions.sorbetPackages,
-                      this->config->opts.extraPackageFilesDirectoryUnderscorePrefixes,
-                      this->config->opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
-                      this->config->opts.extraPackageFilesDirectorySlashPrefixes,
-                      this->config->opts.packageSkipRBIExportEnforcementDirs,
-                      this->config->opts.allowRelaxedPackagerChecksFor, this->config->opts.updateVisibilityFor,
-                      this->config->opts.packagerLayers, this->config->opts.sorbetPackagesHint,
-                      core::packages::GenPackagesMode::Disabled, enableGenPackagesAllowRelaxingTestVisibility));
+    auto typecheckerGS =
+        std::exchange(this->gs, this->gs->copyForLSPTypechecker(
+                                    this->config->opts.cacheSensitiveOptions.sorbetPackages,
+                                    this->config->opts.extraPackageFilesDirectoryUnderscorePrefixes,
+                                    this->config->opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
+                                    this->config->opts.extraPackageFilesDirectorySlashPrefixes,
+                                    this->config->opts.packageSkipRBIExportEnforcementDirs,
+                                    this->config->opts.allowRelaxedPackagerChecksFor,
+                                    this->config->opts.updateVisibilityFor, this->config->opts.packagerLayers,
+                                    this->config->opts.sorbetPackagesHint, core::packages::GenPackagesMode::Disabled,
+                                    enableGenPackagesAllowRelaxingTestVisibility, this->config->opts.testPackages));
 
     task.setGlobalState(std::move(typecheckerGS));
     task.setKeyValueStore(std::move(this->kvstore));

--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -654,6 +654,9 @@ buildOptions(const vector<pipeline::semantic_extension::SemanticExtensionProvide
     options.add_options(section)("experimental-package-directed",
                                  "Enable support for checking by package, instead of processing all files at once",
                                  cxxopts::value<bool>());
+    options.add_options(section)("experimental-test-packages",
+                                 "Disable support for implicit test namespaces in existing packages",
+                                 cxxopts::value<bool>());
     // }}}
 
     // ----- STRIPE AUTOGEN ----------------------------------------------- {{{
@@ -1243,6 +1246,12 @@ void readOptions(Options &opts,
         opts.uniquelyDefinedBehavior = raw["uniquely-defined-behavior"].as<bool>();
         opts.cacheSensitiveOptions.sorbetPackages =
             raw["sorbet-packages"].as<bool>() || raw["stripe-packages"].as<bool>();
+
+        opts.testPackages = raw["experimental-test-packages"].as<bool>();
+        if (opts.testPackages && !opts.cacheSensitiveOptions.sorbetPackages) {
+            logger->error("--experimental-test-packages can only be speciried in --sorbet-packages mode");
+            throw EarlyReturnWithCode(1);
+        }
 
         opts.packageAttributedErrors = raw["package-attributed-errors"].as<bool>();
         if (opts.packageAttributedErrors && !opts.cacheSensitiveOptions.sorbetPackages) {

--- a/main/options/options.h
+++ b/main/options/options.h
@@ -162,6 +162,7 @@ struct Options {
     std::vector<std::string> allowRelaxedPackagerChecksFor;
     std::vector<std::string> updateVisibilityFor;
     std::vector<std::string> packagerLayers;
+    bool testPackages = false;
     std::string typedSource = "";
     std::string cacheDir = "";
     // This configured both maximum filesystem db size and max virtual memory usage

--- a/main/pipeline/pipeline.cc
+++ b/main/pipeline/pipeline.cc
@@ -112,7 +112,7 @@ void setGlobalStateOptions(core::GlobalState &gs, const options::Options &opts) 
             opts.extraPackageFilesDirectoryUnderscorePrefixes, opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
             opts.extraPackageFilesDirectorySlashPrefixes, opts.packageSkipRBIExportEnforcementDirs,
             opts.allowRelaxedPackagerChecksFor, opts.updateVisibilityFor, opts.packagerLayers, opts.sorbetPackagesHint,
-            opts.genPackagesMode, opts.allowRelaxingTestVisibility, opts.packageAttributedErrors);
+            opts.genPackagesMode, opts.allowRelaxingTestVisibility, opts.packageAttributedErrors, opts.testPackages);
     }
 #endif
 }
@@ -129,7 +129,8 @@ unique_ptr<core::GlobalState> copyForSlowPath(const core::GlobalState &from, con
         opts.extraPackageFilesDirectoryUnderscorePrefixes, opts.extraPackageFilesDirectorySlashDeprecatedPrefixes,
         opts.extraPackageFilesDirectorySlashPrefixes, opts.packageSkipRBIExportEnforcementDirs,
         opts.allowRelaxedPackagerChecksFor, opts.updateVisibilityFor, opts.packagerLayers, opts.sorbetPackagesHint,
-        opts.genPackagesMode, opts.allowRelaxingTestVisibility, opts.packageAttributedErrors, forStratum);
+        opts.genPackagesMode, opts.allowRelaxingTestVisibility, opts.packageAttributedErrors, opts.testPackages,
+        forStratum);
 
     // Fall back on initializing from the payload if we're not copying part of from's symbol table.
     if (forStratum == core::packages::Stratum(0)) {
@@ -720,7 +721,7 @@ ast::ParsedFilesOrCancelled indexSuppliedFiles(core::GlobalState &baseGs, absl::
         opts.extraPackageFilesDirectorySlashDeprecatedPrefixes, opts.extraPackageFilesDirectorySlashPrefixes,
         opts.packageSkipRBIExportEnforcementDirs, opts.allowRelaxedPackagerChecksFor, opts.updateVisibilityFor,
         opts.packagerLayers, opts.sorbetPackagesHint, opts.genPackagesMode, opts.allowRelaxingTestVisibility,
-        opts.packageAttributedErrors);
+        opts.packageAttributedErrors, opts.testPackages);
 
     workers.multiplexJob("indexSuppliedFiles", [emptyGs, &opts, fileq, resultq, &kvstore, cancelable]() {
         Timer timeit(emptyGs->tracer(), "indexSuppliedFilesWorker");
@@ -732,7 +733,7 @@ ast::ParsedFilesOrCancelled indexSuppliedFiles(core::GlobalState &baseGs, absl::
             opts.extraPackageFilesDirectorySlashDeprecatedPrefixes, opts.extraPackageFilesDirectorySlashPrefixes,
             opts.packageSkipRBIExportEnforcementDirs, opts.allowRelaxedPackagerChecksFor, opts.updateVisibilityFor,
             opts.packagerLayers, opts.sorbetPackagesHint, opts.genPackagesMode, opts.allowRelaxingTestVisibility,
-            opts.packageAttributedErrors);
+            opts.packageAttributedErrors, opts.testPackages);
         auto &epochManager = *localGs->epochManager;
 
         IndexThreadResultPack threadResult;

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -423,7 +423,9 @@ private:
 
         // TODO(trevor) this can be removed once we've fully migrated to test-packages, as the special
         // treatment of `Test::` will be gone.
-        if (this->pkg.usesTestPackages && inTestNamespace(gs)) {
+        // TODO(trevor) we consider `testPackages` here so that we only raise an error for the `Test::`
+        // namespace if we're not forcing test-packages everywhere.
+        if (this->pkg.usesTestPackages && !gs.packageDB().testPackages() && inTestNamespace(gs)) {
             return false;
         }
 

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -549,9 +549,15 @@ struct PackageSpecBodyWalk {
                     // TODO(trevor): this check can be removed after we've fully switched to test-packages, as
                     // `test_import` will no longer exist
                     if (info.usesTestPackages && send.fun == core::Names::testImport()) {
-                        if (auto e = ctx.beginError(send.funLoc, core::errors::Packager::InvalidPackageExpression)) {
-                            e.setHeader("Test imports must use `{}`", "import");
-                            e.replaceWith("Use import", ctx.locAt(send.funLoc), "import");
+                        // TODO(trevor) we completely ignore `test_import` if we're in test-packages mode. As part of
+                        // the migration is swapping in test files without modifying the originals, this gives us a good
+                        // path forward for not making a lot of potentially conflicting changes all at once.
+                        if (!ctx.state.packageDB().testPackages()) {
+                            if (auto e =
+                                    ctx.beginError(send.funLoc, core::errors::Packager::InvalidPackageExpression)) {
+                                e.setHeader("Test imports must use `{}`", "import");
+                                e.replaceWith("Use import", ctx.locAt(send.funLoc), "import");
+                            }
                         }
                     } else {
                         imp = &info.importedPackageNames.emplace_back(importName, method2ImportType(send), send.loc);

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -997,7 +997,7 @@ void rewritePackageSpec(const core::GlobalState &gs, ast::ParsedFile &package, P
     // packaging systems allow for `__package.rb` files to live inside of a `test` directory.
     //
     // TODO: all of this can go away once test-packages is fully rolled out
-    if (package.file.data(gs).isTestPackage(gs)) {
+    if (gs.packageDB().testPackages() || package.file.data(gs).isTestPackage(gs)) {
         info.usesTestPackages = true;
     } else {
         auto path = package.file.data(gs).path();

--- a/test/cli/test-packages-ignore-test-import/in_between/__package.rb
+++ b/test/cli/test-packages-ignore-test-import/in_between/__package.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+class InBetween < PackageSpec
+  import Migrated
+
+  test_import Migrated::Test
+end

--- a/test/cli/test-packages-ignore-test-import/in_between/foo.rb
+++ b/test/cli/test-packages-ignore-test-import/in_between/foo.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+module InBetween
+  class Foo
+  end
+end

--- a/test/cli/test-packages-ignore-test-import/in_between/test/__package.rb
+++ b/test/cli/test-packages-ignore-test-import/in_between/test/__package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+class Test::InBetween < PackageSpec
+  test!
+
+  import InBetween, uses_internals: true
+  import Migrated::Test
+end

--- a/test/cli/test-packages-ignore-test-import/in_between/test/foo.test.rb
+++ b/test/cli/test-packages-ignore-test-import/in_between/test/foo.test.rb
@@ -1,0 +1,10 @@
+# typed: true
+
+module Test::InBetween
+  class FooTest
+    def test_1
+      Migrated::Test::Helper.new
+      InBetween::Foo.new
+    end
+  end
+end

--- a/test/cli/test-packages-ignore-test-import/migrated/__package.rb
+++ b/test/cli/test-packages-ignore-test-import/migrated/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Migrated < PackageSpec
+  export Migrated::Foo
+end

--- a/test/cli/test-packages-ignore-test-import/migrated/foo.rb
+++ b/test/cli/test-packages-ignore-test-import/migrated/foo.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+module Migrated
+  class Foo
+  end
+end

--- a/test/cli/test-packages-ignore-test-import/migrated/test/__package.rb
+++ b/test/cli/test-packages-ignore-test-import/migrated/test/__package.rb
@@ -1,0 +1,9 @@
+# typed: strict
+
+class Migrated::Test < PackageSpec
+  test!
+
+  export Migrated::Test::Helper
+  
+  import Migrated, uses_internals: true
+end

--- a/test/cli/test-packages-ignore-test-import/migrated/test/helper.rb
+++ b/test/cli/test-packages-ignore-test-import/migrated/test/helper.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+module Migrated::Test
+  class Helper
+  end
+end

--- a/test/cli/test-packages-ignore-test-import/old_style/__package.rb
+++ b/test/cli/test-packages-ignore-test-import/old_style/__package.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+class OldStyle < PackageSpec
+  import Migrated
+
+  test_import Migrated::Test
+end

--- a/test/cli/test-packages-ignore-test-import/old_style/foo.rb
+++ b/test/cli/test-packages-ignore-test-import/old_style/foo.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+module OldStyle
+  class Foo
+  end
+end

--- a/test/cli/test-packages-ignore-test-import/old_style/test/foo.test.rb
+++ b/test/cli/test-packages-ignore-test-import/old_style/test/foo.test.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+module Test::OldStyle
+  class FooTest
+    def test_1
+      OldStyle::Foo.new
+    end
+  end
+end

--- a/test/cli/test-packages-ignore-test-import/test.out
+++ b/test/cli/test-packages-ignore-test-import/test.out
@@ -1,0 +1,7 @@
+old_style/test/foo.test.rb:3: File belongs to package `OldStyle` but defines a constant that does not match this namespace https://srb.help/3713
+     3 |module Test::OldStyle
+               ^^^^^^^^^^^^^^
+    old_style/__package.rb:3: Enclosing package declared here
+     3 |class OldStyle < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 1

--- a/test/cli/test-packages-ignore-test-import/test.sh
+++ b/test/cli/test-packages-ignore-test-import/test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+root="$PWD"
+
+cd test/cli/test-packages-ignore-test-import || ( echo "Failed to cd!"; exit 1 )
+
+"$root/main/sorbet" \
+  --censor-for-snapshot-tests --silence-dev-message --max-threads=0 \
+  --sorbet-packages --experimental-test-packages . 2>&1

--- a/website/docs/cli-ref.md
+++ b/website/docs/cli-ref.md
@@ -337,6 +337,9 @@ Usage:
       --experimental-package-directed
                                 Enable support for checking by package, instead of
                                 processing all files at once
+      --experimental-test-packages
+                                Disable support for implicit test namespaces in existing
+                                packages
 
 ```
 


### PR DESCRIPTION
Add the `--experimental-test-packages` flag back again, but this time change its behavior to force all packages to report that they're migrated. There are a few other behaviors that need to be conditional based on this flag:

1. special treatment of the `Test::` namespace by `GlobalState::enterClassSymbol`,
2. special treatment of `Test::` when determining if a constant is declared in the appropriate namespace, and
3. ignoring `test_import` completely when the flag is enabled

This will help the migration by allowing us to introduce test packages without modifying the original packges at the same time, enabling a more incremental cleanup effort.

I'd recommend reviewing by commit, as the change to re-introduce the flag is pretty noisy.

### Motivation
Simpler test-packages migration.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
