### PR TITLE
Ignore tests_min_typed_level with --experimental-test-packages

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -801,10 +801,15 @@ struct PackageSpecBodyWalk {
                         minTypedLevelLoc = value.loc();
                     } else if (keyLit->asSymbol() == core::Names::testsMinTypedLevel()) {
                         if (testPackages) {
-                            if (auto e = ctx.beginError(keyLit->loc.join(value.loc()),
-                                                        core::errors::Packager::InvalidPackageExpression)) {
-                                e.setHeader("Invalid expression in package: the only valid argument for `{}` is `{}`",
-                                            "sorbet", core::Names::minTypedLevel().shortName(ctx));
+                            // TODO(trevor) we suppress the error about `tests_min_typed_level` for the test-packages
+                            // migration.
+                            if (!ctx.state.packageDB().testPackages()) {
+                                if (auto e = ctx.beginError(keyLit->loc.join(value.loc()),
+                                                            core::errors::Packager::InvalidPackageExpression)) {
+                                    e.setHeader(
+                                        "Invalid expression in package: the only valid argument for `{}` is `{}`",
+                                        "sorbet", core::Names::minTypedLevel().shortName(ctx));
+                                }
                             }
                         } else {
                             testsMinTypedLevel = typedLevel;

--- a/test/cli/test-packages-ignore-test-import/in_between/__package.rb
+++ b/test/cli/test-packages-ignore-test-import/in_between/__package.rb
@@ -1,6 +1,8 @@
 # typed: strict
 
 class InBetween < PackageSpec
+  sorbet min_typed_level: "true", tests_min_typed_level: "true"
+
   import Migrated
 
   test_import Migrated::Test

--- a/test/cli/test-packages-ignore-test-import/in_between/test/__package.rb
+++ b/test/cli/test-packages-ignore-test-import/in_between/test/__package.rb
@@ -3,6 +3,8 @@
 class Test::InBetween < PackageSpec
   test!
 
+  sorbet min_typed_level: "true"
+
   import InBetween, uses_internals: true
   import Migrated::Test
 end

--- a/test/cli/test-packages-ignore-test-import/old_style/__package.rb
+++ b/test/cli/test-packages-ignore-test-import/old_style/__package.rb
@@ -3,5 +3,7 @@
 class OldStyle < PackageSpec
   import Migrated
 
+  sorbet min_typed_level: "true", tests_min_typed_level: "true"
+
   test_import Migrated::Test
 end

--- a/test/cli/test-packages-ignore-test-import/test.out
+++ b/test/cli/test-packages-ignore-test-import/test.out
@@ -1,15 +1,7 @@
-in_between/__package.rb:4: Invalid expression in package: the only valid argument for `sorbet` is `min_typed_level` https://srb.help/3710
-     4 |  sorbet min_typed_level: "true", tests_min_typed_level: "true"
-                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-old_style/__package.rb:6: Invalid expression in package: the only valid argument for `sorbet` is `min_typed_level` https://srb.help/3710
-     6 |  sorbet min_typed_level: "true", tests_min_typed_level: "true"
-                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 old_style/test/foo.test.rb:3: File belongs to package `OldStyle` but defines a constant that does not match this namespace https://srb.help/3713
      3 |module Test::OldStyle
                ^^^^^^^^^^^^^^
     old_style/__package.rb:3: Enclosing package declared here
      3 |class OldStyle < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 3
+Errors: 1

--- a/test/cli/test-packages-ignore-test-import/test.out
+++ b/test/cli/test-packages-ignore-test-import/test.out
@@ -1,7 +1,15 @@
+in_between/__package.rb:4: Invalid expression in package: the only valid argument for `sorbet` is `min_typed_level` https://srb.help/3710
+     4 |  sorbet min_typed_level: "true", tests_min_typed_level: "true"
+                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+old_style/__package.rb:6: Invalid expression in package: the only valid argument for `sorbet` is `min_typed_level` https://srb.help/3710
+     6 |  sorbet min_typed_level: "true", tests_min_typed_level: "true"
+                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 old_style/test/foo.test.rb:3: File belongs to package `OldStyle` but defines a constant that does not match this namespace https://srb.help/3713
      3 |module Test::OldStyle
                ^^^^^^^^^^^^^^
     old_style/__package.rb:3: Enclosing package declared here
      3 |class OldStyle < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 1
+Errors: 3


### PR DESCRIPTION
When running with `--experimental-test-packages`, skip raising errors about `tests_min_typed_level` in the `sorbet` declaration of a package spec. This gets us closer to being able to introduce test packages without modifying the original at all.


### Motivation
The great test-packages migration.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
