### PR TITLE
Revive a dead enforce

### DIFF
--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -2537,8 +2537,9 @@ Namer::runInternal(core::GlobalState &gs, absl::Span<ast::ParsedFile> trees, Wor
                               core::FoundDefHashesResult *foundHashesOut) {
     // In non-incremental namer, there are no old FoundDefHashes; just defineSymbols like normal.
     vector<core::ClassOrModuleRef> updatedSymbols;
-    return runInternal(gs, trees, workers, {}, foundHashesOut, updatedSymbols);
+    auto canceled = runInternal(gs, trees, workers, {}, foundHashesOut, updatedSymbols);
     ENFORCE(updatedSymbols.empty());
+    return canceled;
 }
 
 [[nodiscard]] bool


### PR DESCRIPTION
I think that this happened through some refactoring, but an `ENFORCE` ended up after a `return` in `Namer::run`.


### Motivation
Fixing my embarassing mistakes.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

No changes expected, this `ENFORCE` should have been valid the whole time.
