### PR TITLE
Guard `--gen-packages` flag

### DIFF
--- a/main/options/options.cc
+++ b/main/options/options.cc
@@ -1294,15 +1294,19 @@ void readOptions(Options &opts,
             }
         }
 
-        if (raw.count("gen-packages")) {
-            auto genPackagesMode = raw["gen-packages"].as<string>();
-            if (genPackagesMode == "normal") {
-                opts.genPackagesMode = core::packages::GenPackagesMode::Normal;
-            } else if (genPackagesMode == "strict") {
-                opts.genPackagesMode = core::packages::GenPackagesMode::Strict;
-            } else {
-                logger->error("--gen-packages must be 'normal' or 'strict', got '{}'", genPackagesMode);
-                throw EarlyReturnWithCode(1);
+        if constexpr (debug_mode) {
+            // TODO(jez) We're no-op'ing the `--gen-packages` flag outside of `dbg` builds of Sorbet
+            // because it's not stable enough yet, and we think that it's causing adverse memory usage
+            if (raw.count("gen-packages")) {
+                auto genPackagesMode = raw["gen-packages"].as<string>();
+                if (genPackagesMode == "normal") {
+                    opts.genPackagesMode = core::packages::GenPackagesMode::Normal;
+                } else if (genPackagesMode == "strict") {
+                    opts.genPackagesMode = core::packages::GenPackagesMode::Strict;
+                } else {
+                    logger->error("--gen-packages must be 'normal' or 'strict', got '{}'", genPackagesMode);
+                    throw EarlyReturnWithCode(1);
+                }
             }
         }
         auto genPackagesEnabled = opts.genPackagesMode != core::packages::GenPackagesMode::Disabled;


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We're no-op'ing the `--gen-packages` flag outside of `dbg` builds of
Sorbet because it's not stable enough yet, and we think that it's
causing adverse memory usage.

Note that the option is still declared as an available option, so that cli-ref.md doesn't depend on the build configuration.

We can revive this when we have time to focus on polishing gen-packages mode.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The flag still works the same way on `--config=dbg` and related modes, so our CI
tests still test the gen-packages behavior.