### PR TITLE
avoid using the file source during CFG construction, redux

### DIFF
--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -52,7 +52,7 @@ public:
                                     core::LocOffsets funLoc, ExpressionPtr blk, Send::Flags flags = {}) {
         Send::ARGS_store nargs;
         if (blk != nullptr) {
-            flags.hasBlock = Send::BlockType::Present;
+            flags.blockType = Send::BlockType::Present;
             nargs.emplace_back(std::move(blk));
         }
         return Send(loc, std::move(recv), fun, funLoc, 0, std::move(nargs), flags);

--- a/ast/Helpers.h
+++ b/ast/Helpers.h
@@ -52,7 +52,7 @@ public:
                                     core::LocOffsets funLoc, ExpressionPtr blk, Send::Flags flags = {}) {
         Send::ARGS_store nargs;
         if (blk != nullptr) {
-            flags.hasBlock = true;
+            flags.hasBlock = Send::BlockType::Present;
             nargs.emplace_back(std::move(blk));
         }
         return Send(loc, std::move(recv), fun, funLoc, 0, std::move(nargs), flags);

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1127,7 +1127,7 @@ ExpressionPtr *Send::kwSplat() {
 
 void Send::clearArgs() {
     this->args.clear();
-    this->flags.hasBlock = BlockType::None;
+    this->flags.blockType = BlockType::None;
     this->numPosArgs_ = 0;
 }
 
@@ -1145,12 +1145,12 @@ void Send::insertPosArg(uint16_t index, ExpressionPtr arg) {
 void Send::setBlock(ExpressionPtr block, BlockType type) {
     if (hasBlock()) {
         this->args.pop_back();
-        flags.hasBlock = BlockType::None;
+        flags.blockType = BlockType::None;
     }
 
     if (block != nullptr) {
         this->args.emplace_back(move(block));
-        flags.hasBlock = type;
+        flags.blockType = type;
         ENFORCE(this->block() != nullptr);
     }
 }
@@ -1160,7 +1160,7 @@ ExpressionPtr Send::withNewBody(core::LocOffsets loc, ExpressionPtr recv, core::
 
     // Reset important metadata on this function.
     this->numPosArgs_ = 0;
-    this->flags.hasBlock = BlockType::None;
+    this->flags.blockType = BlockType::None;
 
     return rv;
 }

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -1127,7 +1127,7 @@ ExpressionPtr *Send::kwSplat() {
 
 void Send::clearArgs() {
     this->args.clear();
-    this->flags.hasBlock = false;
+    this->flags.hasBlock = BlockType::None;
     this->numPosArgs_ = 0;
 }
 
@@ -1142,15 +1142,15 @@ void Send::insertPosArg(uint16_t index, ExpressionPtr arg) {
     this->numPosArgs_++;
 }
 
-void Send::setBlock(ExpressionPtr block) {
+void Send::setBlock(ExpressionPtr block, BlockType type) {
     if (hasBlock()) {
         this->args.pop_back();
-        flags.hasBlock = false;
+        flags.hasBlock = BlockType::None;
     }
 
     if (block != nullptr) {
         this->args.emplace_back(move(block));
-        flags.hasBlock = true;
+        flags.hasBlock = type;
         ENFORCE(this->block() != nullptr);
     }
 }
@@ -1160,7 +1160,7 @@ ExpressionPtr Send::withNewBody(core::LocOffsets loc, ExpressionPtr recv, core::
 
     // Reset important metadata on this function.
     this->numPosArgs_ = 0;
-    this->flags.hasBlock = false;
+    this->flags.hasBlock = BlockType::None;
 
     return rv;
 }

--- a/ast/Trees.cc
+++ b/ast/Trees.cc
@@ -472,6 +472,20 @@ void printArgs(const core::GlobalState &gs, fmt::memory_buffer &buf, absl::Span<
     fmt::format_to(std::back_inserter(buf), ")");
 }
 
+// The name used for a block type in the `flags` list of a raw `Send`. Blocks without a known syntax aren't named at
+// all, as the `block` field already shows whether a block is present.
+string_view showBlockType(Send::BlockType type) {
+    switch (type) {
+        case Send::BlockType::None:
+        case Send::BlockType::Present:
+            return ""sv;
+        case Send::BlockType::DoEnd:
+            return "doEndBlock"sv;
+        case Send::BlockType::Braces:
+            return "bracesBlock"sv;
+    }
+}
+
 } // namespace
 
 core::FoundClass::Kind ClassDef::kindToFoundClassKind(Kind kind) {
@@ -1002,6 +1016,9 @@ string Send::showRaw(const core::GlobalState &gs, int tabs) const {
     }
     if (this->flags.isRewriterSynthesized) {
         stringifiedFlags.emplace_back("rewriterSynthesized");
+    }
+    if (auto blockType = showBlockType(this->flags.blockType); !blockType.empty()) {
+        stringifiedFlags.emplace_back(blockType);
     }
 
     printTabs(buf, tabs + 1);
@@ -1766,6 +1783,9 @@ string Send::showRawWithLocs(const core::GlobalState &gs, core::FileRef file, in
     }
     if (this->flags.isRewriterSynthesized) {
         stringifiedFlags.emplace_back("rewriterSynthesized");
+    }
+    if (auto blockType = showBlockType(this->flags.blockType); !blockType.empty()) {
+        stringifiedFlags.emplace_back(blockType);
     }
 
     printTabs(buf, tabs + 1);

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -830,13 +830,22 @@ public:
     core::NameRef fun;
     const core::LocOffsets funLoc;
 
+    // Whether a block is present on the send, and if the style of the block argument is known (do/end vs braces). A
+    // value of `Present` is always valid here if it's not known if the block was defined with do/end or braces.
+    enum class BlockType : uint8_t {
+        None = 0,
+        Present = 1,
+        DoEnd = 2,
+        Braces = 3,
+    };
+
     struct Flags {
         // True if the receiver was self (either implicit like `foo()` or explicit like `self.foo()`)
         //   - Prior to Ruby 2.7, it was illegal to call a private method with an explicit receiver.
         //   - As of Ruby 2.7, it became legal to call private methods on self, e.g. `self.foo()`.
         bool isPrivateOk : 1 = false;
         bool isRewriterSynthesized : 1 = false;
-        bool hasBlock : 1 = false;
+        BlockType hasBlock : 2 = BlockType::None;
 
         Flags() {}
 
@@ -898,7 +907,7 @@ public:
     const ExpressionPtr *kwSplat() const;
     ExpressionPtr *kwSplat();
 
-    void setBlock(ExpressionPtr block);
+    void setBlock(ExpressionPtr block, BlockType type);
 
     std::string toStringWithTabs(const core::GlobalState &gs, int tabs = 0) const;
     std::string showRaw(const core::GlobalState &gs, int tabs = 0) const;
@@ -1005,7 +1014,7 @@ public:
 
     // True when this send contains a block argument.
     bool hasBlock() const {
-        return flags.hasBlock;
+        return flags.hasBlock != BlockType::None;
     }
 
     // True when this send contains at least 1 position argument.

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -839,6 +839,25 @@ public:
         Braces = 3,
     };
 
+    static void constexpr validateBlockTypeBits(BlockType b) {
+        // Unfortunately, we can't collapse these cases because the compiler isn't smart
+        // enough to see what the value of b is.
+        switch (b) {
+            case BlockType::None:
+                static_assert(int(BlockType::None) < (1 << 2), "BlockType must fit into two bits");
+                break;
+            case BlockType::Present:
+                static_assert(int(BlockType::Present) < (1 << 2), "BlockType must fit into two bits");
+                break;
+            case BlockType::DoEnd:
+                static_assert(int(BlockType::DoEnd) < (1 << 2), "BlockType must fit into two bits");
+                break;
+            case BlockType::Braces:
+                static_assert(int(BlockType::Braces) < (1 << 2), "BlockType must fit into two bits");
+                break;
+        }
+    }
+
     struct Flags {
         // True if the receiver was self (either implicit like `foo()` or explicit like `self.foo()`)
         //   - Prior to Ruby 2.7, it was illegal to call a private method with an explicit receiver.

--- a/ast/Trees.h
+++ b/ast/Trees.h
@@ -845,7 +845,7 @@ public:
         //   - As of Ruby 2.7, it became legal to call private methods on self, e.g. `self.foo()`.
         bool isPrivateOk : 1 = false;
         bool isRewriterSynthesized : 1 = false;
-        BlockType hasBlock : 2 = BlockType::None;
+        BlockType blockType : 2 = BlockType::None;
 
         Flags() {}
 
@@ -1014,7 +1014,7 @@ public:
 
     // True when this send contains a block argument.
     bool hasBlock() const {
-        return flags.hasBlock != BlockType::None;
+        return flags.blockType != BlockType::None;
     }
 
     // True when this send contains at least 1 position argument.

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -998,7 +998,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                             // E.g. `foo(*splat, &:to_s)`
 
                             auto desugaredBlockLiteral = symbol2Proc(dctx, move(blockPassArg));
-                            flags.hasBlock =
+                            flags.blockType =
                                 getBlockType(dctx.ctx, dctx.ctx.locAt(desugaredBlockLiteral.loc()));
                             sendargs.emplace_back(move(desugaredBlockLiteral));
 
@@ -1044,7 +1044,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                             // E.g. `a.map(:to_s)`
 
                             auto desugaredBlockLiteral = symbol2Proc(dctx, move(blockPassArg));
-                            flags.hasBlock =
+                            flags.blockType =
                                 getBlockType(dctx.ctx, dctx.ctx.locAt(desugaredBlockLiteral.loc()));
                             args.emplace_back(move(desugaredBlockLiteral));
 

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -191,6 +191,30 @@ void checkBlockRestParam(DesugarContext dctx, const MethodDef::PARAMS_store &arg
     }
 }
 
+namespace {
+
+// Determine what kind of block argument is defined by the given location.
+ast::Send::BlockType getBlockType(const core::GlobalState &gs, core::Loc blockLoc) {
+    if (!blockLoc.exists()) {
+        return ast::Send::BlockType::None;
+    }
+
+    auto blockEndPos = blockLoc.copyEndWithZeroLength();
+    auto endBraceLoc = blockEndPos.adjustLen(gs, -1, 1);
+    if (endBraceLoc.source(gs) == "}") {
+        return ast::Send::BlockType::Braces;
+    }
+
+    auto endKwLoc = blockEndPos.adjustLen(gs, -3, 3);
+    if (endKwLoc.source(gs) == "end") {
+        return ast::Send::BlockType::DoEnd;
+    }
+
+    return ast::Send::BlockType::Present;
+}
+
+} // namespace
+
 ExpressionPtr desugarBlock(DesugarContext dctx, parser::Block *block) {
     block->send->loc = block->send->loc.join(block->loc);
     auto recv = node2TreeImpl(dctx, block->send);
@@ -226,7 +250,8 @@ ExpressionPtr desugarBlock(DesugarContext dctx, parser::Block *block) {
                          dctx.enclosingMethodName, inBlock, dctx.inModule, dctx.preserveConcreteSyntax);
     auto desugaredBody = desugarBody(dctx1, block->loc, block->body, move(destructures));
 
-    send->setBlock(MK::Block(block->loc, move(desugaredBody), move(Params)));
+    send->setBlock(MK::Block(block->loc, move(desugaredBody), move(Params)),
+                   getBlockType(dctx.ctx, dctx.ctx.locAt(block->loc)));
     return res;
 }
 
@@ -973,8 +998,9 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                             // E.g. `foo(*splat, &:to_s)`
 
                             auto desugaredBlockLiteral = symbol2Proc(dctx, move(blockPassArg));
+                            flags.hasBlock =
+                                getBlockType(dctx.ctx, dctx.ctx.locAt(desugaredBlockLiteral.loc()));
                             sendargs.emplace_back(move(desugaredBlockLiteral));
-                            flags.hasBlock = true;
 
                             res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplat(), send->methodLoc, 4,
                                            move(sendargs), flags);
@@ -1018,8 +1044,9 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                             // E.g. `a.map(:to_s)`
 
                             auto desugaredBlockLiteral = symbol2Proc(dctx, move(blockPassArg));
+                            flags.hasBlock =
+                                getBlockType(dctx.ctx, dctx.ctx.locAt(desugaredBlockLiteral.loc()));
                             args.emplace_back(move(desugaredBlockLiteral));
-                            flags.hasBlock = true;
 
                             res =
                                 MK::Send(loc, move(rec), send->method, send->methodLoc, numPosArgs, move(args), flags);

--- a/ast/desugar/Desugar.cc
+++ b/ast/desugar/Desugar.cc
@@ -193,24 +193,16 @@ void checkBlockRestParam(DesugarContext dctx, const MethodDef::PARAMS_store &arg
 
 namespace {
 
-// Determine what kind of block argument is defined by the given location.
-ast::Send::BlockType getBlockType(const core::GlobalState &gs, core::Loc blockLoc) {
-    if (!blockLoc.exists()) {
-        return ast::Send::BlockType::None;
+// Translate the block syntax recorded by the parser to the representation used on `ast::Send`.
+ast::Send::BlockType blockStyleToType(parser::BlockStyle style) {
+    switch (style) {
+        case parser::BlockStyle::Present:
+            return ast::Send::BlockType::Present;
+        case parser::BlockStyle::DoEnd:
+            return ast::Send::BlockType::DoEnd;
+        case parser::BlockStyle::Braces:
+            return ast::Send::BlockType::Braces;
     }
-
-    auto blockEndPos = blockLoc.copyEndWithZeroLength();
-    auto endBraceLoc = blockEndPos.adjustLen(gs, -1, 1);
-    if (endBraceLoc.source(gs) == "}") {
-        return ast::Send::BlockType::Braces;
-    }
-
-    auto endKwLoc = blockEndPos.adjustLen(gs, -3, 3);
-    if (endKwLoc.source(gs) == "end") {
-        return ast::Send::BlockType::DoEnd;
-    }
-
-    return ast::Send::BlockType::Present;
 }
 
 } // namespace
@@ -250,8 +242,7 @@ ExpressionPtr desugarBlock(DesugarContext dctx, parser::Block *block) {
                          dctx.enclosingMethodName, inBlock, dctx.inModule, dctx.preserveConcreteSyntax);
     auto desugaredBody = desugarBody(dctx1, block->loc, block->body, move(destructures));
 
-    send->setBlock(MK::Block(block->loc, move(desugaredBody), move(Params)),
-                   getBlockType(dctx.ctx, dctx.ctx.locAt(block->loc)));
+    send->setBlock(MK::Block(block->loc, move(desugaredBody), move(Params)), blockStyleToType(block->style));
     return res;
 }
 
@@ -998,8 +989,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                             // E.g. `foo(*splat, &:to_s)`
 
                             auto desugaredBlockLiteral = symbol2Proc(dctx, move(blockPassArg));
-                            flags.blockType =
-                                getBlockType(dctx.ctx, dctx.ctx.locAt(desugaredBlockLiteral.loc()));
+                            flags.blockType = ast::Send::BlockType::Present;
                             sendargs.emplace_back(move(desugaredBlockLiteral));
 
                             res = MK::Send(loc, MK::Magic(loc), core::Names::callWithSplat(), send->methodLoc, 4,
@@ -1044,8 +1034,7 @@ ExpressionPtr node2TreeImplBody(DesugarContext dctx, parser::Node *what) {
                             // E.g. `a.map(:to_s)`
 
                             auto desugaredBlockLiteral = symbol2Proc(dctx, move(blockPassArg));
-                            flags.blockType =
-                                getBlockType(dctx.ctx, dctx.ctx.locAt(desugaredBlockLiteral.loc()));
+                            flags.blockType = ast::Send::BlockType::Present;
                             args.emplace_back(move(desugaredBlockLiteral));
 
                             res =

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -2642,7 +2642,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
 
                 ast::Send::Flags flags;
                 flags.isPrivateOk = true;
-                flags.hasBlock = ast::Send::BlockType::Present;
+                flags.blockType = ast::Send::BlockType::Present;
 
                 return MK::Send(location, move(receiver), methodName, location, posArgs, move(args), flags);
             }
@@ -4507,7 +4507,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
             if (block.hasLiteralBlock()) {
                 // Both block pass AND literal block: `foo(...) { "literal" }`
                 magicSendArgs.emplace_back(move(block.literalBlockExpr));
-                flags.hasBlock = ast::Send::BlockType::Present;
+                flags.blockType = ast::Send::BlockType::Present;
             }
 
             return MK::Send(sendWithBlockLoc, MK::Magic(blockPassLoc), core::Names::callWithSplatAndBlockPass(),
@@ -4517,7 +4517,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
         if (block.hasLiteralBlock()) {
             // Just a literal block, no block pass
             magicSendArgs.emplace_back(move(block.literalBlockExpr));
-            flags.hasBlock = ast::Send::BlockType::Present;
+            flags.blockType = ast::Send::BlockType::Present;
         }
 
         // Desugar any call with a splat and without a block pass argument.
@@ -4549,7 +4549,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
         if (block.hasLiteralBlock()) {
             // This supports the invalid case of having both a block pass AND a literal block
             magicSendArgs.emplace_back(move(block.literalBlockExpr));
-            flags.hasBlock = ast::Send::BlockType::Present;
+            flags.blockType = ast::Send::BlockType::Present;
         }
 
         for (auto *arg : prismArgs) {
@@ -4586,7 +4586,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
 
     if (block.hasLiteralBlock()) {
         sendArgs.emplace_back(move(block.literalBlockExpr));
-        flags.hasBlock = ast::Send::BlockType::Present;
+        flags.blockType = ast::Send::BlockType::Present;
     }
 
     return MK::Send(sendWithBlockLoc, move(receiver), methodName, messageLoc, numPosArgs, move(sendArgs), flags);

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -322,8 +322,7 @@ public:
 private:
     // Hide the constructor, in favour of named factory methods, so that we can add validation logic if needed.
     DesugaredBlockArgument(ast::ExpressionPtr literalBlockExpr, ast::ExpressionPtr blockPassExpr,
-                           core::LocOffsets blockPassLoc,
-                           ast::Send::BlockType blockType = ast::Send::BlockType::None)
+                           core::LocOffsets blockPassLoc, ast::Send::BlockType blockType = ast::Send::BlockType::None)
         : literalBlockExpr(move(literalBlockExpr)), blockPassExpr(move(blockPassExpr)), blockPassLoc(blockPassLoc),
           blockType(blockType) {}
 
@@ -4135,8 +4134,7 @@ Desugarer::DesugaredBlockArgument Desugarer::desugarBlock(pm_node_t *block, pm_a
         if (blockArgInArgs != nullptr) {
             auto blockPassResult = desugarBlockPassArgument(blockArgInArgs);
             if (blockPassResult.hasBlockPass()) {
-                return DesugaredBlockArgument::both(move(literalBlock), blockType,
-                                                    move(blockPassResult.blockPassExpr),
+                return DesugaredBlockArgument::both(move(literalBlock), blockType, move(blockPassResult.blockPassExpr),
                                                     blockPassResult.blockPassLoc);
             } else if (blockPassResult.hasLiteralBlock()) {
                 // Handle an error case like `a.map(&:foo) { "literal" }`

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -257,6 +257,8 @@ private:
 
     std::string_view sliceLocation(pm_location_t loc) const;
 
+    ast::Send::BlockType blockTypeOf(pm_location_t openingLoc) const;
+
     std::pair<core::NameRef, core::LocOffsets> translateSymbol(pm_symbol_node *symbol);
 
     // String interpolation desugaring
@@ -314,11 +316,16 @@ public:
     // or a zero-length loc for forwarding like `...`
     core::LocOffsets blockPassLoc;
 
+    // The syntax used to write the literal block, if there is one.
+    ast::Send::BlockType blockType;
+
 private:
     // Hide the constructor, in favour of named factory methods, so that we can add validation logic if needed.
     DesugaredBlockArgument(ast::ExpressionPtr literalBlockExpr, ast::ExpressionPtr blockPassExpr,
-                           core::LocOffsets blockPassLoc)
-        : literalBlockExpr(move(literalBlockExpr)), blockPassExpr(move(blockPassExpr)), blockPassLoc(blockPassLoc) {}
+                           core::LocOffsets blockPassLoc,
+                           ast::Send::BlockType blockType = ast::Send::BlockType::None)
+        : literalBlockExpr(move(literalBlockExpr)), blockPassExpr(move(blockPassExpr)), blockPassLoc(blockPassLoc),
+          blockType(blockType) {}
 
 public:
     // Move-only type
@@ -335,13 +342,13 @@ public:
         return DesugaredBlockArgument(nullptr, move(blockPassExpr), blockPassLoc);
     }
 
-    static DesugaredBlockArgument literalBlock(ast::ExpressionPtr block) {
-        return DesugaredBlockArgument(move(block), nullptr, core::LocOffsets::none());
+    static DesugaredBlockArgument literalBlock(ast::ExpressionPtr block, ast::Send::BlockType blockType) {
+        return DesugaredBlockArgument(move(block), nullptr, core::LocOffsets::none(), blockType);
     }
 
-    static DesugaredBlockArgument both(ast::ExpressionPtr block, ast::ExpressionPtr blockPassExpr,
-                                       core::LocOffsets blockPassLoc) {
-        return DesugaredBlockArgument(move(block), move(blockPassExpr), blockPassLoc);
+    static DesugaredBlockArgument both(ast::ExpressionPtr block, ast::Send::BlockType blockType,
+                                       ast::ExpressionPtr blockPassExpr, core::LocOffsets blockPassLoc) {
+        return DesugaredBlockArgument(move(block), move(blockPassExpr), blockPassLoc, blockType);
     }
 
     bool exists() const {
@@ -2642,7 +2649,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
 
                 ast::Send::Flags flags;
                 flags.isPrivateOk = true;
-                flags.blockType = ast::Send::BlockType::Present;
+                flags.blockType = blockTypeOf(blockNode->opening_loc);
 
                 return MK::Send(location, move(receiver), methodName, location, posArgs, move(args), flags);
             }
@@ -2928,7 +2935,8 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             auto receiver = MK::Constant(operatorLoc, core::Symbols::Kernel());
             pm_arguments_node *args = nullptr;
             auto block = DesugaredBlockArgument::literalBlock(
-                desugarLiteralBlock(lambdaNode->body, lambdaNode->parameters, blockLoc, lambdaNode->operator_loc));
+                desugarLiteralBlock(lambdaNode->body, lambdaNode->parameters, blockLoc, lambdaNode->operator_loc),
+                blockTypeOf(lambdaNode->opening_loc));
             auto isPrivateOk = false; // `Kernel.lambda` is not a private call
             return desugarMethodCall(move(receiver), core::Names::lambda(), operatorLoc, args, lambdaNode->closing_loc,
                                      move(block), location, isPrivateOk);
@@ -4120,13 +4128,15 @@ Desugarer::DesugaredBlockArgument Desugarer::desugarBlock(pm_node_t *block, pm_a
     if (auto *blockNode = down_cast<pm_block_node>(block)) { // a literal block with `{ ... }` or `do ... end`
         auto literalBlock = desugarLiteralBlock(blockNode->body, blockNode->parameters, blockNode->base.location,
                                                 blockNode->opening_loc);
+        auto blockType = blockTypeOf(blockNode->opening_loc);
 
         // Handle combination of block pass argument AND a literal block.
         // e.g., `foo(&block) { "literal" }` - both need to be kept.
         if (blockArgInArgs != nullptr) {
             auto blockPassResult = desugarBlockPassArgument(blockArgInArgs);
             if (blockPassResult.hasBlockPass()) {
-                return DesugaredBlockArgument::both(move(literalBlock), move(blockPassResult.blockPassExpr),
+                return DesugaredBlockArgument::both(move(literalBlock), blockType,
+                                                    move(blockPassResult.blockPassExpr),
                                                     blockPassResult.blockPassLoc);
             } else if (blockPassResult.hasLiteralBlock()) {
                 // Handle an error case like `a.map(&:foo) { "literal" }`
@@ -4134,7 +4144,7 @@ Desugarer::DesugaredBlockArgument Desugarer::desugarBlock(pm_node_t *block, pm_a
                 // We keep both, moving the Symbol proc to the literal block position.
                 auto symbolProc = move(blockPassResult.literalBlockExpr);
                 auto symbolProcLoc = symbolProc.loc();
-                return DesugaredBlockArgument::both(move(literalBlock), move(symbolProc), symbolProcLoc);
+                return DesugaredBlockArgument::both(move(literalBlock), blockType, move(symbolProc), symbolProcLoc);
             } else {
                 unreachable("Expected either a block pass or a literal block, but got neither");
             }
@@ -4146,11 +4156,11 @@ Desugarer::DesugaredBlockArgument Desugarer::desugarBlock(pm_node_t *block, pm_a
             // The local variable uses the full call location, but the Magic node uses zero-length at END
             auto fullLoc = translateLoc(parentLoc);
             auto magicLoc = fullLoc.copyEndWithZeroLength();
-            return DesugaredBlockArgument::both(move(literalBlock), MK::Local(fullLoc, core::Names::fwdBlock()),
-                                                magicLoc);
+            return DesugaredBlockArgument::both(move(literalBlock), blockType,
+                                                MK::Local(fullLoc, core::Names::fwdBlock()), magicLoc);
         }
 
-        return DesugaredBlockArgument::literalBlock(move(literalBlock));
+        return DesugaredBlockArgument::literalBlock(move(literalBlock), blockType);
 
     } else if (auto *bp = down_cast<pm_block_argument_node>(block)) { // the `&b` in `a.map(&b)`
         return desugarBlockPassArgument(bp);
@@ -4248,8 +4258,9 @@ Desugarer::DesugaredBlockArgument Desugarer::desugarBlockPassArgument(pm_block_a
 
     if (bp->expression) { // Block pass with an explicit expression, like `f(&block)`
         if (auto *symbol = down_cast<pm_symbol_node>(bp->expression)) {
-            // Symbol proc, e.g. `&:foo` - desugar to a literal block
-            return DesugaredBlockArgument::literalBlock(desugarSymbolProc(symbol));
+            // Symbol proc, e.g. `&:foo` - desugar to a literal block.
+            // There's no block syntax in the source to record for these.
+            return DesugaredBlockArgument::literalBlock(desugarSymbolProc(symbol), ast::Send::BlockType::Present);
         } else {
             return DesugaredBlockArgument::blockPass(desugar(bp->expression), blockPassLoc);
         }
@@ -4507,7 +4518,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
             if (block.hasLiteralBlock()) {
                 // Both block pass AND literal block: `foo(...) { "literal" }`
                 magicSendArgs.emplace_back(move(block.literalBlockExpr));
-                flags.blockType = ast::Send::BlockType::Present;
+                flags.blockType = block.blockType;
             }
 
             return MK::Send(sendWithBlockLoc, MK::Magic(blockPassLoc), core::Names::callWithSplatAndBlockPass(),
@@ -4517,7 +4528,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
         if (block.hasLiteralBlock()) {
             // Just a literal block, no block pass
             magicSendArgs.emplace_back(move(block.literalBlockExpr));
-            flags.blockType = ast::Send::BlockType::Present;
+            flags.blockType = block.blockType;
         }
 
         // Desugar any call with a splat and without a block pass argument.
@@ -4549,7 +4560,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
         if (block.hasLiteralBlock()) {
             // This supports the invalid case of having both a block pass AND a literal block
             magicSendArgs.emplace_back(move(block.literalBlockExpr));
-            flags.blockType = ast::Send::BlockType::Present;
+            flags.blockType = block.blockType;
         }
 
         for (auto *arg : prismArgs) {
@@ -4586,7 +4597,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
 
     if (block.hasLiteralBlock()) {
         sendArgs.emplace_back(move(block.literalBlockExpr));
-        flags.blockType = ast::Send::BlockType::Present;
+        flags.blockType = block.blockType;
     }
 
     return MK::Send(sendWithBlockLoc, move(receiver), methodName, messageLoc, numPosArgs, move(sendArgs), flags);
@@ -5336,6 +5347,22 @@ ast::ExpressionPtr Desugarer::desugarRegexp(core::LocOffsets location, core::Loc
 
 string_view Desugarer::sliceLocation(pm_location_t loc) const {
     return cast_prism_string(loc.start, loc.end - loc.start);
+}
+
+// Determine the syntax that was used to write a block, based on the token that opens it.
+//
+// Synthesized blocks (like the ones the RBS rewriters create) have a zero-width opening loc, and so they're only known
+// to be `Present`.
+ast::Send::BlockType Desugarer::blockTypeOf(pm_location_t openingLoc) const {
+    auto opening = sliceLocation(openingLoc);
+
+    if (opening == "{"sv) {
+        return ast::Send::BlockType::Braces;
+    } else if (opening == "do"sv) {
+        return ast::Send::BlockType::DoEnd;
+    } else {
+        return ast::Send::BlockType::Present;
+    }
 }
 
 // Handle invalid or missing constant paths in class/module declarations.

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -257,7 +257,7 @@ private:
 
     std::string_view sliceLocation(pm_location_t loc) const;
 
-    ast::Send::BlockType blockTypeOf(pm_location_t openingLoc) const;
+    ast::Send::BlockType blockTypeOf(pm_location_t loc) const;
 
     std::pair<core::NameRef, core::LocOffsets> translateSymbol(pm_symbol_node *symbol);
 
@@ -2648,7 +2648,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
 
                 ast::Send::Flags flags;
                 flags.isPrivateOk = true;
-                flags.blockType = blockTypeOf(blockNode->opening_loc);
+                flags.blockType = blockTypeOf(blockNode->closing_loc);
 
                 return MK::Send(location, move(receiver), methodName, location, posArgs, move(args), flags);
             }
@@ -2935,7 +2935,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
             pm_arguments_node *args = nullptr;
             auto block = DesugaredBlockArgument::literalBlock(
                 desugarLiteralBlock(lambdaNode->body, lambdaNode->parameters, blockLoc, lambdaNode->operator_loc),
-                blockTypeOf(lambdaNode->opening_loc));
+                blockTypeOf(lambdaNode->closing_loc));
             auto isPrivateOk = false; // `Kernel.lambda` is not a private call
             return desugarMethodCall(move(receiver), core::Names::lambda(), operatorLoc, args, lambdaNode->closing_loc,
                                      move(block), location, isPrivateOk);
@@ -4127,7 +4127,7 @@ Desugarer::DesugaredBlockArgument Desugarer::desugarBlock(pm_node_t *block, pm_a
     if (auto *blockNode = down_cast<pm_block_node>(block)) { // a literal block with `{ ... }` or `do ... end`
         auto literalBlock = desugarLiteralBlock(blockNode->body, blockNode->parameters, blockNode->base.location,
                                                 blockNode->opening_loc);
-        auto blockType = blockTypeOf(blockNode->opening_loc);
+        auto blockType = blockTypeOf(blockNode->closing_loc);
 
         // Handle combination of block pass argument AND a literal block.
         // e.g., `foo(&block) { "literal" }` - both need to be kept.
@@ -5347,16 +5347,16 @@ string_view Desugarer::sliceLocation(pm_location_t loc) const {
     return cast_prism_string(loc.start, loc.end - loc.start);
 }
 
-// Determine the syntax that was used to write a block, based on the token that opens it.
+// Determine the syntax that was used to write a block, based on the token that closes it.
 //
-// Synthesized blocks (like the ones the RBS rewriters create) have a zero-width opening loc, and so they're only known
+// Synthesized blocks (like the ones the RBS rewriters create) have a zero-width closing loc, and so they're only known
 // to be `Present`.
-ast::Send::BlockType Desugarer::blockTypeOf(pm_location_t openingLoc) const {
-    auto opening = sliceLocation(openingLoc);
+ast::Send::BlockType Desugarer::blockTypeOf(pm_location_t loc) const {
+    auto token = sliceLocation(loc);
 
-    if (opening == "{"sv) {
+    if (token == "}"sv) {
         return ast::Send::BlockType::Braces;
-    } else if (opening == "do"sv) {
+    } else if (token == "end"sv) {
         return ast::Send::BlockType::DoEnd;
     } else {
         return ast::Send::BlockType::Present;

--- a/ast/desugar/prism/Desugar.cc
+++ b/ast/desugar/prism/Desugar.cc
@@ -2642,7 +2642,7 @@ ast::ExpressionPtr Desugarer::desugar(pm_node_t *node) {
 
                 ast::Send::Flags flags;
                 flags.isPrivateOk = true;
-                flags.hasBlock = true;
+                flags.hasBlock = ast::Send::BlockType::Present;
 
                 return MK::Send(location, move(receiver), methodName, location, posArgs, move(args), flags);
             }
@@ -4507,7 +4507,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
             if (block.hasLiteralBlock()) {
                 // Both block pass AND literal block: `foo(...) { "literal" }`
                 magicSendArgs.emplace_back(move(block.literalBlockExpr));
-                flags.hasBlock = true;
+                flags.hasBlock = ast::Send::BlockType::Present;
             }
 
             return MK::Send(sendWithBlockLoc, MK::Magic(blockPassLoc), core::Names::callWithSplatAndBlockPass(),
@@ -4517,7 +4517,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
         if (block.hasLiteralBlock()) {
             // Just a literal block, no block pass
             magicSendArgs.emplace_back(move(block.literalBlockExpr));
-            flags.hasBlock = true;
+            flags.hasBlock = ast::Send::BlockType::Present;
         }
 
         // Desugar any call with a splat and without a block pass argument.
@@ -4549,7 +4549,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
         if (block.hasLiteralBlock()) {
             // This supports the invalid case of having both a block pass AND a literal block
             magicSendArgs.emplace_back(move(block.literalBlockExpr));
-            flags.hasBlock = true;
+            flags.hasBlock = ast::Send::BlockType::Present;
         }
 
         for (auto *arg : prismArgs) {
@@ -4586,7 +4586,7 @@ ast::ExpressionPtr Desugarer::desugarMethodCall(ast::ExpressionPtr receiver, cor
 
     if (block.hasLiteralBlock()) {
         sendArgs.emplace_back(move(block.literalBlockExpr));
-        flags.hasBlock = true;
+        flags.hasBlock = ast::Send::BlockType::Present;
     }
 
     return MK::Send(sendWithBlockLoc, move(receiver), methodName, messageLoc, numPosArgs, move(sendArgs), flags);

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -813,9 +813,9 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::ExpressionPtr &what, Ba
                         if (blockLast->exprs.empty() || isa_instruction<LoadSelf>(blockLast->exprs.back().value) ||
                             isa_instruction<YieldLoadArg>(blockLast->exprs.back().value)) {
                             auto blockEndPos = blockReturnLoc.copyEndWithZeroLength();
-                            if (s.flags.hasBlock == ast::Send::BlockType::DoEnd) {
+                            if (s.flags.blockType == ast::Send::BlockType::DoEnd) {
                                 blockReturnLoc = cctx.ctx.locAt(blockEndPos).adjustLen(cctx.ctx, -3, 3).offsets();
-                            } else if (s.flags.hasBlock == ast::Send::BlockType::Braces) {
+                            } else if (s.flags.blockType == ast::Send::BlockType::Braces) {
                                 blockReturnLoc = cctx.ctx.locAt(blockEndPos).adjustLen(cctx.ctx, -1, 1).offsets();
                             }
                         } else {

--- a/cfg/builder/builder_walk.cc
+++ b/cfg/builder/builder_walk.cc
@@ -813,12 +813,10 @@ BasicBlock *CFGBuilder::walk(CFGContext cctx, const ast::ExpressionPtr &what, Ba
                         if (blockLast->exprs.empty() || isa_instruction<LoadSelf>(blockLast->exprs.back().value) ||
                             isa_instruction<YieldLoadArg>(blockLast->exprs.back().value)) {
                             auto blockEndPos = blockReturnLoc.copyEndWithZeroLength();
-                            auto endKwLoc = cctx.ctx.locAt(blockEndPos).adjustLen(cctx.ctx, -3, 3);
-                            auto endBraceLoc = cctx.ctx.locAt(blockEndPos).adjustLen(cctx.ctx, -1, 1);
-                            if (endKwLoc.source(cctx.ctx) == "end") {
-                                blockReturnLoc = endKwLoc.offsets();
-                            } else if (endBraceLoc.source(cctx.ctx) == "}") {
-                                blockReturnLoc = endBraceLoc.offsets();
+                            if (s.flags.hasBlock == ast::Send::BlockType::DoEnd) {
+                                blockReturnLoc = cctx.ctx.locAt(blockEndPos).adjustLen(cctx.ctx, -3, 3).offsets();
+                            } else if (s.flags.hasBlock == ast::Send::BlockType::Braces) {
+                                blockReturnLoc = cctx.ctx.locAt(blockEndPos).adjustLen(cctx.ctx, -1, 1).offsets();
                             }
                         } else {
                             blockReturnLoc = blockLast->exprs.back().loc;

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -234,6 +234,7 @@ class LocalNameInserter {
         ENFORCE(original.fun == core::Names::super() || original.fun == core::Names::untypedSuper());
 
         ast::ExpressionPtr originalBlock;
+        auto originalBlockType = original.flags.hasBlock;
         if (auto *rawBlock = original.rawBlock()) {
             originalBlock = move(*rawBlock);
         }
@@ -416,7 +417,7 @@ class LocalNameInserter {
                 newRecv = ast::MK::Magic(original.loc);
                 newFun = core::Names::callWithSplat();
                 // Re-add block argument
-                newFlags.hasBlock = true;
+                newFlags.hasBlock = originalBlockType;
                 newArgs.push_back(std::move(originalBlock));
             } else if (blockArg != nullptr) {
                 // <call-with-splat-and-block-pass>(..., &blk)
@@ -476,7 +477,7 @@ class LocalNameInserter {
             }
             // Re-add original block
             if (originalBlock) {
-                newFlags.hasBlock = true;
+                newFlags.hasBlock = originalBlockType;
                 newArgs.push_back(std::move(originalBlock));
             }
             kwArgKeyEntries.clear();

--- a/local_vars/local_vars.cc
+++ b/local_vars/local_vars.cc
@@ -234,7 +234,7 @@ class LocalNameInserter {
         ENFORCE(original.fun == core::Names::super() || original.fun == core::Names::untypedSuper());
 
         ast::ExpressionPtr originalBlock;
-        auto originalBlockType = original.flags.hasBlock;
+        auto originalBlockType = original.flags.blockType;
         if (auto *rawBlock = original.rawBlock()) {
             originalBlock = move(*rawBlock);
         }
@@ -417,7 +417,7 @@ class LocalNameInserter {
                 newRecv = ast::MK::Magic(original.loc);
                 newFun = core::Names::callWithSplat();
                 // Re-add block argument
-                newFlags.hasBlock = originalBlockType;
+                newFlags.blockType = originalBlockType;
                 newArgs.push_back(std::move(originalBlock));
             } else if (blockArg != nullptr) {
                 // <call-with-splat-and-block-pass>(..., &blk)
@@ -477,7 +477,7 @@ class LocalNameInserter {
             }
             // Re-add original block
             if (originalBlock) {
-                newFlags.hasBlock = originalBlockType;
+                newFlags.blockType = originalBlockType;
                 newArgs.push_back(std::move(originalBlock));
             }
             kwArgKeyEntries.clear();

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -592,6 +592,7 @@ public:
         auto blockLoc = tokLoc(begin).join(tokLoc(end));
 
         auto style = BlockStyle::Present;
+        ENFORCE(end != nullptr);
         if (end != nullptr) {
             style = end->type() == ruby_parser::token_type::tRCURLY ? BlockStyle::Braces : BlockStyle::DoEnd;
         }

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -590,10 +590,16 @@ public:
         }
 
         auto blockLoc = tokLoc(begin).join(tokLoc(end));
+
+        auto style = BlockStyle::Present;
+        if (end != nullptr) {
+            style = end->type() == ruby_parser::token_type::tRCURLY ? BlockStyle::Braces : BlockStyle::DoEnd;
+        }
+
         Node &n = *methodCall;
         const type_info &ty = typeid(n);
         if (ty == typeid(Send) || ty == typeid(CSend) || ty == typeid(Super) || ty == typeid(ZSuper)) {
-            return make_unique<Block>(blockLoc, std::move(methodCall), std::move(args), std::move(body));
+            return make_unique<Block>(blockLoc, std::move(methodCall), std::move(args), std::move(body), style);
         }
 
         sorbet::parser::NodeVec *exprs;
@@ -607,7 +613,8 @@ public:
             [&](Node *n) { Exception::raise("Unexpected send node: {}", n->nodeName()); });
 
         auto &send = exprs->front();
-        unique_ptr<Node> block = make_unique<Block>(blockLoc, std::move(send), std::move(args), std::move(body));
+        unique_ptr<Node> block =
+            make_unique<Block>(blockLoc, std::move(send), std::move(args), std::move(body), style);
         exprs->front().swap(block);
         return methodCall;
     }

--- a/parser/Builder.cc
+++ b/parser/Builder.cc
@@ -613,8 +613,7 @@ public:
             [&](Node *n) { Exception::raise("Unexpected send node: {}", n->nodeName()); });
 
         auto &send = exprs->front();
-        unique_ptr<Node> block =
-            make_unique<Block>(blockLoc, std::move(send), std::move(args), std::move(body), style);
+        unique_ptr<Node> block = make_unique<Block>(blockLoc, std::move(send), std::move(args), std::move(body), style);
         exprs->front().swap(block);
         return methodCall;
     }

--- a/parser/Node.cc
+++ b/parser/Node.cc
@@ -9,6 +9,17 @@ using namespace std;
 
 namespace sorbet::parser {
 
+string_view showBlockStyle(BlockStyle style) {
+    switch (style) {
+        case BlockStyle::Present:
+            return "present";
+        case BlockStyle::DoEnd:
+            return "do-end";
+        case BlockStyle::Braces:
+            return "braces";
+    }
+}
+
 void Node::printTabs(fmt::memory_buffer &to, int count) const {
     int i = 0;
     while (i < count) {

--- a/parser/Node.h
+++ b/parser/Node.h
@@ -9,6 +9,18 @@
 
 namespace sorbet::parser {
 
+// The syntax used to write the block argument of a send, when it's known.
+//
+// A value of `Present` means that a block is present, but the syntax used to write it isn't known (usually because the
+// block was synthesized, rather than parsed from source).
+enum class BlockStyle : uint8_t {
+    Present = 0,
+    DoEnd = 1,
+    Braces = 2,
+};
+
+std::string_view showBlockStyle(BlockStyle style);
+
 class Node {
 public:
     Node(core::LocOffsets loc) : loc(loc) {

--- a/parser/NodeCopying.cc
+++ b/parser/NodeCopying.cc
@@ -48,7 +48,7 @@ std::unique_ptr<Node> deepCopy(const Node *node) {
         [&](const parser::Begin *begin) { result = std::make_unique<Begin>(begin->loc, deepCopyVec(begin->stmts)); },
         [&](const parser::Block *block) {
             result = std::make_unique<Block>(block->loc, deepCopy(block->send.get()), deepCopy(block->params.get()),
-                                             deepCopy(block->body.get()));
+                                             deepCopy(block->body.get()), block->style);
         },
         [&](const parser::BlockParam *blockParam) {
             result = std::make_unique<BlockParam>(blockParam->loc, blockParam->name);

--- a/parser/helper.h
+++ b/parser/helper.h
@@ -341,7 +341,7 @@ public:
     static std::unique_ptr<parser::Node> TTypeAlias(core::LocOffsets loc, std::unique_ptr<parser::Node> type) {
         auto send = Send0(loc, T(loc), core::Names::typeAlias(), loc);
         auto body = std::make_unique<parser::Begin>(loc, parser::NodeVec1(move(type)));
-        return std::make_unique<parser::Block>(loc, move(send), nullptr, move(body));
+        return std::make_unique<parser::Block>(loc, move(send), nullptr, move(body), parser::BlockStyle::Present);
     }
 
     /*

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -944,8 +944,8 @@ void emitNodeClassfile(ostream &out, NodeDef &node) {
                     << ");\n";
                 break;
             case FieldType::BlockStyle:
-                out << "    fmt::format_to(std::back_inserter(buf), \"" << arg.name
-                    << " = {}\\n\", showBlockStyle(" << arg.name << "));\n";
+                out << "    fmt::format_to(std::back_inserter(buf), \"" << arg.name << " = {}\\n\", showBlockStyle("
+                    << arg.name << "));\n";
                 break;
         }
     }

--- a/parser/tools/generate_ast.cc
+++ b/parser/tools/generate_ast.cc
@@ -14,6 +14,7 @@ enum class FieldType {
     Uint,
     Loc,
     Bool,
+    BlockStyle,
     Symbol,
 };
 
@@ -93,7 +94,10 @@ NodeDef nodes[] = {
     {
         "Block",
         "block",
-        vector<FieldDef>({{"send", FieldType::Node}, {"params", FieldType::Node}, {"body", FieldType::Node}}),
+        vector<FieldDef>({{"send", FieldType::Node},
+                          {"params", FieldType::Node},
+                          {"body", FieldType::Node},
+                          {"style", FieldType::BlockStyle}}),
     },
     // Wraps a `&foo` parameter in a parameter list
     {
@@ -815,6 +819,8 @@ string constructorArgType(FieldType arg) {
             return "core::LocOffsets";
         case FieldType::Bool:
             return "bool";
+        case FieldType::BlockStyle:
+            return "BlockStyle";
     }
 }
 
@@ -836,6 +842,8 @@ string fieldType(FieldType arg) {
             return "core::LocOffsets";
         case FieldType::Bool:
             return "bool";
+        case FieldType::BlockStyle:
+            return "BlockStyle";
     }
 }
 
@@ -935,6 +943,10 @@ void emitNodeClassfile(ostream &out, NodeDef &node) {
                 out << "    fmt::format_to(std::back_inserter(buf), \"" << arg.name << " = {}\\n\", " << arg.name
                     << ");\n";
                 break;
+            case FieldType::BlockStyle:
+                out << "    fmt::format_to(std::back_inserter(buf), \"" << arg.name
+                    << " = {}\\n\", showBlockStyle(" << arg.name << "));\n";
+                break;
         }
     }
     out << "    printTabs(buf, tabs);\n";
@@ -1014,6 +1026,10 @@ void emitNodeClassfile(ostream &out, NodeDef &node) {
             case FieldType::Bool:
                 out << "    fmt::format_to(std::back_inserter(buf), \"" << arg.name << " = {}\\n\", " << arg.name
                     << ");\n";
+                break;
+            case FieldType::BlockStyle:
+                out << R"(    fmt::format_to(std::back_inserter(buf),  "\")" << arg.name << R"(\" : \"{}\")"
+                    << maybeComma << "\\n\", showBlockStyle(" << arg.name << "));\n";
                 break;
         }
     }
@@ -1098,6 +1114,10 @@ void emitNodeClassfile(ostream &out, NodeDef &node) {
                 out << R"(    fmt::format_to(std::back_inserter(buf),  "\")" << arg.name << R"(\" : \"{}\")"
                     << maybeComma << "\\n\", " << arg.name << ");\n";
                 break;
+            case FieldType::BlockStyle:
+                out << R"(    fmt::format_to(std::back_inserter(buf),  "\")" << arg.name << R"(\" : \"{}\")"
+                    << maybeComma << "\\n\", showBlockStyle(" << arg.name << "));\n";
+                break;
         }
     }
     out << "    printTabs(buf, tabs);" << '\n';
@@ -1157,6 +1177,9 @@ void emitNodeClassfile(ostream &out, NodeDef &node) {
             case FieldType::Loc:
                 continue;
             case FieldType::Bool:
+                continue;
+            case FieldType::BlockStyle:
+                // The whitequark format has no notion of the syntax used to write a block.
                 continue;
         }
     }

--- a/resolver/resolver.cc
+++ b/resolver/resolver.cc
@@ -1830,7 +1830,7 @@ public:
                     // resolution that won't match our expected invariants (and in fact will fail our sanity checks)
                     // auto temporaryUntyped = ast::MK::Untyped(asgn->lhs.get()->loc);
                     auto temporaryUntyped = ast::MK::Block0(asgn.lhs.loc(), ast::MK::Untyped(asgn.lhs.loc()));
-                    send->setBlock(std::move(temporaryUntyped));
+                    send->setBlock(std::move(temporaryUntyped), ast::Send::BlockType::Present);
 
                     // because we're synthesizing a fake "untyped" here and actually adding it to the AST, we won't
                     // report an arity mismatch for `T.untyped` in the future, so report the arity mismatch now

--- a/test/prism_regression/call_all_args.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_all_args.rb.desugar-tree-raw.exp
@@ -144,7 +144,7 @@ ClassDef{
     }
 
     Send{
-      flags = {}
+      flags = {bracesBlock}
       recv = ConstantLit{
         symbol = (class ::<Magic>)
         orig = nullptr
@@ -308,7 +308,7 @@ ClassDef{
     }
 
     Send{
-      flags = {}
+      flags = {doEndBlock}
       recv = ConstantLit{
         symbol = (class ::<Magic>)
         orig = nullptr

--- a/test/prism_regression/call_args_and_block.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_args_and_block.rb.desugar-tree-raw.exp
@@ -8,7 +8,7 @@ ClassDef{
     }]
   rhs = [
     Send{
-      flags = {privateOk}
+      flags = {privateOk, bracesBlock}
       recv = Self
       fun = <U foo1>
       block = Block {
@@ -24,7 +24,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, doEndBlock}
       recv = Self
       fun = <U foo2>
       block = Block {
@@ -40,7 +40,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, doEndBlock}
       recv = Self
       fun = <U foo5>
       block = Block {

--- a/test/prism_regression/call_block_with_anonymous_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_block_with_anonymous_params.rb.desugar-tree-raw.exp
@@ -8,7 +8,7 @@ ClassDef{
     }]
   rhs = [
     Send{
-      flags = {privateOk}
+      flags = {privateOk, doEndBlock}
       recv = Self
       fun = <U foo>
       block = Block {

--- a/test/prism_regression/call_conditional.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_conditional.rb.desugar-tree-raw.exp
@@ -300,7 +300,7 @@ ClassDef{
           ]
         }
         elsep = Send{
-          flags = {}
+          flags = {bracesBlock}
           recv = UnresolvedIdent{
             kind = Local
             name = <D <U <assignTemp>> $6>

--- a/test/prism_regression/call_forwarding_permutations.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/call_forwarding_permutations.rb.desugar-tree-raw.exp
@@ -165,7 +165,7 @@ ClassDef{
           name = <U <blk>>
         } }]
       rhs = Send{
-        flags = {privateOk}
+        flags = {privateOk, bracesBlock}
         recv = Self
         fun = <U bar>
         block = Block {
@@ -193,7 +193,7 @@ ClassDef{
           name = <U <fwd-block>>
         } }]
       rhs = Send{
-        flags = {privateOk}
+        flags = {privateOk, bracesBlock}
         recv = ConstantLit{
           symbol = (class ::<Magic>)
           orig = nullptr
@@ -269,7 +269,7 @@ ClassDef{
           name = <U block>
         } }]
       rhs = Send{
-        flags = {privateOk}
+        flags = {privateOk, bracesBlock}
         recv = ConstantLit{
           symbol = (class ::<Magic>)
           orig = nullptr
@@ -300,7 +300,7 @@ ClassDef{
           name = <U &>
         } }]
       rhs = Send{
-        flags = {privateOk}
+        flags = {privateOk, bracesBlock}
         recv = ConstantLit{
           symbol = (class ::<Magic>)
           orig = nullptr

--- a/test/prism_regression/it_param_assignment.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/it_param_assignment.rb.desugar-tree-raw.exp
@@ -8,7 +8,7 @@ ClassDef{
     }]
   rhs = [
     Send{
-      flags = {}
+      flags = {bracesBlock}
       recv = Array{
         elems = [
           Literal{ value = 1 }

--- a/test/prism_regression/it_param_basic.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/it_param_basic.rb.desugar-tree-raw.exp
@@ -8,7 +8,7 @@ ClassDef{
     }]
   rhs = [
     Send{
-      flags = {}
+      flags = {bracesBlock}
       recv = Array{
         elems = [
           Literal{ value = 1 }

--- a/test/prism_regression/it_param_edge_cases.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/it_param_edge_cases.rb.desugar-tree-raw.exp
@@ -13,7 +13,7 @@ ClassDef{
         name = <U result1>
       }
       rhs = Send{
-        flags = {}
+        flags = {doEndBlock}
         recv = Array{
           elems = [
             Literal{ value = 1 }
@@ -55,7 +55,7 @@ ClassDef{
         name = <U result2>
       }
       rhs = Send{
-        flags = {}
+        flags = {bracesBlock}
         recv = Array{
           elems = [
             Literal{ value = 1 }
@@ -101,7 +101,7 @@ ClassDef{
         name = <U result3>
       }
       rhs = Send{
-        flags = {}
+        flags = {doEndBlock}
         recv = Array{
           elems = [
             Literal{ value = 1 }

--- a/test/prism_regression/it_param_lambda.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/it_param_lambda.rb.desugar-tree-raw.exp
@@ -8,7 +8,7 @@ ClassDef{
     }]
   rhs = [
     Send{
-      flags = {privateOk}
+      flags = {privateOk, bracesBlock}
       recv = Self
       fun = <U lambda>
       block = Block {

--- a/test/prism_regression/it_param_method_call.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/it_param_method_call.rb.desugar-tree-raw.exp
@@ -8,7 +8,7 @@ ClassDef{
     }]
   rhs = [
     Send{
-      flags = {}
+      flags = {bracesBlock}
       recv = Array{
         elems = [
           Literal{ value = "hello" }

--- a/test/prism_regression/it_param_method_precedence_inside.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/it_param_method_precedence_inside.rb.desugar-tree-raw.exp
@@ -23,7 +23,7 @@ ClassDef{
         name = <U result>
       }
       rhs = Send{
-        flags = {}
+        flags = {bracesBlock}
         recv = Array{
           elems = [
             Literal{ value = 1 }
@@ -60,7 +60,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, bracesBlock}
       recv = Self
       fun = <U tap>
       block = Block {
@@ -82,7 +82,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, bracesBlock}
       recv = Self
       fun = <U tap>
       block = Block {

--- a/test/prism_regression/it_param_nested.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/it_param_nested.rb.desugar-tree-raw.exp
@@ -8,7 +8,7 @@ ClassDef{
     }]
   rhs = [
     Send{
-      flags = {}
+      flags = {bracesBlock}
       recv = Array{
         elems = [
           Array{
@@ -34,7 +34,7 @@ ClassDef{
           }
         ]
         body = Send{
-          flags = {}
+          flags = {bracesBlock}
           recv = UnresolvedIdent{
             kind = Local
             name = <U it>

--- a/test/prism_regression/it_param_precedence.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/it_param_precedence.rb.desugar-tree-raw.exp
@@ -21,7 +21,7 @@ ClassDef{
         name = <U result>
       }
       rhs = Send{
-        flags = {}
+        flags = {bracesBlock}
         recv = Array{
           elems = [
             Literal{ value = 1 }

--- a/test/prism_regression/keyword_it.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/keyword_it.rb.desugar-tree-raw.exp
@@ -8,7 +8,7 @@ ClassDef{
     }]
   rhs = [
     Send{
-      flags = {}
+      flags = {doEndBlock}
       recv = UnresolvedConstantLit{
         cnst = <C <U Proc>>
         scope = EmptyTree
@@ -32,7 +32,7 @@ ClassDef{
     }
 
     Send{
-      flags = {}
+      flags = {doEndBlock}
       recv = UnresolvedConstantLit{
         cnst = <C <U Proc>>
         scope = EmptyTree

--- a/test/prism_regression/lambda.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/lambda.rb.desugar-tree-raw.exp
@@ -8,7 +8,7 @@ ClassDef{
     }]
   rhs = [
     Send{
-      flags = {}
+      flags = {bracesBlock}
       recv = ConstantLit{
         symbol = (module ::Kernel)
         orig = nullptr
@@ -25,7 +25,7 @@ ClassDef{
     }
 
     Send{
-      flags = {}
+      flags = {bracesBlock}
       recv = ConstantLit{
         symbol = (module ::Kernel)
         orig = nullptr
@@ -49,7 +49,7 @@ ClassDef{
     }
 
     Send{
-      flags = {}
+      flags = {bracesBlock}
       recv = ConstantLit{
         symbol = (module ::Kernel)
         orig = nullptr
@@ -76,7 +76,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, bracesBlock}
       recv = Self
       fun = <U lambda>
       block = Block {
@@ -90,7 +90,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, bracesBlock}
       recv = Self
       fun = <U lambda>
       block = Block {
@@ -119,7 +119,7 @@ ClassDef{
       args = [
         Literal{ value = :arg1 }
         Send{
-          flags = {}
+          flags = {bracesBlock}
           recv = ConstantLit{
             symbol = (module ::Kernel)
             orig = nullptr
@@ -138,7 +138,7 @@ ClassDef{
     }
 
     Send{
-      flags = {}
+      flags = {bracesBlock}
       recv = ConstantLit{
         symbol = (module ::Kernel)
         orig = nullptr
@@ -197,7 +197,7 @@ ClassDef{
               name = <U <blk>>
             } }]
           rhs = Send{
-            flags = {}
+            flags = {bracesBlock}
             recv = ConstantLit{
               symbol = (module ::Kernel)
               orig = nullptr
@@ -217,7 +217,7 @@ ClassDef{
     }
 
     Send{
-      flags = {}
+      flags = {bracesBlock}
       recv = ConstantLit{
         symbol = (module ::Kernel)
         orig = nullptr

--- a/test/prism_regression/multi_target.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/multi_target.rb.desugar-tree-raw.exp
@@ -648,7 +648,7 @@ ClassDef{
     }
 
     Send{
-      flags = {}
+      flags = {doEndBlock}
       recv = UnresolvedConstantLit{
         cnst = <C <U Proc>>
         scope = EmptyTree
@@ -2484,7 +2484,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, doEndBlock}
       recv = Self
       fun = <U block_empty>
       block = Block {
@@ -2586,7 +2586,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, doEndBlock}
       recv = Self
       fun = <U block_single>
       block = Block {
@@ -2696,7 +2696,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, doEndBlock}
       recv = Self
       fun = <U block_multi>
       block = Block {
@@ -2819,7 +2819,7 @@ ClassDef{
     }
 
     Send{
-      flags = {}
+      flags = {bracesBlock}
       recv = ConstantLit{
         symbol = (module ::Kernel)
         orig = nullptr
@@ -2924,7 +2924,7 @@ ClassDef{
     }
 
     Send{
-      flags = {}
+      flags = {bracesBlock}
       recv = ConstantLit{
         symbol = (module ::Kernel)
         orig = nullptr
@@ -3037,7 +3037,7 @@ ClassDef{
     }
 
     Send{
-      flags = {}
+      flags = {bracesBlock}
       recv = ConstantLit{
         symbol = (module ::Kernel)
         orig = nullptr

--- a/test/prism_regression/multiple_numbered_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/multiple_numbered_params.rb.desugar-tree-raw.exp
@@ -18,7 +18,7 @@ ClassDef{
           name = <U <blk>>
         } }]
       rhs = Send{
-        flags = {}
+        flags = {bracesBlock}
         recv = UnresolvedConstantLit{
           cnst = <C <U RATCHET>>
           scope = EmptyTree

--- a/test/prism_regression/numbered_params.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/numbered_params.rb.desugar-tree-raw.exp
@@ -8,7 +8,7 @@ ClassDef{
     }]
   rhs = [
     Send{
-      flags = {privateOk}
+      flags = {privateOk, bracesBlock}
       recv = Self
       fun = <U proc>
       block = Block {
@@ -45,7 +45,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, doEndBlock}
       recv = Self
       fun = <U proc>
       block = Block {
@@ -82,7 +82,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, bracesBlock}
       recv = Self
       fun = <U proc>
       block = Block {
@@ -135,7 +135,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, doEndBlock}
       recv = Self
       fun = <U proc>
       block = Block {
@@ -188,7 +188,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, bracesBlock}
       recv = Self
       fun = <U proc>
       block = Block {
@@ -225,7 +225,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, bracesBlock}
       recv = Self
       fun = <U proc>
       block = Block {

--- a/test/prism_regression/super.rb.desugar-tree-raw.exp
+++ b/test/prism_regression/super.rb.desugar-tree-raw.exp
@@ -60,7 +60,7 @@ ClassDef{
             ]
           }
           Send{
-            flags = {privateOk}
+            flags = {privateOk, doEndBlock}
             recv = Self
             fun = <U <super>>
             block = Block {
@@ -84,7 +84,7 @@ ClassDef{
             ]
           }
           Send{
-            flags = {privateOk}
+            flags = {privateOk, doEndBlock}
             recv = Self
             fun = <U <super>>
             block = Block {
@@ -111,7 +111,7 @@ ClassDef{
             ]
           }
           Send{
-            flags = {privateOk}
+            flags = {privateOk, doEndBlock}
             recv = Self
             fun = <U <super>>
             block = Block {
@@ -139,7 +139,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, doEndBlock}
           recv = Self
           fun = <U <super>>
           block = Block {

--- a/test/testdata/cfg/blocks.rb.parse-tree.exp
+++ b/test/testdata/cfg/blocks.rb.parse-tree.exp
@@ -36,6 +36,7 @@ Class {
       body = LVar {
         name = <U x>
       }
+      style = do-end
     }
   }
 }

--- a/test/testdata/desugar/numbered_parameters.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/numbered_parameters.rb.desugar-tree-raw.exp
@@ -18,7 +18,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, bracesBlock}
       recv = Self
       fun = <U foo>
       block = Block {
@@ -39,7 +39,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, bracesBlock}
       recv = Self
       fun = <U foo>
       block = Block {
@@ -92,7 +92,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, bracesBlock}
       recv = Self
       fun = <U foo>
       block = Block {
@@ -129,7 +129,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, doEndBlock}
       recv = Self
       fun = <U foo>
       block = Block {
@@ -150,7 +150,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, doEndBlock}
       recv = Self
       fun = <U foo>
       block = Block {
@@ -203,7 +203,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, doEndBlock}
       recv = Self
       fun = <U foo>
       block = Block {
@@ -240,7 +240,7 @@ ClassDef{
     }
 
     Send{
-      flags = {}
+      flags = {bracesBlock}
       recv = ConstantLit{
         symbol = (module ::Kernel)
         orig = nullptr
@@ -264,7 +264,7 @@ ClassDef{
     }
 
     Send{
-      flags = {}
+      flags = {bracesBlock}
       recv = ConstantLit{
         symbol = (module ::Kernel)
         orig = nullptr
@@ -320,7 +320,7 @@ ClassDef{
     }
 
     Send{
-      flags = {}
+      flags = {bracesBlock}
       recv = ConstantLit{
         symbol = (module ::Kernel)
         orig = nullptr
@@ -360,7 +360,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, doEndBlock}
       recv = Self
       fun = <U foo>
       block = Block {

--- a/test/testdata/desugar/opasgn_accessor.rb.desugar-tree-raw.exp
+++ b/test/testdata/desugar/opasgn_accessor.rb.desugar-tree-raw.exp
@@ -37,7 +37,7 @@ ClassDef{
         }
 
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {

--- a/test/testdata/infer/generics/bounds.rb.name-tree-raw.exp
+++ b/test/testdata/infer/generics/bounds.rb.name-tree-raw.exp
@@ -138,7 +138,7 @@ ClassDef{
             }
           }
           rhs = Send{
-            flags = {privateOk}
+            flags = {privateOk, bracesBlock}
             recv = Self
             fun = <U type_member>
             block = Block {
@@ -171,7 +171,7 @@ ClassDef{
             }
           }
           rhs = Send{
-            flags = {privateOk}
+            flags = {privateOk, bracesBlock}
             recv = Self
             fun = <U type_member>
             block = Block {
@@ -211,7 +211,7 @@ ClassDef{
             }
           }
           rhs = Send{
-            flags = {privateOk}
+            flags = {privateOk, bracesBlock}
             recv = Self
             fun = <U type_member>
             block = Block {
@@ -244,7 +244,7 @@ ClassDef{
             }
           }
           rhs = Send{
-            flags = {privateOk}
+            flags = {privateOk, bracesBlock}
             recv = Self
             fun = <U type_member>
             block = Block {
@@ -284,7 +284,7 @@ ClassDef{
             }
           }
           rhs = Send{
-            flags = {privateOk}
+            flags = {privateOk, bracesBlock}
             recv = Self
             fun = <U type_member>
             block = Block {
@@ -332,7 +332,7 @@ ClassDef{
             }
           }
           rhs = Send{
-            flags = {privateOk}
+            flags = {privateOk, bracesBlock}
             recv = Self
             fun = <U type_member>
             block = Block {
@@ -380,7 +380,7 @@ ClassDef{
             }
           }
           rhs = Send{
-            flags = {privateOk}
+            flags = {privateOk, bracesBlock}
             recv = Self
             fun = <U type_member>
             block = Block {
@@ -441,7 +441,7 @@ ClassDef{
             }
           }
           rhs = Send{
-            flags = {privateOk}
+            flags = {privateOk, bracesBlock}
             recv = Self
             fun = <U type_member>
             block = Block {
@@ -474,7 +474,7 @@ ClassDef{
             }
           }
           rhs = Send{
-            flags = {privateOk}
+            flags = {privateOk, bracesBlock}
             recv = Self
             fun = <U type_member>
             block = Block {
@@ -507,7 +507,7 @@ ClassDef{
             }
           }
           rhs = Send{
-            flags = {privateOk}
+            flags = {privateOk, bracesBlock}
             recv = Self
             fun = <U type_member>
             block = Block {
@@ -561,7 +561,7 @@ ClassDef{
             }
           }
           rhs = Send{
-            flags = {privateOk}
+            flags = {privateOk, bracesBlock}
             recv = Self
             fun = <U type_member>
             block = Block {
@@ -601,7 +601,7 @@ ClassDef{
             }
           }
           rhs = Send{
-            flags = {privateOk}
+            flags = {privateOk, bracesBlock}
             recv = Self
             fun = <U type_member>
             block = Block {
@@ -675,7 +675,7 @@ ClassDef{
             }
           }
           rhs = Send{
-            flags = {privateOk}
+            flags = {privateOk, bracesBlock}
             recv = Self
             fun = <U type_member>
             block = Block {
@@ -766,7 +766,7 @@ ClassDef{
             }
           }
           rhs = Send{
-            flags = {privateOk}
+            flags = {privateOk, bracesBlock}
             recv = Self
             fun = <U type_member>
             block = Block {
@@ -815,7 +815,7 @@ ClassDef{
         }]
       rhs = [
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {
@@ -911,7 +911,7 @@ ClassDef{
         }
 
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {

--- a/test/testdata/infer/yield_multiple.rb.desugar-tree-raw.exp
+++ b/test/testdata/infer/yield_multiple.rb.desugar-tree-raw.exp
@@ -25,7 +25,7 @@ ClassDef{
     }
 
     Send{
-      flags = {privateOk}
+      flags = {privateOk, doEndBlock}
       recv = Self
       fun = <U sig>
       block = Block {

--- a/test/testdata/local_vars/z_super_args.rb.index-tree-raw.exp
+++ b/test/testdata/local_vars/z_super_args.rb.index-tree-raw.exp
@@ -509,7 +509,7 @@ ClassDef{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
-            flags = {}
+            flags = {doEndBlock}
             recv = Literal{ value = 1 }
             fun = <U times>
             block = Block {

--- a/test/testdata/local_vars/z_super_args_splats_blocks.rb.index-tree-raw.exp
+++ b/test/testdata/local_vars/z_super_args_splats_blocks.rb.index-tree-raw.exp
@@ -49,7 +49,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U <untypedSuper>>
           block = Block {
@@ -139,7 +139,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -275,7 +275,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -434,7 +434,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -618,7 +618,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -756,7 +756,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U <untypedSuper>>
           block = Block {
@@ -846,7 +846,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -982,7 +982,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -1141,7 +1141,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -1325,7 +1325,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -1475,7 +1475,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U <untypedSuper>>
           block = Block {
@@ -1588,7 +1588,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -1750,7 +1750,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -1935,7 +1935,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -2145,7 +2145,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -2311,7 +2311,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U <untypedSuper>>
           block = Block {
@@ -2436,7 +2436,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -2610,7 +2610,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -2807,7 +2807,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -3029,7 +3029,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -3230,7 +3230,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U <untypedSuper>>
           block = Block {
@@ -3407,7 +3407,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -3633,7 +3633,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -3882,7 +3882,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -4156,7 +4156,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -4348,7 +4348,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U <untypedSuper>>
           block = Block {
@@ -4461,7 +4461,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -4623,7 +4623,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -4808,7 +4808,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -5018,7 +5018,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -5184,7 +5184,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U <untypedSuper>>
           block = Block {
@@ -5309,7 +5309,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -5483,7 +5483,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -5680,7 +5680,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -5902,7 +5902,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -6103,7 +6103,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U <untypedSuper>>
           block = Block {
@@ -6280,7 +6280,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -6506,7 +6506,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -6755,7 +6755,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr
@@ -7029,7 +7029,7 @@ ClassDef{
           }
         ],
         expr = Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = ConstantLit{
             symbol = (class ::<Magic>)
             orig = nullptr

--- a/test/testdata/local_vars/z_super_args_strict.rb.index-tree-raw.exp
+++ b/test/testdata/local_vars/z_super_args_strict.rb.index-tree-raw.exp
@@ -20,7 +20,7 @@ ClassDef{
         }]
       rhs = [
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {
@@ -77,7 +77,7 @@ ClassDef{
         }
 
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {
@@ -134,7 +134,7 @@ ClassDef{
         }
 
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {
@@ -214,7 +214,7 @@ ClassDef{
         }
 
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {
@@ -294,7 +294,7 @@ ClassDef{
         }
 
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {
@@ -359,7 +359,7 @@ ClassDef{
         }
 
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {
@@ -424,7 +424,7 @@ ClassDef{
         }
 
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {
@@ -495,7 +495,7 @@ ClassDef{
         }
 
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {
@@ -573,7 +573,7 @@ ClassDef{
         }]
       rhs = [
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {
@@ -630,7 +630,7 @@ ClassDef{
         }
 
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {
@@ -688,7 +688,7 @@ ClassDef{
         }
 
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {
@@ -757,7 +757,7 @@ ClassDef{
         }
 
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {
@@ -825,7 +825,7 @@ ClassDef{
         }
 
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {
@@ -920,7 +920,7 @@ ClassDef{
         }
 
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {
@@ -997,7 +997,7 @@ ClassDef{
         }
 
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {
@@ -1073,7 +1073,7 @@ ClassDef{
         }
 
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {
@@ -1101,7 +1101,7 @@ ClassDef{
               localVariable = <U <blk>>
             } }]
           rhs = Send{
-            flags = {}
+            flags = {doEndBlock}
             recv = Literal{ value = 1 }
             fun = <U times>
             block = Block {
@@ -1154,7 +1154,7 @@ ClassDef{
       ancestors = []
       rhs = [
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {

--- a/test/testdata/namer/arguments.rb.desugar-tree-raw.exp
+++ b/test/testdata/namer/arguments.rb.desugar-tree-raw.exp
@@ -93,7 +93,7 @@ ClassDef{
               }
             ],
             expr = Send{
-              flags = {privateOk}
+              flags = {privateOk, doEndBlock}
               recv = Self
               fun = <U proc>
               block = Block {

--- a/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
+++ b/test/testdata/namer/arguments.rb.flatten-tree-raw.exp
@@ -81,7 +81,7 @@ ClassDef{
               }
             ],
             expr = Send{
-              flags = {privateOk}
+              flags = {privateOk, doEndBlock}
               recv = Self
               fun = <U proc>
               block = Block {

--- a/test/testdata/namer/simple.rb.parse-tree.exp
+++ b/test/testdata/namer/simple.rb.parse-tree.exp
@@ -128,6 +128,7 @@ Begin {
             }
             params = NULL
             body = NULL
+            style = do-end
           }
           Send {
             receiver = Send {

--- a/test/testdata/parser/misc.rb.parse-tree.exp
+++ b/test/testdata/parser/misc.rb.parse-tree.exp
@@ -145,6 +145,7 @@ Begin {
       }
       params = NULL
       body = NULL
+      style = braces
     }
     Case {
       condition = Send {
@@ -609,6 +610,7 @@ Begin {
           }
           params = NULL
           body = NULL
+          style = do-end
         }
       ]
     }
@@ -672,6 +674,7 @@ Begin {
               }
             ]
           }
+          style = braces
         }
       }
     }

--- a/test/testdata/parser/ruby_25.rb.parse-tree.exp
+++ b/test/testdata/parser/ruby_25.rb.parse-tree.exp
@@ -43,6 +43,7 @@ Begin {
             }
             ensure = NULL
           }
+          style = do-end
         }
       }
     }

--- a/test/testdata/resolver/resolve_tree_printing.rb.flatten-tree-raw.exp
+++ b/test/testdata/resolver/resolve_tree_printing.rb.flatten-tree-raw.exp
@@ -89,7 +89,7 @@ ClassDef{
               localVariable = <U <blk>>
             }]
           rhs = Send{
-            flags = {privateOk}
+            flags = {privateOk, doEndBlock}
             recv = Self
             fun = <U loop>
             block = Block {
@@ -110,7 +110,7 @@ ClassDef{
               localVariable = <U <blk>>
             }]
           rhs = Send{
-            flags = {privateOk}
+            flags = {privateOk, doEndBlock}
             recv = Self
             fun = <U loop>
             block = Block {

--- a/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
+++ b/test/testdata/rewriter/prop.rb.rewrite-tree-raw.exp
@@ -1407,7 +1407,7 @@ ClassDef{
         }
 
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {
@@ -1488,7 +1488,7 @@ ClassDef{
         }
 
         Send{
-          flags = {privateOk}
+          flags = {privateOk, bracesBlock}
           recv = Self
           fun = <U sig>
           block = Block {
@@ -3822,7 +3822,7 @@ ClassDef{
             }
             Literal{ value = :foreign }
             Send{
-              flags = {}
+              flags = {bracesBlock}
               recv = ConstantLit{
                 symbol = (module ::Kernel)
                 orig = nullptr
@@ -3861,7 +3861,7 @@ ClassDef{
             }
             Literal{ value = :foreign }
             Send{
-              flags = {privateOk}
+              flags = {privateOk, bracesBlock}
               recv = Self
               fun = <U proc>
               block = Block {
@@ -3897,7 +3897,7 @@ ClassDef{
             }
             Literal{ value = :foreign }
             Send{
-              flags = {privateOk}
+              flags = {privateOk, bracesBlock}
               recv = Self
               fun = <U proc>
               block = Block {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
cc @elliottt 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This is blocking potential changes to not have to hold the file sources in memory all the time.  It is #8746 rebased + prism support, and the whitequark issues that blocked that PR, I've chosen to punt on here, by just not making them something that factors into the exp files -- it doesn't feel like this flag has semantic value and the prism changes + the other raw-exp file changes capture the intent of what we're trying to do.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
