### PR TITLE
rbi: Add `JSON::Coder` members

### DIFF
--- a/rbi/stdlib/json.rbi
+++ b/rbi/stdlib/json.rbi
@@ -442,6 +442,93 @@ class JSON::CircularDatastructure < JSON::NestingError
 end
 
 class JSON::Coder
+  # Argument `options`, if given, contains a
+  # [`Hash`](https://docs.ruby-lang.org/en/master/Hash.html) of options for both
+  # parsing and generating. It is passed positionally by json 2.x and as keyword
+  # arguments by json 3.x, so both are accepted here.
+  #
+  # For generation, the `strict: true` option is always set. When a Ruby object
+  # with no native [`JSON`](https://docs.ruby-lang.org/en/master/JSON.html)
+  # counterpart is encountered, the block given here is invoked, and must return
+  # a Ruby object that has a native
+  # [`JSON`](https://docs.ruby-lang.org/en/master/JSON.html) counterpart.
+  sig do
+    params(
+      options: ::T.nilable(::T::Hash[Symbol, ::T.anything]),
+      kwoptions: ::T.anything,
+      as_json: ::T.nilable(::T.proc.params(object: ::T.anything).returns(::T.anything)),
+    )
+    .void
+  end
+  def initialize(options=nil, **kwoptions, &as_json); end
+
+  # Serialize the given object into a
+  # [`JSON`](https://docs.ruby-lang.org/en/master/JSON.html) document, returning
+  # a [`String`](https://docs.ruby-lang.org/en/master/String.html), or `io` when
+  # one is given.
+  sig do
+    params(
+      object: ::T.anything,
+    )
+    .returns(String)
+  end
+  sig do
+    type_parameters(:IO)
+    .params(
+      object: ::T.anything,
+      io: ::T.type_parameter(:IO),
+    )
+    .returns(::T.type_parameter(:IO))
+  end
+  def dump(object, io=T.unsafe(nil)); end
+
+  # Alias for [`dump`](https://docs.ruby-lang.org/en/master/JSON/Coder.html#method-i-dump).
+  sig do
+    params(
+      object: ::T.anything,
+    )
+    .returns(String)
+  end
+  sig do
+    type_parameters(:IO)
+    .params(
+      object: ::T.anything,
+      io: ::T.type_parameter(:IO),
+    )
+    .returns(::T.type_parameter(:IO))
+  end
+  def generate(object, io=T.unsafe(nil)); end
+
+  # Parse the given [`JSON`](https://docs.ruby-lang.org/en/master/JSON.html)
+  # document and return an equivalent Ruby object. The result depends on the
+  # document, so it is `T.untyped` as it is for
+  # [`JSON.parse`](https://docs.ruby-lang.org/en/master/JSON.html#method-i-parse).
+  sig do
+    params(
+      source: String,
+    )
+    .returns(::T.untyped)
+  end
+  def load(source); end
+
+  # Alias for [`load`](https://docs.ruby-lang.org/en/master/JSON/Coder.html#method-i-load).
+  sig do
+    params(
+      source: String,
+    )
+    .returns(::T.untyped)
+  end
+  def parse(source); end
+
+  # Parse the [`JSON`](https://docs.ruby-lang.org/en/master/JSON.html) document
+  # at `path` and return an equivalent Ruby object.
+  sig do
+    params(
+      path: ::T.any(String, ::Pathname),
+    )
+    .returns(::T.untyped)
+  end
+  def load_file(path); end
 end
 
 # This exception is raised if a generator or unparser error occurs.

--- a/test/testdata/rbi/json.rb
+++ b/test/testdata/rbi/json.rb
@@ -9,3 +9,28 @@ T.reveal_type(nil.to_json) # error: Revealed type: `String`
 T.reveal_type(Object.new.to_json) # error: Revealed type: `String`
 T.reveal_type("123".to_json) # error: Revealed type: `String`
 T.reveal_type(true.to_json) # error: Revealed type: `String`
+
+# `JSON::Coder.new` takes a block, and accepts its options positionally (json
+# 2.x) or as keyword arguments (json 3.x).
+coder = JSON::Coder.new do |object|
+  T.reveal_type(object) # error: Revealed type: `T.anything`
+  case object
+  when Time then object.iso8601
+  else object
+  end
+end
+T.reveal_type(coder) # error: Revealed type: `JSON::Coder`
+JSON::Coder.new(symbolize_names: true) {}
+JSON::Coder.new({ symbolize_names: true }) {}
+JSON::Coder.new
+
+# `dump` returns a `String`, or the `io` it was given.
+T.reveal_type(coder.dump({ "a" => 1 })) # error: Revealed type: `String`
+T.reveal_type(coder.dump({ "a" => 1 }, StringIO.new)) # error: Revealed type: `StringIO`
+T.reveal_type(coder.generate({ "a" => 1 })) # error: Revealed type: `String`
+T.reveal_type(coder.generate({ "a" => 1 }, StringIO.new)) # error: Revealed type: `StringIO`
+
+# The parsed result depends on the document, so it is `T.untyped`.
+T.reveal_type(coder.load('{"a":1}')) # error: Revealed type: `T.untyped`
+T.reveal_type(coder.parse('{"a":1}')) # error: Revealed type: `T.untyped`
+T.reveal_type(coder.load_file("example.json")) # error: Revealed type: `T.untyped`


### PR DESCRIPTION
Fills in the members of `JSON::Coder`: `#initialize`, `#dump`, `#generate`, `#load`, `#parse` and `#load_file`.

### Motivation

#9708 added `class JSON::Coder; end` to resolve the constant, but left it empty, so any actual use of the class fails to typecheck:

```
Method `BasicObject#initialize` does not take a block https://srb.help/7035
    coder = JSON::Coder.new do |object|

Method `dump` does not exist on `JSON::Coder` https://srb.help/7003
    error_pipe&.puts coder.dump(error)
```

This came up migrating Homebrew off `json/add/exception`, which json 3.0 removed. The json changelog points people at `JSON::Coder` as the replacement for a custom serializer, so the class is about to get a lot more use.

Two signature details worth flagging:

- json 3.x declares `initialize(object_class: nil, array_class: nil, on_load: nil, **options, &as_json)`, so passing options positionally raises `ArgumentError: wrong number of arguments (given 1, expected 0)`, whereas json 2.x accepts both a positional `Hash` and keyword options. The signature here allows an optional positional `Hash` plus keyword options, so it covers every form that is valid on either version.
- `#dump` and `#generate` are `dump(object) -> String` and `dump(object, io) -> io`, so they are typed as two overloads, with the `io` form generic in `io` rather than returning a union.

`#load`, `#parse` and `#load_file` return `T.untyped`, matching `JSON.parse`, since the result depends on the document.

### Test plan

See included automated tests. `test/testdata/rbi/json.rb` now asserts the revealed type of every added method, including both `#dump` overloads:

```ruby
T.reveal_type(coder.dump({ "a" => 1 })) # error: Revealed type: `String`
T.reveal_type(coder.dump({ "a" => 1 }, StringIO.new)) # error: Revealed type: `StringIO`
T.reveal_type(coder.load('{"a":1}')) # error: Revealed type: `T.untyped`
```

It also exercises the three constructor forms (block only, keyword options, positional `Hash`).

```
$ ./bazel test //test:test_PosTests/testdata/rbi/json --config=dbg
//test:test_PosTests/testdata/rbi/json                                   PASSED in 2.1s

Executed 1 out of 1 test: 1 test passes.
```

This change touches only `rbi/` and `test/testdata/`, so none of the checks in `.buildkite/linters.sh` apply to it.
