### PR TITLE
Use `--run_under` flag to inject `llvm-symbolizer`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -181,13 +181,16 @@ build:release-sanitized-mac --define jemalloc=false
 build:test-sanitized-linux --config=release-sanitized-linux --config=dbg --nostamp --define release=false
 common:test-sanitized-linux --test_env="UBSAN_OPTIONS=print_stacktrace=1"
 common:test-sanitized-linux --test_env="ASAN_OPTIONS=detect_leaks=0"
+test:test-sanitized-linux --run_under=//tools:sanitizer_test_wrapper
 
 build:test-sanitized-linux-aarch64 --config=release-sanitized-linux-aarch64 --config=dbg --nostamp --define release=false
 common:test-sanitized-linux-aarch64 --test_env="UBSAN_OPTIONS=print_stacktrace=1"
 common:test-sanitized-linux-aarch64 --test_env="ASAN_OPTIONS=detect_leaks=0"
+test:test-sanitized-linux-aarch64 --run_under=//tools:sanitizer_test_wrapper
 
 build:test-sanitized-mac --config=release-sanitized-mac --config=dbg --nostamp --define release=false
 common:test-sanitized-mac --test_env="UBSAN_OPTIONS=print_stacktrace=1"
+test:test-sanitized-mac --run_under=//tools:sanitizer_test_wrapper
 
 build:reduce-intermediate-file-size-base --copt=-g0 --linkopt=-g0 # used by buildfarm to have less debug information on disk
 build:reduce-intermediate-file-size-base --strip=always

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,7 +1,4 @@
-load("//tools:clang.bzl", "clang_tool")  # todo: this should be decoupled and use the library toolchain, not the compiler one
 load(":pipeline_test.bzl", "pipeline_tests")
-
-clang_tool("llvm-symbolizer")
 
 cc_binary(
     name = "pipeline_test_runner",

--- a/test/cli/BUILD
+++ b/test/cli/BUILD
@@ -1,7 +1,4 @@
-load("//tools:clang.bzl", "clang_tool")  # todo: this should be decoupled and use the library toolchain, not the compiler one
 load(":cli_test.bzl", "cli_tests")
-
-clang_tool("llvm-symbolizer")
 
 cli_tests(
     "cli",

--- a/test/cli/cli_test.bzl
+++ b/test/cli/cli_test.bzl
@@ -72,7 +72,6 @@ def _cli_test(name, script, tags = []):
             script_path,
             ":run_{}".format(name),
             output,
-            "//test/cli:llvm-symbolizer",
         ],
         size = "medium",
         tags = tags,

--- a/test/cli/test_one.sh
+++ b/test/cli/test_one.sh
@@ -2,9 +2,6 @@
 script="$1"
 expect="$2"
 
-ASAN_SYMBOLIZER_PATH="$(pwd)/external/llvm_toolchain_15_0_7/bin/llvm-symbolizer"
-export ASAN_SYMBOLIZER_PATH
-
 if ! diff "$expect" -u <("$script"); then
   cat <<EOF
 ================================================================================

--- a/test/pipeline_test.bzl
+++ b/test/pipeline_test.bzl
@@ -13,7 +13,6 @@ def dropExtension(p):
     return p.partition(".")[0]
 
 _TEST_SCRIPT = """#!/usr/bin/env bash
-export ASAN_SYMBOLIZER_PATH=`pwd`/external/llvm_toolchain_15_0_7/bin/llvm-symbolizer
 set -x
 exec {runner} --single_test "{test}" {parser}
 """
@@ -28,10 +27,7 @@ def _exp_test_impl(ctx):
         ),
     )
 
-    runfiles = ctx.runfiles(files = ctx.files.runner + ctx.files.test + ctx.files.data)
-    runfiles = runfiles.merge(ctx.attr._llvm_symbolizer[DefaultInfo].default_runfiles)
-
-    return [DefaultInfo(runfiles = runfiles)]
+    return [DefaultInfo(runfiles = ctx.runfiles(files = ctx.files.runner + ctx.files.test + ctx.files.data))]
 
 exp_test = rule(
     implementation = _exp_test_impl,
@@ -47,9 +43,6 @@ exp_test = rule(
             executable = True,
             cfg = "target",
             allow_files = True,
-        ),
-        "_llvm_symbolizer": attr.label(
-            default = "//test:llvm-symbolizer",
         ),
         "parser": attr.string(mandatory = False),
     },

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -6,6 +6,12 @@ clang_tool("clang-format")
 
 clang_tool("clang-tidy")
 
+sh_binary(
+    name = "sanitizer_test_wrapper",
+    srcs = ["sanitizer_test_wrapper.sh"],
+    data = ["@llvm_toolchain_15_0_7//:bin/llvm-symbolizer"],
+)
+
 compilation_database(
     name = "compdb",
     testonly = True,

--- a/tools/sanitizer_test_wrapper.sh
+++ b/tools/sanitizer_test_wrapper.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+symbolizer="${TEST_SRCDIR}/llvm_toolchain_15_0_7/bin/llvm-symbolizer"
+if [[ ! -x "${symbolizer}" ]]; then
+    echo "Could not find llvm-symbolizer at ${symbolizer}" >&2
+    exit 1
+fi
+
+export ASAN_SYMBOLIZER_PATH="${symbolizer}"
+exec "$@"


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

A few days ago I was debugging a flaky ASAN failure. It was hard to see what
went wrong at a glance in the Buildkite failures because we don't expose ASAN to
the test runner, even though Bazel makes that (shockingly) easy.

<https://bazel.build/docs/user-manual#test-run-under>

From that doc:

> This specifies a prefix that the test runner will insert in front
> of the test command before running it. The
> _command-prefix_ is split into words using Bourne shell
> tokenization rules, and then the list of words is prepended to the
> command that will be executed.
>
> If the first word is a fully-qualified label (starts with
> `//`) it is built. Then the label is substituted by the
> corresponding executable location that is prepended to the command
> that will be executed along with the other words.
>
> Some caveats apply:
>
> *   The PATH used for running tests may be different than the PATH in your environment,
>     so you may need to use an **absolute path** for the `--run_under`
>     command (the first word in _command-prefix_).
> *   **`stdin` is not connected**, so `--run_under`
>     can't be used for interactive commands.
>
> Examples:
>
>     --run_under=/usr/bin/strace
>     --run_under='/usr/bin/strace -c'
>     --run_under=/usr/bin/valgrind
>     --run_under='/usr/bin/valgrind --quiet --num-callers=20'


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

I injected a use-after-free and then ran the test locally.

Examle ASAN failure before, with injected use-after-free:

    ❯ ./bazel test --config=buildfarm-sanitized-linux-aarch64 --test_output=errors //test/lsp:multithreaded_protocol_test_corpus
    ...
    ==3640169==ERROR: AddressSanitizer: heap-use-after-free on address 0xfd6f97a02e10 at pc 0xbdf659c39b8c bp 0xffffc8262210 sp 0xffffc8262208
    READ of size 4 at 0xfd6f97a02e10 thread T0
        #0 0xbdf659c39b88  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x21e9b88) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #1 0xbdf659c36ce0  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x21e6ce0) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #2 0xbdf65bb99800  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x4149800) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #3 0xbdf65bb9d1dc  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x414d1dc) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #4 0xfd6f9afd84c0  (/lib/aarch64-linux-gnu/libc.so.6+0x284c0) (BuildId: 54ae5337044aaabab70d65e0c3444f7e4735e059)
        #5 0xfd6f9afd8594  (/lib/aarch64-linux-gnu/libc.so.6+0x28594) (BuildId: 54ae5337044aaabab70d65e0c3444f7e4735e059)
        #6 0xbdf659ab80ac  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x20680ac) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)

    0xfd6f97a02e10 is located 0 bytes inside of 4-byte region [0xfd6f97a02e10,0xfd6f97a02e14)
    freed by thread T0 here:
        #0 0xbdf659b2fc70  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x20dfc70) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #1 0xbdf659c39b40  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x21e9b40) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #2 0xbdf659c36ce0  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x21e6ce0) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #3 0xbdf65bb99800  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x4149800) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #4 0xbdf65bb9d1dc  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x414d1dc) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #5 0xfd6f9afd84c0  (/lib/aarch64-linux-gnu/libc.so.6+0x284c0) (BuildId: 54ae5337044aaabab70d65e0c3444f7e4735e059)
        #6 0xfd6f9afd8594  (/lib/aarch64-linux-gnu/libc.so.6+0x28594) (BuildId: 54ae5337044aaabab70d65e0c3444f7e4735e059)
        #7 0xbdf659ab80ac  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x20680ac) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)

    previously allocated by thread T0 here:
        #0 0xbdf659b2ff04  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x20dff04) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #1 0xbdf659bc89c8  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x21789c8) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #2 0xbdf659c39b2c  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x21e9b2c) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #3 0xbdf659c36ce0  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x21e6ce0) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #4 0xbdf65bb99800  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x4149800) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #5 0xbdf65bb9d1dc  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x414d1dc) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #6 0xfd6f9afd84c0  (/lib/aarch64-linux-gnu/libc.so.6+0x284c0) (BuildId: 54ae5337044aaabab70d65e0c3444f7e4735e059)
        #7 0xfd6f9afd8594  (/lib/aarch64-linux-gnu/libc.so.6+0x28594) (BuildId: 54ae5337044aaabab70d65e0c3444f7e4735e059)
        #8 0xbdf659ab80ac  (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x20680ac) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)

    SUMMARY: AddressSanitizer: heap-use-after-free (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x21e9b88) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
    Shadow bytes around the buggy address:
      0x1fbdf2f40570: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1fbdf2f40580: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1fbdf2f40590: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1fbdf2f405a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1fbdf2f405b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
    =>0x1fbdf2f405c0: fa fa[fd]fa fa fa fd fd fa fa fd fa fa fa 00 fa
      0x1fbdf2f405d0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1fbdf2f405e0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1fbdf2f405f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1fbdf2f40600: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1fbdf2f40610: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
    Shadow byte legend (one shadow byte represents 8 application bytes):
      Addressable:           00
      Partially addressable: 01 02 03 04 05 06 07
      Heap left redzone:       fa
      Freed heap region:       fd
      Stack left redzone:      f1
      Stack mid redzone:       f2
      Stack right redzone:     f3
      Stack after return:      f5
      Stack use after scope:   f8
      Global redzone:          f9
      Global init order:       f6
      Poisoned by user:        f7
      Container overflow:      fc
      Array cookie:            ac
      Intra object redzone:    bb
      ASan internal:           fe
      Left alloca redzone:     ca
      Right alloca redzone:    cb
    ==3640169==ABORTING
    ================================================================================

Examle ASAN failure after, with injected use-after-free:

    ❯ ./bazel test --config=buildfarm-sanitized-linux-aarch64 --test_output=errors //test/lsp:multithreaded_protocol_test_corpus
    ...
    =================================================================
    ==3627871==ERROR: AddressSanitizer: heap-use-after-free on address 0xe290c8602e10 at pc 0xc0a9d16b9b8c bp 0xfffffec099d0 sp 0xfffffec099c8
    READ of size 4 at 0xe290c8602e10 thread T0
        #0 0xc0a9d16b9b88 in sorbet::test::lsp::(anonymous namespace)::readFreedMemoryForSymbolizerTest() multithreaded_protocol_test_corpus.cc
        #1 0xc0a9d16b6ce0 in sorbet::test::lsp::DOCTEST_ANON_FUNC_2() multithreaded_protocol_test_corpus.cc
        #2 0xc0a9d3619800 in doctest::Context::run() (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x4149800) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #3 0xc0a9d361d1dc in main (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x414d1dc) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #4 0xe290cbd384c0  (/lib/aarch64-linux-gnu/libc.so.6+0x284c0) (BuildId: 54ae5337044aaabab70d65e0c3444f7e4735e059)
        #5 0xe290cbd38594 in __libc_start_main (/lib/aarch64-linux-gnu/libc.so.6+0x28594) (BuildId: 54ae5337044aaabab70d65e0c3444f7e4735e059)
        #6 0xc0a9d15380ac in _start (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x20680ac) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)

    0xe290c8602e10 is located 0 bytes inside of 4-byte region [0xe290c8602e10,0xe290c8602e14)
    freed by thread T0 here:
        #0 0xc0a9d15afc70 in free (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x20dfc70) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #1 0xc0a9d16b9b40 in sorbet::test::lsp::(anonymous namespace)::readFreedMemoryForSymbolizerTest() multithreaded_protocol_test_corpus.cc
        #2 0xc0a9d16b6ce0 in sorbet::test::lsp::DOCTEST_ANON_FUNC_2() multithreaded_protocol_test_corpus.cc
        #3 0xc0a9d3619800 in doctest::Context::run() (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x4149800) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #4 0xc0a9d361d1dc in main (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x414d1dc) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #5 0xe290cbd384c0  (/lib/aarch64-linux-gnu/libc.so.6+0x284c0) (BuildId: 54ae5337044aaabab70d65e0c3444f7e4735e059)
        #6 0xe290cbd38594 in __libc_start_main (/lib/aarch64-linux-gnu/libc.so.6+0x28594) (BuildId: 54ae5337044aaabab70d65e0c3444f7e4735e059)
        #7 0xc0a9d15380ac in _start (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x20680ac) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)

    previously allocated by thread T0 here:
        #0 0xc0a9d15aff04 in malloc (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x20dff04) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #1 0xc0a9d16489c8 in operator new(unsigned long) (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x21789c8) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #2 0xc0a9d16b9b2c in sorbet::test::lsp::(anonymous namespace)::readFreedMemoryForSymbolizerTest() multithreaded_protocol_test_corpus.cc
        #3 0xc0a9d16b6ce0 in sorbet::test::lsp::DOCTEST_ANON_FUNC_2() multithreaded_protocol_test_corpus.cc
        #4 0xc0a9d3619800 in doctest::Context::run() (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x4149800) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #5 0xc0a9d361d1dc in main (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x414d1dc) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)
        #6 0xe290cbd384c0  (/lib/aarch64-linux-gnu/libc.so.6+0x284c0) (BuildId: 54ae5337044aaabab70d65e0c3444f7e4735e059)
        #7 0xe290cbd38594 in __libc_start_main (/lib/aarch64-linux-gnu/libc.so.6+0x28594) (BuildId: 54ae5337044aaabab70d65e0c3444f7e4735e059)
        #8 0xc0a9d15380ac in _start (/pay/cache/.cache/bazel/_bazel_jez/d20d72b1ca32c441487bd2cd86bc6db0/execroot/com_stripe_ruby_typer/bazel-out/aarch64-dbg/bin/test/lsp/multithreaded_protocol_test_corpus+0x20680ac) (BuildId: 814f4b998dcc6c23f3f626b5ca309eec)

    SUMMARY: AddressSanitizer: heap-use-after-free multithreaded_protocol_test_corpus.cc in sorbet::test::lsp::(anonymous namespace)::readFreedMemoryForSymbolizerTest()
    Shadow bytes around the buggy address:
      0x1c62190c0570: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1c62190c0580: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1c62190c0590: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1c62190c05a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1c62190c05b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
    =>0x1c62190c05c0: fa fa[fd]fa fa fa fd fd fa fa fd fa fa fa 00 fa
      0x1c62190c05d0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1c62190c05e0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1c62190c05f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1c62190c0600: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
      0x1c62190c0610: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
    Shadow byte legend (one shadow byte represents 8 application bytes):
      Addressable:           00
      Partially addressable: 01 02 03 04 05 06 07
      Heap left redzone:       fa
      Freed heap region:       fd
      Stack left redzone:      f1
      Stack mid redzone:       f2
      Stack right redzone:     f3
      Stack after return:      f5
      Stack use after scope:   f8
      Global redzone:          f9
      Global init order:       f6
      Poisoned by user:        f7
      Container overflow:      fc
      Array cookie:            ac
      Intra object redzone:    bb
      ASan internal:           fe
      Left alloca redzone:     ca
      Right alloca redzone:    cb
    ==3627871==ABORTING
    ================================================================================