### PR TITLE
rbi/stdlib/coverage: Add `eval` as a kwarg to `Coverage.start`

### DIFF
--- a/rbi/stdlib/coverage.rbi
+++ b/rbi/stdlib/coverage.rbi
@@ -81,9 +81,10 @@ module Coverage
         lines: T::Boolean,
         branches: T::Boolean,
         methods: T::Boolean,
+        eval: T::Boolean,
         oneshot_lines: T::Boolean
     )
     .returns(NilClass)
   end
-  def self.start(all = T.unsafe(nil), lines: T.unsafe(nil), branches: T.unsafe(nil), methods: T.unsafe(nil), oneshot_lines: T.unsafe(nil)); end
+  def self.start(all = T.unsafe(nil), lines: T.unsafe(nil), branches: T.unsafe(nil), methods: T.unsafe(nil), eval: T.unsafe(nil), oneshot_lines: T.unsafe(nil)); end
 end


### PR DESCRIPTION
### Motivation

- Add `eval` as a keyword argument to the `Coverage.start` method as it's documented at https://docs.ruby-lang.org/en/master/Coverage.html#method-c-start.
- Before this change trying to typecheck a file which used `Coverage.start` with `eval: true` raised a Sorbet error that eval was not a valid kwarg.


### Test plan

See included automated tests.
