### PR TITLE
Handle Test:: exports during the test-packages migration

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -22,7 +22,8 @@ namespace {
 
 constexpr string_view PACKAGE_FILE_NAME = "__package.rb"sv;
 
-bool isTestConstant(const ast::UnresolvedConstantLit *sym) {
+bool isTestConstant(const ast::ExpressionPtr &expr) {
+    auto sym = ast::cast_tree<ast::UnresolvedConstantLit>(expr);
     while (sym) {
         if (ast::isa_tree<ast::EmptyTree>(sym->scope)) {
             return sym->cnst == core::Names::Constants::Test();
@@ -541,17 +542,18 @@ struct PackageSpecBodyWalk {
 
         if (send.fun == core::Names::export_()) {
             if (send.numPosArgs() == 1) {
-                // Record every syntactically valid export. verifyConstant only checks that the argument is a constant
-                // path, so this also records constants that will fail to resolve later. The rest of the pipeline uses
-                // these locations for autocorrects.
-                if (auto *arg = verifyConstant(ctx, core::Names::export_(), send.getPosArg(0))) {
-                    // TODO(trevor) If the experimental-test-packages migration flag is enabled, we remove exports
-                    // of `Test::` symbols from non-test packages. This allows the original files to remain unchanged
-                    // during the migration period, and the newly introduced test-packages to be the source of truth for
-                    // what they export. This should be removed once we're fully migrated.
-                    if (ctx.state.packageDB().testPackages() && !this->info.testPackage() && isTestConstant(arg)) {
-                        tree = ast::make_expression<ast::EmptyTree>();
-                    } else {
+                auto &expr = send.getPosArg(0);
+                // TODO(trevor) If the experimental-test-packages migration flag is enabled, we remove exports of
+                // `Test::` symbols from non-test packages. This allows the original files to remain unchanged during
+                // the migration period, and the newly introduced test-packages to be the source of truth for what they
+                // export. This should be removed once we're fully migrated.
+                if (ctx.state.packageDB().testPackages() && !this->info.testPackage() && isTestConstant(expr)) {
+                    tree = ast::make_expression<ast::EmptyTree>();
+                } else {
+                    // Record every syntactically valid export. verifyConstant only checks that the argument is a
+                    // constant path, so this also records constants that will fail to resolve later. The rest of the
+                    // pipeline uses these locations for autocorrects.
+                    if (verifyConstant(ctx, core::Names::export_(), expr) != nullptr) {
                         info.exports_.emplace_back(send.loc);
                     }
                 }
@@ -1375,8 +1377,7 @@ bool isTestExport(const ast::ExpressionPtr &expr) {
         return false;
     }
 
-    auto sym = ast::cast_tree<ast::UnresolvedConstantLit>(send->getPosArg(0));
-    return isTestConstant(sym);
+    return isTestConstant(send->getPosArg(0));
 }
 
 } // namespace

--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -22,6 +22,22 @@ namespace {
 
 constexpr string_view PACKAGE_FILE_NAME = "__package.rb"sv;
 
+bool isTestConstant(const ast::UnresolvedConstantLit *sym) {
+    while (sym) {
+        if (ast::isa_tree<ast::EmptyTree>(sym->scope)) {
+            return sym->cnst == core::Names::Constants::Test();
+        }
+
+        if (auto parent = ast::cast_tree<ast::UnresolvedConstantLit>(sym->scope)) {
+            sym = parent;
+        } else {
+            break;
+        }
+    }
+
+    return false;
+}
+
 string buildValidLayersStr(const core::GlobalState &gs) {
     auto validLayers = gs.packageDB().layers();
     ENFORCE(validLayers.size() > 0);
@@ -528,8 +544,16 @@ struct PackageSpecBodyWalk {
                 // Record every syntactically valid export. verifyConstant only checks that the argument is a constant
                 // path, so this also records constants that will fail to resolve later. The rest of the pipeline uses
                 // these locations for autocorrects.
-                if (verifyConstant(ctx, core::Names::export_(), send.getPosArg(0)) != nullptr) {
-                    info.exports_.emplace_back(send.loc);
+                if (auto *arg = verifyConstant(ctx, core::Names::export_(), send.getPosArg(0))) {
+                    // TODO(trevor) If the experimental-test-packages migration flag is enabled, we remove exports
+                    // of `Test::` symbols from non-test packages. This allows the original files to remain unchanged
+                    // during the migration period, and the newly introduced test-packages to be the source of truth for
+                    // what they export. This should be removed once we're fully migrated.
+                    if (ctx.state.packageDB().testPackages() && !this->info.testPackage() && isTestConstant(arg)) {
+                        tree = ast::make_expression<ast::EmptyTree>();
+                    } else {
+                        info.exports_.emplace_back(send.loc);
+                    }
                 }
             }
         } else if ((send.fun == core::Names::import() || send.fun == core::Names::testImport())) {
@@ -1352,19 +1376,7 @@ bool isTestExport(const ast::ExpressionPtr &expr) {
     }
 
     auto sym = ast::cast_tree<ast::UnresolvedConstantLit>(send->getPosArg(0));
-    while (sym) {
-        if (ast::isa_tree<ast::EmptyTree>(sym->scope)) {
-            return sym->cnst == core::Names::Constants::Test();
-        }
-
-        if (auto parent = ast::cast_tree<ast::UnresolvedConstantLit>(sym->scope)) {
-            sym = parent;
-        } else {
-            break;
-        }
-    }
-
-    return false;
+    return isTestConstant(sym);
 }
 
 } // namespace

--- a/test/cli/test-packages-ignore-test-import/in_between/__package.rb
+++ b/test/cli/test-packages-ignore-test-import/in_between/__package.rb
@@ -6,4 +6,6 @@ class InBetween < PackageSpec
   import Migrated
 
   test_import Migrated::Test
+
+  export Test::InBetween::FooTest
 end

--- a/test/cli/test-packages-ignore-test-import/old_style/__package.rb
+++ b/test/cli/test-packages-ignore-test-import/old_style/__package.rb
@@ -6,4 +6,6 @@ class OldStyle < PackageSpec
   sorbet min_typed_level: "true", tests_min_typed_level: "true"
 
   test_import Migrated::Test
+
+  export Test::OldStyle::FooTest
 end

--- a/test/cli/test-packages-ignore-test-import/test.out
+++ b/test/cli/test-packages-ignore-test-import/test.out
@@ -1,7 +1,29 @@
+in_between/__package.rb:10: Cannot export `Test::InBetween::FooTest` because it is owned by another package https://srb.help/3721
+    10 |  export Test::InBetween::FooTest
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    in_between/test/foo.test.rb:4: Defined here
+     4 |  class FooTest
+          ^^^^^^^^^^^^^
+
+old_style/__package.rb:10: Constant `Test::OldStyle::FooTest` lacks a declaration in this package and cannot be exported https://srb.help/3721
+    10 |  export Test::OldStyle::FooTest
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Autocorrect: Use `-a` to autocorrect
+    old_style/__package.rb:10: Delete
+    10 |  export Test::OldStyle::FooTest
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+old_style/__package.rb:10: Cannot export `Test::OldStyle::FooTest` because it is owned by another package https://srb.help/3721
+    10 |  export Test::OldStyle::FooTest
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    old_style/test/foo.test.rb:4: Defined here
+     4 |  class FooTest
+          ^^^^^^^^^^^^^
+
 old_style/test/foo.test.rb:3: File belongs to package `OldStyle` but defines a constant that does not match this namespace https://srb.help/3713
      3 |module Test::OldStyle
                ^^^^^^^^^^^^^^
     old_style/__package.rb:3: Enclosing package declared here
      3 |class OldStyle < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 1
+Errors: 4

--- a/test/cli/test-packages-ignore-test-import/test.out
+++ b/test/cli/test-packages-ignore-test-import/test.out
@@ -1,29 +1,7 @@
-in_between/__package.rb:10: Cannot export `Test::InBetween::FooTest` because it is owned by another package https://srb.help/3721
-    10 |  export Test::InBetween::FooTest
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    in_between/test/foo.test.rb:4: Defined here
-     4 |  class FooTest
-          ^^^^^^^^^^^^^
-
-old_style/__package.rb:10: Constant `Test::OldStyle::FooTest` lacks a declaration in this package and cannot be exported https://srb.help/3721
-    10 |  export Test::OldStyle::FooTest
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Autocorrect: Use `-a` to autocorrect
-    old_style/__package.rb:10: Delete
-    10 |  export Test::OldStyle::FooTest
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-old_style/__package.rb:10: Cannot export `Test::OldStyle::FooTest` because it is owned by another package https://srb.help/3721
-    10 |  export Test::OldStyle::FooTest
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    old_style/test/foo.test.rb:4: Defined here
-     4 |  class FooTest
-          ^^^^^^^^^^^^^
-
 old_style/test/foo.test.rb:3: File belongs to package `OldStyle` but defines a constant that does not match this namespace https://srb.help/3713
      3 |module Test::OldStyle
                ^^^^^^^^^^^^^^
     old_style/__package.rb:3: Enclosing package declared here
      3 |class OldStyle < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 4
+Errors: 1


### PR DESCRIPTION
When running with `--experimental-test-packages`, this PR will filter out exports from non-test packages that look like:

```
export Test::...
```

This is under the assumption that a new `test!` package will have been introduced in parallel, and that any uses of that symbol will now be through an import of the package with a `Test::` prefix.


### Motivation
Migrating to test-packages.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
