### PR TITLE
Make constant resolution package-aware

### DIFF
--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -12,6 +12,16 @@
 using namespace std;
 
 namespace sorbet::core::packages {
+bool Import::isAvailableTo(const core::GlobalState &gs, core::FileRef file) const {
+    if (this->type == ImportType::Normal) {
+        return true;
+    }
+    if (!file.data(gs).isPackagedTest()) {
+        return false;
+    }
+    return this->type != ImportType::TestUnit || !file.data(gs).isPackagedTestHelper();
+}
+
 string_view strictDependenciesLevelToString(StrictDependenciesLevel level) {
     switch (level) {
         case StrictDependenciesLevel::None:
@@ -514,7 +524,7 @@ PackageInfo::checkReferenceAgainstImports(core::Context ctx, core::LocOffsets er
     // Is this a test import not intended for use in helpers?
     auto testUnitImportInHelper = wasImported && import->type == core::packages::ImportType::TestUnit &&
                                   ctx.file.data(ctx).isPackagedTestHelper();
-    bool importNeeded = !wasImported || testImportInProd || testUnitImportInHelper;
+    bool importNeeded = !wasImported || !import->isAvailableTo(ctx.state, ctx.file);
 
     if (!importNeeded) {
         return nullopt;

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -494,14 +494,13 @@ static void addAutocorrect(core::Context ctx, core::ErrorBuilder &e,
 
 } // namespace
 
-// Returns `std::nullopt` if it's okay to use the symbol.
+// Returns `std::nullopt` if it's okay to reference the package from this file.
 // Returns a `PackageReferenceInfo` if the usage was not okay (e.g. missing import, modularity error, etc.)
 optional<core::packages::PackageReferenceInfo>
-PackageInfo::checkReferenceAgainstImports(core::Context ctx, core::LocOffsets errLoc, core::SymbolRef litSymbol) const {
+PackageInfo::checkReferenceAgainstImports(core::Context ctx, core::LocOffsets errLoc, MangledName otherPackage) const {
     auto &db = ctx.state.packageDB();
-    auto otherPackage = litSymbol.enclosingClass(ctx).data(ctx)->package;
     ENFORCE(otherPackage.exists() && this->mangledName() != otherPackage);
-    auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
+    auto &pkg = db.getPackageInfo(otherPackage);
 
     auto *import = this->importsPackage(otherPackage);
     auto wasImported = import != nullptr;
@@ -565,7 +564,7 @@ PackageInfo::checkReferenceAgainstImports(core::Context ctx, core::LocOffsets er
 
         if (!wasImported) {
             if (auto e = ctx.beginError(errLoc, core::errors::Packager::MissingImport)) {
-                e.setHeader("`{}` resolves but its package is not imported", litSymbol.show(ctx));
+                e.setHeader("`{}` is not imported", pkg.show(ctx));
                 e.addErrorLine(pkg.declLoc(), "Package defined here");
                 addAutocorrect(ctx, e, move(importAutocorrect));
             }
@@ -573,14 +572,14 @@ PackageInfo::checkReferenceAgainstImports(core::Context ctx, core::LocOffsets er
             ENFORCE(!isTestImport);
             ENFORCE(!this->usesTestPackages, "test_import found in --test-packages mode");
             if (auto e = ctx.beginError(errLoc, core::errors::Packager::UsedTestOnlyName)) {
-                e.setHeader("Used `{}` constant `{}` in non-test file", "test_import", litSymbol.show(ctx));
+                e.setHeader("Used `{}` package `{}` in non-test file", "test_import", pkg.show(ctx));
                 e.addErrorLine(pkg.declLoc(), "Defined here");
                 addAutocorrect(ctx, e, move(importAutocorrect));
             }
         } else if (testUnitImportInHelper) {
             ENFORCE(!this->usesTestPackages, "test_import found in --test-packages mode");
             if (auto e = ctx.beginError(errLoc, core::errors::Packager::UsedTestOnlyName)) {
-                e.setHeader("The `{}` constant `{}` can only be used in `{}` files", "test_import", litSymbol.show(ctx),
+                e.setHeader("The `{}` package `{}` can only be used in `{}` files", "test_import", pkg.show(ctx),
                             ".test.rb");
                 e.addErrorLine(pkg.declLoc(), "Defined here");
                 e.addErrorNote("This is because this `{}` is declared with `{}`, which means the constant can "
@@ -618,7 +617,7 @@ PackageInfo::checkReferenceAgainstImports(core::Context ctx, core::LocOffsets er
             }
             if (causesCycle) {
                 reasons.emplace_back(
-                    core::ErrorColors::format("importing its package would put `{}` into a cycle", this->show(ctx)));
+                    core::ErrorColors::format("importing it would put `{}` into a cycle", this->show(ctx)));
                 auto currentStrictDepsLevel = fmt::format(
                     "strict_dependencies '{}'", core::packages::strictDependenciesLevelToString(strictDepsLevel));
                 e.addErrorLine(core::Loc(this->file, this->locs.strictDependenciesLevel),
@@ -628,7 +627,7 @@ PackageInfo::checkReferenceAgainstImports(core::Context ctx, core::LocOffsets er
             }
 
             if (layeringViolation) {
-                reasons.emplace_back("importing its package would cause a layering violation");
+                reasons.emplace_back("importing it would cause a layering violation");
                 ENFORCE(pkg.layer.exists(), "causesLayeringViolation should return false if layer is not set");
                 ENFORCE(this->layer.exists(), "causesLayeringViolation should return false if layer is not set");
                 e.addErrorLine(core::Loc(pkg.file, pkg.locs.layer),
@@ -676,11 +675,11 @@ PackageInfo::checkReferenceAgainstImports(core::Context ctx, core::LocOffsets er
             } else {
                 ENFORCE(false, "At most six reasons should be present");
             }
-            e.setHeader("`{}` cannot be referenced here because {}", litSymbol.show(ctx), reason);
+            e.setHeader("`{}` cannot be referenced here because {}", pkg.show(ctx), reason);
             if (!wasImported) {
-                e.addErrorNote("`{}`'s package is not imported", litSymbol.show(ctx));
+                e.addErrorNote("`{}` is not imported", pkg.show(ctx));
             } else if (testImportInProd || testUnitImportInHelper) {
-                e.addErrorNote("`{}`'s package is imported as `{}`", litSymbol.show(ctx), "test_import");
+                e.addErrorNote("`{}` is imported as `{}`", pkg.show(ctx), "test_import");
             }
         }
     }

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -503,14 +503,6 @@ PackageInfo::checkReferenceAgainstImports(core::Context ctx, core::LocOffsets er
     ENFORCE(otherPackage.exists() && this->mangledName() != otherPackage);
     auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
 
-    auto otherFile = litSymbol.loc(ctx).file();
-    if (!otherFile.exists()) {
-        // This is unfortunate--we only need otherFile to determine weird --test-packages stuff
-        // (because we need to look at whether the file that the constant is defined in `isPackagedTest`, etc.)
-        // We can delete this after that migration.
-        return nullopt;
-    }
-
     auto *import = this->importsPackage(otherPackage);
     auto wasImported = import != nullptr;
     if (wasImported && this->usesTestPackages) {
@@ -525,16 +517,11 @@ PackageInfo::checkReferenceAgainstImports(core::Context ctx, core::LocOffsets er
                                   ctx.file.data(ctx).isPackagedTestHelper();
     bool importNeeded = !wasImported || testImportInProd || testUnitImportInHelper;
 
-    // If the imported symbol comes from the test namespace, we must also be in the test namespace.
-    // TODO(trevor): this check is redundant with import checking after the test-packages migration is complete.
-    bool testNamespaceInProd =
-        !pkg.usesTestPackages && otherFile.data(ctx).isPackagedTest() && !ctx.file.data(ctx).isPackagedTest();
-
-    if (!importNeeded && !testNamespaceInProd) {
+    if (!importNeeded) {
         return nullopt;
     }
 
-    bool isTestImport = otherFile.data(ctx).isPackagedTestHelper() || ctx.file.data(ctx).isPackagedTest();
+    bool isTestImport = ctx.file.data(ctx).isPackagedTest();
     if (this->usesTestPackages) {
         isTestImport = false;
     }
@@ -554,7 +541,7 @@ PackageInfo::checkReferenceAgainstImports(core::Context ctx, core::LocOffsets er
     bool causesVisibilityError = !pkg.isVisibleTo(ctx, *this, autocorrectedImportType);
     bool badTestReference = this->usesTestPackages && pkg.testPackage() && !this->testPackage();
     optional<string> path;
-    if (!isTestImport && !testNamespaceInProd && db.enforceLayering()) {
+    if (!isTestImport && db.enforceLayering()) {
         layeringViolation =
             strictDepsLevel > core::packages::StrictDependenciesLevel::False && this->causesLayeringViolation(db, pkg);
         strictDependenciesTooLow = importStrictDepsLevel != core::packages::StrictDependenciesLevel::None &&
@@ -565,7 +552,7 @@ PackageInfo::checkReferenceAgainstImports(core::Context ctx, core::LocOffsets er
         causesCycle = strictDepsLevel >= core::packages::StrictDependenciesLevel::LayeredDag && path.has_value();
     }
     bool hasModularityError = layeringViolation || strictDependenciesTooLow || causesCycle || badTestReference ||
-                              causesVisibilityError || testNamespaceInProd;
+                              causesVisibilityError;
     // visible_to errors are handled separately (by `updateVisibilityFor`),
     // so they're not included in this causesModularityError field of referencedPackages
     bool causesModularityError = hasModularityError && !causesVisibilityError;
@@ -610,7 +597,6 @@ PackageInfo::checkReferenceAgainstImports(core::Context ctx, core::LocOffsets er
         auto error = causesCycle           ? core::errors::Packager::StrictDependenciesViolation
                      : layeringViolation   ? core::errors::Packager::LayeringViolation
                      : badTestReference    ? core::errors::Packager::TestImportMismatch
-                     : testNamespaceInProd ? core::errors::Packager::UsedTestOnlyName
                                            : core::errors::Packager::StrictDependenciesViolation;
         if (auto e = ctx.beginError(errLoc, error)) {
             vector<string> reasons;
@@ -629,9 +615,6 @@ PackageInfo::checkReferenceAgainstImports(core::Context ctx, core::LocOffsets er
                 reasons.emplace_back(
                     core::ErrorColors::format("`{}` may not reference `{}` packages", this->show(ctx), "test!"));
                 e.addErrorLine(pkg.declLoc(), "Referenced `{}` package defined here", "test!");
-            }
-            if (testNamespaceInProd) {
-                reasons.emplace_back("it is defined in a test namespace and cannot be referenced in a non-test file");
             }
             if (causesCycle) {
                 reasons.emplace_back(
@@ -694,12 +677,10 @@ PackageInfo::checkReferenceAgainstImports(core::Context ctx, core::LocOffsets er
                 ENFORCE(false, "At most six reasons should be present");
             }
             e.setHeader("`{}` cannot be referenced here because {}", litSymbol.show(ctx), reason);
-            if (!testNamespaceInProd) {
                 if (!wasImported) {
                     e.addErrorNote("`{}`'s package is not imported", litSymbol.show(ctx));
                 } else if (testImportInProd || testUnitImportInHelper) {
                     e.addErrorNote("`{}`'s package is imported as `{}`", litSymbol.show(ctx), "test_import");
-                }
             }
         }
     }

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -551,8 +551,8 @@ PackageInfo::checkReferenceAgainstImports(core::Context ctx, core::LocOffsets er
         path = pkg.pathTo(ctx, this->mangledName());
         causesCycle = strictDepsLevel >= core::packages::StrictDependenciesLevel::LayeredDag && path.has_value();
     }
-    bool hasModularityError = layeringViolation || strictDependenciesTooLow || causesCycle || badTestReference ||
-                              causesVisibilityError;
+    bool hasModularityError =
+        layeringViolation || strictDependenciesTooLow || causesCycle || badTestReference || causesVisibilityError;
     // visible_to errors are handled separately (by `updateVisibilityFor`),
     // so they're not included in this causesModularityError field of referencedPackages
     bool causesModularityError = hasModularityError && !causesVisibilityError;
@@ -594,10 +594,10 @@ PackageInfo::checkReferenceAgainstImports(core::Context ctx, core::LocOffsets er
     } else {
         // TODO(neil): Provide actionable advice and/or link to a doc that would help the user resolve these
         // layering/strict_dependencies issues.
-        auto error = causesCycle           ? core::errors::Packager::StrictDependenciesViolation
-                     : layeringViolation   ? core::errors::Packager::LayeringViolation
-                     : badTestReference    ? core::errors::Packager::TestImportMismatch
-                                           : core::errors::Packager::StrictDependenciesViolation;
+        auto error = causesCycle         ? core::errors::Packager::StrictDependenciesViolation
+                     : layeringViolation ? core::errors::Packager::LayeringViolation
+                     : badTestReference  ? core::errors::Packager::TestImportMismatch
+                                         : core::errors::Packager::StrictDependenciesViolation;
         if (auto e = ctx.beginError(errLoc, error)) {
             vector<string> reasons;
             e.addErrorLine(this->declLoc(), "Enclosing package declared here");
@@ -677,10 +677,10 @@ PackageInfo::checkReferenceAgainstImports(core::Context ctx, core::LocOffsets er
                 ENFORCE(false, "At most six reasons should be present");
             }
             e.setHeader("`{}` cannot be referenced here because {}", litSymbol.show(ctx), reason);
-                if (!wasImported) {
-                    e.addErrorNote("`{}`'s package is not imported", litSymbol.show(ctx));
-                } else if (testImportInProd || testUnitImportInHelper) {
-                    e.addErrorNote("`{}`'s package is imported as `{}`", litSymbol.show(ctx), "test_import");
+            if (!wasImported) {
+                e.addErrorNote("`{}`'s package is not imported", litSymbol.show(ctx));
+            } else if (testImportInProd || testUnitImportInHelper) {
+                e.addErrorNote("`{}`'s package is imported as `{}`", litSymbol.show(ctx), "test_import");
             }
         }
     }

--- a/core/packages/PackageInfo.cc
+++ b/core/packages/PackageInfo.cc
@@ -822,6 +822,21 @@ void PackageInfo::trackPackageReferences(FileRef file, vector<pair<MangledName, 
     packagesReferencedByFile[file].swap(references);
 }
 
+void PackageInfo::trackPackageReference(FileRef file, MangledName package, PackageReferenceInfo referenceInfo) {
+    auto &references = packagesReferencedByFile[file];
+    auto existing = absl::c_find_if(references, [package](const auto &entry) { return entry.first == package; });
+    if (existing == references.end()) {
+        references.emplace_back(package, referenceInfo);
+    } else {
+        existing->second.importNeeded |= referenceInfo.importNeeded;
+        existing->second.causesModularityError |= referenceInfo.causesModularityError;
+    }
+}
+
+void PackageInfo::resetPackageReferences(FileRef file) {
+    packagesReferencedByFile.erase(file);
+}
+
 core::packages::ImportType PackageInfo::fileToImportType(const core::GlobalState &gs, core::FileRef file) const {
     if (this->usesTestPackages) {
         return core::packages::ImportType::Normal;

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -350,6 +350,8 @@ public:
     // Track that `file` references the packages in `references`, along with some metadata about each reference
     void trackPackageReferences(const core::FileRef file,
                                 std::vector<std::pair<core::packages::MangledName, PackageReferenceInfo>> &references);
+    void trackPackageReference(const core::FileRef file, MangledName package, PackageReferenceInfo referenceInfo);
+    void resetPackageReferences(const core::FileRef file);
 
     std::optional<core::AutocorrectSuggestion> aggregateMissingImports(const core::GlobalState &gs) const;
     std::optional<core::AutocorrectSuggestion> aggregateMissingImportsForFile(const core::GlobalState &gs,

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -64,6 +64,8 @@ struct Import {
     bool isTestImport() const {
         return type != ImportType::Normal;
     }
+
+    bool isAvailableTo(const core::GlobalState &gs, core::FileRef file) const;
 };
 
 struct Export {

--- a/core/packages/PackageInfo.h
+++ b/core/packages/PackageInfo.h
@@ -286,10 +286,10 @@ public:
 
     bool causesLayeringViolation(const PackageDB &packageDB, core::NameRef otherPkgLayer) const;
 
-    // Returns `std::nullopt` if it's okay to use the symbol.
+    // Returns `std::nullopt` if it's okay to reference the package from this file.
     // Returns a `PackageReferenceInfo` if the usage was not okay (e.g. missing import, modularity error, etc.)
     std::optional<core::packages::PackageReferenceInfo>
-    checkReferenceAgainstImports(core::Context ctx, core::LocOffsets errLoc, core::SymbolRef litSymbol) const;
+    checkReferenceAgainstImports(core::Context ctx, core::LocOffsets errLoc, MangledName otherPackage) const;
 
     // What is the minimum strict dependencies level that this package's imports must have?
     StrictDependenciesLevel minimumStrictDependenciesLevel() const;

--- a/main/lsp/DefLocSaver.cc
+++ b/main/lsp/DefLocSaver.cc
@@ -98,8 +98,16 @@ void matchesQuery(core::Context ctx, const ast::ConstantLit *lit, const core::ls
     auto symbol = symbolBeforeDealias.dealias(ctx);
     while (lit && symbol.exists() && lit->original()) {
         auto &unresolved = *lit->original();
-        if (lspQuery.matchesLoc(ctx.locAt(lit->loc())) || lspQuery.matchesSymbol(symbol) ||
-            lspQuery.matchesSymbol(symbolBeforeDealias)) {
+
+        // `<PackageSpecRegistry>` symbols can show up in non-`__package.rb` files now (only in
+        // files with resolver errors), so we have to filter them out of reference results to
+        // pretend that they're not there.
+        auto isPackageCursor = symbolBeforeDealias.isClassOrModule() &&
+                               symbolBeforeDealias.asClassOrModuleRef().isPackageSpecSymbol(ctx) &&
+                               !ctx.file.data(ctx).isPackage(ctx);
+
+        if (!isPackageCursor && (lspQuery.matchesLoc(ctx.locAt(lit->loc())) || lspQuery.matchesSymbol(symbol) ||
+                                 lspQuery.matchesSymbol(symbolBeforeDealias))) {
             // This basically approximates the cfg::Alias case from Environment::processBinding.
             core::TypeAndOrigins tp;
             tp.origins.emplace_back(symbol.loc(ctx));

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -569,7 +569,7 @@ public:
             return;
         }
 
-        auto importError = this->package.checkReferenceAgainstImports(ctx, lit.loc(), litSymbol);
+        auto importError = this->package.checkReferenceAgainstImports(ctx, lit.loc(), otherPackage);
         referencedPackages[otherPackage] = importError.value_or(core::packages::PackageReferenceInfo{});
         if (importError.has_value()) {
             // An error was reported already

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -710,7 +710,16 @@ public:
                 for (auto &[packageName, packageReferenceInfo] : referencedPackages) {
                     references.emplace_back(make_pair(packageName, packageReferenceInfo));
                 }
-                nonConstPackageInfo->trackPackageReferences(file, references);
+                if (gs.packageDB().genPackagesMode() == core::packages::GenPackagesMode::Disabled) {
+                    // Resolver has already recorded references that it rejected at package boundaries. Merge the
+                    // successfully resolved references found here into the same per-file entry.
+                    for (auto &[packageName, packageReferenceInfo] : references) {
+                        nonConstPackageInfo->trackPackageReference(file, packageName, packageReferenceInfo);
+                    }
+                } else {
+                    // Resolver package checking is disabled in gen-packages mode, so this pass owns the complete set.
+                    nonConstPackageInfo->trackPackageReferences(file, references);
+                }
 
                 auto &referencedSymbols = threadResult->referencedSymbols;
                 nonConstGs.setSymbolsReferencedByFile(file, referencedSymbols);

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -577,22 +577,6 @@ public:
         }
 
         auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
-        auto otherFile = litSymbol.loc(ctx).file();
-        if (!otherFile.exists()) {
-            return;
-        }
-
-        // If the referenced symbol comes from the legacy test namespace, we must also be in a test file. This check
-        // depends on the resolved symbol's definition file, so it cannot be part of package import checking.
-        // TODO(trevor): this check is redundant with import checking after the test-packages migration is complete.
-        if (!pkg.usesTestPackages && otherFile.data(ctx).isPackagedTest() && !ctx.file.data(ctx).isPackagedTest()) {
-            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
-                e.setHeader("`{}` is defined in a test namespace and cannot be referenced in a non-test file",
-                            litSymbol.show(ctx));
-            }
-            return;
-        }
-
         bool isExported = pkg.locs.exportAll.exists();
         if (litSymbol.isClassOrModule()) {
             isExported = isExported || litSymbol.asClassOrModuleRef().data(ctx)->flags.isExported;

--- a/packager/VisibilityChecker.cc
+++ b/packager/VisibilityChecker.cc
@@ -577,6 +577,22 @@ public:
         }
 
         auto &pkg = ctx.state.packageDB().getPackageInfo(otherPackage);
+        auto otherFile = litSymbol.loc(ctx).file();
+        if (!otherFile.exists()) {
+            return;
+        }
+
+        // If the referenced symbol comes from the legacy test namespace, we must also be in a test file. This check
+        // depends on the resolved symbol's definition file, so it cannot be part of package import checking.
+        // TODO(trevor): this check is redundant with import checking after the test-packages migration is complete.
+        if (!pkg.usesTestPackages && otherFile.data(ctx).isPackagedTest() && !ctx.file.data(ctx).isPackagedTest()) {
+            if (auto e = ctx.beginError(lit.loc(), core::errors::Packager::UsedTestOnlyName)) {
+                e.setHeader("`{}` is defined in a test namespace and cannot be referenced in a non-test file",
+                            litSymbol.show(ctx));
+            }
+            return;
+        }
+
         bool isExported = pkg.locs.exportAll.exists();
         if (litSymbol.isClassOrModule()) {
             isExported = isExported || litSymbol.asClassOrModuleRef().data(ctx)->flags.isExported;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -763,10 +763,12 @@ private:
             case PackageResolutionAction::ReportPackageError: {
                 auto cursorPackage = core::packages::MangledName(job.packageRegistryCursor);
                 auto currentPackage = gs.packageDB().getPackageNameForFile(file);
-                auto &currentPackageInfo = gs.packageDB().getPackageInfo(currentPackage);
+                auto currentPackageInfo = gs.packageDB().getPackageInfoNonConst(currentPackage);
                 auto errorLoc = packageBoundaryLoc(ctx, original, cursorPackage);
                 // TODO(jez) This call is still duplicated in VisibilityChecker--remove it after GenPackages cleanups
-                currentPackageInfo.checkReferenceAgainstImports(ctx, errorLoc, cursorPackage);
+                auto referenceInfo = currentPackageInfo->checkReferenceAgainstImports(ctx, errorLoc, cursorPackage);
+                ENFORCE(referenceInfo.has_value());
+                currentPackageInfo->trackPackageReference(file, cursorPackage, referenceInfo.value());
                 return;
             }
             case PackageResolutionAction::DeferToOutermost:
@@ -1996,6 +1998,13 @@ public:
 
     static ast::ParsedFilesOrCancelled resolveConstants(core::GlobalState &gs, vector<ast::ParsedFile> trees,
                                                         WorkerPool &workers) {
+        for (const auto &tree : trees) {
+            auto package = gs.packageDB().getPackageNameForFile(tree.file);
+            if (package.exists()) {
+                gs.packageDB().getPackageInfoNonConst(package)->resetPackageReferences(tree.file);
+            }
+        }
+
         UnorderedSet<core::ClassOrModuleRef> suppressPayloadSuperclassRedefinitionFor;
         for (string_view className : gs.suppressPayloadSuperclassRedefinitionFor) {
             auto klass = resolvePayloadSuperclassClassName(gs, className);

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -799,8 +799,10 @@ private:
                     }
                 }
 
-                if (!foundCommonTypo && suggestionCount < MAX_SUGGESTION_COUNT && suggestScope.exists() &&
-                    suggestScope.isClassOrModule()) {
+                auto suppressLegacyTestSuggestion =
+                    legacyTestRoot && !ctx.file.data(ctx).isPackagedTest() && shouldCheckPackage(ctx);
+                if (!foundCommonTypo && !suppressLegacyTestSuggestion && suggestionCount < MAX_SUGGESTION_COUNT &&
+                    suggestScope.exists() && suggestScope.isClassOrModule()) {
                     suggestionCount++;
 
                     core::packages::MangledName filterToPackage;

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -10,6 +10,7 @@
 #include "core/StrictLevel.h"
 #include "core/core.h"
 #include "core/errors/internal.h"
+#include "core/errors/packager.h"
 #include "core/lsp/TypecheckEpochManager.h"
 #include "resolver/CorrectTypeAlias.h"
 #include "resolver/resolver.h"
@@ -165,13 +166,33 @@ private:
         return loadScopeDepth_ == 0;
     }
 
+    enum class PackageCursorPosition : uint8_t {
+        // This constant path does not correspond to anything in the package registry.
+        None,
+        // The cursor names a package-registry namespace, but not a package.
+        NamespacePrefix,
+        // This component of the constant path names a package exactly.
+        PackageBoundary,
+        // The path has continued beyond a package, while the cursor remains at that package.
+        PackageMember,
+    };
+
     struct ConstantResolutionItem {
         shared_ptr<Nesting> scope;
         ast::ConstantLit *out;
+        core::ClassOrModuleRef packageRegistryCursor;
         bool resolutionFailed = false;
+        bool isOutermost = true;
+        bool legacyTestPath = false;
+        PackageCursorPosition packageCursorPosition = PackageCursorPosition::None;
 
         ConstantResolutionItem() = default;
         ConstantResolutionItem(const shared_ptr<Nesting> &scope, ast::ConstantLit *lit) : scope(scope), out(lit) {}
+        ConstantResolutionItem(const shared_ptr<Nesting> &scope, ast::ConstantLit *lit,
+                               core::ClassOrModuleRef packageRegistryCursor, bool isOutermost, bool legacyTestPath,
+                               PackageCursorPosition packageCursorPosition)
+            : scope(scope), out(lit), packageRegistryCursor(packageRegistryCursor), isOutermost(isOutermost),
+              legacyTestPath(legacyTestPath), packageCursorPosition(packageCursorPosition) {}
         ConstantResolutionItem(ConstantResolutionItem &&rhs) noexcept = default;
         ConstantResolutionItem &operator=(ConstantResolutionItem &&rhs) noexcept = default;
 
@@ -325,6 +346,73 @@ private:
         return !checker.seenUnresolved;
     }
 
+    static bool shouldCheckPackage(core::Context ctx) {
+        return ctx.state.packageDB().enabled() && !ctx.file.data(ctx).isPackage(ctx) &&
+               // TODO(jez) Get this working with GenPackages
+               ctx.state.packageDB().genPackagesMode() == core::packages::GenPackagesMode::Disabled &&
+               ctx.state.packageDB().getPackageNameForFile(ctx.file).exists();
+    }
+
+    static bool canReferencePackage(core::Context ctx, core::packages::MangledName otherPackage) {
+        if (!otherPackage.exists()) {
+            return true;
+        }
+
+        auto &packageDB = ctx.state.packageDB();
+        auto currentPackage = packageDB.getPackageNameForFile(ctx.file);
+        if (!currentPackage.exists() || currentPackage == otherPackage) {
+            return true;
+        }
+
+        auto &currentPackageInfo = packageDB.getPackageInfo(currentPackage);
+        ENFORCE(currentPackageInfo.exists());
+        auto *import = currentPackageInfo.importsPackage(otherPackage);
+        return import != nullptr && import->isAvailableTo(ctx.state, ctx.file);
+    }
+
+    static bool isStrictPackagePrefix(core::Context ctx, core::packages::MangledName prefix,
+                                      core::packages::MangledName package) {
+        auto cur = package.owner;
+        while (cur.exists() && cur != core::Symbols::root()) {
+            cur = cur.data(ctx)->owner;
+            if (cur == prefix.owner) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static bool isStrictPrefixOfAvailablePackage(core::Context ctx, core::packages::MangledName otherPackage) {
+        if (!otherPackage.exists()) {
+            return false;
+        }
+
+        auto &packageDB = ctx.state.packageDB();
+        auto currentPackage = packageDB.getPackageNameForFile(ctx.file);
+        if (!currentPackage.exists()) {
+            return false;
+        }
+        auto &currentPackageInfo = packageDB.getPackageInfo(currentPackage);
+
+        // TODO(jez) This could be more efficient if we had something like a trie of imported package names,
+        // but for the time being this at least works.
+        if (isStrictPackagePrefix(ctx, otherPackage, currentPackage)) {
+            return true;
+        }
+        for (const auto &import : currentPackageInfo.importedPackageNames) {
+            if (import.isAvailableTo(ctx.state, ctx.file) &&
+                isStrictPackagePrefix(ctx, otherPackage, import.mangledName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static bool cursorIsPackage(core::Context ctx, core::ClassOrModuleRef cursor) {
+        ENFORCE(cursor.exists());
+        return ctx.state.packageDB().getPackageInfo(core::packages::MangledName(cursor)).exists();
+    }
+
     // Find load-time out-of-order references.
     // Algorithm:
     // if resolved symbol is only defined in the current file, and
@@ -361,12 +449,63 @@ private:
         }
     }
 
+    // Ensures that we only allow resolving `job` to `result` if the package imports allow it
+    static core::SymbolRef enforcePackageBoundary(core::Context ctx, ConstantResolutionItem &job,
+                                                  core::SymbolRef result) {
+        if (!shouldCheckPackage(ctx) || !result.exists()) {
+            return result;
+        }
+        auto enclosing = result.enclosingClass(ctx);
+        core::packages::MangledName otherPackage;
+        if (enclosing.isPackageSpecSymbol(ctx)) {
+            if (!cursorIsPackage(ctx, enclosing)) {
+                // This is an intermediate package-registry namespace. Preserve it so resolution can continue
+                // looking for a package nested beneath it.
+                return result;
+            }
+            otherPackage = core::packages::MangledName(enclosing);
+        } else {
+            otherPackage = enclosing.data(ctx)->package;
+        }
+        if (canReferencePackage(ctx, otherPackage)) {
+            return result;
+        }
+        if (!job.isOutermost && isStrictPrefixOfAvailablePackage(ctx, otherPackage)) {
+            return result;
+        }
+
+        // Prevent the constant from resolving (even though it resolved) because it's not imported
+        job.packageRegistryCursor = otherPackage.owner;
+        job.packageCursorPosition = PackageCursorPosition::PackageBoundary;
+        return core::Symbols::noSymbol();
+    }
+
     static core::SymbolRef resolveConstant(core::Context ctx, ConstantResolutionItem &job) {
         auto &c = *job.out->original();
         if (ast::isa_tree<ast::EmptyTree>(c.scope)) {
             auto result = resolveLhs(ctx, job.scope, c.cnst);
+            auto isPotentialLegacyTestRoot =
+                shouldCheckPackage(ctx) && c.cnst == core::packages::PackageDB::TEST_NAMESPACE;
+            if (!result.exists()) {
+                job.legacyTestPath = isPotentialLegacyTestRoot;
+                return result;
+            }
+            if (isPotentialLegacyTestRoot) {
+                auto rootTest = core::Symbols::root().data(ctx)->findMemberNoDealias(c.cnst);
+                job.legacyTestPath = result.dealias(ctx) == rootTest;
 
-            return result;
+                // The `::Test` constant is defined by the first strata containing test code, so it
+                // might not exist at first. Conservatively say that `Test` doesn't resolve in any
+                // `/test/` file, even if it happened to be defined already, so that resolution does
+                // not depend on where the first test gets scheduled.
+                //
+                // TODO(jez) We can do better, but let's punt for now to keep this small.
+                if (job.legacyTestPath && !ctx.file.data(ctx).isPackagedTest()) {
+                    return core::Symbols::noSymbol();
+                }
+            }
+
+            return enforcePackageBoundary(ctx, job, result);
         }
         if (auto id = ast::cast_tree<ast::ConstantLit>(c.scope)) {
             auto sym = id->symbol();
@@ -401,7 +540,7 @@ private:
                 }
             }
 
-            return result;
+            return enforcePackageBoundary(ctx, job, result);
         }
 
         if (!job.resolutionFailed) {
@@ -411,6 +550,94 @@ private:
         }
         job.resolutionFailed = true;
         return core::Symbols::noSymbol();
+    }
+
+    static bool isLegacyTestRoot(const ConstantResolutionItem &job) {
+        return job.legacyTestPath && ast::isa_tree<ast::EmptyTree>(job.out->original()->scope);
+    }
+
+    enum class PackageResolutionAction : uint8_t {
+        None,
+        DeferToOutermost,
+        ReportPackageError,
+    };
+
+    // There was an error, but we want to figure out whether to report it...
+    // - as a package error now,
+    // - as package error in the future (after processing the outermost symbol), or
+    // - as a normal "Unable to resolve constant" error
+    static PackageResolutionAction packageResolutionAction(core::Context ctx, const ConstantResolutionItem &job,
+                                                           bool alreadyReported) {
+        if (!shouldCheckPackage(ctx)) {
+            return PackageResolutionAction::None;
+        }
+
+        auto cursorIdentifiesPackage =
+            job.packageRegistryCursor.exists() && cursorIsPackage(ctx, job.packageRegistryCursor);
+        auto cursorPackage = core::packages::MangledName(job.packageRegistryCursor);
+        auto inaccessibleCursorPackage = cursorIdentifiesPackage && !canReferencePackage(ctx, cursorPackage);
+        auto productionLegacyTestPath = job.legacyTestPath && !ctx.file.data(ctx).isPackagedTest();
+
+        if (!alreadyReported && !productionLegacyTestPath && inaccessibleCursorPackage) {
+            bool shouldReport;
+            switch (job.packageCursorPosition) {
+                case PackageCursorPosition::PackageBoundary:
+                    shouldReport = job.isOutermost || !isStrictPrefixOfAvailablePackage(ctx, cursorPackage);
+                    break;
+                case PackageCursorPosition::PackageMember:
+                    shouldReport = job.isOutermost && !isStrictPrefixOfAvailablePackage(ctx, cursorPackage);
+                    break;
+                case PackageCursorPosition::None:
+                case PackageCursorPosition::NamespacePrefix:
+                    shouldReport = false;
+                    break;
+            }
+            if (shouldReport) {
+                return PackageResolutionAction::ReportPackageError;
+            }
+        }
+
+        if (!job.isOutermost && job.packageRegistryCursor.exists() && !isLegacyTestRoot(job) &&
+            (!cursorIdentifiesPackage || inaccessibleCursorPackage)) {
+            return PackageResolutionAction::DeferToOutermost;
+        }
+
+        return PackageResolutionAction::None;
+    }
+
+    // Walks the tree back up the scope, but ONLY during error reporting
+    //
+    // In general, we're trying to avoid having to walk back up the scope for package-related errors,
+    // so that processing a constant lit is "final" in some sense.
+    //
+    // However, if we `DeferToOutermost` for the error, that would report the error loc on the full
+    // loc of the outermost literal. I think the errors look better if we can find the actual bad
+    // constant, which requires looking back through the scope or storing more state in the job.
+    //
+    // Walking back seems best, but a second best would be deciding that the juice isn't worth the
+    // squeeze, and reporting the errors on the outermost constant's full loc.
+    static core::LocOffsets packageBoundaryLoc(core::Context ctx, const ast::UnresolvedConstantLit &original,
+                                               core::packages::MangledName package) {
+        auto result = original.loc;
+        auto *scope = &original.scope;
+        while (auto lit = ast::cast_tree<ast::ConstantLit>(*scope)) {
+            auto symbol = lit->symbol();
+            if (symbol.exists() && symbol != core::Symbols::todo()) {
+                auto enclosing = symbol.enclosingClass(ctx);
+                auto referencesPackage = enclosing.isPackageSpecSymbol(ctx)
+                                             ? core::packages::MangledName(enclosing) == package
+                                             : enclosing.data(ctx)->package == package;
+                if (referencesPackage) {
+                    // Keep walking toward the root to find the first component that crosses this package boundary.
+                    result = lit->loc();
+                }
+            }
+            if (lit->original() == nullptr) {
+                break;
+            }
+            scope = &lit->original()->scope;
+        }
+        return result;
     }
 
     static const int MAX_SUGGESTION_COUNT = 10;
@@ -439,6 +666,20 @@ private:
             job.out->setSymbol(resolved);
             return;
         }
+        if (resolved.exists()) {
+            // An inner component may have been resolved to its package-registry cursor earlier in this final pass,
+            // allowing this component to resolve now even though the fixed point had previously exhausted itself.
+            ENFORCE(resolved.isClassOrModule() && resolved.asClassOrModuleRef().isPackageSpecSymbol(ctx.state));
+
+            if (!job.isOutermost) {
+                job.out->setSymbol(resolved);
+                return;
+            }
+
+            // A package-registry cursor can help resolve later components, but it does not define the runtime constant
+            // named by an outermost reference.
+            resolved = core::Symbols::noSymbol();
+        }
         if (job.resolutionFailed) {
             // we only set this when a job has failed for other reasons and we've already reported an error, and
             // continuing on will only redundantly report that we can't resolve the constant, so bail early here
@@ -450,9 +691,27 @@ private:
         ENFORCE(!resolved.exists());
         ENFORCE(!job.out->symbol().exists());
 
+        auto &original = *job.out->original();
+        auto legacyTestRoot = isLegacyTestRoot(job);
+        auto cursorIdentifiesPackage =
+            job.packageRegistryCursor.exists() && cursorIsPackage(ctx, job.packageRegistryCursor);
+        auto scope = ast::cast_tree<ast::ConstantLit>(original.scope);
+        auto scopeWasStubbed = scope != nullptr && scope->symbol() == core::Symbols::StubModule();
+        if (shouldCheckPackage(ctx) && !job.isOutermost && job.packageRegistryCursor.exists() &&
+            !cursorIdentifiesPackage && !legacyTestRoot && !scopeWasStubbed) {
+            // Lie, and say that this constant resolves to a `<PackageSpecRegistry>`-scoped symbol.
+            //
+            // We want to report the import that would make the outermost constant resolve, which
+            // requires finding the narrowest package which might own that constant. We can hijack
+            // resolution to help us find this by continuing the resolution search on the package
+            // spec symbol. Once a future job can't find the symbol, even on the package spec
+            // cursor, that's the package we need to import.
+            job.out->setSymbol(job.packageRegistryCursor);
+            return;
+        }
+
         bool alreadyReported = false;
         job.out->markUnresolved();
-        auto &original = *job.out->original();
         if (auto id = ast::cast_tree<ast::ConstantLit>(original.scope)) {
             auto originalScope = id->symbol();
             if (originalScope == core::Symbols::StubModule()) {
@@ -498,6 +757,24 @@ private:
             isImport = suggestScope.asClassOrModuleRef().isPackageSpecSymbol(ctx.state);
             isExport = !suggestScope.asClassOrModuleRef().isPackageSpecSymbol(ctx.state);
         }
+
+        auto packageAction = packageResolutionAction(ctx, job, alreadyReported);
+        switch (packageAction) {
+            case PackageResolutionAction::ReportPackageError: {
+                auto cursorPackage = core::packages::MangledName(job.packageRegistryCursor);
+                auto currentPackage = gs.packageDB().getPackageNameForFile(file);
+                auto &currentPackageInfo = gs.packageDB().getPackageInfo(currentPackage);
+                auto errorLoc = packageBoundaryLoc(ctx, original, cursorPackage);
+                // TODO(jez) This call is still duplicated in VisibilityChecker--remove it after GenPackages cleanups
+                currentPackageInfo.checkReferenceAgainstImports(ctx, errorLoc, cursorPackage);
+                return;
+            }
+            case PackageResolutionAction::DeferToOutermost:
+                return;
+            case PackageResolutionAction::None:
+                break;
+        }
+
         bool silenceError = false;
         if (constantNameMissing || alreadyReported) {
             silenceError = true;
@@ -1190,15 +1467,106 @@ private:
         todoAncestors_.emplace_back(std::move(job));
     }
 
-    void walkUnresolvedConstantLit(core::Context ctx, ast::ExpressionPtr &tree) {
+    struct PackageCursorState {
+        core::ClassOrModuleRef cursor;
+        bool legacyTestPath = false;
+        PackageCursorPosition position = PackageCursorPosition::None;
+    };
+
+    static PackageCursorState advancePackageCursor(core::Context ctx, PackageCursorState state, core::NameRef name) {
+        if (!state.cursor.exists()) {
+            return {};
+        }
+        auto member = state.cursor.data(ctx)->findMemberNoDealias(name);
+        if (member.exists() && member.isClassOrModule()) {
+            state.cursor = member.asClassOrModuleRef();
+            state.position = cursorIsPackage(ctx, state.cursor) ? PackageCursorPosition::PackageBoundary
+                                                                : PackageCursorPosition::NamespacePrefix;
+            return state;
+        }
+        // Once a path has reached a package, all non-package descendants remain owned by that package.
+        if (cursorIsPackage(ctx, state.cursor)) {
+            state.position = PackageCursorPosition::PackageMember;
+            return state;
+        }
+        return {};
+    }
+
+    static PackageCursorState cursorForSymbol(core::Context ctx, core::SymbolRef symbol) {
+        if (!shouldCheckPackage(ctx) || !symbol.exists() || symbol == core::Symbols::todo()) {
+            return {};
+        }
+        auto enclosing = symbol.enclosingClass(ctx);
+        auto cursor = enclosing.data(ctx)->packageRegistryOwner;
+        if (!cursor.exists()) {
+            return {};
+        }
+        auto position = PackageCursorPosition::NamespacePrefix;
+        if (cursorIsPackage(ctx, cursor)) {
+            position = enclosing.data(ctx)->isPackageNamespace() ? PackageCursorPosition::PackageBoundary
+                                                                 : PackageCursorPosition::PackageMember;
+        }
+        return {cursor, false, position};
+    }
+
+    static PackageCursorState cursorForBareConstant(core::Context ctx, const shared_ptr<Nesting> &nesting,
+                                                    core::NameRef name) {
+        if (!shouldCheckPackage(ctx)) {
+            return {};
+        }
+        for (auto scope = nesting.get(); scope != nullptr; scope = scope->parent.get()) {
+            if (!scope->scope.isClassOrModule()) {
+                continue;
+            }
+            auto cursor = scope->scope.asClassOrModuleRef().data(ctx)->packageRegistryOwner;
+            if (!cursor.exists()) {
+                continue;
+            }
+            auto member = cursor.data(ctx)->findMemberNoDealias(name);
+            if (member.exists() && member.isClassOrModule()) {
+                auto result = member.asClassOrModuleRef();
+                auto position = cursorIsPackage(ctx, result) ? PackageCursorPosition::PackageBoundary
+                                                             : PackageCursorPosition::NamespacePrefix;
+                return {result, false, position};
+            }
+        }
+        return advancePackageCursor(ctx, {core::Symbols::PackageSpecRegistry()}, name);
+    }
+
+    PackageCursorState walkUnresolvedConstantLit(core::Context ctx, ast::ExpressionPtr &tree, bool isOutermost = true) {
         if (auto c = ast::cast_tree<ast::UnresolvedConstantLit>(tree)) {
-            walkUnresolvedConstantLit(ctx, c->scope);
+            auto scopeWasEmpty = ast::isa_tree<ast::EmptyTree>(c->scope);
+            auto scopeCursor = walkUnresolvedConstantLit(ctx, c->scope, false);
             auto out = ast::make_expression<ast::ConstantLit>(core::Symbols::noSymbol(),
                                                               tree.toUnique<ast::UnresolvedConstantLit>());
             auto constant = ast::cast_tree<ast::ConstantLit>(out);
-            ConstantResolutionItem job{nesting_, constant};
-            if (resolveConstantJob(ctx, job)) {
+
+            PackageCursorState cursor;
+            if (scopeWasEmpty && constant->original()->cnst == core::packages::PackageDB::TEST_NAMESPACE &&
+                shouldCheckPackage(ctx)) {
+                cursor.cursor = core::Symbols::PackageSpecRegistry();
+                cursor.position = PackageCursorPosition::NamespacePrefix;
+            } else if (scopeWasEmpty) {
+                cursor = cursorForBareConstant(ctx, nesting_, constant->original()->cnst);
+            } else {
+                cursor = advancePackageCursor(ctx, scopeCursor, constant->original()->cnst);
+            }
+
+            ConstantResolutionItem job{
+                nesting_, constant, cursor.cursor, isOutermost, cursor.legacyTestPath, cursor.position,
+            };
+            auto resolved = resolveConstantJob(ctx, job);
+            if (scopeWasEmpty && constant->original()->cnst == core::packages::PackageDB::TEST_NAMESPACE &&
+                shouldCheckPackage(ctx)) {
+                cursor.legacyTestPath = job.legacyTestPath;
+            }
+            if (resolved) {
                 categoryCounterInc("resolve.constants.nonancestor", "firstpass");
+                auto resolvedCursor = cursorForSymbol(ctx, constant->symbol());
+                if (resolvedCursor.cursor.exists()) {
+                    resolvedCursor.legacyTestPath = job.legacyTestPath;
+                    cursor = resolvedCursor;
+                }
                 if (this->loadTimeScope() && (!constant->symbol().isClassOrModule() ||
                                               constant->symbol().asClassOrModuleRef().data(ctx)->isDeclared())) {
                     // While Sorbet treats class A::B; end like an implicit definition of A, it's actually a
@@ -1217,15 +1585,19 @@ private:
                 todo_.emplace_back(std::move(job));
             }
             tree = std::move(out);
-            return;
+            return cursor;
         }
-        if (ast::isa_tree<ast::EmptyTree>(tree) || ast::isa_tree<ast::ConstantLit>(tree)) {
-            return;
+        if (ast::isa_tree<ast::EmptyTree>(tree)) {
+            return {};
+        }
+        if (auto lit = ast::cast_tree<ast::ConstantLit>(tree)) {
+            return cursorForSymbol(ctx, lit->symbol());
         }
 
         // Uncommon case. Will result in "Dynamic constant references are not allowed" eventually.
         // Still want to do our best to recover (for e.g., LSP queries)
         ast::TreeWalk::apply(ctx, *this, tree);
+        return {};
     }
 
 public:

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1548,6 +1548,8 @@ private:
             PackageCursorState cursor;
             if (scopeWasEmpty && constant->original()->cnst == core::packages::PackageDB::TEST_NAMESPACE &&
                 shouldCheckPackage(ctx)) {
+                ENFORCE(!scopeCursor.cursor.exists() && !scopeCursor.legacyTestPath &&
+                        scopeCursor.position == PackageCursorPosition::None);
                 cursor.cursor = core::Symbols::PackageSpecRegistry();
                 cursor.position = PackageCursorPosition::NamespacePrefix;
             } else if (scopeWasEmpty) {

--- a/test/cli/autocorrect-package-import/test.out
+++ b/test/cli/autocorrect-package-import/test.out
@@ -1,6 +1,6 @@
-a/foo.rb:4: `B::Foo` resolves but its package is not imported https://srb.help/3718
+a/foo.rb:4: `B` is not imported https://srb.help/3718
      4 |  B::Foo.new
-          ^^^^^^
+          ^
     b/__package.rb:3: Package defined here
      3 |class B < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/condensation-package-autocorrect-missing-import/test.out
+++ b/test/cli/condensation-package-autocorrect-missing-import/test.out
@@ -12,20 +12,6 @@ use_other_package/foo.rb:16: Unable to resolve constant `MyClass` https://srb.he
 use_other_package/foo.rb:18: Unable to resolve constant `Test` https://srb.help/5002
     18 |  Test::Foo::Bar::OtherPackage::TestUtil
           ^^^^
-  Autocorrect: Done
-    use_other_package/foo.rb:18: Replaced with `Set`
-    18 |  Test::Foo::Bar::OtherPackage::TestUtil
-          ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/set.rbi#LCENSORED: `Set` defined here
-      NN |class Set < Object
-          ^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_other_package/foo.rb:18: Replaced with `Net`
-    18 |  Test::Foo::Bar::OtherPackage::TestUtil
-          ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#LCENSORED: `Net` defined here
-    NN |module Net
-        ^^^^^^^^^^
 
 use_other_package/foo.rb:7: `Foo::Bar::OtherPackage` is not imported https://srb.help/3718
      7 |      Foo::Bar::OtherPackage::OtherClass # resolves via root
@@ -112,20 +98,6 @@ end
 use_app_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
     13 |  Test::Foo::Bar::AppPackage::TestUtil
           ^^^^
-  Autocorrect: Done
-    use_app_package/foo.rb:13: Replaced with `Set`
-    13 |  Test::Foo::Bar::AppPackage::TestUtil
-          ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/set.rbi#LCENSORED: `Set` defined here
-      NN |class Set < Object
-          ^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_app_package/foo.rb:13: Replaced with `Net`
-    13 |  Test::Foo::Bar::AppPackage::TestUtil
-          ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#LCENSORED: `Net` defined here
-    NN |module Net
-        ^^^^^^^^^^
 
 use_app_package/foo.rb:6: `Foo::Bar::AppPackage` cannot be referenced here because importing it would cause a layering violation https://srb.help/3726
      6 |      Foo::Bar::AppPackage::OtherClass # resolves via root
@@ -178,20 +150,6 @@ end
 use_false_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
     13 |  Test::Foo::Bar::FalsePackage::TestUtil
           ^^^^
-  Autocorrect: Done
-    use_false_package/foo.rb:13: Replaced with `Set`
-    13 |  Test::Foo::Bar::FalsePackage::TestUtil
-          ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/set.rbi#LCENSORED: `Set` defined here
-      NN |class Set < Object
-          ^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_false_package/foo.rb:13: Replaced with `Net`
-    13 |  Test::Foo::Bar::FalsePackage::TestUtil
-          ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#LCENSORED: `Net` defined here
-    NN |module Net
-        ^^^^^^^^^^
 
 use_false_package/foo.rb:6: `Foo::Bar::FalsePackage` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
      6 |      Foo::Bar::FalsePackage::OtherClass # resolves via root
@@ -244,20 +202,6 @@ end
 use_false_and_app_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
     13 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
           ^^^^
-  Autocorrect: Done
-    use_false_and_app_package/foo.rb:13: Replaced with `Set`
-    13 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
-          ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/set.rbi#LCENSORED: `Set` defined here
-      NN |class Set < Object
-          ^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_false_and_app_package/foo.rb:13: Replaced with `Net`
-    13 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
-          ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#LCENSORED: `Net` defined here
-    NN |module Net
-        ^^^^^^^^^^
 
 use_false_and_app_package/foo.rb:6: `Foo::Bar::FalseAndAppPackage` cannot be referenced here because importing it would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
      6 |      Foo::Bar::FalseAndAppPackage::OtherClass # resolves via root
@@ -350,20 +294,6 @@ use_cycle_package/foo.rb:7: `Foo::Bar::CyclePackageTest` cannot be referenced he
 use_cycle_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
     13 |  Test::Foo::Bar::CyclePackage::TestUtil
           ^^^^
-  Autocorrect: Done
-    use_cycle_package/foo.rb:13: Replaced with `Set`
-    13 |  Test::Foo::Bar::CyclePackage::TestUtil
-          ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/set.rbi#LCENSORED: `Set` defined here
-      NN |class Set < Object
-          ^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_cycle_package/foo.rb:13: Replaced with `Net`
-    13 |  Test::Foo::Bar::CyclePackage::TestUtil
-          ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#LCENSORED: `Net` defined here
-    NN |module Net
-        ^^^^^^^^^^
 
 use_cycle_package/foo.test.rb:4: `Foo::Bar::CyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::CyclePackage::TestUtil
@@ -432,20 +362,6 @@ use_app_cycle_package/foo.rb:7: `Foo::Bar::AppCyclePackageTest` cannot be refere
 use_app_cycle_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
     13 |  Test::Foo::Bar::AppCyclePackage::TestUtil
           ^^^^
-  Autocorrect: Done
-    use_app_cycle_package/foo.rb:13: Replaced with `Set`
-    13 |  Test::Foo::Bar::AppCyclePackage::TestUtil
-          ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/set.rbi#LCENSORED: `Set` defined here
-      NN |class Set < Object
-          ^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_app_cycle_package/foo.rb:13: Replaced with `Net`
-    13 |  Test::Foo::Bar::AppCyclePackage::TestUtil
-          ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#LCENSORED: `Net` defined here
-    NN |module Net
-        ^^^^^^^^^^
 
 use_app_cycle_package/foo.test.rb:4: `Foo::Bar::AppCyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::AppCyclePackage::TestUtil
@@ -514,20 +430,6 @@ use_false_cycle_package/foo.rb:7: `Foo::Bar::FalseCyclePackageTest` cannot be re
 use_false_cycle_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
     13 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
           ^^^^
-  Autocorrect: Done
-    use_false_cycle_package/foo.rb:13: Replaced with `Set`
-    13 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
-          ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/set.rbi#LCENSORED: `Set` defined here
-      NN |class Set < Object
-          ^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_false_cycle_package/foo.rb:13: Replaced with `Net`
-    13 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
-          ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#LCENSORED: `Net` defined here
-    NN |module Net
-        ^^^^^^^^^^
 
 use_false_cycle_package/foo.test.rb:4: `Foo::Bar::FalseCyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
@@ -602,20 +504,6 @@ use_app_false_cycle_package/foo.rb:7: `Foo::Bar::AppFalseCyclePackageTest` canno
 use_app_false_cycle_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
     13 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil
           ^^^^
-  Autocorrect: Done
-    use_app_false_cycle_package/foo.rb:13: Replaced with `Set`
-    13 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil
-          ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/set.rbi#LCENSORED: `Set` defined here
-      NN |class Set < Object
-          ^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_app_false_cycle_package/foo.rb:13: Replaced with `Net`
-    13 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil
-          ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#LCENSORED: `Net` defined here
-    NN |module Net
-        ^^^^^^^^^^
 
 use_app_false_cycle_package/foo.test.rb:4: `Foo::Bar::AppFalseCyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil

--- a/test/cli/condensation-package-autocorrect-missing-import/test.out
+++ b/test/cli/condensation-package-autocorrect-missing-import/test.out
@@ -313,9 +313,9 @@ end
 
 --------------------------------------------------------------------------
 
-use_cycle_package/foo.rb:6: Unable to resolve constant `Bar` https://srb.help/5002
+use_cycle_package/foo.rb:6: `Foo::Bar::CyclePackage` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle https://srb.help/3727
      6 |      Foo::Bar::CyclePackage::OtherClass # resolves via root
-              ^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     use_cycle_package/foo.rb:6: Replaced with `Dir`
      6 |      Foo::Bar::CyclePackage::OtherClass # resolves via root
@@ -324,9 +324,9 @@ use_cycle_package/foo.rb:6: Unable to resolve constant `Bar` https://srb.help/50
     NN |class Dir < Object
         ^^^^^^^^^^^^^^^^^^
 
-use_cycle_package/foo.rb:7: Unable to resolve constant `Bar` https://srb.help/5002
+use_cycle_package/foo.rb:7: `Foo::Bar::CyclePackageTest` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle https://srb.help/3727
      7 |      Foo::Bar::CyclePackageTest::OtherClass # resolves via root
-              ^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     use_cycle_package/foo.rb:7: Replaced with `Dir`
      7 |      Foo::Bar::CyclePackageTest::OtherClass # resolves via root
@@ -353,9 +353,9 @@ use_cycle_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/
     NN |module Net
         ^^^^^^^^^^
 
-use_cycle_package/foo.test.rb:4: Unable to resolve constant `Bar` https://srb.help/5002
+use_cycle_package/foo.test.rb:4: `Foo::Bar::CyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::CyclePackage::TestUtil
-          ^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     use_cycle_package/foo.test.rb:4: Replaced with `Dir`
      4 |  Test::Foo::Bar::CyclePackage::TestUtil
@@ -376,9 +376,9 @@ end
 
 --------------------------------------------------------------------------
 
-use_app_cycle_package/foo.rb:6: Unable to resolve constant `Bar` https://srb.help/5002
+use_app_cycle_package/foo.rb:6: `Foo::Bar::AppCyclePackage` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, and importing it would cause a layering violation https://srb.help/3727
      6 |      Foo::Bar::AppCyclePackage::OtherClass # resolves via root
-              ^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     use_app_cycle_package/foo.rb:6: Replaced with `Dir`
      6 |      Foo::Bar::AppCyclePackage::OtherClass # resolves via root
@@ -387,9 +387,9 @@ use_app_cycle_package/foo.rb:6: Unable to resolve constant `Bar` https://srb.hel
     NN |class Dir < Object
         ^^^^^^^^^^^^^^^^^^
 
-use_app_cycle_package/foo.rb:7: Unable to resolve constant `Bar` https://srb.help/5002
+use_app_cycle_package/foo.rb:7: `Foo::Bar::AppCyclePackageTest` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, and importing it would cause a layering violation https://srb.help/3727
      7 |      Foo::Bar::AppCyclePackageTest::OtherClass # resolves via root
-              ^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     use_app_cycle_package/foo.rb:7: Replaced with `Dir`
      7 |      Foo::Bar::AppCyclePackageTest::OtherClass # resolves via root
@@ -416,9 +416,9 @@ use_app_cycle_package/foo.rb:13: Unable to resolve constant `Test` https://srb.h
     NN |module Net
         ^^^^^^^^^^
 
-use_app_cycle_package/foo.test.rb:4: Unable to resolve constant `Bar` https://srb.help/5002
+use_app_cycle_package/foo.test.rb:4: `Foo::Bar::AppCyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::AppCyclePackage::TestUtil
-          ^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     use_app_cycle_package/foo.test.rb:4: Replaced with `Dir`
      4 |  Test::Foo::Bar::AppCyclePackage::TestUtil
@@ -439,9 +439,9 @@ end
 
 --------------------------------------------------------------------------
 
-use_false_cycle_package/foo.rb:6: Unable to resolve constant `Bar` https://srb.help/5002
+use_false_cycle_package/foo.rb:6: `Foo::Bar::FalseCyclePackage` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, and its `strict_dependencies` is not strict enough https://srb.help/3727
      6 |      Foo::Bar::FalseCyclePackage::OtherClass # resolves via root
-              ^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     use_false_cycle_package/foo.rb:6: Replaced with `Dir`
      6 |      Foo::Bar::FalseCyclePackage::OtherClass # resolves via root
@@ -450,9 +450,9 @@ use_false_cycle_package/foo.rb:6: Unable to resolve constant `Bar` https://srb.h
     NN |class Dir < Object
         ^^^^^^^^^^^^^^^^^^
 
-use_false_cycle_package/foo.rb:7: Unable to resolve constant `Bar` https://srb.help/5002
+use_false_cycle_package/foo.rb:7: `Foo::Bar::FalseCyclePackageTest` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, and its `strict_dependencies` is not strict enough https://srb.help/3727
      7 |      Foo::Bar::FalseCyclePackageTest::OtherClass # resolves via root
-              ^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     use_false_cycle_package/foo.rb:7: Replaced with `Dir`
      7 |      Foo::Bar::FalseCyclePackageTest::OtherClass # resolves via root
@@ -479,9 +479,9 @@ use_false_cycle_package/foo.rb:13: Unable to resolve constant `Test` https://srb
     NN |module Net
         ^^^^^^^^^^
 
-use_false_cycle_package/foo.test.rb:4: Unable to resolve constant `Bar` https://srb.help/5002
+use_false_cycle_package/foo.test.rb:4: `Foo::Bar::FalseCyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
-          ^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     use_false_cycle_package/foo.test.rb:4: Replaced with `Dir`
      4 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
@@ -502,9 +502,9 @@ end
 
 --------------------------------------------------------------------------
 
-use_app_false_cycle_package/foo.rb:6: Unable to resolve constant `Bar` https://srb.help/5002
+use_app_false_cycle_package/foo.rb:6: `Foo::Bar::AppFalseCyclePackage` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, importing it would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
      6 |      Foo::Bar::AppFalseCyclePackage::OtherClass # resolves via root
-              ^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     use_app_false_cycle_package/foo.rb:6: Replaced with `Dir`
      6 |      Foo::Bar::AppFalseCyclePackage::OtherClass # resolves via root
@@ -513,9 +513,9 @@ use_app_false_cycle_package/foo.rb:6: Unable to resolve constant `Bar` https://s
     NN |class Dir < Object
         ^^^^^^^^^^^^^^^^^^
 
-use_app_false_cycle_package/foo.rb:7: Unable to resolve constant `Bar` https://srb.help/5002
+use_app_false_cycle_package/foo.rb:7: `Foo::Bar::AppFalseCyclePackageTest` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, importing it would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
      7 |      Foo::Bar::AppFalseCyclePackageTest::OtherClass # resolves via root
-              ^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     use_app_false_cycle_package/foo.rb:7: Replaced with `Dir`
      7 |      Foo::Bar::AppFalseCyclePackageTest::OtherClass # resolves via root
@@ -542,9 +542,9 @@ use_app_false_cycle_package/foo.rb:13: Unable to resolve constant `Test` https:/
     NN |module Net
         ^^^^^^^^^^
 
-use_app_false_cycle_package/foo.test.rb:4: Unable to resolve constant `Bar` https://srb.help/5002
+use_app_false_cycle_package/foo.test.rb:4: `Foo::Bar::AppFalseCyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil
-          ^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
     use_app_false_cycle_package/foo.test.rb:4: Replaced with `Dir`
      4 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil

--- a/test/cli/condensation-package-autocorrect-missing-import/test.out
+++ b/test/cli/condensation-package-autocorrect-missing-import/test.out
@@ -49,9 +49,9 @@ use_other_package/foo.rb:8: `Foo::Bar::OtherPackage` is not imported https://srb
      7 |  strict_dependencies 'layered'
                                        ^
 
-use_other_package/foo.rb:9: Used `test_import` constant `Foo::Bar::OtherPackageTest::OtherClass` in non-test file https://srb.help/3720
+use_other_package/foo.rb:9: Used `test_import` package `Foo::Bar::OtherPackageTest` in non-test file https://srb.help/3720
      9 |      Foo::Bar::OtherPackageTest::OtherClass
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^
     other_test/__package.rb:3: Defined here
      3 |class Foo::Bar::OtherPackageTest < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/condensation-package-autocorrect-missing-import/test.out
+++ b/test/cli/condensation-package-autocorrect-missing-import/test.out
@@ -1,18 +1,3 @@
-use_other_package/foo.rb:16: Unable to resolve constant `MyClass` https://srb.help/5002
-    16 |  Foo::Bar::MyClass::SUBCLASSES # resolves via root
-          ^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_other_package/foo.rb:16: Replaced with `Class`
-    16 |  Foo::Bar::MyClass::SUBCLASSES # resolves via root
-          ^^^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/class.rbi#LCENSORED: `Class` defined here
-    NN |class Class < Module
-        ^^^^^^^^^^^^^^^^^^^^
-
-use_other_package/foo.rb:18: Unable to resolve constant `Test` https://srb.help/5002
-    18 |  Test::Foo::Bar::OtherPackage::TestUtil
-          ^^^^
-
 use_other_package/foo.rb:7: `Foo::Bar::OtherPackage` is not imported https://srb.help/3718
      7 |      Foo::Bar::OtherPackage::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^
@@ -60,6 +45,21 @@ use_other_package/foo.rb:15: `Foo::Bar::OtherPackage` is not imported https://sr
      7 |  strict_dependencies 'layered'
                                        ^
 
+use_other_package/foo.rb:16: Unable to resolve constant `MyClass` https://srb.help/5002
+    16 |  Foo::Bar::MyClass::SUBCLASSES # resolves via root
+          ^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    use_other_package/foo.rb:16: Replaced with `Class`
+    16 |  Foo::Bar::MyClass::SUBCLASSES # resolves via root
+          ^^^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/class.rbi#LCENSORED: `Class` defined here
+    NN |class Class < Module
+        ^^^^^^^^^^^^^^^^^^^^
+
+use_other_package/foo.rb:18: Unable to resolve constant `Test` https://srb.help/5002
+    18 |  Test::Foo::Bar::OtherPackage::TestUtil
+          ^^^^
+
 use_other_package/foo.test.rb:4: `Foo::Bar::OtherPackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::OtherPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -95,10 +95,6 @@ end
 
 --------------------------------------------------------------------------
 
-use_app_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
-    13 |  Test::Foo::Bar::AppPackage::TestUtil
-          ^^^^
-
 use_app_package/foo.rb:6: `Foo::Bar::AppPackage` cannot be referenced here because importing it would cause a layering violation https://srb.help/3726
      6 |      Foo::Bar::AppPackage::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^
@@ -122,6 +118,10 @@ use_app_package/foo.rb:7: `Foo::Bar::AppPackageTest` cannot be referenced here b
                 ^^^^^
   Note:
     `Foo::Bar::AppPackageTest` is imported as `test_import`
+
+use_app_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
+    13 |  Test::Foo::Bar::AppPackage::TestUtil
+          ^^^^
 
 use_app_package/foo.test.rb:6: `Foo::Bar::AppPackage` is not imported https://srb.help/3718
      6 |  Foo::Bar::AppPackage::ImportMeTestOnly
@@ -147,10 +147,6 @@ end
 
 --------------------------------------------------------------------------
 
-use_false_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
-    13 |  Test::Foo::Bar::FalsePackage::TestUtil
-          ^^^^
-
 use_false_package/foo.rb:6: `Foo::Bar::FalsePackage` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
      6 |      Foo::Bar::FalsePackage::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^
@@ -175,6 +171,10 @@ use_false_package/foo.rb:7: `Foo::Bar::FalsePackageTest` cannot be referenced he
   Note:
     `Foo::Bar::FalsePackageTest` is imported as `test_import`
 
+use_false_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
+    13 |  Test::Foo::Bar::FalsePackage::TestUtil
+          ^^^^
+
 use_false_package/foo.test.rb:4: `Foo::Bar::FalsePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalsePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -198,10 +198,6 @@ class Foo::MyPackage < PackageSpec
 end
 
 --------------------------------------------------------------------------
-
-use_false_and_app_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
-    13 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
-          ^^^^
 
 use_false_and_app_package/foo.rb:6: `Foo::Bar::FalseAndAppPackage` cannot be referenced here because importing it would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
      6 |      Foo::Bar::FalseAndAppPackage::OtherClass # resolves via root
@@ -232,6 +228,10 @@ use_false_and_app_package/foo.rb:7: `Foo::Bar::FalseAndAppPackageTest` cannot be
                               ^^^^^^^
   Note:
     `Foo::Bar::FalseAndAppPackageTest` is imported as `test_import`
+
+use_false_and_app_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
+    13 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
+          ^^^^
 
 use_false_and_app_package/foo.test.rb:4: `Foo::Bar::FalseAndAppPackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil

--- a/test/cli/condensation-package-autocorrect-missing-import/test.out
+++ b/test/cli/condensation-package-autocorrect-missing-import/test.out
@@ -27,9 +27,9 @@ use_other_package/foo.rb:18: Unable to resolve constant `Test` https://srb.help/
     NN |module Net
         ^^^^^^^^^^
 
-use_other_package/foo.rb:7: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
+use_other_package/foo.rb:7: `Foo::Bar::OtherPackage` is not imported https://srb.help/3718
      7 |      Foo::Bar::OtherPackage::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^
     other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -38,9 +38,9 @@ use_other_package/foo.rb:7: `Foo::Bar::OtherPackage::OtherClass` resolves but it
      7 |  strict_dependencies 'layered'
                                        ^
 
-use_other_package/foo.rb:8: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
+use_other_package/foo.rb:8: `Foo::Bar::OtherPackage` is not imported https://srb.help/3718
      8 |      Bar::OtherPackage::OtherClass # resolves via `module Foo`
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^
     other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -63,9 +63,9 @@ use_other_package/foo.rb:9: Used `test_import` constant `Foo::Bar::OtherPackageT
      8 |  test_import Foo::Bar::OtherPackageTest
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-use_other_package/foo.rb:15: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
+use_other_package/foo.rb:15: `Foo::Bar::OtherPackage` is not imported https://srb.help/3718
     15 |  Foo::Bar::OtherPackage::OtherClass # resolves via root
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^
     other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -74,9 +74,9 @@ use_other_package/foo.rb:15: `Foo::Bar::OtherPackage::OtherClass` resolves but i
      7 |  strict_dependencies 'layered'
                                        ^
 
-use_other_package/foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
+use_other_package/foo.test.rb:4: `Foo::Bar::OtherPackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::OtherPackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -85,9 +85,9 @@ use_other_package/foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolv
      7 |  strict_dependencies 'layered'
                                        ^
 
-use_other_package/foo.test.rb:6: `Foo::Bar::OtherPackage::ImportMeTestOnly` resolves but its package is not imported https://srb.help/3718
+use_other_package/foo.test.rb:6: `Foo::Bar::OtherPackage` is not imported https://srb.help/3718
      6 |  Foo::Bar::OtherPackage::ImportMeTestOnly
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^
     other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -127,9 +127,9 @@ use_app_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/50
     NN |module Net
         ^^^^^^^^^^
 
-use_app_package/foo.rb:6: `Foo::Bar::AppPackage::OtherClass` cannot be referenced here because importing its package would cause a layering violation https://srb.help/3726
+use_app_package/foo.rb:6: `Foo::Bar::AppPackage` cannot be referenced here because importing it would cause a layering violation https://srb.help/3726
      6 |      Foo::Bar::AppPackage::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^
     use_app_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -137,11 +137,11 @@ use_app_package/foo.rb:6: `Foo::Bar::AppPackage::OtherClass` cannot be reference
      4 |  layer 'app'
                 ^^^^^
   Note:
-    `Foo::Bar::AppPackage::OtherClass`'s package is not imported
+    `Foo::Bar::AppPackage` is not imported
 
-use_app_package/foo.rb:7: `Foo::Bar::AppPackageTest::OtherClass` cannot be referenced here because importing its package would cause a layering violation https://srb.help/3726
+use_app_package/foo.rb:7: `Foo::Bar::AppPackageTest` cannot be referenced here because importing it would cause a layering violation https://srb.help/3726
      7 |      Foo::Bar::AppPackageTest::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -149,11 +149,11 @@ use_app_package/foo.rb:7: `Foo::Bar::AppPackageTest::OtherClass` cannot be refer
      4 |  layer 'app'
                 ^^^^^
   Note:
-    `Foo::Bar::AppPackageTest::OtherClass`'s package is imported as `test_import`
+    `Foo::Bar::AppPackageTest` is imported as `test_import`
 
-use_app_package/foo.test.rb:6: `Foo::Bar::AppPackage::ImportMeTestOnly` resolves but its package is not imported https://srb.help/3718
+use_app_package/foo.test.rb:6: `Foo::Bar::AppPackage` is not imported https://srb.help/3718
      6 |  Foo::Bar::AppPackage::ImportMeTestOnly
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^
     app_package/__package.rb:3: Package defined here
      3 |class Foo::Bar::AppPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -193,9 +193,9 @@ use_false_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/
     NN |module Net
         ^^^^^^^^^^
 
-use_false_package/foo.rb:6: `Foo::Bar::FalsePackage::OtherClass` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
+use_false_package/foo.rb:6: `Foo::Bar::FalsePackage` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
      6 |      Foo::Bar::FalsePackage::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^
     use_false_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -203,11 +203,11 @@ use_false_package/foo.rb:6: `Foo::Bar::FalsePackage::OtherClass` cannot be refer
      5 |  strict_dependencies 'false'
                               ^^^^^^^
   Note:
-    `Foo::Bar::FalsePackage::OtherClass`'s package is not imported
+    `Foo::Bar::FalsePackage` is not imported
 
-use_false_package/foo.rb:7: `Foo::Bar::FalsePackageTest::OtherClass` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
+use_false_package/foo.rb:7: `Foo::Bar::FalsePackageTest` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
      7 |      Foo::Bar::FalsePackageTest::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -215,11 +215,11 @@ use_false_package/foo.rb:7: `Foo::Bar::FalsePackageTest::OtherClass` cannot be r
      5 |  strict_dependencies 'false'
                               ^^^^^^^
   Note:
-    `Foo::Bar::FalsePackageTest::OtherClass`'s package is imported as `test_import`
+    `Foo::Bar::FalsePackageTest` is imported as `test_import`
 
-use_false_package/foo.test.rb:4: `Test::Foo::Bar::FalsePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
+use_false_package/foo.test.rb:4: `Foo::Bar::FalsePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalsePackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     false_package/__package.rb:3: Package defined here
      3 |class Foo::Bar::FalsePackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -259,9 +259,9 @@ use_false_and_app_package/foo.rb:13: Unable to resolve constant `Test` https://s
     NN |module Net
         ^^^^^^^^^^
 
-use_false_and_app_package/foo.rb:6: `Foo::Bar::FalseAndAppPackage::OtherClass` cannot be referenced here because importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
+use_false_and_app_package/foo.rb:6: `Foo::Bar::FalseAndAppPackage` cannot be referenced here because importing it would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
      6 |      Foo::Bar::FalseAndAppPackage::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_and_app_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -272,11 +272,11 @@ use_false_and_app_package/foo.rb:6: `Foo::Bar::FalseAndAppPackage::OtherClass` c
      5 |  strict_dependencies 'false'
                               ^^^^^^^
   Note:
-    `Foo::Bar::FalseAndAppPackage::OtherClass`'s package is not imported
+    `Foo::Bar::FalseAndAppPackage` is not imported
 
-use_false_and_app_package/foo.rb:7: `Foo::Bar::FalseAndAppPackageTest::OtherClass` cannot be referenced here because importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
+use_false_and_app_package/foo.rb:7: `Foo::Bar::FalseAndAppPackageTest` cannot be referenced here because importing it would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
      7 |      Foo::Bar::FalseAndAppPackageTest::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_and_app_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -287,11 +287,11 @@ use_false_and_app_package/foo.rb:7: `Foo::Bar::FalseAndAppPackageTest::OtherClas
      5 |  strict_dependencies 'false'
                               ^^^^^^^
   Note:
-    `Foo::Bar::FalseAndAppPackageTest::OtherClass`'s package is imported as `test_import`
+    `Foo::Bar::FalseAndAppPackageTest` is imported as `test_import`
 
-use_false_and_app_package/foo.test.rb:4: `Test::Foo::Bar::FalseAndAppPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
+use_false_and_app_package/foo.test.rb:4: `Foo::Bar::FalseAndAppPackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     false_and_app_package/__package.rb:3: Package defined here
      3 |class Foo::Bar::FalseAndAppPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/condensation-package-autocorrect-missing-import/test.out
+++ b/test/cli/condensation-package-autocorrect-missing-import/test.out
@@ -316,24 +316,36 @@ end
 use_cycle_package/foo.rb:6: `Foo::Bar::CyclePackage` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle https://srb.help/3727
      6 |      Foo::Bar::CyclePackage::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_cycle_package/foo.rb:6: Replaced with `Dir`
-     6 |      Foo::Bar::CyclePackage::OtherClass # resolves via root
-              ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/dir.rbi#LCENSORED: `Dir` defined here
-    NN |class Dir < Object
-        ^^^^^^^^^^^^^^^^^^
+    use_cycle_package/__package.rb:5: Enclosing package declared here
+     5 |class Foo::MyPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
+     7 |  strict_dependencies 'layered_dag'
+                              ^^^^^^^^^^^^^
+  Note:
+    Path from `Foo::Bar::CyclePackage` to `Foo::MyPackage`:
+    `Foo::Bar::CyclePackage` →
+    `Foo::MyPackage`
+
+  Note:
+    `Foo::Bar::CyclePackage` is not imported
 
 use_cycle_package/foo.rb:7: `Foo::Bar::CyclePackageTest` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle https://srb.help/3727
      7 |      Foo::Bar::CyclePackageTest::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_cycle_package/foo.rb:7: Replaced with `Dir`
-     7 |      Foo::Bar::CyclePackageTest::OtherClass # resolves via root
-              ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/dir.rbi#LCENSORED: `Dir` defined here
-    NN |class Dir < Object
-        ^^^^^^^^^^^^^^^^^^
+    use_cycle_package/__package.rb:5: Enclosing package declared here
+     5 |class Foo::MyPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
+     7 |  strict_dependencies 'layered_dag'
+                              ^^^^^^^^^^^^^
+  Note:
+    Path from `Foo::Bar::CyclePackageTest` to `Foo::MyPackage`:
+    `Foo::Bar::CyclePackageTest` →
+    `Foo::MyPackage`
+
+  Note:
+    `Foo::Bar::CyclePackageTest` is imported as `test_import`
 
 use_cycle_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
     13 |  Test::Foo::Bar::CyclePackage::TestUtil
@@ -356,13 +368,13 @@ use_cycle_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/
 use_cycle_package/foo.test.rb:4: `Foo::Bar::CyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::CyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    cycle_package/__package.rb:5: Package defined here
+     5 |class Foo::Bar::CyclePackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    use_cycle_package/foo.test.rb:4: Replaced with `Dir`
-     4 |  Test::Foo::Bar::CyclePackage::TestUtil
-          ^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/dir.rbi#LCENSORED: `Dir` defined here
-    NN |class Dir < Object
-        ^^^^^^^^^^^^^^^^^^
+    use_cycle_package/__package.rb:7: Inserted `test_import Foo::Bar::CyclePackage, only: "test_rb"`
+     7 |  strict_dependencies 'layered_dag'
+                                           ^
 Errors: 4
 # frozen_string_literal: true
 # typed: strict
@@ -371,6 +383,7 @@ Errors: 4
 class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered_dag'
+  test_import Foo::Bar::CyclePackage, only: "test_rb"
   test_import Foo::Bar::CyclePackageTest
 end
 
@@ -379,24 +392,42 @@ end
 use_app_cycle_package/foo.rb:6: `Foo::Bar::AppCyclePackage` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, and importing it would cause a layering violation https://srb.help/3727
      6 |      Foo::Bar::AppCyclePackage::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_app_cycle_package/foo.rb:6: Replaced with `Dir`
-     6 |      Foo::Bar::AppCyclePackage::OtherClass # resolves via root
-              ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/dir.rbi#LCENSORED: `Dir` defined here
-    NN |class Dir < Object
-        ^^^^^^^^^^^^^^^^^^
+    use_app_cycle_package/__package.rb:5: Enclosing package declared here
+     5 |class Foo::MyPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_app_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
+     7 |  strict_dependencies 'layered_dag'
+                              ^^^^^^^^^^^^^
+  Note:
+    Path from `Foo::Bar::AppCyclePackage` to `Foo::MyPackage`:
+    `Foo::Bar::AppCyclePackage` →
+    `Foo::MyPackage`
+
+    app_cycle_package/__package.rb:6: Package `Foo::Bar::AppCyclePackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
+     6 |  layer 'app'
+                ^^^^^
+  Note:
+    `Foo::Bar::AppCyclePackage` is not imported
 
 use_app_cycle_package/foo.rb:7: `Foo::Bar::AppCyclePackageTest` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, and importing it would cause a layering violation https://srb.help/3727
      7 |      Foo::Bar::AppCyclePackageTest::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_app_cycle_package/foo.rb:7: Replaced with `Dir`
-     7 |      Foo::Bar::AppCyclePackageTest::OtherClass # resolves via root
-              ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/dir.rbi#LCENSORED: `Dir` defined here
-    NN |class Dir < Object
-        ^^^^^^^^^^^^^^^^^^
+    use_app_cycle_package/__package.rb:5: Enclosing package declared here
+     5 |class Foo::MyPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_app_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
+     7 |  strict_dependencies 'layered_dag'
+                              ^^^^^^^^^^^^^
+  Note:
+    Path from `Foo::Bar::AppCyclePackageTest` to `Foo::MyPackage`:
+    `Foo::Bar::AppCyclePackageTest` →
+    `Foo::MyPackage`
+
+    app_cycle_package_test/__package.rb:6: Package `Foo::Bar::AppCyclePackageTest` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
+     6 |  layer 'app'
+                ^^^^^
+  Note:
+    `Foo::Bar::AppCyclePackageTest` is imported as `test_import`
 
 use_app_cycle_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
     13 |  Test::Foo::Bar::AppCyclePackage::TestUtil
@@ -419,13 +450,13 @@ use_app_cycle_package/foo.rb:13: Unable to resolve constant `Test` https://srb.h
 use_app_cycle_package/foo.test.rb:4: `Foo::Bar::AppCyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::AppCyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    app_cycle_package/__package.rb:5: Package defined here
+     5 |class Foo::Bar::AppCyclePackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    use_app_cycle_package/foo.test.rb:4: Replaced with `Dir`
-     4 |  Test::Foo::Bar::AppCyclePackage::TestUtil
-          ^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/dir.rbi#LCENSORED: `Dir` defined here
-    NN |class Dir < Object
-        ^^^^^^^^^^^^^^^^^^
+    use_app_cycle_package/__package.rb:7: Inserted `test_import Foo::Bar::AppCyclePackage, only: "test_rb"`
+     7 |  strict_dependencies 'layered_dag'
+                                           ^
 Errors: 4
 # frozen_string_literal: true
 # typed: strict
@@ -434,6 +465,7 @@ Errors: 4
 class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered_dag'
+  test_import Foo::Bar::AppCyclePackage, only: "test_rb"
   test_import Foo::Bar::AppCyclePackageTest
 end
 
@@ -442,24 +474,42 @@ end
 use_false_cycle_package/foo.rb:6: `Foo::Bar::FalseCyclePackage` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, and its `strict_dependencies` is not strict enough https://srb.help/3727
      6 |      Foo::Bar::FalseCyclePackage::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_false_cycle_package/foo.rb:6: Replaced with `Dir`
-     6 |      Foo::Bar::FalseCyclePackage::OtherClass # resolves via root
-              ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/dir.rbi#LCENSORED: `Dir` defined here
-    NN |class Dir < Object
-        ^^^^^^^^^^^^^^^^^^
+    use_false_cycle_package/__package.rb:5: Enclosing package declared here
+     5 |class Foo::MyPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_false_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
+     7 |  strict_dependencies 'layered_dag'
+                              ^^^^^^^^^^^^^
+  Note:
+    Path from `Foo::Bar::FalseCyclePackage` to `Foo::MyPackage`:
+    `Foo::Bar::FalseCyclePackage` →
+    `Foo::MyPackage`
+
+    false_cycle_package/__package.rb:7: `Foo::Bar::FalseCyclePackage` must be at least `strict_dependencies 'layered'` but is currently `strict_dependencies 'false'`
+     7 |  strict_dependencies 'false'
+                              ^^^^^^^
+  Note:
+    `Foo::Bar::FalseCyclePackage` is not imported
 
 use_false_cycle_package/foo.rb:7: `Foo::Bar::FalseCyclePackageTest` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, and its `strict_dependencies` is not strict enough https://srb.help/3727
      7 |      Foo::Bar::FalseCyclePackageTest::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_false_cycle_package/foo.rb:7: Replaced with `Dir`
-     7 |      Foo::Bar::FalseCyclePackageTest::OtherClass # resolves via root
-              ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/dir.rbi#LCENSORED: `Dir` defined here
-    NN |class Dir < Object
-        ^^^^^^^^^^^^^^^^^^
+    use_false_cycle_package/__package.rb:5: Enclosing package declared here
+     5 |class Foo::MyPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_false_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
+     7 |  strict_dependencies 'layered_dag'
+                              ^^^^^^^^^^^^^
+  Note:
+    Path from `Foo::Bar::FalseCyclePackageTest` to `Foo::MyPackage`:
+    `Foo::Bar::FalseCyclePackageTest` →
+    `Foo::MyPackage`
+
+    false_cycle_package_test/__package.rb:7: `Foo::Bar::FalseCyclePackageTest` must be at least `strict_dependencies 'layered'` but is currently `strict_dependencies 'false'`
+     7 |  strict_dependencies 'false'
+                              ^^^^^^^
+  Note:
+    `Foo::Bar::FalseCyclePackageTest` is imported as `test_import`
 
 use_false_cycle_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
     13 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
@@ -482,13 +532,13 @@ use_false_cycle_package/foo.rb:13: Unable to resolve constant `Test` https://srb
 use_false_cycle_package/foo.test.rb:4: `Foo::Bar::FalseCyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    false_cycle_package/__package.rb:5: Package defined here
+     5 |class Foo::Bar::FalseCyclePackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    use_false_cycle_package/foo.test.rb:4: Replaced with `Dir`
-     4 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
-          ^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/dir.rbi#LCENSORED: `Dir` defined here
-    NN |class Dir < Object
-        ^^^^^^^^^^^^^^^^^^
+    use_false_cycle_package/__package.rb:7: Inserted `test_import Foo::Bar::FalseCyclePackage, only: "test_rb"`
+     7 |  strict_dependencies 'layered_dag'
+                                           ^
 Errors: 4
 # frozen_string_literal: true
 # typed: strict
@@ -497,6 +547,7 @@ Errors: 4
 class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered_dag'
+  test_import Foo::Bar::FalseCyclePackage, only: "test_rb"
   test_import Foo::Bar::FalseCyclePackageTest
 end
 
@@ -505,24 +556,48 @@ end
 use_app_false_cycle_package/foo.rb:6: `Foo::Bar::AppFalseCyclePackage` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, importing it would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
      6 |      Foo::Bar::AppFalseCyclePackage::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_app_false_cycle_package/foo.rb:6: Replaced with `Dir`
-     6 |      Foo::Bar::AppFalseCyclePackage::OtherClass # resolves via root
-              ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/dir.rbi#LCENSORED: `Dir` defined here
-    NN |class Dir < Object
-        ^^^^^^^^^^^^^^^^^^
+    use_app_false_cycle_package/__package.rb:5: Enclosing package declared here
+     5 |class Foo::MyPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_app_false_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
+     7 |  strict_dependencies 'layered_dag'
+                              ^^^^^^^^^^^^^
+  Note:
+    Path from `Foo::Bar::AppFalseCyclePackage` to `Foo::MyPackage`:
+    `Foo::Bar::AppFalseCyclePackage` →
+    `Foo::MyPackage`
+
+    app_false_cycle_package/__package.rb:6: Package `Foo::Bar::AppFalseCyclePackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
+     6 |  layer 'app'
+                ^^^^^
+    app_false_cycle_package/__package.rb:7: `Foo::Bar::AppFalseCyclePackage` must be at least `strict_dependencies 'layered'` but is currently `strict_dependencies 'false'`
+     7 |  strict_dependencies 'false'
+                              ^^^^^^^
+  Note:
+    `Foo::Bar::AppFalseCyclePackage` is not imported
 
 use_app_false_cycle_package/foo.rb:7: `Foo::Bar::AppFalseCyclePackageTest` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, importing it would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
      7 |      Foo::Bar::AppFalseCyclePackageTest::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_app_false_cycle_package/foo.rb:7: Replaced with `Dir`
-     7 |      Foo::Bar::AppFalseCyclePackageTest::OtherClass # resolves via root
-              ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/dir.rbi#LCENSORED: `Dir` defined here
-    NN |class Dir < Object
-        ^^^^^^^^^^^^^^^^^^
+    use_app_false_cycle_package/__package.rb:5: Enclosing package declared here
+     5 |class Foo::MyPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_app_false_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
+     7 |  strict_dependencies 'layered_dag'
+                              ^^^^^^^^^^^^^
+  Note:
+    Path from `Foo::Bar::AppFalseCyclePackageTest` to `Foo::MyPackage`:
+    `Foo::Bar::AppFalseCyclePackageTest` →
+    `Foo::MyPackage`
+
+    app_false_cycle_package_test/__package.rb:6: Package `Foo::Bar::AppFalseCyclePackageTest` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
+     6 |  layer 'app'
+                ^^^^^
+    app_false_cycle_package_test/__package.rb:7: `Foo::Bar::AppFalseCyclePackageTest` must be at least `strict_dependencies 'layered'` but is currently `strict_dependencies 'false'`
+     7 |  strict_dependencies 'false'
+                              ^^^^^^^
+  Note:
+    `Foo::Bar::AppFalseCyclePackageTest` is imported as `test_import`
 
 use_app_false_cycle_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
     13 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil
@@ -545,13 +620,13 @@ use_app_false_cycle_package/foo.rb:13: Unable to resolve constant `Test` https:/
 use_app_false_cycle_package/foo.test.rb:4: `Foo::Bar::AppFalseCyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    app_false_cycle_package/__package.rb:5: Package defined here
+     5 |class Foo::Bar::AppFalseCyclePackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    use_app_false_cycle_package/foo.test.rb:4: Replaced with `Dir`
-     4 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil
-          ^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/dir.rbi#LCENSORED: `Dir` defined here
-    NN |class Dir < Object
-        ^^^^^^^^^^^^^^^^^^
+    use_app_false_cycle_package/__package.rb:7: Inserted `test_import Foo::Bar::AppFalseCyclePackage, only: "test_rb"`
+     7 |  strict_dependencies 'layered_dag'
+                                           ^
 Errors: 4
 # frozen_string_literal: true
 # typed: strict
@@ -560,5 +635,6 @@ Errors: 4
 class Foo::MyPackage < PackageSpec
   layer 'lib'
   strict_dependencies 'layered_dag'
+  test_import Foo::Bar::AppFalseCyclePackage, only: "test_rb"
   test_import Foo::Bar::AppFalseCyclePackageTest
 end

--- a/test/cli/condensation-package-error-missing-export/test.out
+++ b/test/cli/condensation-package-error-missing-export/test.out
@@ -38,9 +38,9 @@ use_other/foo_class.rb:13: `Foo::Bar::OtherPackage::Inner::AlsoNotExported` reso
   Note:
     Either export it manually, or better, restructure the code so that package namespaces do not define behavior.
 Errors: 4
-use_app_false_cycle_package/foo.rb:6: Unable to resolve constant `Bar` https://srb.help/5002
+use_app_false_cycle_package/foo.rb:6: `Foo::Bar::AppFalseCyclePackage` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, importing it would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
      6 |      Foo::Bar::AppFalseCyclePackage::OtherClass
-              ^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Did you mean `Dir`? Use `-a` to autocorrect
     use_app_false_cycle_package/foo.rb:6: Replace with `Dir`
      6 |      Foo::Bar::AppFalseCyclePackage::OtherClass

--- a/test/cli/condensation-package-error-missing-export/test.out
+++ b/test/cli/condensation-package-error-missing-export/test.out
@@ -41,11 +41,23 @@ Errors: 4
 use_app_false_cycle_package/foo.rb:6: `Foo::Bar::AppFalseCyclePackage` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, importing it would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
      6 |      Foo::Bar::AppFalseCyclePackage::OtherClass
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Did you mean `Dir`? Use `-a` to autocorrect
-    use_app_false_cycle_package/foo.rb:6: Replace with `Dir`
-     6 |      Foo::Bar::AppFalseCyclePackage::OtherClass
-              ^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/dir.rbi#L11: `Dir` defined here
-    11 |class Dir < Object
-        ^^^^^^^^^^^^^^^^^^
+    use_app_false_cycle_package/__package.rb:5: Enclosing package declared here
+     5 |class Foo::MyPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_app_false_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
+     7 |  strict_dependencies 'layered_dag'
+                              ^^^^^^^^^^^^^
+  Note:
+    Path from `Foo::Bar::AppFalseCyclePackage` to `Foo::MyPackage`:
+    `Foo::Bar::AppFalseCyclePackage` →
+    `Foo::MyPackage`
+
+    app_false_cycle_package/__package.rb:6: Package `Foo::Bar::AppFalseCyclePackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
+     6 |  layer 'app'
+                ^^^^^
+    app_false_cycle_package/__package.rb:7: `Foo::Bar::AppFalseCyclePackage` must be at least `strict_dependencies 'layered'` but is currently `strict_dependencies 'false'`
+     7 |  strict_dependencies 'false'
+                              ^^^^^^^
+  Note:
+    `Foo::Bar::AppFalseCyclePackage` is not imported
 Errors: 1

--- a/test/cli/legacy-test-constant-resolution/early_bridge/__package.rb
+++ b/test/cli/legacy-test-constant-resolution/early_bridge/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class EarlyBridge < PackageSpec
+  test_import EarlyTarget
+end

--- a/test/cli/legacy-test-constant-resolution/early_bridge/lib.rb
+++ b/test/cli/legacy-test-constant-resolution/early_bridge/lib.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+module EarlyBridge
+end

--- a/test/cli/legacy-test-constant-resolution/early_target/__package.rb
+++ b/test/cli/legacy-test-constant-resolution/early_target/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class EarlyTarget < PackageSpec
+  export Test::EarlyTarget::Value
+end

--- a/test/cli/legacy-test-constant-resolution/early_target/lib.rb
+++ b/test/cli/legacy-test-constant-resolution/early_target/lib.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+module EarlyTarget
+end

--- a/test/cli/legacy-test-constant-resolution/early_target/test/value.rb
+++ b/test/cli/legacy-test-constant-resolution/early_target/test/value.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Test::EarlyTarget::Value
+end

--- a/test/cli/legacy-test-constant-resolution/helper_import/__package.rb
+++ b/test/cli/legacy-test-constant-resolution/helper_import/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class HelperImport < PackageSpec
+  test_import Target
+end

--- a/test/cli/legacy-test-constant-resolution/helper_import/test/helper.rb
+++ b/test/cli/legacy-test-constant-resolution/helper_import/test/helper.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+Test::Target::Helper
+Test::Target::TestCase

--- a/test/cli/legacy-test-constant-resolution/helper_unit_import/__package.rb
+++ b/test/cli/legacy-test-constant-resolution/helper_unit_import/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class HelperUnitImport < PackageSpec
+  test_import Target, only: "test_rb"
+end

--- a/test/cli/legacy-test-constant-resolution/helper_unit_import/test/helper.rb
+++ b/test/cli/legacy-test-constant-resolution/helper_unit_import/test/helper.rb
@@ -1,0 +1,3 @@
+# typed: strict
+
+Test::Target::TestCase

--- a/test/cli/legacy-test-constant-resolution/late_target/__package.rb
+++ b/test/cli/legacy-test-constant-resolution/late_target/__package.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+class LateTarget < PackageSpec
+  # This edge guarantees that UnitLate's test stratum runs first.
+  test_import UnitLate
+  export Test::LateTarget::Value
+end

--- a/test/cli/legacy-test-constant-resolution/late_target/lib.rb
+++ b/test/cli/legacy-test-constant-resolution/late_target/lib.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+module LateTarget
+end

--- a/test/cli/legacy-test-constant-resolution/late_target/test/value.rb
+++ b/test/cli/legacy-test-constant-resolution/late_target/test/value.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Test::LateTarget::Value
+end

--- a/test/cli/legacy-test-constant-resolution/prod_none/__package.rb
+++ b/test/cli/legacy-test-constant-resolution/prod_none/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class ProdNone < PackageSpec
+end

--- a/test/cli/legacy-test-constant-resolution/prod_none/use.rb
+++ b/test/cli/legacy-test-constant-resolution/prod_none/use.rb
@@ -1,0 +1,11 @@
+# typed: strict
+
+Test::Target::Helper
+
+module ProdNone::Nested
+  module Test
+    X = 1
+  end
+
+  T.let(Test::X, Integer)
+end

--- a/test/cli/legacy-test-constant-resolution/prod_normal/__package.rb
+++ b/test/cli/legacy-test-constant-resolution/prod_normal/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class ProdNormal < PackageSpec
+  import Target
+end

--- a/test/cli/legacy-test-constant-resolution/prod_normal/use.rb
+++ b/test/cli/legacy-test-constant-resolution/prod_normal/use.rb
@@ -1,0 +1,3 @@
+# typed: strict
+
+Test::Target::Helper

--- a/test/cli/legacy-test-constant-resolution/prod_test/__package.rb
+++ b/test/cli/legacy-test-constant-resolution/prod_test/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class ProdTest < PackageSpec
+  test_import Target
+end

--- a/test/cli/legacy-test-constant-resolution/prod_test/use.rb
+++ b/test/cli/legacy-test-constant-resolution/prod_test/use.rb
@@ -1,0 +1,3 @@
+# typed: strict
+
+Test::Target::Helper

--- a/test/cli/legacy-test-constant-resolution/target/__package.rb
+++ b/test/cli/legacy-test-constant-resolution/target/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+class Target < PackageSpec
+  export Test::Target::Helper
+  export Test::Target::TestCase
+end

--- a/test/cli/legacy-test-constant-resolution/target/lib.rb
+++ b/test/cli/legacy-test-constant-resolution/target/lib.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+module Target
+end

--- a/test/cli/legacy-test-constant-resolution/target/test/helper.rb
+++ b/test/cli/legacy-test-constant-resolution/target/test/helper.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Test::Target::Helper
+end

--- a/test/cli/legacy-test-constant-resolution/target/test/target.test.rb
+++ b/test/cli/legacy-test-constant-resolution/target/test/target.test.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Test::Target::TestCase
+end

--- a/test/cli/legacy-test-constant-resolution/test.out
+++ b/test/cli/legacy-test-constant-resolution/test.out
@@ -10,9 +10,9 @@ prod_none/use.rb:3: `Test::Target::Helper` resolves but its package is not impor
      3 |class ProdNone < PackageSpec
                                     ^
 
-unit_early/test/use.test.rb:3: `Test::EarlyTarget::Value` resolves but its package is not imported https://srb.help/3718
+unit_early/test/use.test.rb:3: `EarlyTarget` is not imported https://srb.help/3718
      3 |Test::EarlyTarget::Value
-        ^^^^^^^^^^^^^^^^^^^^^^^^
+        ^^^^^^^^^^^^^^^^^
     early_target/__package.rb:3: Package defined here
      3 |class EarlyTarget < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -21,9 +21,9 @@ unit_early/test/use.test.rb:3: `Test::EarlyTarget::Value` resolves but its packa
      5 |  test_import EarlyBridge
                                  ^
 
-unit_late/test/use.test.rb:3: `Test::LateTarget::Value` resolves but its package is not imported https://srb.help/3718
+unit_late/test/use.test.rb:3: `LateTarget` is not imported https://srb.help/3718
      3 |Test::LateTarget::Value
-        ^^^^^^^^^^^^^^^^^^^^^^^
+        ^^^^^^^^^^^^^^^^
     late_target/__package.rb:3: Package defined here
      3 |class LateTarget < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,9 +32,9 @@ unit_late/test/use.test.rb:3: `Test::LateTarget::Value` resolves but its package
      3 |class UnitLate < PackageSpec
                                     ^
 
-unit_none/test/use.test.rb:3: `Test::Target::TestCase` resolves but its package is not imported https://srb.help/3718
+unit_none/test/use.test.rb:3: `Target` is not imported https://srb.help/3718
      3 |Test::Target::TestCase
-        ^^^^^^^^^^^^^^^^^^^^^^
+        ^^^^^^^^^^^^
     target/__package.rb:3: Package defined here
      3 |class Target < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,9 +121,9 @@ prod_test/use.rb:3: Unable to resolve constant `Test` https://srb.help/5002
         ^^^^^^^^^^
 Errors: 1
 ------ package-directed: isolated test unit, no import ------
-unit_none/test/use.test.rb:3: `Test::Target::TestCase` resolves but its package is not imported https://srb.help/3718
+unit_none/test/use.test.rb:3: `Target` is not imported https://srb.help/3718
      3 |Test::Target::TestCase
-        ^^^^^^^^^^^^^^^^^^^^^^
+        ^^^^^^^^^^^^
     target/__package.rb:3: Package defined here
      3 |class Target < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -152,9 +152,9 @@ unit_late/test/use.test.rb:3: Unable to resolve constant `Test` https://srb.help
         ^^^^^^^^^^
 Errors: 1
 ------ package-directed: unimported target test SCC is earlier ------
-unit_early/test/use.test.rb:3: `Test::EarlyTarget::Value` resolves but its package is not imported https://srb.help/3718
+unit_early/test/use.test.rb:3: `EarlyTarget` is not imported https://srb.help/3718
      3 |Test::EarlyTarget::Value
-        ^^^^^^^^^^^^^^^^^^^^^^^^
+        ^^^^^^^^^^^^^^^^^
     early_target/__package.rb:3: Package defined here
      3 |class EarlyTarget < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -221,20 +221,20 @@ prod_test/use.rb:3: Unable to resolve constant `Test` https://srb.help/5002
     NN |module Net
         ^^^^^^^^^^
 
-unit_late/test/use.test.rb:3: Unable to resolve constant `LateTarget` https://srb.help/5002
+unit_late/test/use.test.rb:3: `LateTarget` is not imported https://srb.help/3718
      3 |Test::LateTarget::Value
         ^^^^^^^^^^^^^^^^
-  Did you mean `DateTime`? Use `-a` to autocorrect
-    unit_late/test/use.test.rb:3: Replace with `DateTime`
-     3 |Test::LateTarget::Value
-        ^^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/date_time.rbi#LCENSORED: `DateTime` defined here
-      NN |class DateTime < Date
-          ^^^^^^^^^^^^^^^^^^^^^
+    late_target/__package.rb:3: Package defined here
+     3 |class LateTarget < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    unit_late/__package.rb:3: Insert `test_import LateTarget, only: "test_rb"`
+     3 |class UnitLate < PackageSpec
+                                    ^
 
-unit_none/test/use.test.rb:3: `Test::Target::TestCase` resolves but its package is not imported https://srb.help/3718
+unit_none/test/use.test.rb:3: `Target` is not imported https://srb.help/3718
      3 |Test::Target::TestCase
-        ^^^^^^^^^^^^^^^^^^^^^^
+        ^^^^^^^^^^^^
     target/__package.rb:3: Package defined here
      3 |class Target < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -263,9 +263,9 @@ helper_unit_import/test/helper.rb:3: The `test_import` constant `Test::Target::T
      4 |  test_import Target, only: "test_rb"
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-unit_early/test/use.test.rb:3: `Test::EarlyTarget::Value` resolves but its package is not imported https://srb.help/3718
+unit_early/test/use.test.rb:3: `EarlyTarget` is not imported https://srb.help/3718
      3 |Test::EarlyTarget::Value
-        ^^^^^^^^^^^^^^^^^^^^^^^^
+        ^^^^^^^^^^^^^^^^^
     early_target/__package.rb:3: Package defined here
      3 |class EarlyTarget < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/legacy-test-constant-resolution/test.out
+++ b/test/cli/legacy-test-constant-resolution/test.out
@@ -1,14 +1,7 @@
 ------ monolithic -------------------------------
-prod_none/use.rb:3: `Test::Target::Helper` resolves but its package is not imported https://srb.help/3718
+prod_none/use.rb:3: Unable to resolve constant `Test` https://srb.help/5002
      3 |Test::Target::Helper
-        ^^^^^^^^^^^^^^^^^^^^
-    target/__package.rb:3: Package defined here
-     3 |class Target < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Use `-a` to autocorrect
-    prod_none/__package.rb:3: Insert `import Target`
-     3 |class ProdNone < PackageSpec
-                                    ^
+        ^^^^
 
 unit_early/test/use.test.rb:3: `EarlyTarget` is not imported https://srb.help/3718
      3 |Test::EarlyTarget::Value
@@ -59,66 +52,28 @@ helper_unit_import/test/helper.rb:3: The `test_import` package `Target` can only
      4 |  test_import Target, only: "test_rb"
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-prod_test/use.rb:3: Used `test_import` constant `Test::Target::Helper` in non-test file https://srb.help/3720
+prod_test/use.rb:3: Unable to resolve constant `Test` https://srb.help/5002
      3 |Test::Target::Helper
-        ^^^^^^^^^^^^^^^^^^^^
-    target/__package.rb:3: Defined here
-     3 |class Target < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Use `-a` to autocorrect
-    prod_test/__package.rb:3: Insert `import Target`
-     3 |class ProdTest < PackageSpec
-                                    ^
-    prod_test/__package.rb:4: Delete
-     4 |  test_import Target
-        ^^^^^^^^^^^^^^^^^^^^
+        ^^^^
 
-prod_normal/use.rb:3: `Test::Target::Helper` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+prod_normal/use.rb:3: Unable to resolve constant `Test` https://srb.help/5002
      3 |Test::Target::Helper
-        ^^^^^^^^^^^^^^^^^^^^
+        ^^^^
 Errors: 7
 ------ package-directed: isolated production, no import ------
 prod_none/use.rb:3: Unable to resolve constant `Test` https://srb.help/5002
      3 |Test::Target::Helper
         ^^^^
-  Did you mean `Set`? Use `-a` to autocorrect
-    prod_none/use.rb:3: Replace with `Set`
-     3 |Test::Target::Helper
-        ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/set.rbi#LCENSORED: `Set` defined here
-      NN |class Set < Object
-          ^^^^^^^^^^^^^^^^^^
-  Did you mean `Net`? Use `-a` to autocorrect
-    prod_none/use.rb:3: Replace with `Net`
-     3 |Test::Target::Helper
-        ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#LCENSORED: `Net` defined here
-    NN |module Net
-        ^^^^^^^^^^
 Errors: 1
 ------ package-directed: isolated production, normal import ------
-prod_normal/use.rb:3: `Test::Target::Helper` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+prod_normal/use.rb:3: Unable to resolve constant `Test` https://srb.help/5002
      3 |Test::Target::Helper
-        ^^^^^^^^^^^^^^^^^^^^
+        ^^^^
 Errors: 1
 ------ package-directed: isolated production, test import ------
 prod_test/use.rb:3: Unable to resolve constant `Test` https://srb.help/5002
      3 |Test::Target::Helper
         ^^^^
-  Did you mean `Set`? Use `-a` to autocorrect
-    prod_test/use.rb:3: Replace with `Set`
-     3 |Test::Target::Helper
-        ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/set.rbi#LCENSORED: `Set` defined here
-      NN |class Set < Object
-          ^^^^^^^^^^^^^^^^^^
-  Did you mean `Net`? Use `-a` to autocorrect
-    prod_test/use.rb:3: Replace with `Net`
-     3 |Test::Target::Helper
-        ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#LCENSORED: `Net` defined here
-    NN |module Net
-        ^^^^^^^^^^
 Errors: 1
 ------ package-directed: isolated test unit, no import ------
 unit_none/test/use.test.rb:3: `Target` is not imported https://srb.help/3718
@@ -188,38 +143,10 @@ Errors: 1
 prod_none/use.rb:3: Unable to resolve constant `Test` https://srb.help/5002
      3 |Test::Target::Helper
         ^^^^
-  Did you mean `Set`? Use `-a` to autocorrect
-    prod_none/use.rb:3: Replace with `Set`
-     3 |Test::Target::Helper
-        ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/set.rbi#LCENSORED: `Set` defined here
-      NN |class Set < Object
-          ^^^^^^^^^^^^^^^^^^
-  Did you mean `Net`? Use `-a` to autocorrect
-    prod_none/use.rb:3: Replace with `Net`
-     3 |Test::Target::Helper
-        ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#LCENSORED: `Net` defined here
-    NN |module Net
-        ^^^^^^^^^^
 
 prod_test/use.rb:3: Unable to resolve constant `Test` https://srb.help/5002
      3 |Test::Target::Helper
         ^^^^
-  Did you mean `Set`? Use `-a` to autocorrect
-    prod_test/use.rb:3: Replace with `Set`
-     3 |Test::Target::Helper
-        ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/set.rbi#LCENSORED: `Set` defined here
-      NN |class Set < Object
-          ^^^^^^^^^^^^^^^^^^
-  Did you mean `Net`? Use `-a` to autocorrect
-    prod_test/use.rb:3: Replace with `Net`
-     3 |Test::Target::Helper
-        ^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#LCENSORED: `Net` defined here
-    NN |module Net
-        ^^^^^^^^^^
 
 unit_late/test/use.test.rb:3: `LateTarget` is not imported https://srb.help/3718
      3 |Test::LateTarget::Value
@@ -243,9 +170,9 @@ unit_none/test/use.test.rb:3: `Target` is not imported https://srb.help/3718
      3 |class UnitNone < PackageSpec
                                     ^
 
-prod_normal/use.rb:3: `Test::Target::Helper` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+prod_normal/use.rb:3: Unable to resolve constant `Test` https://srb.help/5002
      3 |Test::Target::Helper
-        ^^^^^^^^^^^^^^^^^^^^
+        ^^^^
 
 helper_unit_import/test/helper.rb:3: The `test_import` package `Target` can only be used in `.test.rb` files https://srb.help/3720
      3 |Test::Target::TestCase

--- a/test/cli/legacy-test-constant-resolution/test.out
+++ b/test/cli/legacy-test-constant-resolution/test.out
@@ -1,0 +1,276 @@
+------ monolithic -------------------------------
+prod_none/use.rb:3: `Test::Target::Helper` resolves but its package is not imported https://srb.help/3718
+     3 |Test::Target::Helper
+        ^^^^^^^^^^^^^^^^^^^^
+    target/__package.rb:3: Package defined here
+     3 |class Target < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    prod_none/__package.rb:3: Insert `import Target`
+     3 |class ProdNone < PackageSpec
+                                    ^
+
+unit_early/test/use.test.rb:3: `Test::EarlyTarget::Value` resolves but its package is not imported https://srb.help/3718
+     3 |Test::EarlyTarget::Value
+        ^^^^^^^^^^^^^^^^^^^^^^^^
+    early_target/__package.rb:3: Package defined here
+     3 |class EarlyTarget < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    unit_early/__package.rb:5: Insert `test_import EarlyTarget, only: "test_rb"`
+     5 |  test_import EarlyBridge
+                                 ^
+
+unit_late/test/use.test.rb:3: `Test::LateTarget::Value` resolves but its package is not imported https://srb.help/3718
+     3 |Test::LateTarget::Value
+        ^^^^^^^^^^^^^^^^^^^^^^^
+    late_target/__package.rb:3: Package defined here
+     3 |class LateTarget < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    unit_late/__package.rb:3: Insert `test_import LateTarget, only: "test_rb"`
+     3 |class UnitLate < PackageSpec
+                                    ^
+
+unit_none/test/use.test.rb:3: `Test::Target::TestCase` resolves but its package is not imported https://srb.help/3718
+     3 |Test::Target::TestCase
+        ^^^^^^^^^^^^^^^^^^^^^^
+    target/__package.rb:3: Package defined here
+     3 |class Target < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    unit_none/__package.rb:3: Insert `test_import Target, only: "test_rb"`
+     3 |class UnitNone < PackageSpec
+                                    ^
+
+helper_unit_import/test/helper.rb:3: The `test_import` constant `Test::Target::TestCase` can only be used in `.test.rb` files https://srb.help/3720
+     3 |Test::Target::TestCase
+        ^^^^^^^^^^^^^^^^^^^^^^
+    target/__package.rb:3: Defined here
+     3 |class Target < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    This is because this `test_import` is declared with `only: 'test_rb'`, which means the constant can only be used in `.test.rb` files.
+  Autocorrect: Use `-a` to autocorrect
+    helper_unit_import/__package.rb:3: Insert `test_import Target`
+     3 |class HelperUnitImport < PackageSpec
+                                            ^
+    helper_unit_import/__package.rb:4: Delete
+     4 |  test_import Target, only: "test_rb"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+prod_test/use.rb:3: Used `test_import` constant `Test::Target::Helper` in non-test file https://srb.help/3720
+     3 |Test::Target::Helper
+        ^^^^^^^^^^^^^^^^^^^^
+    target/__package.rb:3: Defined here
+     3 |class Target < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    prod_test/__package.rb:3: Insert `import Target`
+     3 |class ProdTest < PackageSpec
+                                    ^
+    prod_test/__package.rb:4: Delete
+     4 |  test_import Target
+        ^^^^^^^^^^^^^^^^^^^^
+
+prod_normal/use.rb:3: `Test::Target::Helper` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+     3 |Test::Target::Helper
+        ^^^^^^^^^^^^^^^^^^^^
+Errors: 7
+------ package-directed: isolated production, no import ------
+prod_none/use.rb:3: Unable to resolve constant `Test` https://srb.help/5002
+     3 |Test::Target::Helper
+        ^^^^
+  Did you mean `Set`? Use `-a` to autocorrect
+    prod_none/use.rb:3: Replace with `Set`
+     3 |Test::Target::Helper
+        ^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/set.rbi#LCENSORED: `Set` defined here
+      NN |class Set < Object
+          ^^^^^^^^^^^^^^^^^^
+  Did you mean `Net`? Use `-a` to autocorrect
+    prod_none/use.rb:3: Replace with `Net`
+     3 |Test::Target::Helper
+        ^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#LCENSORED: `Net` defined here
+    NN |module Net
+        ^^^^^^^^^^
+Errors: 1
+------ package-directed: isolated production, normal import ------
+prod_normal/use.rb:3: `Test::Target::Helper` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+     3 |Test::Target::Helper
+        ^^^^^^^^^^^^^^^^^^^^
+Errors: 1
+------ package-directed: isolated production, test import ------
+prod_test/use.rb:3: Unable to resolve constant `Test` https://srb.help/5002
+     3 |Test::Target::Helper
+        ^^^^
+  Did you mean `Set`? Use `-a` to autocorrect
+    prod_test/use.rb:3: Replace with `Set`
+     3 |Test::Target::Helper
+        ^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/set.rbi#LCENSORED: `Set` defined here
+      NN |class Set < Object
+          ^^^^^^^^^^^^^^^^^^
+  Did you mean `Net`? Use `-a` to autocorrect
+    prod_test/use.rb:3: Replace with `Net`
+     3 |Test::Target::Helper
+        ^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#LCENSORED: `Net` defined here
+    NN |module Net
+        ^^^^^^^^^^
+Errors: 1
+------ package-directed: isolated test unit, no import ------
+unit_none/test/use.test.rb:3: `Test::Target::TestCase` resolves but its package is not imported https://srb.help/3718
+     3 |Test::Target::TestCase
+        ^^^^^^^^^^^^^^^^^^^^^^
+    target/__package.rb:3: Package defined here
+     3 |class Target < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    unit_none/__package.rb:3: Insert `test_import Target, only: "test_rb"`
+     3 |class UnitNone < PackageSpec
+                                    ^
+Errors: 1
+------ package-directed: unimported target test SCC is later ------
+unit_late/test/use.test.rb:3: Unable to resolve constant `Test` https://srb.help/5002
+     3 |Test::LateTarget::Value
+        ^^^^
+  Did you mean `Set`? Use `-a` to autocorrect
+    unit_late/test/use.test.rb:3: Replace with `Set`
+     3 |Test::LateTarget::Value
+        ^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/set.rbi#LCENSORED: `Set` defined here
+      NN |class Set < Object
+          ^^^^^^^^^^^^^^^^^^
+  Did you mean `Net`? Use `-a` to autocorrect
+    unit_late/test/use.test.rb:3: Replace with `Net`
+     3 |Test::LateTarget::Value
+        ^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#LCENSORED: `Net` defined here
+    NN |module Net
+        ^^^^^^^^^^
+Errors: 1
+------ package-directed: unimported target test SCC is earlier ------
+unit_early/test/use.test.rb:3: `Test::EarlyTarget::Value` resolves but its package is not imported https://srb.help/3718
+     3 |Test::EarlyTarget::Value
+        ^^^^^^^^^^^^^^^^^^^^^^^^
+    early_target/__package.rb:3: Package defined here
+     3 |class EarlyTarget < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    unit_early/__package.rb:5: Insert `test_import EarlyTarget, only: "test_rb"`
+     5 |  test_import EarlyBridge
+                                 ^
+Errors: 1
+------ package-directed: isolated test unit, test import ------
+No errors! Great job.
+------ package-directed: isolated helper, helper import ------
+No errors! Great job.
+------ package-directed: isolated helper, test-unit import ------
+helper_unit_import/test/helper.rb:3: The `test_import` constant `Test::Target::TestCase` can only be used in `.test.rb` files https://srb.help/3720
+     3 |Test::Target::TestCase
+        ^^^^^^^^^^^^^^^^^^^^^^
+    target/__package.rb:3: Defined here
+     3 |class Target < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    This is because this `test_import` is declared with `only: 'test_rb'`, which means the constant can only be used in `.test.rb` files.
+  Autocorrect: Use `-a` to autocorrect
+    helper_unit_import/__package.rb:3: Insert `test_import Target`
+     3 |class HelperUnitImport < PackageSpec
+                                            ^
+    helper_unit_import/__package.rb:4: Delete
+     4 |  test_import Target, only: "test_rb"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 1
+------ package-directed: complete graph ----------------------
+prod_none/use.rb:3: Unable to resolve constant `Test` https://srb.help/5002
+     3 |Test::Target::Helper
+        ^^^^
+  Did you mean `Set`? Use `-a` to autocorrect
+    prod_none/use.rb:3: Replace with `Set`
+     3 |Test::Target::Helper
+        ^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/set.rbi#LCENSORED: `Set` defined here
+      NN |class Set < Object
+          ^^^^^^^^^^^^^^^^^^
+  Did you mean `Net`? Use `-a` to autocorrect
+    prod_none/use.rb:3: Replace with `Net`
+     3 |Test::Target::Helper
+        ^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#LCENSORED: `Net` defined here
+    NN |module Net
+        ^^^^^^^^^^
+
+prod_test/use.rb:3: Unable to resolve constant `Test` https://srb.help/5002
+     3 |Test::Target::Helper
+        ^^^^
+  Did you mean `Set`? Use `-a` to autocorrect
+    prod_test/use.rb:3: Replace with `Set`
+     3 |Test::Target::Helper
+        ^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/set.rbi#LCENSORED: `Set` defined here
+      NN |class Set < Object
+          ^^^^^^^^^^^^^^^^^^
+  Did you mean `Net`? Use `-a` to autocorrect
+    prod_test/use.rb:3: Replace with `Net`
+     3 |Test::Target::Helper
+        ^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/net.rbi#LCENSORED: `Net` defined here
+    NN |module Net
+        ^^^^^^^^^^
+
+unit_late/test/use.test.rb:3: Unable to resolve constant `LateTarget` https://srb.help/5002
+     3 |Test::LateTarget::Value
+        ^^^^^^^^^^^^^^^^
+  Did you mean `DateTime`? Use `-a` to autocorrect
+    unit_late/test/use.test.rb:3: Replace with `DateTime`
+     3 |Test::LateTarget::Value
+        ^^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/date_time.rbi#LCENSORED: `DateTime` defined here
+      NN |class DateTime < Date
+          ^^^^^^^^^^^^^^^^^^^^^
+
+unit_none/test/use.test.rb:3: `Test::Target::TestCase` resolves but its package is not imported https://srb.help/3718
+     3 |Test::Target::TestCase
+        ^^^^^^^^^^^^^^^^^^^^^^
+    target/__package.rb:3: Package defined here
+     3 |class Target < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    unit_none/__package.rb:3: Insert `test_import Target, only: "test_rb"`
+     3 |class UnitNone < PackageSpec
+                                    ^
+
+prod_normal/use.rb:3: `Test::Target::Helper` is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+     3 |Test::Target::Helper
+        ^^^^^^^^^^^^^^^^^^^^
+
+helper_unit_import/test/helper.rb:3: The `test_import` constant `Test::Target::TestCase` can only be used in `.test.rb` files https://srb.help/3720
+     3 |Test::Target::TestCase
+        ^^^^^^^^^^^^^^^^^^^^^^
+    target/__package.rb:3: Defined here
+     3 |class Target < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    This is because this `test_import` is declared with `only: 'test_rb'`, which means the constant can only be used in `.test.rb` files.
+  Autocorrect: Use `-a` to autocorrect
+    helper_unit_import/__package.rb:3: Insert `test_import Target`
+     3 |class HelperUnitImport < PackageSpec
+                                            ^
+    helper_unit_import/__package.rb:4: Delete
+     4 |  test_import Target, only: "test_rb"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+unit_early/test/use.test.rb:3: `Test::EarlyTarget::Value` resolves but its package is not imported https://srb.help/3718
+     3 |Test::EarlyTarget::Value
+        ^^^^^^^^^^^^^^^^^^^^^^^^
+    early_target/__package.rb:3: Package defined here
+     3 |class EarlyTarget < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    unit_early/__package.rb:5: Insert `test_import EarlyTarget, only: "test_rb"`
+     5 |  test_import EarlyBridge
+                                 ^
+Errors: 7

--- a/test/cli/legacy-test-constant-resolution/test.out
+++ b/test/cli/legacy-test-constant-resolution/test.out
@@ -43,9 +43,9 @@ unit_none/test/use.test.rb:3: `Target` is not imported https://srb.help/3718
      3 |class UnitNone < PackageSpec
                                     ^
 
-helper_unit_import/test/helper.rb:3: The `test_import` constant `Test::Target::TestCase` can only be used in `.test.rb` files https://srb.help/3720
+helper_unit_import/test/helper.rb:3: The `test_import` package `Target` can only be used in `.test.rb` files https://srb.help/3720
      3 |Test::Target::TestCase
-        ^^^^^^^^^^^^^^^^^^^^^^
+        ^^^^^^^^^^^^
     target/__package.rb:3: Defined here
      3 |class Target < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -168,9 +168,9 @@ No errors! Great job.
 ------ package-directed: isolated helper, helper import ------
 No errors! Great job.
 ------ package-directed: isolated helper, test-unit import ------
-helper_unit_import/test/helper.rb:3: The `test_import` constant `Test::Target::TestCase` can only be used in `.test.rb` files https://srb.help/3720
+helper_unit_import/test/helper.rb:3: The `test_import` package `Target` can only be used in `.test.rb` files https://srb.help/3720
      3 |Test::Target::TestCase
-        ^^^^^^^^^^^^^^^^^^^^^^
+        ^^^^^^^^^^^^
     target/__package.rb:3: Defined here
      3 |class Target < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -247,9 +247,9 @@ prod_normal/use.rb:3: `Test::Target::Helper` is defined in a test namespace and 
      3 |Test::Target::Helper
         ^^^^^^^^^^^^^^^^^^^^
 
-helper_unit_import/test/helper.rb:3: The `test_import` constant `Test::Target::TestCase` can only be used in `.test.rb` files https://srb.help/3720
+helper_unit_import/test/helper.rb:3: The `test_import` package `Target` can only be used in `.test.rb` files https://srb.help/3720
      3 |Test::Target::TestCase
-        ^^^^^^^^^^^^^^^^^^^^^^
+        ^^^^^^^^^^^^
     target/__package.rb:3: Defined here
      3 |class Target < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/legacy-test-constant-resolution/test.sh
+++ b/test/cli/legacy-test-constant-resolution/test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Characterize legacy Test:: constant lookup in monolithic and package-directed
+# modes. In particular, package-directed production strata run before legacy
+# test sources have defined their constants.
+
+cd test/cli/legacy-test-constant-resolution || exit 1
+
+args=(--silence-dev-message --censor-for-snapshot-tests --sorbet-packages --max-threads=0)
+
+echo '------ monolithic -------------------------------'
+../../../main/sorbet "${args[@]}" . 2>&1
+
+args+=(--experimental-package-directed)
+
+echo '------ package-directed: isolated production, no import ------'
+../../../main/sorbet "${args[@]}" target prod_none 2>&1
+
+echo '------ package-directed: isolated production, normal import ------'
+../../../main/sorbet "${args[@]}" target prod_normal 2>&1
+
+echo '------ package-directed: isolated production, test import ------'
+../../../main/sorbet "${args[@]}" target prod_test 2>&1
+
+echo '------ package-directed: isolated test unit, no import ------'
+../../../main/sorbet "${args[@]}" target unit_none 2>&1
+
+echo '------ package-directed: unimported target test SCC is later ------'
+../../../main/sorbet "${args[@]}" late_target unit_late 2>&1
+
+echo '------ package-directed: unimported target test SCC is earlier ------'
+../../../main/sorbet "${args[@]}" early_target early_bridge unit_early 2>&1
+
+echo '------ package-directed: isolated test unit, test import ------'
+../../../main/sorbet "${args[@]}" target unit_import 2>&1
+
+echo '------ package-directed: isolated helper, helper import ------'
+../../../main/sorbet "${args[@]}" target helper_import 2>&1
+
+echo '------ package-directed: isolated helper, test-unit import ------'
+../../../main/sorbet "${args[@]}" target helper_unit_import 2>&1
+
+# Running the complete graph lets unrelated test_import edges load Target's
+# test SCC before some production strata. This characterizes the corresponding
+# traversal-order-sensitive behavior.
+echo '------ package-directed: complete graph ----------------------'
+../../../main/sorbet "${args[@]}" . 2>&1

--- a/test/cli/legacy-test-constant-resolution/unit_early/__package.rb
+++ b/test/cli/legacy-test-constant-resolution/unit_early/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+class UnitEarly < PackageSpec
+  # This transitively schedules EarlyTarget first without importing it here.
+  test_import EarlyBridge
+end

--- a/test/cli/legacy-test-constant-resolution/unit_early/test/use.test.rb
+++ b/test/cli/legacy-test-constant-resolution/unit_early/test/use.test.rb
@@ -1,0 +1,3 @@
+# typed: strict
+
+Test::EarlyTarget::Value

--- a/test/cli/legacy-test-constant-resolution/unit_import/__package.rb
+++ b/test/cli/legacy-test-constant-resolution/unit_import/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class UnitImport < PackageSpec
+  test_import Target
+end

--- a/test/cli/legacy-test-constant-resolution/unit_import/test/use.test.rb
+++ b/test/cli/legacy-test-constant-resolution/unit_import/test/use.test.rb
@@ -1,0 +1,3 @@
+# typed: strict
+
+Test::Target::TestCase

--- a/test/cli/legacy-test-constant-resolution/unit_late/__package.rb
+++ b/test/cli/legacy-test-constant-resolution/unit_late/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class UnitLate < PackageSpec
+end

--- a/test/cli/legacy-test-constant-resolution/unit_late/test/use.test.rb
+++ b/test/cli/legacy-test-constant-resolution/unit_late/test/use.test.rb
@@ -1,0 +1,3 @@
+# typed: strict
+
+Test::LateTarget::Value

--- a/test/cli/legacy-test-constant-resolution/unit_none/__package.rb
+++ b/test/cli/legacy-test-constant-resolution/unit_none/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class UnitNone < PackageSpec
+end

--- a/test/cli/legacy-test-constant-resolution/unit_none/test/use.test.rb
+++ b/test/cli/legacy-test-constant-resolution/unit_none/test/use.test.rb
@@ -1,0 +1,3 @@
+# typed: strict
+
+Test::Target::TestCase

--- a/test/cli/package-alias-import-autocorrect/alias/__package.rb
+++ b/test/cli/package-alias-import-autocorrect/alias/__package.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+class AliasPackage < PackageSpec
+  import TargetPackage
+
+  export AliasPackage::Alias
+end

--- a/test/cli/package-alias-import-autocorrect/alias/alias.rb
+++ b/test/cli/package-alias-import-autocorrect/alias/alias.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+module AliasPackage
+  Alias = TargetPackage::Container
+end

--- a/test/cli/package-alias-import-autocorrect/consumer/__package.rb
+++ b/test/cli/package-alias-import-autocorrect/consumer/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Consumer < PackageSpec
+end

--- a/test/cli/package-alias-import-autocorrect/consumer/use.rb
+++ b/test/cli/package-alias-import-autocorrect/consumer/use.rb
@@ -1,0 +1,3 @@
+# typed: strict
+
+AliasPackage::Alias::Thing.new

--- a/test/cli/package-alias-import-autocorrect/target/__package.rb
+++ b/test/cli/package-alias-import-autocorrect/target/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class TargetPackage < PackageSpec
+  export TargetPackage::Container
+end

--- a/test/cli/package-alias-import-autocorrect/target/container.rb
+++ b/test/cli/package-alias-import-autocorrect/target/container.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+module TargetPackage::Container
+  class Thing
+  end
+end

--- a/test/cli/package-alias-import-autocorrect/test.out
+++ b/test/cli/package-alias-import-autocorrect/test.out
@@ -1,25 +1,36 @@
-consumer/use.rb:3: `TargetPackage::Container::Thing` resolves but its package is not imported https://srb.help/3718
+consumer/use.rb:3: `AliasPackage` is not imported https://srb.help/3718
      3 |AliasPackage::Alias::Thing.new
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^
-    target/__package.rb:3: Package defined here
-     3 |class TargetPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        ^^^^^^^^^^^^
+    alias/__package.rb:3: Package defined here
+     3 |class AliasPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Autocorrect: Done
-    consumer/__package.rb:3: Inserted `import TargetPackage`
+    consumer/__package.rb:3: Inserted `import AliasPackage`
      3 |class Consumer < PackageSpec
                                     ^
 Errors: 1
 # typed: strict
 
 class Consumer < PackageSpec
-  import TargetPackage
+  import AliasPackage
 end
 
 --------------------------------------------------------------------------
 
-No errors! Great job.
+consumer/use.rb:3: `TargetPackage` is not imported https://srb.help/3718
+     3 |AliasPackage::Alias::Thing.new
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    target/__package.rb:3: Package defined here
+     3 |class TargetPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    consumer/__package.rb:4: Inserted `import TargetPackage`
+     4 |  import AliasPackage
+                             ^
+Errors: 1
 # typed: strict
 
 class Consumer < PackageSpec
+  import AliasPackage
   import TargetPackage
 end

--- a/test/cli/package-alias-import-autocorrect/test.out
+++ b/test/cli/package-alias-import-autocorrect/test.out
@@ -1,0 +1,25 @@
+consumer/use.rb:3: `TargetPackage::Container::Thing` resolves but its package is not imported https://srb.help/3718
+     3 |AliasPackage::Alias::Thing.new
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    target/__package.rb:3: Package defined here
+     3 |class TargetPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    consumer/__package.rb:3: Inserted `import TargetPackage`
+     3 |class Consumer < PackageSpec
+                                    ^
+Errors: 1
+# typed: strict
+
+class Consumer < PackageSpec
+  import TargetPackage
+end
+
+--------------------------------------------------------------------------
+
+No errors! Great job.
+# typed: strict
+
+class Consumer < PackageSpec
+  import TargetPackage
+end

--- a/test/cli/package-alias-import-autocorrect/test.sh
+++ b/test/cli/package-alias-import-autocorrect/test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+cwd="$(pwd)"
+tmp="$(mktemp -d)"
+
+mkdir -p "$tmp"/{alias,consumer,target}
+cp test/cli/package-alias-import-autocorrect/alias/*.rb "$tmp/alias"
+cp test/cli/package-alias-import-autocorrect/consumer/*.rb "$tmp/consumer"
+cp test/cli/package-alias-import-autocorrect/target/*.rb "$tmp/target"
+
+cd "$tmp" || exit 1
+
+"$cwd/main/sorbet" --silence-dev-message --sorbet-packages --max-threads=0 -a . 2>&1
+cat consumer/__package.rb
+
+echo
+echo --------------------------------------------------------------------------
+echo
+
+"$cwd/main/sorbet" --silence-dev-message --sorbet-packages --max-threads=0 -a . 2>&1
+cat consumer/__package.rb

--- a/test/cli/package-attributed-errors/test.out
+++ b/test/cli/package-attributed-errors/test.out
@@ -1,6 +1,6 @@
-[App] app/main.rb:5: `Lib::Nested::SomeClass` resolves but its package is not imported https://srb.help/3718
+[App] app/main.rb:5: `Lib::Nested` is not imported https://srb.help/3718
      5 |    Lib::Nested::SomeClass
-            ^^^^^^^^^^^^^^^^^^^^^^
+            ^^^^^^^^^^^
     lib/nested/__package.rb:3: Package defined here
      3 |class Lib::Nested < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -56,12 +56,16 @@ use_other_package/foo.rb:15: `Foo::Bar::OtherPackage::OtherClass` resolves but i
      7 |  strict_dependencies 'layered'
                                        ^
 
-use_other_package/foo.rb:18: `Test::Foo::Bar::OtherPackage::TestUtil` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+use_other_package/foo.rb:18: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
     18 |  Test::Foo::Bar::OtherPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_other_package/__package.rb:5: Enclosing package declared here
-     5 |class Foo::MyPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    other/__package.rb:3: Package defined here
+     3 |class Foo::Bar::OtherPackage < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    use_other_package/__package.rb:7: Inserted `import Foo::Bar::OtherPackage`
+     7 |  strict_dependencies 'layered'
+                                       ^
 
 use_other_package/foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::OtherPackage::TestUtil
@@ -122,12 +126,17 @@ use_app_package/foo.rb:7: `Foo::Bar::AppPackageTest::OtherClass` cannot be refer
   Note:
     `Foo::Bar::AppPackageTest::OtherClass`'s package is imported as `test_import`
 
-use_app_package/foo.rb:13: `Test::Foo::Bar::AppPackage::TestUtil` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+use_app_package/foo.rb:13: `Test::Foo::Bar::AppPackage::TestUtil` cannot be referenced here because importing its package would cause a layering violation https://srb.help/3726
     13 |  Test::Foo::Bar::AppPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    app_package/__package.rb:4: Package `Foo::Bar::AppPackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
+     4 |  layer 'app'
+                ^^^^^
+  Note:
+    `Test::Foo::Bar::AppPackage::TestUtil`'s package is not imported
 
 use_app_package/foo.test.rb:6: `Foo::Bar::AppPackage::ImportMeTestOnly` resolves but its package is not imported https://srb.help/3718
      6 |  Foo::Bar::AppPackage::ImportMeTestOnly
@@ -177,12 +186,17 @@ use_false_package/foo.rb:7: `Foo::Bar::FalsePackageTest::OtherClass` cannot be r
   Note:
     `Foo::Bar::FalsePackageTest::OtherClass`'s package is imported as `test_import`
 
-use_false_package/foo.rb:13: `Test::Foo::Bar::FalsePackage::TestUtil` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+use_false_package/foo.rb:13: `Test::Foo::Bar::FalsePackage::TestUtil` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
     13 |  Test::Foo::Bar::FalsePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    false_package/__package.rb:5: `Foo::Bar::FalsePackage` must be at least `strict_dependencies 'layered'` but is currently `strict_dependencies 'false'`
+     5 |  strict_dependencies 'false'
+                              ^^^^^^^
+  Note:
+    `Test::Foo::Bar::FalsePackage::TestUtil`'s package is not imported
 
 use_false_package/foo.test.rb:4: `Test::Foo::Bar::FalsePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalsePackage::TestUtil
@@ -238,12 +252,20 @@ use_false_and_app_package/foo.rb:7: `Foo::Bar::FalseAndAppPackageTest::OtherClas
   Note:
     `Foo::Bar::FalseAndAppPackageTest::OtherClass`'s package is imported as `test_import`
 
-use_false_and_app_package/foo.rb:13: `Test::Foo::Bar::FalseAndAppPackage::TestUtil` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+use_false_and_app_package/foo.rb:13: `Test::Foo::Bar::FalseAndAppPackage::TestUtil` cannot be referenced here because importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
     13 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_and_app_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    false_and_app_package/__package.rb:4: Package `Foo::Bar::FalseAndAppPackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
+     4 |  layer 'app'
+                ^^^^^
+    false_and_app_package/__package.rb:5: `Foo::Bar::FalseAndAppPackage` must be at least `strict_dependencies 'layered'` but is currently `strict_dependencies 'false'`
+     5 |  strict_dependencies 'false'
+                              ^^^^^^^
+  Note:
+    `Test::Foo::Bar::FalseAndAppPackage::TestUtil`'s package is not imported
 
 use_false_and_app_package/foo.test.rb:4: `Test::Foo::Bar::FalseAndAppPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
@@ -303,12 +325,22 @@ use_cycle_package/foo.rb:7: `Foo::Bar::CyclePackageTest::OtherClass` cannot be r
   Note:
     `Foo::Bar::CyclePackageTest::OtherClass`'s package is imported as `test_import`
 
-use_cycle_package/foo.rb:13: `Test::Foo::Bar::CyclePackage::TestUtil` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+use_cycle_package/foo.rb:13: `Test::Foo::Bar::CyclePackage::TestUtil` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle https://srb.help/3727
     13 |  Test::Foo::Bar::CyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_cycle_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
+     7 |  strict_dependencies 'layered_dag'
+                              ^^^^^^^^^^^^^
+  Note:
+    Path from `Foo::Bar::CyclePackage` to `Foo::MyPackage`:
+    `Foo::Bar::CyclePackage` →
+    `Foo::MyPackage`
+
+  Note:
+    `Test::Foo::Bar::CyclePackage::TestUtil`'s package is not imported
 
 use_cycle_package/foo.test.rb:4: `Test::Foo::Bar::CyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::CyclePackage::TestUtil
@@ -374,12 +406,25 @@ use_app_cycle_package/foo.rb:7: `Foo::Bar::AppCyclePackageTest::OtherClass` cann
   Note:
     `Foo::Bar::AppCyclePackageTest::OtherClass`'s package is imported as `test_import`
 
-use_app_cycle_package/foo.rb:13: `Test::Foo::Bar::AppCyclePackage::TestUtil` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+use_app_cycle_package/foo.rb:13: `Test::Foo::Bar::AppCyclePackage::TestUtil` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, and importing its package would cause a layering violation https://srb.help/3727
     13 |  Test::Foo::Bar::AppCyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_cycle_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_app_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
+     7 |  strict_dependencies 'layered_dag'
+                              ^^^^^^^^^^^^^
+  Note:
+    Path from `Foo::Bar::AppCyclePackage` to `Foo::MyPackage`:
+    `Foo::Bar::AppCyclePackage` →
+    `Foo::MyPackage`
+
+    app_cycle_package/__package.rb:6: Package `Foo::Bar::AppCyclePackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
+     6 |  layer 'app'
+                ^^^^^
+  Note:
+    `Test::Foo::Bar::AppCyclePackage::TestUtil`'s package is not imported
 
 use_app_cycle_package/foo.test.rb:4: `Test::Foo::Bar::AppCyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::AppCyclePackage::TestUtil
@@ -445,12 +490,25 @@ use_false_cycle_package/foo.rb:7: `Foo::Bar::FalseCyclePackageTest::OtherClass` 
   Note:
     `Foo::Bar::FalseCyclePackageTest::OtherClass`'s package is imported as `test_import`
 
-use_false_cycle_package/foo.rb:13: `Test::Foo::Bar::FalseCyclePackage::TestUtil` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+use_false_cycle_package/foo.rb:13: `Test::Foo::Bar::FalseCyclePackage::TestUtil` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, and its `strict_dependencies` is not strict enough https://srb.help/3727
     13 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_cycle_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_false_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
+     7 |  strict_dependencies 'layered_dag'
+                              ^^^^^^^^^^^^^
+  Note:
+    Path from `Foo::Bar::FalseCyclePackage` to `Foo::MyPackage`:
+    `Foo::Bar::FalseCyclePackage` →
+    `Foo::MyPackage`
+
+    false_cycle_package/__package.rb:7: `Foo::Bar::FalseCyclePackage` must be at least `strict_dependencies 'layered'` but is currently `strict_dependencies 'false'`
+     7 |  strict_dependencies 'false'
+                              ^^^^^^^
+  Note:
+    `Test::Foo::Bar::FalseCyclePackage::TestUtil`'s package is not imported
 
 use_false_cycle_package/foo.test.rb:4: `Test::Foo::Bar::FalseCyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
@@ -522,12 +580,28 @@ use_app_false_cycle_package/foo.rb:7: `Foo::Bar::AppFalseCyclePackageTest::Other
   Note:
     `Foo::Bar::AppFalseCyclePackageTest::OtherClass`'s package is imported as `test_import`
 
-use_app_false_cycle_package/foo.rb:13: `Test::Foo::Bar::AppFalseCyclePackage::TestUtil` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file https://srb.help/3720
+use_app_false_cycle_package/foo.rb:13: `Test::Foo::Bar::AppFalseCyclePackage::TestUtil` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
     13 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_false_cycle_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    use_app_false_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
+     7 |  strict_dependencies 'layered_dag'
+                              ^^^^^^^^^^^^^
+  Note:
+    Path from `Foo::Bar::AppFalseCyclePackage` to `Foo::MyPackage`:
+    `Foo::Bar::AppFalseCyclePackage` →
+    `Foo::MyPackage`
+
+    app_false_cycle_package/__package.rb:6: Package `Foo::Bar::AppFalseCyclePackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
+     6 |  layer 'app'
+                ^^^^^
+    app_false_cycle_package/__package.rb:7: `Foo::Bar::AppFalseCyclePackage` must be at least `strict_dependencies 'layered'` but is currently `strict_dependencies 'false'`
+     7 |  strict_dependencies 'false'
+                              ^^^^^^^
+  Note:
+    `Test::Foo::Bar::AppFalseCyclePackage::TestUtil`'s package is not imported
 
 use_app_false_cycle_package/foo.test.rb:4: `Test::Foo::Bar::AppFalseCyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -56,16 +56,9 @@ use_other_package/foo.rb:15: `Foo::Bar::OtherPackage` is not imported https://sr
      7 |  strict_dependencies 'layered'
                                        ^
 
-use_other_package/foo.rb:18: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
+use_other_package/foo.rb:18: Unable to resolve constant `Test` https://srb.help/5002
     18 |  Test::Foo::Bar::OtherPackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Package defined here
-     3 |class Foo::Bar::OtherPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_other_package/__package.rb:7: Inserted `import Foo::Bar::OtherPackage`
-     7 |  strict_dependencies 'layered'
-                                       ^
+          ^^^^
 
 use_other_package/foo.test.rb:4: `Foo::Bar::OtherPackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::OtherPackage::TestUtil
@@ -126,17 +119,9 @@ use_app_package/foo.rb:7: `Foo::Bar::AppPackageTest` cannot be referenced here b
   Note:
     `Foo::Bar::AppPackageTest` is imported as `test_import`
 
-use_app_package/foo.rb:13: `Test::Foo::Bar::AppPackage::TestUtil` cannot be referenced here because importing its package would cause a layering violation https://srb.help/3726
+use_app_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
     13 |  Test::Foo::Bar::AppPackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_app_package/__package.rb:5: Enclosing package declared here
-     5 |class Foo::MyPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    app_package/__package.rb:4: Package `Foo::Bar::AppPackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
-     4 |  layer 'app'
-                ^^^^^
-  Note:
-    `Test::Foo::Bar::AppPackage::TestUtil`'s package is not imported
+          ^^^^
 
 use_app_package/foo.test.rb:6: `Foo::Bar::AppPackage` is not imported https://srb.help/3718
      6 |  Foo::Bar::AppPackage::ImportMeTestOnly
@@ -186,17 +171,9 @@ use_false_package/foo.rb:7: `Foo::Bar::FalsePackageTest` cannot be referenced he
   Note:
     `Foo::Bar::FalsePackageTest` is imported as `test_import`
 
-use_false_package/foo.rb:13: `Test::Foo::Bar::FalsePackage::TestUtil` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
+use_false_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
     13 |  Test::Foo::Bar::FalsePackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_false_package/__package.rb:5: Enclosing package declared here
-     5 |class Foo::MyPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    false_package/__package.rb:5: `Foo::Bar::FalsePackage` must be at least `strict_dependencies 'layered'` but is currently `strict_dependencies 'false'`
-     5 |  strict_dependencies 'false'
-                              ^^^^^^^
-  Note:
-    `Test::Foo::Bar::FalsePackage::TestUtil`'s package is not imported
+          ^^^^
 
 use_false_package/foo.test.rb:4: `Foo::Bar::FalsePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalsePackage::TestUtil
@@ -252,20 +229,9 @@ use_false_and_app_package/foo.rb:7: `Foo::Bar::FalseAndAppPackageTest` cannot be
   Note:
     `Foo::Bar::FalseAndAppPackageTest` is imported as `test_import`
 
-use_false_and_app_package/foo.rb:13: `Test::Foo::Bar::FalseAndAppPackage::TestUtil` cannot be referenced here because importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
+use_false_and_app_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
     13 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_false_and_app_package/__package.rb:5: Enclosing package declared here
-     5 |class Foo::MyPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    false_and_app_package/__package.rb:4: Package `Foo::Bar::FalseAndAppPackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
-     4 |  layer 'app'
-                ^^^^^
-    false_and_app_package/__package.rb:5: `Foo::Bar::FalseAndAppPackage` must be at least `strict_dependencies 'layered'` but is currently `strict_dependencies 'false'`
-     5 |  strict_dependencies 'false'
-                              ^^^^^^^
-  Note:
-    `Test::Foo::Bar::FalseAndAppPackage::TestUtil`'s package is not imported
+          ^^^^
 
 use_false_and_app_package/foo.test.rb:4: `Foo::Bar::FalseAndAppPackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
@@ -325,22 +291,9 @@ use_cycle_package/foo.rb:7: `Foo::Bar::CyclePackageTest` cannot be referenced he
   Note:
     `Foo::Bar::CyclePackageTest` is imported as `test_import`
 
-use_cycle_package/foo.rb:13: `Test::Foo::Bar::CyclePackage::TestUtil` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle https://srb.help/3727
+use_cycle_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
     13 |  Test::Foo::Bar::CyclePackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_cycle_package/__package.rb:5: Enclosing package declared here
-     5 |class Foo::MyPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
-     7 |  strict_dependencies 'layered_dag'
-                              ^^^^^^^^^^^^^
-  Note:
-    Path from `Foo::Bar::CyclePackage` to `Foo::MyPackage`:
-    `Foo::Bar::CyclePackage` →
-    `Foo::MyPackage`
-
-  Note:
-    `Test::Foo::Bar::CyclePackage::TestUtil`'s package is not imported
+          ^^^^
 
 use_cycle_package/foo.test.rb:4: `Foo::Bar::CyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::CyclePackage::TestUtil
@@ -406,25 +359,9 @@ use_app_cycle_package/foo.rb:7: `Foo::Bar::AppCyclePackageTest` cannot be refere
   Note:
     `Foo::Bar::AppCyclePackageTest` is imported as `test_import`
 
-use_app_cycle_package/foo.rb:13: `Test::Foo::Bar::AppCyclePackage::TestUtil` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, and importing its package would cause a layering violation https://srb.help/3727
+use_app_cycle_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
     13 |  Test::Foo::Bar::AppCyclePackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_app_cycle_package/__package.rb:5: Enclosing package declared here
-     5 |class Foo::MyPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_app_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
-     7 |  strict_dependencies 'layered_dag'
-                              ^^^^^^^^^^^^^
-  Note:
-    Path from `Foo::Bar::AppCyclePackage` to `Foo::MyPackage`:
-    `Foo::Bar::AppCyclePackage` →
-    `Foo::MyPackage`
-
-    app_cycle_package/__package.rb:6: Package `Foo::Bar::AppCyclePackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
-     6 |  layer 'app'
-                ^^^^^
-  Note:
-    `Test::Foo::Bar::AppCyclePackage::TestUtil`'s package is not imported
+          ^^^^
 
 use_app_cycle_package/foo.test.rb:4: `Foo::Bar::AppCyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::AppCyclePackage::TestUtil
@@ -490,25 +427,9 @@ use_false_cycle_package/foo.rb:7: `Foo::Bar::FalseCyclePackageTest` cannot be re
   Note:
     `Foo::Bar::FalseCyclePackageTest` is imported as `test_import`
 
-use_false_cycle_package/foo.rb:13: `Test::Foo::Bar::FalseCyclePackage::TestUtil` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, and its `strict_dependencies` is not strict enough https://srb.help/3727
+use_false_cycle_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
     13 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_false_cycle_package/__package.rb:5: Enclosing package declared here
-     5 |class Foo::MyPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_false_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
-     7 |  strict_dependencies 'layered_dag'
-                              ^^^^^^^^^^^^^
-  Note:
-    Path from `Foo::Bar::FalseCyclePackage` to `Foo::MyPackage`:
-    `Foo::Bar::FalseCyclePackage` →
-    `Foo::MyPackage`
-
-    false_cycle_package/__package.rb:7: `Foo::Bar::FalseCyclePackage` must be at least `strict_dependencies 'layered'` but is currently `strict_dependencies 'false'`
-     7 |  strict_dependencies 'false'
-                              ^^^^^^^
-  Note:
-    `Test::Foo::Bar::FalseCyclePackage::TestUtil`'s package is not imported
+          ^^^^
 
 use_false_cycle_package/foo.test.rb:4: `Foo::Bar::FalseCyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
@@ -580,28 +501,9 @@ use_app_false_cycle_package/foo.rb:7: `Foo::Bar::AppFalseCyclePackageTest` canno
   Note:
     `Foo::Bar::AppFalseCyclePackageTest` is imported as `test_import`
 
-use_app_false_cycle_package/foo.rb:13: `Test::Foo::Bar::AppFalseCyclePackage::TestUtil` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
+use_app_false_cycle_package/foo.rb:13: Unable to resolve constant `Test` https://srb.help/5002
     13 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_app_false_cycle_package/__package.rb:5: Enclosing package declared here
-     5 |class Foo::MyPackage < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    use_app_false_cycle_package/__package.rb:7: `Foo::MyPackage` is `strict_dependencies 'layered_dag'`, which disallows cycles
-     7 |  strict_dependencies 'layered_dag'
-                              ^^^^^^^^^^^^^
-  Note:
-    Path from `Foo::Bar::AppFalseCyclePackage` to `Foo::MyPackage`:
-    `Foo::Bar::AppFalseCyclePackage` →
-    `Foo::MyPackage`
-
-    app_false_cycle_package/__package.rb:6: Package `Foo::Bar::AppFalseCyclePackage` must be at most layer `lib` (to match package `Foo::MyPackage`) but is currently layer `app`
-     6 |  layer 'app'
-                ^^^^^
-    app_false_cycle_package/__package.rb:7: `Foo::Bar::AppFalseCyclePackage` must be at least `strict_dependencies 'layered'` but is currently `strict_dependencies 'false'`
-     7 |  strict_dependencies 'false'
-                              ^^^^^^^
-  Note:
-    `Test::Foo::Bar::AppFalseCyclePackage::TestUtil`'s package is not imported
+          ^^^^
 
 use_app_false_cycle_package/foo.test.rb:4: `Foo::Bar::AppFalseCyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -31,9 +31,9 @@ use_other_package/foo.rb:8: `Foo::Bar::OtherPackage` is not imported https://srb
      7 |  strict_dependencies 'layered'
                                        ^
 
-use_other_package/foo.rb:9: Used `test_import` constant `Foo::Bar::OtherPackageTest::OtherClass` in non-test file https://srb.help/3720
+use_other_package/foo.rb:9: Used `test_import` package `Foo::Bar::OtherPackageTest` in non-test file https://srb.help/3720
      9 |      Foo::Bar::OtherPackageTest::OtherClass
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^
     other_test/__package.rb:3: Defined here
      3 |class Foo::Bar::OtherPackageTest < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -9,9 +9,9 @@ use_other_package/foo.rb:16: Unable to resolve constant `MyClass` https://srb.he
     NN |class Class < Module
         ^^^^^^^^^^^^^^^^^^^^
 
-use_other_package/foo.rb:7: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
+use_other_package/foo.rb:7: `Foo::Bar::OtherPackage` is not imported https://srb.help/3718
      7 |      Foo::Bar::OtherPackage::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^
     other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -20,9 +20,9 @@ use_other_package/foo.rb:7: `Foo::Bar::OtherPackage::OtherClass` resolves but it
      7 |  strict_dependencies 'layered'
                                        ^
 
-use_other_package/foo.rb:8: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
+use_other_package/foo.rb:8: `Foo::Bar::OtherPackage` is not imported https://srb.help/3718
      8 |      Bar::OtherPackage::OtherClass # resolves via `module Foo`
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^
     other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -45,9 +45,9 @@ use_other_package/foo.rb:9: Used `test_import` constant `Foo::Bar::OtherPackageT
      8 |  test_import Foo::Bar::OtherPackageTest
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-use_other_package/foo.rb:15: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
+use_other_package/foo.rb:15: `Foo::Bar::OtherPackage` is not imported https://srb.help/3718
     15 |  Foo::Bar::OtherPackage::OtherClass # resolves via root
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^
     other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -67,9 +67,9 @@ use_other_package/foo.rb:18: `Test::Foo::Bar::OtherPackage::TestUtil` resolves b
      7 |  strict_dependencies 'layered'
                                        ^
 
-use_other_package/foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
+use_other_package/foo.test.rb:4: `Foo::Bar::OtherPackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::OtherPackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -78,9 +78,9 @@ use_other_package/foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolv
      7 |  strict_dependencies 'layered'
                                        ^
 
-use_other_package/foo.test.rb:6: `Foo::Bar::OtherPackage::ImportMeTestOnly` resolves but its package is not imported https://srb.help/3718
+use_other_package/foo.test.rb:6: `Foo::Bar::OtherPackage` is not imported https://srb.help/3718
      6 |  Foo::Bar::OtherPackage::ImportMeTestOnly
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^
     other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -102,9 +102,9 @@ end
 
 --------------------------------------------------------------------------
 
-use_app_package/foo.rb:6: `Foo::Bar::AppPackage::OtherClass` cannot be referenced here because importing its package would cause a layering violation https://srb.help/3726
+use_app_package/foo.rb:6: `Foo::Bar::AppPackage` cannot be referenced here because importing it would cause a layering violation https://srb.help/3726
      6 |      Foo::Bar::AppPackage::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^
     use_app_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -112,11 +112,11 @@ use_app_package/foo.rb:6: `Foo::Bar::AppPackage::OtherClass` cannot be reference
      4 |  layer 'app'
                 ^^^^^
   Note:
-    `Foo::Bar::AppPackage::OtherClass`'s package is not imported
+    `Foo::Bar::AppPackage` is not imported
 
-use_app_package/foo.rb:7: `Foo::Bar::AppPackageTest::OtherClass` cannot be referenced here because importing its package would cause a layering violation https://srb.help/3726
+use_app_package/foo.rb:7: `Foo::Bar::AppPackageTest` cannot be referenced here because importing it would cause a layering violation https://srb.help/3726
      7 |      Foo::Bar::AppPackageTest::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -124,7 +124,7 @@ use_app_package/foo.rb:7: `Foo::Bar::AppPackageTest::OtherClass` cannot be refer
      4 |  layer 'app'
                 ^^^^^
   Note:
-    `Foo::Bar::AppPackageTest::OtherClass`'s package is imported as `test_import`
+    `Foo::Bar::AppPackageTest` is imported as `test_import`
 
 use_app_package/foo.rb:13: `Test::Foo::Bar::AppPackage::TestUtil` cannot be referenced here because importing its package would cause a layering violation https://srb.help/3726
     13 |  Test::Foo::Bar::AppPackage::TestUtil
@@ -138,9 +138,9 @@ use_app_package/foo.rb:13: `Test::Foo::Bar::AppPackage::TestUtil` cannot be refe
   Note:
     `Test::Foo::Bar::AppPackage::TestUtil`'s package is not imported
 
-use_app_package/foo.test.rb:6: `Foo::Bar::AppPackage::ImportMeTestOnly` resolves but its package is not imported https://srb.help/3718
+use_app_package/foo.test.rb:6: `Foo::Bar::AppPackage` is not imported https://srb.help/3718
      6 |  Foo::Bar::AppPackage::ImportMeTestOnly
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^
     app_package/__package.rb:3: Package defined here
      3 |class Foo::Bar::AppPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -162,9 +162,9 @@ end
 
 --------------------------------------------------------------------------
 
-use_false_package/foo.rb:6: `Foo::Bar::FalsePackage::OtherClass` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
+use_false_package/foo.rb:6: `Foo::Bar::FalsePackage` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
      6 |      Foo::Bar::FalsePackage::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^
     use_false_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -172,11 +172,11 @@ use_false_package/foo.rb:6: `Foo::Bar::FalsePackage::OtherClass` cannot be refer
      5 |  strict_dependencies 'false'
                               ^^^^^^^
   Note:
-    `Foo::Bar::FalsePackage::OtherClass`'s package is not imported
+    `Foo::Bar::FalsePackage` is not imported
 
-use_false_package/foo.rb:7: `Foo::Bar::FalsePackageTest::OtherClass` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
+use_false_package/foo.rb:7: `Foo::Bar::FalsePackageTest` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
      7 |      Foo::Bar::FalsePackageTest::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -184,7 +184,7 @@ use_false_package/foo.rb:7: `Foo::Bar::FalsePackageTest::OtherClass` cannot be r
      5 |  strict_dependencies 'false'
                               ^^^^^^^
   Note:
-    `Foo::Bar::FalsePackageTest::OtherClass`'s package is imported as `test_import`
+    `Foo::Bar::FalsePackageTest` is imported as `test_import`
 
 use_false_package/foo.rb:13: `Test::Foo::Bar::FalsePackage::TestUtil` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
     13 |  Test::Foo::Bar::FalsePackage::TestUtil
@@ -198,9 +198,9 @@ use_false_package/foo.rb:13: `Test::Foo::Bar::FalsePackage::TestUtil` cannot be 
   Note:
     `Test::Foo::Bar::FalsePackage::TestUtil`'s package is not imported
 
-use_false_package/foo.test.rb:4: `Test::Foo::Bar::FalsePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
+use_false_package/foo.test.rb:4: `Foo::Bar::FalsePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalsePackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     false_package/__package.rb:3: Package defined here
      3 |class Foo::Bar::FalsePackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -222,9 +222,9 @@ end
 
 --------------------------------------------------------------------------
 
-use_false_and_app_package/foo.rb:6: `Foo::Bar::FalseAndAppPackage::OtherClass` cannot be referenced here because importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
+use_false_and_app_package/foo.rb:6: `Foo::Bar::FalseAndAppPackage` cannot be referenced here because importing it would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
      6 |      Foo::Bar::FalseAndAppPackage::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_and_app_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -235,11 +235,11 @@ use_false_and_app_package/foo.rb:6: `Foo::Bar::FalseAndAppPackage::OtherClass` c
      5 |  strict_dependencies 'false'
                               ^^^^^^^
   Note:
-    `Foo::Bar::FalseAndAppPackage::OtherClass`'s package is not imported
+    `Foo::Bar::FalseAndAppPackage` is not imported
 
-use_false_and_app_package/foo.rb:7: `Foo::Bar::FalseAndAppPackageTest::OtherClass` cannot be referenced here because importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
+use_false_and_app_package/foo.rb:7: `Foo::Bar::FalseAndAppPackageTest` cannot be referenced here because importing it would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
      7 |      Foo::Bar::FalseAndAppPackageTest::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_and_app_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -250,7 +250,7 @@ use_false_and_app_package/foo.rb:7: `Foo::Bar::FalseAndAppPackageTest::OtherClas
      5 |  strict_dependencies 'false'
                               ^^^^^^^
   Note:
-    `Foo::Bar::FalseAndAppPackageTest::OtherClass`'s package is imported as `test_import`
+    `Foo::Bar::FalseAndAppPackageTest` is imported as `test_import`
 
 use_false_and_app_package/foo.rb:13: `Test::Foo::Bar::FalseAndAppPackage::TestUtil` cannot be referenced here because importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3726
     13 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
@@ -267,9 +267,9 @@ use_false_and_app_package/foo.rb:13: `Test::Foo::Bar::FalseAndAppPackage::TestUt
   Note:
     `Test::Foo::Bar::FalseAndAppPackage::TestUtil`'s package is not imported
 
-use_false_and_app_package/foo.test.rb:4: `Test::Foo::Bar::FalseAndAppPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
+use_false_and_app_package/foo.test.rb:4: `Foo::Bar::FalseAndAppPackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalseAndAppPackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     false_and_app_package/__package.rb:3: Package defined here
      3 |class Foo::Bar::FalseAndAppPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -291,9 +291,9 @@ end
 
 --------------------------------------------------------------------------
 
-use_cycle_package/foo.rb:6: `Foo::Bar::CyclePackage::OtherClass` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle https://srb.help/3727
+use_cycle_package/foo.rb:6: `Foo::Bar::CyclePackage` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle https://srb.help/3727
      6 |      Foo::Bar::CyclePackage::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^
     use_cycle_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -306,11 +306,11 @@ use_cycle_package/foo.rb:6: `Foo::Bar::CyclePackage::OtherClass` cannot be refer
     `Foo::MyPackage`
 
   Note:
-    `Foo::Bar::CyclePackage::OtherClass`'s package is not imported
+    `Foo::Bar::CyclePackage` is not imported
 
-use_cycle_package/foo.rb:7: `Foo::Bar::CyclePackageTest::OtherClass` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle https://srb.help/3727
+use_cycle_package/foo.rb:7: `Foo::Bar::CyclePackageTest` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle https://srb.help/3727
      7 |      Foo::Bar::CyclePackageTest::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_cycle_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -323,7 +323,7 @@ use_cycle_package/foo.rb:7: `Foo::Bar::CyclePackageTest::OtherClass` cannot be r
     `Foo::MyPackage`
 
   Note:
-    `Foo::Bar::CyclePackageTest::OtherClass`'s package is imported as `test_import`
+    `Foo::Bar::CyclePackageTest` is imported as `test_import`
 
 use_cycle_package/foo.rb:13: `Test::Foo::Bar::CyclePackage::TestUtil` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle https://srb.help/3727
     13 |  Test::Foo::Bar::CyclePackage::TestUtil
@@ -342,9 +342,9 @@ use_cycle_package/foo.rb:13: `Test::Foo::Bar::CyclePackage::TestUtil` cannot be 
   Note:
     `Test::Foo::Bar::CyclePackage::TestUtil`'s package is not imported
 
-use_cycle_package/foo.test.rb:4: `Test::Foo::Bar::CyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
+use_cycle_package/foo.test.rb:4: `Foo::Bar::CyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::CyclePackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     cycle_package/__package.rb:5: Package defined here
      5 |class Foo::Bar::CyclePackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -366,9 +366,9 @@ end
 
 --------------------------------------------------------------------------
 
-use_app_cycle_package/foo.rb:6: `Foo::Bar::AppCyclePackage::OtherClass` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, and importing its package would cause a layering violation https://srb.help/3727
+use_app_cycle_package/foo.rb:6: `Foo::Bar::AppCyclePackage` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, and importing it would cause a layering violation https://srb.help/3727
      6 |      Foo::Bar::AppCyclePackage::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_cycle_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -384,11 +384,11 @@ use_app_cycle_package/foo.rb:6: `Foo::Bar::AppCyclePackage::OtherClass` cannot b
      6 |  layer 'app'
                 ^^^^^
   Note:
-    `Foo::Bar::AppCyclePackage::OtherClass`'s package is not imported
+    `Foo::Bar::AppCyclePackage` is not imported
 
-use_app_cycle_package/foo.rb:7: `Foo::Bar::AppCyclePackageTest::OtherClass` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, and importing its package would cause a layering violation https://srb.help/3727
+use_app_cycle_package/foo.rb:7: `Foo::Bar::AppCyclePackageTest` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, and importing it would cause a layering violation https://srb.help/3727
      7 |      Foo::Bar::AppCyclePackageTest::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_cycle_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -404,7 +404,7 @@ use_app_cycle_package/foo.rb:7: `Foo::Bar::AppCyclePackageTest::OtherClass` cann
      6 |  layer 'app'
                 ^^^^^
   Note:
-    `Foo::Bar::AppCyclePackageTest::OtherClass`'s package is imported as `test_import`
+    `Foo::Bar::AppCyclePackageTest` is imported as `test_import`
 
 use_app_cycle_package/foo.rb:13: `Test::Foo::Bar::AppCyclePackage::TestUtil` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, and importing its package would cause a layering violation https://srb.help/3727
     13 |  Test::Foo::Bar::AppCyclePackage::TestUtil
@@ -426,9 +426,9 @@ use_app_cycle_package/foo.rb:13: `Test::Foo::Bar::AppCyclePackage::TestUtil` can
   Note:
     `Test::Foo::Bar::AppCyclePackage::TestUtil`'s package is not imported
 
-use_app_cycle_package/foo.test.rb:4: `Test::Foo::Bar::AppCyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
+use_app_cycle_package/foo.test.rb:4: `Foo::Bar::AppCyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::AppCyclePackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     app_cycle_package/__package.rb:5: Package defined here
      5 |class Foo::Bar::AppCyclePackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -450,9 +450,9 @@ end
 
 --------------------------------------------------------------------------
 
-use_false_cycle_package/foo.rb:6: `Foo::Bar::FalseCyclePackage::OtherClass` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, and its `strict_dependencies` is not strict enough https://srb.help/3727
+use_false_cycle_package/foo.rb:6: `Foo::Bar::FalseCyclePackage` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, and its `strict_dependencies` is not strict enough https://srb.help/3727
      6 |      Foo::Bar::FalseCyclePackage::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_cycle_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -468,11 +468,11 @@ use_false_cycle_package/foo.rb:6: `Foo::Bar::FalseCyclePackage::OtherClass` cann
      7 |  strict_dependencies 'false'
                               ^^^^^^^
   Note:
-    `Foo::Bar::FalseCyclePackage::OtherClass`'s package is not imported
+    `Foo::Bar::FalseCyclePackage` is not imported
 
-use_false_cycle_package/foo.rb:7: `Foo::Bar::FalseCyclePackageTest::OtherClass` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, and its `strict_dependencies` is not strict enough https://srb.help/3727
+use_false_cycle_package/foo.rb:7: `Foo::Bar::FalseCyclePackageTest` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, and its `strict_dependencies` is not strict enough https://srb.help/3727
      7 |      Foo::Bar::FalseCyclePackageTest::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_false_cycle_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -488,7 +488,7 @@ use_false_cycle_package/foo.rb:7: `Foo::Bar::FalseCyclePackageTest::OtherClass` 
      7 |  strict_dependencies 'false'
                               ^^^^^^^
   Note:
-    `Foo::Bar::FalseCyclePackageTest::OtherClass`'s package is imported as `test_import`
+    `Foo::Bar::FalseCyclePackageTest` is imported as `test_import`
 
 use_false_cycle_package/foo.rb:13: `Test::Foo::Bar::FalseCyclePackage::TestUtil` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, and its `strict_dependencies` is not strict enough https://srb.help/3727
     13 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
@@ -510,9 +510,9 @@ use_false_cycle_package/foo.rb:13: `Test::Foo::Bar::FalseCyclePackage::TestUtil`
   Note:
     `Test::Foo::Bar::FalseCyclePackage::TestUtil`'s package is not imported
 
-use_false_cycle_package/foo.test.rb:4: `Test::Foo::Bar::FalseCyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
+use_false_cycle_package/foo.test.rb:4: `Foo::Bar::FalseCyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::FalseCyclePackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     false_cycle_package/__package.rb:5: Package defined here
      5 |class Foo::Bar::FalseCyclePackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -534,9 +534,9 @@ end
 
 --------------------------------------------------------------------------
 
-use_app_false_cycle_package/foo.rb:6: `Foo::Bar::AppFalseCyclePackage::OtherClass` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
+use_app_false_cycle_package/foo.rb:6: `Foo::Bar::AppFalseCyclePackage` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, importing it would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
      6 |      Foo::Bar::AppFalseCyclePackage::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_false_cycle_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -555,11 +555,11 @@ use_app_false_cycle_package/foo.rb:6: `Foo::Bar::AppFalseCyclePackage::OtherClas
      7 |  strict_dependencies 'false'
                               ^^^^^^^
   Note:
-    `Foo::Bar::AppFalseCyclePackage::OtherClass`'s package is not imported
+    `Foo::Bar::AppFalseCyclePackage` is not imported
 
-use_app_false_cycle_package/foo.rb:7: `Foo::Bar::AppFalseCyclePackageTest::OtherClass` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
+use_app_false_cycle_package/foo.rb:7: `Foo::Bar::AppFalseCyclePackageTest` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, importing it would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
      7 |      Foo::Bar::AppFalseCyclePackageTest::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_false_cycle_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -578,7 +578,7 @@ use_app_false_cycle_package/foo.rb:7: `Foo::Bar::AppFalseCyclePackageTest::Other
      7 |  strict_dependencies 'false'
                               ^^^^^^^
   Note:
-    `Foo::Bar::AppFalseCyclePackageTest::OtherClass`'s package is imported as `test_import`
+    `Foo::Bar::AppFalseCyclePackageTest` is imported as `test_import`
 
 use_app_false_cycle_package/foo.rb:13: `Test::Foo::Bar::AppFalseCyclePackage::TestUtil` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
     13 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil
@@ -603,9 +603,9 @@ use_app_false_cycle_package/foo.rb:13: `Test::Foo::Bar::AppFalseCyclePackage::Te
   Note:
     `Test::Foo::Bar::AppFalseCyclePackage::TestUtil`'s package is not imported
 
-use_app_false_cycle_package/foo.test.rb:4: `Test::Foo::Bar::AppFalseCyclePackage::TestUtil` resolves but its package is not imported https://srb.help/3718
+use_app_false_cycle_package/foo.test.rb:4: `Foo::Bar::AppFalseCyclePackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::AppFalseCyclePackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     app_false_cycle_package/__package.rb:5: Package defined here
      5 |class Foo::Bar::AppFalseCyclePackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -627,16 +627,16 @@ end
 
 --------------------------------------------------------------------------
 
-use_visible_to_package/foo.rb:6: `Foo::Bar::OtherPackage::OtherClass` cannot be referenced here because package `Foo::Bar::OtherPackage` includes explicit visibility modifiers and cannot be imported from `Foo::MyPackage` https://srb.help/3727
+use_visible_to_package/foo.rb:6: `Foo::Bar::OtherPackage` cannot be referenced here because package `Foo::Bar::OtherPackage` includes explicit visibility modifiers and cannot be imported from `Foo::MyPackage` https://srb.help/3727
      6 |      Foo::Bar::OtherPackage::OtherClass
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^
     use_visible_to_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `Foo::Bar::OtherPackage`
   Note:
-    `Foo::Bar::OtherPackage::OtherClass`'s package is imported as `test_import`
+    `Foo::Bar::OtherPackage` is imported as `test_import`
 Errors: 1
 # frozen_string_literal: true
 # typed: strict

--- a/test/cli/package-autocorrect-missing-import/test.out
+++ b/test/cli/package-autocorrect-missing-import/test.out
@@ -1,14 +1,3 @@
-use_other_package/foo.rb:16: Unable to resolve constant `MyClass` https://srb.help/5002
-    16 |  Foo::Bar::MyClass::SUBCLASSES # resolves via root
-          ^^^^^^^^^^^^^^^^^
-  Autocorrect: Done
-    use_other_package/foo.rb:16: Replaced with `Class`
-    16 |  Foo::Bar::MyClass::SUBCLASSES # resolves via root
-          ^^^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/class.rbi#LCENSORED: `Class` defined here
-    NN |class Class < Module
-        ^^^^^^^^^^^^^^^^^^^^
-
 use_other_package/foo.rb:7: `Foo::Bar::OtherPackage` is not imported https://srb.help/3718
      7 |      Foo::Bar::OtherPackage::OtherClass # resolves via root
               ^^^^^^^^^^^^^^^^^^^^^^
@@ -55,6 +44,17 @@ use_other_package/foo.rb:15: `Foo::Bar::OtherPackage` is not imported https://sr
     use_other_package/__package.rb:7: Inserted `import Foo::Bar::OtherPackage`
      7 |  strict_dependencies 'layered'
                                        ^
+
+use_other_package/foo.rb:16: Unable to resolve constant `MyClass` https://srb.help/5002
+    16 |  Foo::Bar::MyClass::SUBCLASSES # resolves via root
+          ^^^^^^^^^^^^^^^^^
+  Autocorrect: Done
+    use_other_package/foo.rb:16: Replaced with `Class`
+    16 |  Foo::Bar::MyClass::SUBCLASSES # resolves via root
+          ^^^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/class.rbi#LCENSORED: `Class` defined here
+    NN |class Class < Module
+        ^^^^^^^^^^^^^^^^^^^^
 
 use_other_package/foo.rb:18: Unable to resolve constant `Test` https://srb.help/5002
     18 |  Test::Foo::Bar::OtherPackage::TestUtil

--- a/test/cli/package-error-missing-export-import/test.out
+++ b/test/cli/package-error-missing-export-import/test.out
@@ -1,6 +1,6 @@
-missing_import/foo_class.rb:5: `Other::OtherClass` resolves but its package is not imported https://srb.help/3718
+missing_import/foo_class.rb:5: `Other` is not imported https://srb.help/3718
      5 |    Other::OtherClass
-            ^^^^^^^^^^^^^^^^^
+            ^^^^^
     other/__package.rb:3: Package defined here
      3 |class Other < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/package-error-missing-export-import/test.out
+++ b/test/cli/package-error-missing-export-import/test.out
@@ -11,9 +11,9 @@ missing_import/foo_class.rb:5: `Other` is not imported https://srb.help/3718
   Note:
     Try running generate-packages.sh
 Errors: 1
-imported_as_test/foo_class.rb:5: Used `test_import` constant `Other::OtherClass` in non-test file https://srb.help/3720
+imported_as_test/foo_class.rb:5: Used `test_import` package `Other` in non-test file https://srb.help/3720
      5 |    Other::OtherClass
-            ^^^^^^^^^^^^^^^^^
+            ^^^^^
     other/__package.rb:3: Defined here
      3 |class Other < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -27,9 +27,9 @@ imported_as_test/foo_class.rb:5: Used `test_import` constant `Other::OtherClass`
   Note:
     Try running generate-packages.sh
 Errors: 1
-imported_as_test_unit/test/foo_class.rb:5: The `test_import` constant `Other::OtherClass` can only be used in `.test.rb` files https://srb.help/3720
+imported_as_test_unit/test/foo_class.rb:5: The `test_import` package `Other` can only be used in `.test.rb` files https://srb.help/3720
      5 |    Other::OtherClass
-            ^^^^^^^^^^^^^^^^^
+            ^^^^^
     other/__package.rb:3: Defined here
      3 |class Other < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/package-error-missing-export/test.out
+++ b/test/cli/package-error-missing-export/test.out
@@ -50,9 +50,9 @@ use_other/foo_class.rb:13: `Foo::Bar::OtherPackage::Inner::AlsoNotExported` reso
   Note:
     Try running generate-packages.sh
 Errors: 4
-use_app_false_cycle_package/foo.rb:6: `Foo::Bar::AppFalseCyclePackage::OtherClass` cannot be referenced here because importing its package would put `Foo::MyPackage` into a cycle, importing its package would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
+use_app_false_cycle_package/foo.rb:6: `Foo::Bar::AppFalseCyclePackage` cannot be referenced here because importing it would put `Foo::MyPackage` into a cycle, importing it would cause a layering violation, and its `strict_dependencies` is not strict enough https://srb.help/3727
      6 |      Foo::Bar::AppFalseCyclePackage::OtherClass
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     use_app_false_cycle_package/__package.rb:5: Enclosing package declared here
      5 |class Foo::MyPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,5 +71,5 @@ use_app_false_cycle_package/foo.rb:6: `Foo::Bar::AppFalseCyclePackage::OtherClas
      7 |  strict_dependencies 'false'
                               ^^^^^^^
   Note:
-    `Foo::Bar::AppFalseCyclePackage::OtherClass`'s package is not imported
+    `Foo::Bar::AppFalseCyclePackage` is not imported
 Errors: 1

--- a/test/cli/package-error-missing-import/test.out
+++ b/test/cli/package-error-missing-import/test.out
@@ -1,6 +1,6 @@
-foo_class.rb:7: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
+foo_class.rb:7: `Foo::Bar::OtherPackage` is not imported https://srb.help/3718
      7 |      Foo::Bar::OtherPackage::OtherClass # resolves via root
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^^^^^^
     other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -11,9 +11,9 @@ foo_class.rb:7: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is
   Note:
     Try running generate-packages.sh
 
-foo_class.rb:8: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
+foo_class.rb:8: `Foo::Bar::OtherPackage` is not imported https://srb.help/3718
      8 |      Bar::OtherPackage::OtherClass # resolves via `module Foo`
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              ^^^^^^^^^^^^^^^^^
     other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -24,9 +24,9 @@ foo_class.rb:8: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is
   Note:
     Try running generate-packages.sh
 
-foo_class.rb:14: `Foo::Bar::OtherPackage::OtherClass` resolves but its package is not imported https://srb.help/3718
+foo_class.rb:14: `Foo::Bar::OtherPackage` is not imported https://srb.help/3718
     14 |  Foo::Bar::OtherPackage::OtherClass # resolves via root
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^
     other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -37,9 +37,9 @@ foo_class.rb:14: `Foo::Bar::OtherPackage::OtherClass` resolves but its package i
   Note:
     Try running generate-packages.sh
 
-foo.test.rb:4: `Test::Foo::Bar::OtherPackage::TestUtil` resolves but its package is not imported https://srb.help/3718
+foo.test.rb:4: `Foo::Bar::OtherPackage` is not imported https://srb.help/3718
      4 |  Test::Foo::Bar::OtherPackage::TestUtil
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     other/__package.rb:3: Package defined here
      3 |class Foo::Bar::OtherPackage < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/package-gen-packages-test-packages/test.out
+++ b/test/cli/package-gen-packages-test-packages/test.out
@@ -119,7 +119,7 @@ D/__package.rb:3: `D` is missing exports https://srb.help/3734
      9 |  export D::ANestedPackage::Foo
                                        ^
 
-C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
+C/app.rb:8: `F` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
      8 |      puts F::CONSTANT_FROM_F
                    ^^^^^^^^^^^^^^^^^^
     C/__package.rb:3: Enclosing package declared here
@@ -129,9 +129,9 @@ C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_d
      4 |  strict_dependencies 'layered'
                               ^^^^^^^^^
   Note:
-    `F::CONSTANT_FROM_F`'s package is not imported
+    `F` is not imported
 
-C/app.rb:9: `G::CONSTANT_FROM_G` cannot be referenced here because package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3727
+C/app.rb:9: `G` cannot be referenced here because package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3727
      9 |      puts G::CONSTANT_FROM_G
                    ^^^^^^^^^^^^^^^^^^
     C/__package.rb:3: Enclosing package declared here
@@ -140,7 +140,7 @@ C/app.rb:9: `G::CONSTANT_FROM_G` cannot be referenced here because package `G` i
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
   Note:
-    `G::CONSTANT_FROM_G`'s package is not imported
+    `G` is not imported
 Errors: 12
 
 ###### cat B/__package.rb ######
@@ -345,7 +345,7 @@ A/constants.rb:5: Unable to resolve constant `G` https://srb.help/5002
      3 |module A
         ^^^^^^^^
 
-C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
+C/app.rb:8: `F` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
      8 |      puts F::CONSTANT_FROM_F
                    ^^^^^^^^^^^^^^^^^^
     C/__package.rb:3: Enclosing package declared here
@@ -355,9 +355,9 @@ C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_d
      4 |  strict_dependencies 'layered'
                               ^^^^^^^^^
   Note:
-    `F::CONSTANT_FROM_F`'s package is not imported
+    `F` is not imported
 
-C/app.rb:9: `G::CONSTANT_FROM_G` cannot be referenced here because package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3727
+C/app.rb:9: `G` cannot be referenced here because package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3727
      9 |      puts G::CONSTANT_FROM_G
                    ^^^^^^^^^^^^^^^^^^
     C/__package.rb:3: Enclosing package declared here
@@ -366,7 +366,7 @@ C/app.rb:9: `G::CONSTANT_FROM_G` cannot be referenced here because package `G` i
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
   Note:
-    `G::CONSTANT_FROM_G`'s package is not imported
+    `G` is not imported
 Errors: 11
 
 ###### cat B/__package.rb ######

--- a/test/cli/package-gen-packages/test.out
+++ b/test/cli/package-gen-packages/test.out
@@ -114,7 +114,7 @@ D/ANestedPackage/__package.rb:3: `D::ANestedPackage` is missing exports https://
      5 |  layer 'util'
                       ^
 
-C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
+C/app.rb:8: `F` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
      8 |      puts F::CONSTANT_FROM_F
                    ^^^^^^^^^^^^^^^^^^
     C/__package.rb:3: Enclosing package declared here
@@ -124,9 +124,9 @@ C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_d
      4 |  strict_dependencies 'layered'
                               ^^^^^^^^^
   Note:
-    `F::CONSTANT_FROM_F`'s package is not imported
+    `F` is not imported
 
-C/app.rb:9: `G::CONSTANT_FROM_G` cannot be referenced here because package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3727
+C/app.rb:9: `G` cannot be referenced here because package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3727
      9 |      puts G::CONSTANT_FROM_G
                    ^^^^^^^^^^^^^^^^^^
     C/__package.rb:3: Enclosing package declared here
@@ -135,7 +135,7 @@ C/app.rb:9: `G::CONSTANT_FROM_G` cannot be referenced here because package `G` i
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
   Note:
-    `G::CONSTANT_FROM_G`'s package is not imported
+    `G` is not imported
 Errors: 11
 
 ###### cat B/__package.rb ######
@@ -329,7 +329,7 @@ A/constants.rb:5: Unable to resolve constant `G` https://srb.help/5002
      3 |module A
         ^^^^^^^^
 
-C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
+C/app.rb:8: `F` cannot be referenced here because its `strict_dependencies` is not strict enough https://srb.help/3727
      8 |      puts F::CONSTANT_FROM_F
                    ^^^^^^^^^^^^^^^^^^
     C/__package.rb:3: Enclosing package declared here
@@ -339,9 +339,9 @@ C/app.rb:8: `F::CONSTANT_FROM_F` cannot be referenced here because its `strict_d
      4 |  strict_dependencies 'layered'
                               ^^^^^^^^^
   Note:
-    `F::CONSTANT_FROM_F`'s package is not imported
+    `F` is not imported
 
-C/app.rb:9: `G::CONSTANT_FROM_G` cannot be referenced here because package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3727
+C/app.rb:9: `G` cannot be referenced here because package `G` includes explicit visibility modifiers and cannot be imported from `C` https://srb.help/3727
      9 |      puts G::CONSTANT_FROM_G
                    ^^^^^^^^^^^^^^^^^^
     C/__package.rb:3: Enclosing package declared here
@@ -350,7 +350,7 @@ C/app.rb:9: `G::CONSTANT_FROM_G` cannot be referenced here because package `G` i
   Note:
     Please consult with the owning team before adding a `visible_to` line to the package `G`
   Note:
-    `G::CONSTANT_FROM_G`'s package is not imported
+    `G` is not imported
 Errors: 10
 
 ###### cat B/__package.rb ######

--- a/test/cli/package-strict-dependencies-show-cycle/test.out
+++ b/test/cli/package-strict-dependencies-show-cycle/test.out
@@ -12,9 +12,9 @@ a/__package.rb:7: Strict dependencies violation: importing `B` will put `A` into
     `A`
 
 
-a/foo.rb:5: `Y::Foo` resolves but its package is not imported https://srb.help/3718
+a/foo.rb:5: `Y` is not imported https://srb.help/3718
      5 |    Y::Foo.new
-            ^^^^^^
+            ^
     y/__package.rb:3: Package defined here
      3 |class Y < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/package-test-simple/test.out
+++ b/test/cli/package-test-simple/test.out
@@ -1,6 +1,6 @@
-main_lib/lib.rb:8: Used `test_import` constant `Project::TestOnly::SomeHelper` in non-test file https://srb.help/3720
+main_lib/lib.rb:8: Used `test_import` package `Project::TestOnly` in non-test file https://srb.help/3720
      8 |  Project::TestOnly::SomeHelper.new
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          ^^^^^^^^^^^^^^^^^
     test_only/__package.rb:5: Defined here
      5 |class Project::TestOnly < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/package-top-level-inheritance/test.out
+++ b/test/cli/package-top-level-inheritance/test.out
@@ -1,6 +1,6 @@
-a/foo.rb:5: `Main::B` resolves but its package is not imported https://srb.help/3718
+a/foo.rb:5: `Main` is not imported https://srb.help/3718
      5 |    class Foo < Main::B
-                        ^^^^^^^
+                        ^^^^
     __package.rb:3: Package defined here
      3 |class Main < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/packager_suggest_nested_crash/test.out
+++ b/test/cli/packager_suggest_nested_crash/test.out
@@ -1,6 +1,6 @@
-consumer_auth/data/identifier_struct.rb:6: `Project::ConsumerAuth::IdentifierType` resolves but its package is not imported https://srb.help/3718
+consumer_auth/data/identifier_struct.rb:6: `Project::ConsumerAuth` is not imported https://srb.help/3718
      6 |    puts(Project::ConsumerAuth::IdentifierType)
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                 ^^^^^^^^^^^^^^^^^^^^^
     consumer_auth/__package.rb:5: Package defined here
      5 |class Project::ConsumerAuth < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/cli/strict-deps-autogenerated/test.out
+++ b/test/cli/strict-deps-autogenerated/test.out
@@ -1,7 +1,7 @@
 ------ monolithic -------------------------------
-a/main.rb:3: `B::MyClass` cannot be referenced here because importing its package would put `A` into a cycle https://srb.help/3727
+a/main.rb:3: `B` cannot be referenced here because importing it would put `A` into a cycle https://srb.help/3727
      3 |puts(B::MyClass)
-             ^^^^^^^^^^
+             ^
     a/__package.rb:3: Enclosing package declared here
      3 |class A < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^
@@ -14,17 +14,23 @@ a/main.rb:3: `B::MyClass` cannot be referenced here because importing its packag
     `A`
 
   Note:
-    `B::MyClass`'s package is not imported
+    `B` is not imported
 Errors: 1
 ------ package-directed -------------------------
-a/main.rb:3: Unable to resolve constant `B` https://srb.help/5002
+a/main.rb:3: `B` cannot be referenced here because importing it would put `A` into a cycle https://srb.help/3727
      3 |puts(B::MyClass)
              ^
-  Did you mean `T`? Use `-a` to autocorrect
-    a/main.rb:3: Replace with `T`
-     3 |puts(B::MyClass)
-             ^
-    https://github.com/sorbet/sorbet/tree/master/rbi/sorbet/t.rbi#LCENSORED: `T` defined here
-    NN |module T
-        ^^^^^^^^
+    a/__package.rb:3: Enclosing package declared here
+     3 |class A < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+    a/__package.rb:5: `A` is `strict_dependencies 'dag'`, which disallows cycles
+     5 |  strict_dependencies 'dag'
+                              ^^^^^
+  Note:
+    Path from `B` to `A`:
+    `B` →
+    `A`
+
+  Note:
+    `B` is not imported
 Errors: 1

--- a/test/cli/test-packages-ignore-test-import/consumer/__package.rb
+++ b/test/cli/test-packages-ignore-test-import/consumer/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Consumer < PackageSpec
+end

--- a/test/cli/test-packages-ignore-test-import/consumer/test/__package.rb
+++ b/test/cli/test-packages-ignore-test-import/consumer/test/__package.rb
@@ -1,0 +1,7 @@
+# typed: strict
+
+class Consumer::Test < PackageSpec
+  test!
+
+  import Consumer
+end

--- a/test/cli/test-packages-ignore-test-import/consumer/test/use.rb
+++ b/test/cli/test-packages-ignore-test-import/consumer/test/use.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+module Consumer::Test
+  Test::InBetween::FooTest
+  Test::Migrated::Helper
+  Test::Migrated::Foo
+  Test::Migrated::Test::Helper
+end

--- a/test/cli/test-packages-ignore-test-import/test.out
+++ b/test/cli/test-packages-ignore-test-import/test.out
@@ -1,7 +1,104 @@
+------ monolithic -------------------------------
+consumer/test/use.rb:5: Unable to resolve constant `Migrated` https://srb.help/5002
+     5 |  Test::Migrated::Helper
+          ^^^^^^^^^^^^^^
+  Did you mean `BigMath`? Use `-a` to autocorrect
+    consumer/test/use.rb:5: Replace with `BigMath`
+     5 |  Test::Migrated::Helper
+          ^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/big_math.rbi#LCENSORED: `BigMath` defined here
+    NN |module BigMath
+        ^^^^^^^^^^^^^^
+
+consumer/test/use.rb:6: Unable to resolve constant `Migrated` https://srb.help/5002
+     6 |  Test::Migrated::Foo
+          ^^^^^^^^^^^^^^
+  Did you mean `BigMath`? Use `-a` to autocorrect
+    consumer/test/use.rb:6: Replace with `BigMath`
+     6 |  Test::Migrated::Foo
+          ^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/big_math.rbi#LCENSORED: `BigMath` defined here
+    NN |module BigMath
+        ^^^^^^^^^^^^^^
+
+consumer/test/use.rb:7: Unable to resolve constant `Migrated` https://srb.help/5002
+     7 |  Test::Migrated::Test::Helper
+          ^^^^^^^^^^^^^^
+  Did you mean `BigMath`? Use `-a` to autocorrect
+    consumer/test/use.rb:7: Replace with `BigMath`
+     7 |  Test::Migrated::Test::Helper
+          ^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/big_math.rbi#LCENSORED: `BigMath` defined here
+    NN |module BigMath
+        ^^^^^^^^^^^^^^
+
+consumer/test/use.rb:4: `Test::InBetween::FooTest` resolves but its package is not imported https://srb.help/3718
+     4 |  Test::InBetween::FooTest
+          ^^^^^^^^^^^^^^^^^^^^^^^^
+    in_between/test/__package.rb:3: Package defined here
+     3 |class Test::InBetween < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    consumer/test/__package.rb:6: Insert `import Test::InBetween`
+     6 |  import Consumer
+                         ^
+
 old_style/test/foo.test.rb:3: File belongs to package `OldStyle` but defines a constant that does not match this namespace https://srb.help/3713
      3 |module Test::OldStyle
                ^^^^^^^^^^^^^^
     old_style/__package.rb:3: Enclosing package declared here
      3 |class OldStyle < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 1
+Errors: 5
+------ package-directed -------------------------
+consumer/test/use.rb:4: Unable to resolve constant `InBetween` https://srb.help/5002
+     4 |  Test::InBetween::FooTest
+          ^^^^^^^^^^^^^^^
+  Did you mean `Integer`? Use `-a` to autocorrect
+    consumer/test/use.rb:4: Replace with `Integer`
+     4 |  Test::InBetween::FooTest
+          ^^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED: `Integer` defined here
+    NN |class Integer < Numeric
+        ^^^^^^^^^^^^^^^^^^^^^^^
+
+consumer/test/use.rb:5: Unable to resolve constant `Migrated` https://srb.help/5002
+     5 |  Test::Migrated::Helper
+          ^^^^^^^^^^^^^^
+  Did you mean `BigMath`? Use `-a` to autocorrect
+    consumer/test/use.rb:5: Replace with `BigMath`
+     5 |  Test::Migrated::Helper
+          ^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/big_math.rbi#LCENSORED: `BigMath` defined here
+    NN |module BigMath
+        ^^^^^^^^^^^^^^
+
+consumer/test/use.rb:6: Unable to resolve constant `Migrated` https://srb.help/5002
+     6 |  Test::Migrated::Foo
+          ^^^^^^^^^^^^^^
+  Did you mean `BigMath`? Use `-a` to autocorrect
+    consumer/test/use.rb:6: Replace with `BigMath`
+     6 |  Test::Migrated::Foo
+          ^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/big_math.rbi#LCENSORED: `BigMath` defined here
+    NN |module BigMath
+        ^^^^^^^^^^^^^^
+
+consumer/test/use.rb:7: Unable to resolve constant `Migrated` https://srb.help/5002
+     7 |  Test::Migrated::Test::Helper
+          ^^^^^^^^^^^^^^
+  Did you mean `BigMath`? Use `-a` to autocorrect
+    consumer/test/use.rb:7: Replace with `BigMath`
+     7 |  Test::Migrated::Test::Helper
+          ^^^^^^^^^^^^^^
+    https://github.com/sorbet/sorbet/tree/master/rbi/stdlib/big_math.rbi#LCENSORED: `BigMath` defined here
+    NN |module BigMath
+        ^^^^^^^^^^^^^^
+
+old_style/test/foo.test.rb:3: File belongs to package `OldStyle` but defines a constant that does not match this namespace https://srb.help/3713
+     3 |module Test::OldStyle
+               ^^^^^^^^^^^^^^
+    old_style/__package.rb:3: Enclosing package declared here
+     3 |class OldStyle < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Errors: 5

--- a/test/cli/test-packages-ignore-test-import/test.out
+++ b/test/cli/test-packages-ignore-test-import/test.out
@@ -1,4 +1,15 @@
 ------ monolithic -------------------------------
+consumer/test/use.rb:4: `Test::InBetween` is not imported https://srb.help/3718
+     4 |  Test::InBetween::FooTest
+          ^^^^^^^^^^^^^^^
+    in_between/test/__package.rb:3: Package defined here
+     3 |class Test::InBetween < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    consumer/test/__package.rb:6: Insert `import Test::InBetween`
+     6 |  import Consumer
+                         ^
+
 consumer/test/use.rb:5: Unable to resolve constant `Migrated` https://srb.help/5002
      5 |  Test::Migrated::Helper
           ^^^^^^^^^^^^^^
@@ -32,17 +43,6 @@ consumer/test/use.rb:7: Unable to resolve constant `Migrated` https://srb.help/5
     NN |module BigMath
         ^^^^^^^^^^^^^^
 
-consumer/test/use.rb:4: `Test::InBetween::FooTest` resolves but its package is not imported https://srb.help/3718
-     4 |  Test::InBetween::FooTest
-          ^^^^^^^^^^^^^^^^^^^^^^^^
-    in_between/test/__package.rb:3: Package defined here
-     3 |class Test::InBetween < PackageSpec
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Use `-a` to autocorrect
-    consumer/test/__package.rb:6: Insert `import Test::InBetween`
-     6 |  import Consumer
-                         ^
-
 old_style/test/foo.test.rb:3: File belongs to package `OldStyle` but defines a constant that does not match this namespace https://srb.help/3713
      3 |module Test::OldStyle
                ^^^^^^^^^^^^^^
@@ -51,16 +51,16 @@ old_style/test/foo.test.rb:3: File belongs to package `OldStyle` but defines a c
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 5
 ------ package-directed -------------------------
-consumer/test/use.rb:4: Unable to resolve constant `InBetween` https://srb.help/5002
+consumer/test/use.rb:4: `Test::InBetween` is not imported https://srb.help/3718
      4 |  Test::InBetween::FooTest
           ^^^^^^^^^^^^^^^
-  Did you mean `Integer`? Use `-a` to autocorrect
-    consumer/test/use.rb:4: Replace with `Integer`
-     4 |  Test::InBetween::FooTest
-          ^^^^^^^^^^^^^^^
-    https://github.com/sorbet/sorbet/tree/master/rbi/core/integer.rbi#LCENSORED: `Integer` defined here
-    NN |class Integer < Numeric
-        ^^^^^^^^^^^^^^^^^^^^^^^
+    in_between/test/__package.rb:3: Package defined here
+     3 |class Test::InBetween < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    consumer/test/__package.rb:6: Insert `import Test::InBetween`
+     6 |  import Consumer
+                         ^
 
 consumer/test/use.rb:5: Unable to resolve constant `Migrated` https://srb.help/5002
      5 |  Test::Migrated::Helper

--- a/test/cli/test-packages-ignore-test-import/test.sh
+++ b/test/cli/test-packages-ignore-test-import/test.sh
@@ -4,6 +4,10 @@ root="$PWD"
 
 cd test/cli/test-packages-ignore-test-import || ( echo "Failed to cd!"; exit 1 )
 
-"$root/main/sorbet" \
-  --censor-for-snapshot-tests --silence-dev-message --max-threads=0 \
-  --sorbet-packages --experimental-test-packages . 2>&1
+args=(--censor-for-snapshot-tests --silence-dev-message --max-threads=0 --sorbet-packages --experimental-test-packages)
+
+echo '------ monolithic -------------------------------'
+"$root/main/sorbet" "${args[@]}" . 2>&1
+
+echo '------ package-directed -------------------------'
+"$root/main/sorbet" "${args[@]}" --experimental-package-directed . 2>&1

--- a/test/lsp/watchman_test_corpus.cc
+++ b/test/lsp/watchman_test_corpus.cc
@@ -197,8 +197,8 @@ TEST_CASE_FIXTURE(ProtocolTest, "ZeroingOutPackageFiles") {
     requests.push_back(watchmanFileUpdate({"c/__package.rb", "c/impl.rb"}));
     assertErrorDiagnostics(send(move(requests)), {
                                                      {"b/__package.rb", 4, "Unable to resolve constant"},
-                                                     {"b/impl.rb", 5, "resolves but its package is not imported"},
-                                                     {"b/impl.rb", 7, "resolves but its package is not imported"},
+                                                     {"b/impl.rb", 5, "is not imported"},
+                                                     {"b/impl.rb", 7, "is not imported"},
                                                      {"c/__package.rb", 0, "must contain a package definition"},
                                                  });
 }

--- a/test/testdata/packager/apply-all-fixes/a/foo.rb
+++ b/test/testdata/packager/apply-all-fixes/a/foo.rb
@@ -4,15 +4,15 @@
 
 class A::Foo
   B::Foo.new
-# ^^^^^^ error: `B::Foo` resolves but its package is not imported
+# ^ error: `B` is not imported
 # ^ apply-code-action: [A] Import `B` in package `A`
 # ^ apply-code-action: [B] Apply all Sorbet fixes for file
   B::Foo.new
-# ^^^^^^ error: `B::Foo` resolves but its package is not imported
+# ^ error: `B` is not imported
 # ^ apply-code-action: [C] Import `B` in package `A`
 # ^ apply-code-action: [D] Apply all Sorbet fixes for file
   C::Foo.new
-# ^^^^^^ error: `C::Foo` resolves but its package is not imported
+# ^ error: `C` is not imported
 # ^ apply-code-action: [E] Import `C` in package `A`
 # ^ apply-code-action: [F] Apply all Sorbet fixes for file
   D::Foo.new

--- a/test/testdata/packager/apply-all-fixes/a/foo.rb
+++ b/test/testdata/packager/apply-all-fixes/a/foo.rb
@@ -5,16 +5,16 @@
 class A::Foo
   B::Foo.new
 # ^^^^^^ error: `B::Foo` resolves but its package is not imported
-# ^^^^^^ apply-code-action: [A] Import `B` in package `A`
-# ^^^^^^ apply-code-action: [B] Apply all Sorbet fixes for file
+# ^ apply-code-action: [A] Import `B` in package `A`
+# ^ apply-code-action: [B] Apply all Sorbet fixes for file
   B::Foo.new
 # ^^^^^^ error: `B::Foo` resolves but its package is not imported
-# ^^^^^^ apply-code-action: [C] Import `B` in package `A`
-# ^^^^^^ apply-code-action: [D] Apply all Sorbet fixes for file
+# ^ apply-code-action: [C] Import `B` in package `A`
+# ^ apply-code-action: [D] Apply all Sorbet fixes for file
   C::Foo.new
 # ^^^^^^ error: `C::Foo` resolves but its package is not imported
-# ^^^^^^ apply-code-action: [E] Import `C` in package `A`
-# ^^^^^^ apply-code-action: [F] Apply all Sorbet fixes for file
+# ^ apply-code-action: [E] Import `C` in package `A`
+# ^ apply-code-action: [F] Apply all Sorbet fixes for file
   D::Foo.new
 # ^^^^^^ error: `D::Foo` resolves but is not exported from `D`
 # ^^^^^^ apply-code-action: [G] Export `D::Foo` in package `D`

--- a/test/testdata/packager/apply-all-fixes/a/foo.test.rb
+++ b/test/testdata/packager/apply-all-fixes/a/foo.test.rb
@@ -4,15 +4,15 @@
 
 class Test::A::FooTest
   B::Foo.new
-# ^^^^^^ error: `B::Foo` resolves but its package is not imported
+# ^ error: `B` is not imported
 # ^ apply-code-action: [AA] Test Import `B` in package `A`
 # ^ apply-code-action: [BB] Apply all Sorbet fixes for file
   B::Foo.new
-# ^^^^^^ error: `B::Foo` resolves but its package is not imported
+# ^ error: `B` is not imported
 # ^ apply-code-action: [CC] Test Import `B` in package `A`
 # ^ apply-code-action: [DD] Apply all Sorbet fixes for file
   C::Foo.new
-# ^^^^^^ error: `C::Foo` resolves but its package is not imported
+# ^ error: `C` is not imported
 # ^ apply-code-action: [EE] Test Import `C` in package `A`
 # ^ apply-code-action: [FF] Apply all Sorbet fixes for file
 end

--- a/test/testdata/packager/apply-all-fixes/a/foo.test.rb
+++ b/test/testdata/packager/apply-all-fixes/a/foo.test.rb
@@ -5,14 +5,14 @@
 class Test::A::FooTest
   B::Foo.new
 # ^^^^^^ error: `B::Foo` resolves but its package is not imported
-# ^^^^^^ apply-code-action: [AA] Test Import `B` in package `A`
-# ^^^^^^ apply-code-action: [BB] Apply all Sorbet fixes for file
+# ^ apply-code-action: [AA] Test Import `B` in package `A`
+# ^ apply-code-action: [BB] Apply all Sorbet fixes for file
   B::Foo.new
 # ^^^^^^ error: `B::Foo` resolves but its package is not imported
-# ^^^^^^ apply-code-action: [CC] Test Import `B` in package `A`
-# ^^^^^^ apply-code-action: [DD] Apply all Sorbet fixes for file
+# ^ apply-code-action: [CC] Test Import `B` in package `A`
+# ^ apply-code-action: [DD] Apply all Sorbet fixes for file
   C::Foo.new
 # ^^^^^^ error: `C::Foo` resolves but its package is not imported
-# ^^^^^^ apply-code-action: [EE] Test Import `C` in package `A`
-# ^^^^^^ apply-code-action: [FF] Apply all Sorbet fixes for file
+# ^ apply-code-action: [EE] Test Import `C` in package `A`
+# ^ apply-code-action: [FF] Apply all Sorbet fixes for file
 end

--- a/test/testdata/packager/directed-unpackaged/downstream/downstream.rb
+++ b/test/testdata/packager/directed-unpackaged/downstream/downstream.rb
@@ -3,10 +3,9 @@
 # stratum: 0
 
 module Downstream
-  # this is not imported, but that means that this stratum doesn't
-  # know anything about it, so it manifests as an unresolved constant
+  # The package registry lets the resolver identify this package even though its source stratum has not run.
   MyPackage::MyClass
-# ^^^^^^^^^ error: Unable to resolve
+# ^^^^^^^^^ error: `MyPackage` is not imported
 
   # because this was defined in `MyPackage`, we can't have seen it yet
   UnpackagedTheSequel
@@ -14,7 +13,7 @@ module Downstream
 
   # this is defined by an RBI and not imported
   MyPackage::MyRbiConstant
-# ^^^^^^^^^ error: Unable to resolve
+# ^^^^^^^^^ error: `MyPackage` is not imported
 
   # because this was defined in `MyPackage`, we can't have seen it yet
   SomethingCompletelyDifferent

--- a/test/testdata/packager/directed-unpackaged/packaged/unpackaged-file.rb
+++ b/test/testdata/packager/directed-unpackaged/packaged/unpackaged-file.rb
@@ -20,6 +20,6 @@ class ::UnpackagedTheSequel
 
     # this is defined in a non-imported package
     puts OtherPackageNotImported::ExportedClass.new
-    #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `OtherPackageNotImported::ExportedClass` resolves but its package is not imported
+    #    ^^^^^^^^^^^^^^^^^^^^^^^ error: `OtherPackageNotImported` is not imported
   end
 end

--- a/test/testdata/packager/directed-unqualified_constant_escapes_package/shared/consumer/client.rb
+++ b/test/testdata/packager/directed-unqualified_constant_escapes_package/shared/consumer/client.rb
@@ -10,7 +10,7 @@ module Shared
         # into the parent package's `Shared` namespace). Package-directed mode changes how strata are
         # named and resolved, not the cross-package visibility rule, so the same error still fires.
         Secret
-      # ^^^^^^ error: `Shared::Secret` resolves but its package is not imported
+      # ^^^^^^ error: `Shared` is not imported
       end
     end
   end

--- a/test/testdata/packager/export_for_test/foo/foo.rb
+++ b/test/testdata/packager/export_for_test/foo/foo.rb
@@ -18,12 +18,12 @@ module Opus::Foo
   # via import Opus::Foo::Bar
   Opus::Foo::Bar::BarClass
   Test::Opus::Foo::Bar::BarClassTest
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::Foo::Bar::BarClassTest` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::Foo::Bar::BarClassTest` is defined in a test namespace and cannot be referenced in a non-test file
 
   # via import Opus::Util
   Opus::Util::UtilClass
   Test::Opus::Util::TestUtil
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::Util::TestUtil` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::Util::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file
 
   Opus::Util::Nesting::Public.public_method
 
@@ -36,7 +36,7 @@ module Opus::Foo
   Opus::TestImported::TIClass
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Used `test_import` constant `Opus::TestImported::TIClass` in non-test file
   Test::Opus::TestImported::TITestClass
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::TestImported::TITestClass` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Used `test_import` constant `Test::Opus::TestImported::TITestClass` in non-test file
 
 
   # via export_for_test Opus::Foo::Private::ImplDetail

--- a/test/testdata/packager/export_for_test/foo/foo.rb
+++ b/test/testdata/packager/export_for_test/foo/foo.rb
@@ -34,7 +34,7 @@ module Opus::Foo
 
   # via test_import Opus::TestImported
   Opus::TestImported::TIClass
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Used `test_import` constant `Opus::TestImported::TIClass` in non-test file
+# ^^^^^^^^^^^^^^^^^^ error: Used `test_import` package `Opus::TestImported` in non-test file
   Test::Opus::TestImported::TITestClass
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Used `test_import` constant `Test::Opus::TestImported::TITestClass` in non-test file
 

--- a/test/testdata/packager/export_for_test/foo/foo.rb
+++ b/test/testdata/packager/export_for_test/foo/foo.rb
@@ -18,12 +18,12 @@ module Opus::Foo
   # via import Opus::Foo::Bar
   Opus::Foo::Bar::BarClass
   Test::Opus::Foo::Bar::BarClassTest
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::Foo::Bar::BarClassTest` is defined in a test namespace and cannot be referenced in a non-test file
+# ^^^^ error: Unable to resolve constant `Test`
 
   # via import Opus::Util
   Opus::Util::UtilClass
   Test::Opus::Util::TestUtil
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Opus::Util::TestUtil` is defined in a test namespace and cannot be referenced in a non-test file
+# ^^^^ error: Unable to resolve constant `Test`
 
   Opus::Util::Nesting::Public.public_method
 
@@ -36,7 +36,7 @@ module Opus::Foo
   Opus::TestImported::TIClass
 # ^^^^^^^^^^^^^^^^^^ error: Used `test_import` package `Opus::TestImported` in non-test file
   Test::Opus::TestImported::TITestClass
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Used `test_import` constant `Test::Opus::TestImported::TITestClass` in non-test file
+# ^^^^ error: Unable to resolve constant `Test`
 
 
   # via export_for_test Opus::Foo::Private::ImplDetail

--- a/test/testdata/packager/import_nonexistent_package/root.rb
+++ b/test/testdata/packager/import_nonexistent_package/root.rb
@@ -2,5 +2,5 @@
 
 module Root
   Root::A::Foo
-# ^^^^^^^^^^^^ error: `Root::A::Foo` resolves but its package is not imported
+# ^^^^^^^ error: `Root::A` is not imported
 end

--- a/test/testdata/packager/lsp_features/family.rb
+++ b/test/testdata/packager/lsp_features/family.rb
@@ -41,9 +41,7 @@ module Simpsons
   end
 
   Test::Krabappel::Popquiz
-# ^^^^^^^^^^^^^^^^^^^^^^^^ error: Used `test_import` constant `Test::Krabappel::Popquiz` in non-test file
-  #                ^^^^^^^ usage: popquiz
-# ^^^^^^^^^^^^^^^ importusage: krabappel-pkg
+# ^^^^ error: Unable to resolve constant `Test`
 
   class Private
     #   ^^^^^^^ def: s-private

--- a/test/testdata/packager/lsp_features/family.rb
+++ b/test/testdata/packager/lsp_features/family.rb
@@ -41,7 +41,7 @@ module Simpsons
   end
 
   Test::Krabappel::Popquiz
-# ^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Krabappel::Popquiz` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file
+# ^^^^^^^^^^^^^^^^^^^^^^^^ error: Used `test_import` constant `Test::Krabappel::Popquiz` in non-test file
   #                ^^^^^^^ usage: popquiz
 # ^^^^^^^^^^^^^^^ importusage: krabappel-pkg
 

--- a/test/testdata/packager/lsp_update_package/a.rb
+++ b/test/testdata/packager/lsp_update_package/a.rb
@@ -4,8 +4,8 @@
 class Package::A
   extend T::Sig
 
-  sig {returns(Dep::ExportedItem)} # error: `Dep::ExportedItem` resolves but its package is not imported
+  sig {returns(Dep::ExportedItem)} # error: `Dep` is not imported
   def self.get_exported_item
-    Dep::ExportedItem.new # error: `Dep::ExportedItem` resolves but its package is not imported
+    Dep::ExportedItem.new # error: `Dep` is not imported
   end
 end

--- a/test/testdata/packager/package-prefix-enforcement/nested/nested.rb
+++ b/test/testdata/packager/package-prefix-enforcement/nested/nested.rb
@@ -39,7 +39,7 @@ module Root
     sig { void }
     def example
       NOT_IN_PACKAGE
-    # ^^^^^^^^^^^^^^ error: `Root::NOT_IN_PACKAGE` resolves but its package is not imported
+    # ^^^^^^^^^^^^^^ error: `Root` is not imported
     end
   end
 end

--- a/test/testdata/packager/package_cursor_resolution/consumer/__package.rb
+++ b/test/testdata/packager/package_cursor_resolution/consumer/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+# enable-packager: true
+
+class Consumer < PackageSpec
+end

--- a/test/testdata/packager/package_cursor_resolution/consumer/test/__package.rb
+++ b/test/testdata/packager/package_cursor_resolution/consumer/test/__package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+# enable-packager: true
+
+class Consumer::Test < PackageSpec
+  test!
+
+  import Consumer
+end

--- a/test/testdata/packager/package_cursor_resolution/consumer/test_package.rb
+++ b/test/testdata/packager/package_cursor_resolution/consumer/test_package.rb
@@ -4,5 +4,5 @@
 
 module Consumer
   Only::Test::Thing
-# ^^^^^^^^^^^^^^^^^ error: `Only::Test::Thing` cannot be referenced here because `Consumer` may not reference `test!` packages
+# ^^^^^^^^^^ error: `Only::Test` cannot be referenced here because `Consumer` may not reference `test!` packages
 end

--- a/test/testdata/packager/package_cursor_resolution/consumer/test_package.rb
+++ b/test/testdata/packager/package_cursor_resolution/consumer/test_package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+# enable-packager: true
+# assert-no-code-action: quickfix
+
+module Consumer
+  Only::Test::Thing
+# ^^^^^^^^^^^^^^^^^ error: `Only::Test::Thing` cannot be referenced here because `Consumer` may not reference `test!` packages
+end

--- a/test/testdata/packager/package_cursor_resolution/consumer/use.rb
+++ b/test/testdata/packager/package_cursor_resolution/consumer/use.rb
@@ -1,0 +1,18 @@
+# typed: strict
+# enable-packager: true
+
+module Consumer
+  ::RootQualifiedPackage::Thing # error: is not imported
+
+  # A registry-only namespace must not count as resolving when it is the complete reference.
+  UnmistakablePackageCursorRoot
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `UnmistakablePackageCursorRoot`
+
+  # A package declaration does not define the corresponding runtime namespace.
+  UnmistakablePackageCursorRoot::Nested::EmptyPackage
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `UnmistakablePackageCursorRoot`
+
+  # Neither the root nor `Nested` exists as a runtime namespace, even though they exist in the package registry.
+  UnmistakablePackageCursorRoot::Nested::EmptyPackage::Missing
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `UnmistakablePackageCursorRoot`
+end

--- a/test/testdata/packager/package_cursor_resolution/consumer/use.rb
+++ b/test/testdata/packager/package_cursor_resolution/consumer/use.rb
@@ -10,9 +10,9 @@ module Consumer
 
   # A package declaration does not define the corresponding runtime namespace.
   UnmistakablePackageCursorRoot::Nested::EmptyPackage
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `UnmistakablePackageCursorRoot`
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `UnmistakablePackageCursorRoot::Nested::EmptyPackage` is not imported
 
   # Neither the root nor `Nested` exists as a runtime namespace, even though they exist in the package registry.
   UnmistakablePackageCursorRoot::Nested::EmptyPackage::Missing
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `UnmistakablePackageCursorRoot`
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `UnmistakablePackageCursorRoot::Nested::EmptyPackage` is not imported
 end

--- a/test/testdata/packager/package_cursor_resolution/empty/__package.rb
+++ b/test/testdata/packager/package_cursor_resolution/empty/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# enable-packager: true
+
+class UnmistakablePackageCursorRoot::Nested::EmptyPackage < PackageSpec
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ def: cursor-namespace
+end

--- a/test/testdata/packager/package_cursor_resolution/importer/__package.rb
+++ b/test/testdata/packager/package_cursor_resolution/importer/__package.rb
@@ -1,0 +1,7 @@
+# typed: strict
+# enable-packager: true
+
+class EmptyPackageImporter < PackageSpec
+  import UnmistakablePackageCursorRoot::Nested::EmptyPackage
+       # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ usage: cursor-namespace
+end

--- a/test/testdata/packager/package_cursor_resolution/importer/use.rb
+++ b/test/testdata/packager/package_cursor_resolution/importer/use.rb
@@ -1,0 +1,8 @@
+# typed: strict
+# enable-packager: true
+
+module EmptyPackageImporter
+  # Importing an empty package still does not define its runtime namespace.
+  UnmistakablePackageCursorRoot::Nested::EmptyPackage
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `UnmistakablePackageCursorRoot`
+end

--- a/test/testdata/packager/package_cursor_resolution/importer/use.rb
+++ b/test/testdata/packager/package_cursor_resolution/importer/use.rb
@@ -4,5 +4,5 @@
 module EmptyPackageImporter
   # Importing an empty package still does not define its runtime namespace.
   UnmistakablePackageCursorRoot::Nested::EmptyPackage
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `UnmistakablePackageCursorRoot`
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Unable to resolve constant `EmptyPackage`
 end

--- a/test/testdata/packager/package_cursor_resolution/only/test/__package.rb
+++ b/test/testdata/packager/package_cursor_resolution/only/test/__package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+# enable-packager: true
+
+class Only::Test < PackageSpec
+  test!
+
+  export Only::Test::Thing
+end

--- a/test/testdata/packager/package_cursor_resolution/only/test/thing.rb
+++ b/test/testdata/packager/package_cursor_resolution/only/test/thing.rb
@@ -1,0 +1,7 @@
+# typed: strict
+# enable-packager: true
+
+module Only::Test
+  class Thing
+  end
+end

--- a/test/testdata/packager/package_cursor_resolution/root_qualified/__package.rb
+++ b/test/testdata/packager/package_cursor_resolution/root_qualified/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# enable-packager: true
+
+class RootQualifiedPackage < PackageSpec
+  export RootQualifiedPackage::Thing
+end

--- a/test/testdata/packager/package_cursor_resolution/root_qualified/thing.rb
+++ b/test/testdata/packager/package_cursor_resolution/root_qualified/thing.rb
@@ -1,0 +1,7 @@
+# typed: strict
+# enable-packager: true
+
+module RootQualifiedPackage
+  class Thing
+  end
+end

--- a/test/testdata/packager/prefix_of_imported/main.rb
+++ b/test/testdata/packager/prefix_of_imported/main.rb
@@ -3,7 +3,7 @@
 
 module Opus::Main
   p(Opus::OuterPackage)
-  # ^^^^^^^^^^^^^^^^^^ error: `Opus::OuterPackage` resolves but its package is not imported
+  # ^^^^^^^^^^^^^^^^^^ error: `Opus::OuterPackage` is not imported
 
   p(Opus::OuterPackage::InnerPackage)
 

--- a/test/testdata/packager/prelude_packages_explicit_imports/application/b.rb
+++ b/test/testdata/packager/prelude_packages_explicit_imports/application/b.rb
@@ -5,10 +5,10 @@ module Application
     extend T::Sig
 
     sig { returns([Prelude::First::A, Prelude::Second::B]) }
-    #                                 ^^^^^^^^^^^^^^^^^^ error: not imported
+    #                                 ^^^^^^^^^^^^^^^ error: not imported
     def self.test
       [Prelude::First::A.new, Prelude::Second::B.new]
-      #                       ^^^^^^^^^^^^^^^^^^ error: not imported
+      #                       ^^^^^^^^^^^^^^^ error: not imported
     end
   end
 end

--- a/test/testdata/packager/prelude_packages_explicit_imports/prelude/second/b.rb
+++ b/test/testdata/packager/prelude_packages_explicit_imports/prelude/second/b.rb
@@ -3,7 +3,7 @@
 module Prelude::Second
   class B
     def using_non_imported_constant
-      Prelude::First::A.new # error: `Prelude::First::A` resolves but its package is not imported
+      Prelude::First::A.new # error: `Prelude::First` is not imported
     end
   end
 end

--- a/test/testdata/packager/prelude_packages_imports/prelude/second/b.rb
+++ b/test/testdata/packager/prelude_packages_imports/prelude/second/b.rb
@@ -3,7 +3,7 @@
 module Prelude::Second
   class B
     def using_non_imported_constant
-      Prelude::First::A.new # error: `Prelude::First::A` resolves but its package is not imported
+      Prelude::First::A.new # error: `Prelude::First` is not imported
     end
   end
 end

--- a/test/testdata/packager/shared_prefix/foo/foo.rb
+++ b/test/testdata/packager/shared_prefix/foo/foo.rb
@@ -3,5 +3,5 @@
 
 class Project::Foo::Foo
   puts Project::Bar::This
-  #    ^^^^^^^^^^^^^^^^^^ error: `Project::Bar::This` resolves but its package is not imported
+  #    ^^^^^^^^^^^^^^^^^^ error: `Project::Bar::This` is not imported
 end

--- a/test/testdata/packager/simple_test_import/main_lib/lib.rb
+++ b/test/testdata/packager/simple_test_import/main_lib/lib.rb
@@ -9,8 +9,8 @@ class Project::MainLib::Lib
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Used `test_import` constant `Project::TestOnly::SomeHelper` in non-test file
 
   Test::Project::Util::UtilHelper
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::UtilHelper` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::UtilHelper` is defined in a test namespace and cannot be referenced in a non-test file
 
   Test::Project::Util::Unexported
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::Unexported` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::Unexported` is defined in a test namespace and cannot be referenced in a non-test file
 end

--- a/test/testdata/packager/simple_test_import/main_lib/lib.rb
+++ b/test/testdata/packager/simple_test_import/main_lib/lib.rb
@@ -6,7 +6,7 @@ class Project::MainLib::Lib
 
   # Normal code is not allowed to access names from `test_import`
   Project::TestOnly::SomeHelper.new
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: Used `test_import` constant `Project::TestOnly::SomeHelper` in non-test file
+# ^^^^^^^^^^^^^^^^^ error: Used `test_import` package `Project::TestOnly` in non-test file
 
   Test::Project::Util::UtilHelper
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::UtilHelper` is defined in a test namespace and cannot be referenced in a non-test file

--- a/test/testdata/packager/simple_test_import/main_lib/lib.rb
+++ b/test/testdata/packager/simple_test_import/main_lib/lib.rb
@@ -9,8 +9,8 @@ class Project::MainLib::Lib
 # ^^^^^^^^^^^^^^^^^ error: Used `test_import` package `Project::TestOnly` in non-test file
 
   Test::Project::Util::UtilHelper
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::UtilHelper` is defined in a test namespace and cannot be referenced in a non-test file
+# ^^^^ error: Unable to resolve constant `Test`
 
   Test::Project::Util::Unexported
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `Test::Project::Util::Unexported` is defined in a test namespace and cannot be referenced in a non-test file
+# ^^^^ error: Unable to resolve constant `Test`
 end

--- a/test/testdata/packager/strict_nested/nested/example.rb
+++ b/test/testdata/packager/strict_nested/nested/example.rb
@@ -4,19 +4,19 @@ module Root
   module Nested
     class Example
       p(Root)
-      # ^^^^ error: resolves but its package is not imported
+      # ^^^^ error: `Root` is not imported
       p(Root::MyClass)
-      # ^^^^^^^^^^^^^ error: resolves but its package is not imported
+      # ^^^^ error: `Root` is not imported
     end
 
     p(Root)
-    # ^^^^ error: resolves but its package is not imported
+    # ^^^^ error: `Root` is not imported
     p(Root::MyClass)
-    # ^^^^^^^^^^^^^ error: resolves but its package is not imported
+    # ^^^^ error: `Root` is not imported
   end
 end
 
 p(Root)
-# ^^^^ error: resolves but its package is not imported
+# ^^^^ error: `Root` is not imported
 p(Root::MyClass)
-# ^^^^^^^^^^^^^ error: resolves but its package is not imported
+# ^^^^ error: `Root` is not imported

--- a/test/testdata/packager/test-packages-test-import/test/test.rb
+++ b/test/testdata/packager/test-packages-test-import/test/test.rb
@@ -3,7 +3,7 @@
 module Root::Test
   class ATest
     def test_a
-      Root::A.new # error: `Root::A` resolves but its package is not imported
+      Root::A.new # error: `Root` is not imported
     end
   end
 end

--- a/test/testdata/packager/test_constant_outside_test_namespace_referenced/consumer/use.rb
+++ b/test/testdata/packager/test_constant_outside_test_namespace_referenced/consumer/use.rb
@@ -1,3 +1,3 @@
 # typed: strict
 
-Target::TestOnlyThing # error: `Target::TestOnlyThing` cannot be referenced here because it is defined in a test namespace and cannot be referenced in a non-test file
+Target::TestOnlyThing # error: `Target::TestOnlyThing` is defined in a test namespace and cannot be referenced in a non-test file

--- a/test/testdata/packager/test_constant_outside_test_namespace_referenced/consumer/use.rb
+++ b/test/testdata/packager/test_constant_outside_test_namespace_referenced/consumer/use.rb
@@ -1,3 +1,3 @@
 # typed: strict
 
-Target::TestOnlyThing # error: `Target::TestOnlyThing` is defined in a test namespace and cannot be referenced in a non-test file
+Target::TestOnlyThing

--- a/test/testdata/packager/test_helper_import/root_stuff.rb
+++ b/test/testdata/packager/test_helper_import/root_stuff.rb
@@ -5,13 +5,13 @@ module RootPkg
     A::Thing # allowed
 
     B::Thing # not allowed---test import
-  # ^^^^^^^^ error: Used `test_import` constant `B::Thing` in non-test file
+  # ^ error: Used `test_import` package `B` in non-test file
     B::PrivateThing
-  # ^^^^^^^^^^^^^^^ error: Used `test_import` constant `B::PrivateThing` in non-test file
+  # ^ error: Used `test_import` package `B` in non-test file
 
     C::Thing # not allowed---test import
-  # ^^^^^^^^ error: Used `test_import` constant `C::Thing` in non-test file
+  # ^ error: Used `test_import` package `C` in non-test file
     C::PrivateThing
-  # ^^^^^^^^^^^^^^^ error: Used `test_import` constant `C::PrivateThing` in non-test file
+  # ^ error: Used `test_import` package `C` in non-test file
   end
 end

--- a/test/testdata/packager/test_helper_import/test/test_helper.rb
+++ b/test/testdata/packager/test_helper_import/test/test_helper.rb
@@ -9,8 +9,8 @@ module Test::RootPkg
   # ^^^^^^^^^^^^^^^ error: `B::PrivateThing` resolves but is not exported from `B`
 
     C::Thing # not allowed---test-only import
-  # ^^^^^^^^ error: The `test_import` constant `C::Thing` can only be used in `.test.rb` files
+  # ^ error: The `test_import` package `C` can only be used in `.test.rb` files
     C::PrivateThing
-  # ^^^^^^^^^^^^^^^ error: The `test_import` constant `C::PrivateThing` can only be used in `.test.rb` files
+  # ^ error: The `test_import` package `C` can only be used in `.test.rb` files
   end
 end

--- a/test/testdata/packager/unimported_namespace/aaa/a_class.rb
+++ b/test/testdata/packager/unimported_namespace/aaa/a_class.rb
@@ -3,10 +3,10 @@
 
 class AAA::AClass
   BBB
-# ^^^ error: `BBB` resolves but its package is not imported
+# ^^^ error: `BBB` is not imported
 
   CCC
-# ^^^ error: Unable to resolve constant `CCC`
+# ^^^ error: `CCC` is not imported
 
   C
 # ^ error: Unable to resolve constant `C`

--- a/test/testdata/packager/unpackaged-error/packaged/unpackaged-file.rb
+++ b/test/testdata/packager/unpackaged-error/packaged/unpackaged-file.rb
@@ -9,6 +9,6 @@ class ::UnpackagedTheSequel
     puts MyPackage::MyClass.new
     puts OtherPackageImported::ExportedClass.new
     puts OtherPackageNotImported::ExportedClass.new
-    #    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: `OtherPackageNotImported::ExportedClass` resolves but its package is not imported
+    #    ^^^^^^^^^^^^^^^^^^^^^^^ error: `OtherPackageNotImported` is not imported
   end
 end

--- a/test/testdata/packager/unqualified_constant_escapes_package/shared/consumer/client.rb
+++ b/test/testdata/packager/unqualified_constant_escapes_package/shared/consumer/client.rb
@@ -11,12 +11,12 @@ module Shared
         # resolver never stops at package boundaries; the packager then flags the cross-package
         # reference because `Shared` is neither imported here nor exports `Secret`.
         Secret
-      # ^^^^^^ error: `Shared::Secret` resolves but its package is not imported
+      # ^^^^^^ error: `Shared` is not imported
 
         # `Secret2` is exported from `Shared`, but `Shared::Consumer` still doesn't import `Shared`,
         # so the cross-package reference is flagged for the missing import rather than the export.
         Secret2
-      # ^^^^^^^ error: `Shared::Secret2` resolves but its package is not imported
+      # ^^^^^^^ error: `Shared` is not imported
       end
     end
   end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

I recommend reviewing by commit, cross-referencing with the **Design** section
below to get a high level before diving in. The main implementation is ~300
lines and I couldn't make that smaller.

The commit structure is

1.  assorted prework refactors and new tests capturing master behavior
2.  the main implementation commits
3.  the changes to the tests, triaged into commits where all the diffs
    show similar behavior, so that you can skim for things that look out
    of the ordinary

Many of the commits also have further clarification for things worth noting
about the contents of that commit.

### Design

> A note on the design, which is mostly contained to the "Make constant
> resolution package-aware" commit (de0c742d2141974ad46e2becdc3c66b9a4001c05)

The implementation tracks a package registry cursor symbol (parallel to the
normal constant resolution symbol) to bookkeep the main "package-aware" logic.

It's not sufficient to just resolve the constant and then check `->package` on
the constant that resolves (for each part of the scope), because there are some
cases where we need to allow resolution, despite the `->package` of that part
of the scope not being resolved: namely, when you import
`Opus::OuterPackage::InnerPackage`, we need to allow the `Opus::OuterPackage`
to resolve.

The cursor symbol allows doing this without having to construct a separate
`vector<NameRef>` ahead of time for each constant: the package-aware logic
logic runs in tandem with the normal constant resolution walk.

So while resolver performs normal Ruby constant resolution, it also walks the
same names through `<PackageSpecRegistry>` on the cursor symbol. This lets it
step across package boundaries even when package-directed mode has not loaded
the corresponding runtime constants yet for those intermediate namespace
symbols.

For a path like `Opus::OuterPackage::InnerPackage::Thing`, the cursor advances
component by component and records whether it is:

- Still in a package namespace prefix.
- Exactly at a package boundary.
- Inside a known package.

If ordinary resolution fails, resolver consults the cursor to decide whether
the failure is due to a missing import. If it resolves, it then consults
whether it's allowed to resolve, given the imports of the current package.

That's the main idea, but there are some subtleties:

- If a constant **fails to resolve** but it's not the "outermost" symbol (i.e.,
  anything other than `Thing` in the example above), we set the resolved symbol
  to a `<PackageSpecRegistry>::...` constant, so that we can report the
  **final** import that's required, instead of saying something like
  `Opus::OuterPackage` needs to be imported. Resolving intermediate scopes to
  symbols like `<PackageSpecRegistry>::Opus::OuterPackage` allows eventually
  discovering that `Opus::OuterPackage::InnerPackage` is the required import.
  Once the outermost reference is handled, unresolved constants still become
  `StubModule`, preserving downstream behavior (e.g., inference treating them
  as `T.untyped`).

- Legacy `Test::` paths use the same cursor mechanism but begin at the registry
  root, effectively ignoring the synthetic `Test` prefix. We can delete this
  logic once we have moved entirely to `test!` packages.

The cursor mechanism achieves two things:

- We don't mistakenly suggest importing all intermediate scopes, we only
  suggest the scope where we transition across the package boundary
- The package-directed mode can actually give _better_ errors than it does
  today, e.g. certain "Unable to resolve constant" errors improve to an "is not
  imported" error

The cursor symbol and the associated bookkeeping bits all fit inside the
existing size of a `ConstantResolutionItem`, this approach uses no more memory
than today.



### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Aligns the package-directed and monolithic modes, so we can make sure that the package-directed mode is correct.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

### Performance

Overall, it's obviously slower, but I think that it's not show-stoppingly slower. It doesn't use more memory.

I tested this with 10 AB/BA pairs of warm-cache typecheck runs on my Stripe devbox:

- wall time: +0.301s (+0.52%), ranging from -2.219s to +2.957s
- wall time, with `--stop-after=resolver`: +1.288s (+5.25%), ranging from +0.307s to +2.378s.
- peak RSS: -42 MiB (-0.26%)

So I think this causes a ~1.3s slowdown, but that the infer noise maybe makes that a wash somehow.
The median warm-cache typecheck wall time on master is ~57s, so this brings that up to ~58s.

Memory usage is unchanged, which makes sense because the whole point of the change is to leave data structure sizes the same.

I can produce a more detailed report internally, if people want to see it.

### Posterity

A lot of changes landed in prep for this, maybe you're from the future and trying to find one of them:

- #10614
- #10615
- #10625
- #10632
- #10634
- #10635
- #10641
- #10644
- #10649