### PR TITLE
Add a test showing stacked `private` + `package_private`

### DIFF
--- a/test/testdata/packager/test-packages-package-private/__package.rb
+++ b/test/testdata/packager/test-packages-package-private/__package.rb
@@ -3,6 +3,7 @@
 
 class Root < PackageSpec
   export Root::A
+  export Root::ModifierParent
 
   prelude!
 end

--- a/test/testdata/packager/test-packages-package-private/b/test/test.rb
+++ b/test/testdata/packager/test-packages-package-private/b/test/test.rb
@@ -9,4 +9,18 @@ module Root::B::Test
     # ^^^^^^^^^^^ error: Method `foo` on `T.class_of(Root::A)` is package-private
     end
   end
+
+  class Child < Root::ModifierParent
+    def test_inherited_package_private
+      package_private_private
+      private_package_private
+    # ^^^^^^^^^^^^^^^^^^^^^^^ error: Method `private_package_private` on `Root::ModifierParent` is package-private and cannot be called from package `Root::B::Test`
+      package_private_protected
+      protected_package_private
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^ error: Method `protected_package_private` on `Root::ModifierParent` is package-private and cannot be called from package `Root::B::Test`
+      package_private_public
+      public_package_private
+    # ^^^^^^^^^^^^^^^^^^^^^^ error: Method `public_package_private` on `Root::ModifierParent` is package-private and cannot be called from package `Root::B::Test`
+    end
+  end
 end

--- a/test/testdata/packager/test-packages-package-private/modifiers.rb
+++ b/test/testdata/packager/test-packages-package-private/modifiers.rb
@@ -1,0 +1,14 @@
+# typed: true
+
+module Root
+  class ModifierParent
+    package_private private def package_private_private; end
+    private package_private def private_package_private; end
+
+    package_private protected def package_private_protected; end
+    protected package_private def protected_package_private; end
+
+    package_private public def package_private_public; end
+    public package_private def public_package_private; end
+  end
+end

--- a/test/testdata/packager/test-packages-package-private/root.rbi
+++ b/test/testdata/packager/test-packages-package-private/root.rbi
@@ -1,11 +1,17 @@
 # typed: strict
 
 class ::Module < Object
+  sig do
+    type_parameters(:U)
+      .params(args: T.all(T.type_parameter(:U), T.any(Symbol, String)))
+      .returns(T::Array[T.type_parameter(:U)])
+  end
+  private def package_private(*args); end # = args
 
-  sig { params( arg0: T.any(Symbol, String)).returns(T.self_type) }
-  def package_private(*arg0); end
-
-  sig { params(arg0: T.any(Symbol, String)).returns(T.self_type) }
-  def package_private_class_method(*arg0); end
-
+  sig do
+    type_parameters(:U)
+      .params(args: T.all(T.type_parameter(:U), T.any(Symbol, String)))
+      .returns(T::Array[T.type_parameter(:U)])
+  end
+  private def package_private_class_method(*args); end # = args
 end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

Right now, this only works when the stacking happens like

    private package_private def foo; end

but not the other way around.

Note that the `root.rbi` definition of `package_private` needs to change
too, change the return type. We already made that change internally at
Stripe a while back, but we didn't make that change in Sorbet.

(Stripe employees can see
<http://go/commit/1ced2ad3ea2d661c01066bd7a763fce35f8e2c2a>)

Note that eventually when we more widely encourage packager adoption, we'll
need to define `package_private` and
`package_private_class_method` somewhere in `sorbet-runtime`, but I'm
punting on that. I have copied the signature that we use internally into
the test for now.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Test-only change.

This change will semantically conflict with the changes in #10090. To avoid too
many back-and-forth's on the review, I'm leaving this separate. I'm going to
review that one independently, and land this with the correct assertions after
that change lands.