### PR TITLE
Closes #10631: Error 7027 autocorrect emits `T.let` annotation that fails at runtime for `Struct.new`

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -3035,7 +3035,12 @@ public:
         if (auto e = gs.beginError(loc, core::errors::Infer::UntypedConstantSuggestion)) {
             e.setHeader("Constants must have type annotations with `{}` when specifying `{}`", "T.let",
                         "# typed: strict");
-            if ((gs.suggestUnsafe || !ty.isUntyped()) && loc.exists() && argLocExists) {
+            auto isClassTypeStruct =
+                isa_type<ClassType>(ty) && cast_type_nonnull<ClassType>(ty).symbol == Symbols::Struct();
+            auto isAppliedTypeStruct =
+                isa_type<AppliedType>(ty) && cast_type_nonnull<AppliedType>(ty).klass == Symbols::Struct();
+            auto isStruct = isClassTypeStruct || isAppliedTypeStruct;
+            if ((gs.suggestUnsafe || !ty.isUntyped()) && loc.exists() && argLocExists && !isStruct) {
                 // (skip the autocorrect if we had to fall back to using callLoc, because using that
                 // will suggest something syntactically invalid like `T.let(U = begin; end, NilClass))`
                 e.replaceWith(fmt::format("Initialize as `{}`", ty.show(gs)), loc, "T.let({}, {})",

--- a/test/testdata/infer/suggest_constant_type_struct_new.rb
+++ b/test/testdata/infer/suggest_constant_type_struct_new.rb
@@ -1,0 +1,6 @@
+# typed: strict
+class Example
+  1.times do
+    Generated = Struct.new(:value) # error: Constants must have type annotations
+  end
+end

--- a/test/testdata/infer/suggest_constant_type_struct_new.rb.autocorrects.exp
+++ b/test/testdata/infer/suggest_constant_type_struct_new.rb.autocorrects.exp
@@ -1,0 +1,8 @@
+# -- test/testdata/infer/suggest_constant_type_struct_new.rb --
+# typed: strict
+class Example
+  1.times do
+    Generated = Struct.new(:value) # error: Constants must have type annotations
+  end
+end
+# ------------------------------


### PR DESCRIPTION
Closes #10631.

Verified against the pinned tree: the patch applies cleanly and the issue's post-fix check passes.
**Scope:** this repository does not build as a whole in the sandbox that produced this, so the check ran over the packages this patch touches and their dependencies. The rest of the repository was not built or tested here - please treat CI as the first check over the whole tree.

Written by an AI coding agent (Sloppy) and opened under my account.

<!-- sloppy-mission-proof:slp_p_73Irwx1Y7xNJ3ZGAmYN0_g -->