### PR TITLE
Reapply "Restrict `::` packaging opt-out to prelude packages (#10596)" (#10613)

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -205,14 +205,10 @@ class EnforcePackagePrefix final {
 
     // Meant to track when we're inside something like `class ::A; class B; end; end` instead of
     // `class A; class B; end; end`. Classes that start from an absolutely qualified "cbase" with a
-    // leading `::` are opted out of the EnforcePackagePrefix checks.
+    // leading `::` are opted out of the EnforcePackagePrefix checks in prelude packages.
     //
     // TODO(jez) Document this in the public docs for the packager
     //   (at least in the error reference, but also in any eventual docs on the package system).
-    //
-    //   It's not clear what the long term behavior for this should be. I think that we're going to
-    //   have to invent a concept of "prelude packages" and have all root-scoped stuff like this
-    //   live in those prelude packages.
     //
     //   (The motivation is: if 100% of code in a repo is packaged, where do monkey patches live,
     //   because the stdlib and gems are unpackaged?)
@@ -249,33 +245,30 @@ public:
 
         pushScope(constantLit);
 
-        if (rootConsts > 0) {
+        if (rootConsts > 0 && pkg.isPreludePackage()) {
             // This is a root-scoped constant, like `class ::A; end`.
             // These are exempted from package prefix checking.
             return;
         }
 
-        if (hasParentClass(classDef)) {
+        auto isOnPackagePath = onPackagePath(ctx);
+        auto hasNamespaceMismatch = !isOnPackagePath || (mustUseTestNamespace && !inTestNamespace(ctx));
+
+        if (hasNamespaceMismatch) {
+            ENFORCE(errorDepth == 0);
+            errorDepth++;
+            if (auto e = ctx.beginError(constantLit->loc(), core::errors::Packager::DefinitionPackageMismatch)) {
+                if (rootConsts > 0) {
+                    ENFORCE(!pkg.isPreludePackage(), "Prelude root scopes should have been exempted above");
+                    rootScopedConstantInNonPreludePackage(ctx, e);
+                } else {
+                    definitionPackageMismatch(ctx, e, isOnPackagePath);
+                }
+            }
+        } else if (hasParentClass(classDef)) {
             // A class definition that includes a parent `class Foo::Bar < Baz`
             // must be made in that package
             checkBehaviorLoc(ctx, classDef.declLoc);
-            return;
-        }
-
-        auto isOnPackagePath = onPackagePath(ctx);
-
-        if (!isOnPackagePath) {
-            ENFORCE(errorDepth == 0);
-            errorDepth++;
-            if (auto e = ctx.beginError(constantLit->loc(), core::errors::Packager::DefinitionPackageMismatch)) {
-                definitionPackageMismatch(ctx, e, isOnPackagePath);
-            }
-        } else if (mustUseTestNamespace && !inTestNamespace(ctx)) {
-            ENFORCE(errorDepth == 0);
-            errorDepth++;
-            if (auto e = ctx.beginError(constantLit->loc(), core::errors::Packager::DefinitionPackageMismatch)) {
-                definitionPackageMismatch(ctx, e, isOnPackagePath);
-            }
         }
     }
 
@@ -310,7 +303,7 @@ public:
         }
         auto lhs = ast::cast_tree<ast::ConstantLit>(asgn.lhs);
 
-        if (lhs == nullptr || rootConsts > 0) {
+        if (lhs == nullptr || (rootConsts > 0 && pkg.isPreludePackage())) {
             return;
         }
 
@@ -321,19 +314,19 @@ public:
 
         pushScope(lhs);
 
-        if (rootConsts == 0) {
+        if (rootConsts == 0 || !pkg.isPreludePackage()) {
             auto isOnPackagePath = packageForNamespace(ctx) == pkg.mangledName();
-            if (!isOnPackagePath) {
+            auto hasNamespaceMismatch = !isOnPackagePath || (mustUseTestNamespace && !inTestNamespace(ctx));
+            if (hasNamespaceMismatch) {
                 ENFORCE(errorDepth == 0);
                 errorDepth++;
                 if (auto e = ctx.beginError(lhs->loc(), core::errors::Packager::DefinitionPackageMismatch)) {
-                    definitionPackageMismatch(ctx, e, isOnPackagePath);
-                }
-            } else if (mustUseTestNamespace && !inTestNamespace(ctx)) {
-                ENFORCE(errorDepth == 0);
-                errorDepth++;
-                if (auto e = ctx.beginError(lhs->loc(), core::errors::Packager::DefinitionPackageMismatch)) {
-                    definitionPackageMismatch(ctx, e, isOnPackagePath);
+                    if (rootConsts > 0) {
+                        ENFORCE(!pkg.isPreludePackage(), "Prelude root scopes should have been exempted above");
+                        rootScopedConstantInNonPreludePackage(ctx, e);
+                    } else {
+                        definitionPackageMismatch(ctx, e, isOnPackagePath);
+                    }
                 }
             }
         }
@@ -377,7 +370,7 @@ public:
 
     void checkBehaviorLoc(core::Context ctx, core::LocOffsets loc) {
         ENFORCE(errorDepth == 0);
-        if (rootConsts > 0 || scope.empty()) {
+        if ((rootConsts > 0 && pkg.isPreludePackage()) || scope.empty()) {
             // Doing `class ::A; end` to monkey patch something lets you define behavior (monkey patch)
             // You can also do arbitrary behavior at the top-level outside of any definitions.
             // (Stripe's codebase enforces that the )
@@ -480,6 +473,13 @@ private:
     bool hasParentClass(const ast::ClassDef &def) const {
         return def.kind == ast::ClassDef::Kind::Class && !def.ancestors.empty() &&
                ast::isa_tree<ast::UnresolvedConstantLit>(def.ancestors[0]);
+    }
+
+    void rootScopedConstantInNonPreludePackage(const core::GlobalState &gs, core::ErrorBuilder &e) const {
+        e.setHeader("Defining a root-scoped constant requires this package to be marked `{}`", "prelude!");
+        e.addErrorLine(pkg.declLoc(), "This package is missing a `{}` declaration", "prelude!");
+        e.addErrorNote("Root-scoped constants are exempt from package namespace checks only in `{}` packages",
+                       "prelude!");
     }
 
     void definitionPackageMismatch(const core::GlobalState &gs, core::ErrorBuilder &e, bool isOnPackagePath) const {

--- a/test/cli/package-non-prefix-collision/test.out
+++ b/test/cli/package-non-prefix-collision/test.out
@@ -5,23 +5,17 @@ other/regexp_parser.rbi:3: File belongs to package `Other` but defines a constan
      3 |class Other < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-other/regexp_parser.rbi:6: This file must only define behavior in enclosing package `Other` https://srb.help/3713
-     6 |class Regexp::Parser::Error < StandardError
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/regexp_parser.rbi:6: Defining behavior in `Regexp::Parser::Error` instead:
+other/regexp_parser.rbi:6: File belongs to package `Other` but defines a constant that does not match this namespace https://srb.help/3713
      6 |class Regexp::Parser::Error < StandardError
               ^^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Enclosing package `Other` declared here
+    other/__package.rb:3: Enclosing package declared here
      3 |class Other < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-other/regexp_parser.rbi:9: This file must only define behavior in enclosing package `Other` https://srb.help/3713
-     9 |class Regexp::ScannerError < Regexp::Parser::Error
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    other/regexp_parser.rbi:9: Defining behavior in `Regexp::ScannerError` instead:
+other/regexp_parser.rbi:9: File belongs to package `Other` but defines a constant that does not match this namespace https://srb.help/3713
      9 |class Regexp::ScannerError < Regexp::Parser::Error
               ^^^^^^^^^^^^^^^^^^^^
-    other/__package.rb:3: Enclosing package `Other` declared here
+    other/__package.rb:3: Enclosing package declared here
      3 |class Other < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^^
 Errors: 3

--- a/test/cli/package-prefix-enforcement/nested/root_scoped_matching_package.rb
+++ b/test/cli/package-prefix-enforcement/nested/root_scoped_matching_package.rb
@@ -1,0 +1,8 @@
+# typed: strict
+
+# Root-scoping a constant is allowed in a non-prelude package when the constant
+# still matches the package namespace.
+class ::Root::Nested::AlsoAllowed
+end
+
+::Root::Nested::AlsoAllowedAssignment = 1

--- a/test/cli/package-prefix-enforcement/nested/root_scoped_missing_test_namespace.test.rb
+++ b/test/cli/package-prefix-enforcement/nested/root_scoped_missing_test_namespace.test.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+# The constant matches the package path, but tests in this package must also use
+# the Test:: namespace. Root-scoping does not bypass that requirement.
+class ::Root::Nested::MissingTestNamespace
+end

--- a/test/cli/package-prefix-enforcement/prelude/__package.rb
+++ b/test/cli/package-prefix-enforcement/prelude/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+
+class Prelude < PackageSpec
+  prelude!
+end

--- a/test/cli/package-prefix-enforcement/prelude/root_scoped.rb
+++ b/test/cli/package-prefix-enforcement/prelude/root_scoped.rb
@@ -1,0 +1,16 @@
+# typed: strict
+
+module ::RootScopedFromPrelude
+  extend T::Sig
+
+  CONST = 1
+
+  sig {void}
+  def self.behavior
+  end
+
+  class Nested
+  end
+end
+
+::RootScopedAssignmentFromPrelude = 1

--- a/test/cli/package-prefix-enforcement/test.out
+++ b/test/cli/package-prefix-enforcement/test.out
@@ -94,6 +94,15 @@ nested/nested.rb:56: File belongs to package `Root::Nested` but defines a consta
      3 |class Root < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^
 
+nested/nested.rb:59: Defining a root-scoped constant requires this package to be marked `prelude!` https://srb.help/3713
+    59 |module ::TopLevel
+               ^^^^^^^^^^
+    nested/__package.rb:3: This package is missing a `prelude!` declaration
+     3 |class Root::Nested < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Root-scoped constants are exempt from package namespace checks only in `prelude!` packages
+
 nested/nested.rb:67: File belongs to package `Root::Nested` but defines a constant that does not match this namespace https://srb.help/3713
     67 |Root::X = 1
         ^^^^^^^
@@ -224,6 +233,15 @@ nested/nested.test.rb:20: Cannot initialize the module `Nested` by constant assi
     Sorbet does not allow treating constant assignments as class or module definitions,
     even if the initializer computes a `Module` object at runtime. See the docs for more.
 
+nested/nested.test.rb:3: Defining a root-scoped constant requires this package to be marked `prelude!` https://srb.help/3713
+     3 |class ::UnitTest; end
+              ^^^^^^^^^^
+    nested/__package.rb:3: This package is missing a `prelude!` declaration
+     3 |class Root::Nested < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Root-scoped constants are exempt from package namespace checks only in `prelude!` packages
+
 nested/nested.test.rb:7: Tests in the `Root::Nested` package must define tests in the `Test::Root::Nested` namespace https://srb.help/3713
      7 |  NOT_IN_MODULE = nil
           ^^^^^^^^^^^^^
@@ -250,6 +268,15 @@ nested/nested.test.rb:17: Tests in the `Root::Nested` package must define tests 
     __package.rb:3: Must belong to this package, given constant name `Test::Root::X`
      3 |class Root < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^
+
+nested/root_scoped_missing_test_namespace.test.rb:5: Defining a root-scoped constant requires this package to be marked `prelude!` https://srb.help/3713
+     5 |class ::Root::Nested::MissingTestNamespace
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    nested/__package.rb:3: This package is missing a `prelude!` declaration
+     3 |class Root::Nested < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Root-scoped constants are exempt from package namespace checks only in `prelude!` packages
 
 critic_prefix/real.test.rb:3: Tests in the `Critic::SomePkg` package must define tests in the `Test::Critic::SomePkg` namespace https://srb.help/3713
      3 |module Critic::SomePkg::Real
@@ -282,6 +309,16 @@ commands/foo_command.rb:4: File belongs to package `Root::Commands::Foo` but def
      3 |class Root < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^
 
+extend_sig.rb:4: This file must only define behavior in enclosing package `Root` https://srb.help/3713
+     4 |  include T::Sig
+          ^^^^^^^^^^^^^^
+    extend_sig.rb:3: Defining behavior in `Module` instead:
+     3 |class ::Module
+              ^^^^^^^^
+    __package.rb:3: Enclosing package `Root` declared here
+     3 |class Root < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^^^^
+
 extend_sig.rb:4: `include` may only be used on constants in the package that owns them https://srb.help/5084
      4 |  include T::Sig
                   ^^^^^^
@@ -293,4 +330,4 @@ extend_sig.rb:4: `include` may only be used on constants in the package that own
         ^^^^^^^^^^^^^^^^^^^^^^^^
   Note:
     `Module` is unpackaged, and may be reopened from a package marked `prelude!`
-Errors: 29
+Errors: 33

--- a/test/cli/package-private/test.out
+++ b/test/cli/package-private/test.out
@@ -38,6 +38,15 @@ a/a.rb:37: Method `Global.bar` is not in a package and so cannot be made `packag
     34 |    def self.bar; end
             ^^^^^^^^^^^^
 
+a/a.rb:22: Defining a root-scoped constant requires this package to be marked `prelude!` https://srb.help/3713
+    22 |  class ::Global
+                ^^^^^^^^
+    a/__package.rb:3: This package is missing a `prelude!` declaration
+     3 |class A < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+  Note:
+    Root-scoped constants are exempt from package namespace checks only in `prelude!` packages
+
 a/a.rb:23: `extend` may only be used on constants in the package that owns them https://srb.help/5084
     23 |    extend T::Sig
                    ^^^^^^
@@ -158,6 +167,16 @@ a/a.rb:33: Method `void` does not exist on `T.class_of(Global)` https://srb.help
       NN |  def load(filename, arg0=T.unsafe(nil)); end
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+a/a.rbi:3: This file must only define behavior in enclosing package `A` https://srb.help/3713
+     3 |class ::Module < Object
+        ^^^^^^^^^^^^^^^^^^^^^^^
+    a/a.rbi:3: Defining behavior in `Module` instead:
+     3 |class ::Module < Object
+              ^^^^^^^^
+    a/__package.rb:3: Enclosing package `A` declared here
+     3 |class A < PackageSpec
+        ^^^^^^^^^^^^^^^^^^^^^
+
 a/a.rbi:3: Superclasses may only be set on constants in the package that owns them https://srb.help/5084
      3 |class ::Module < Object
                          ^^^^^^
@@ -197,4 +216,4 @@ b/b.rb:19: Method `foo` on `A` is package-private and cannot be called from pack
     a/a.rb:12: Defined in `A` here
     12 |  package_private def foo
                           ^^^^^^^
-Errors: 18
+Errors: 20

--- a/test/testdata/packager/directed-unpackaged/packaged/packaged.rbi
+++ b/test/testdata/packager/directed-unpackaged/packaged/packaged.rbi
@@ -10,6 +10,6 @@ class SomethingElse
     # ^^^^^^^^^^^^^ error: defines a constant that does not match this namespace
 end
 
-# This will be okay because of the leading `::`
-class ::SomethingCompletelyDifferent
+# Root-scoped constants may only opt out of package prefix checks in prelude packages.
+class ::SomethingCompletelyDifferent # error: requires this package to be marked `prelude!`
 end

--- a/test/testdata/packager/directed-unpackaged/packaged/unpackaged-file.rb
+++ b/test/testdata/packager/directed-unpackaged/packaged/unpackaged-file.rb
@@ -2,7 +2,7 @@
 
 # Because this constant has a leading `::`, the packager allows us to
 # define things on it despite it not belonging to the enclosing namespace
-class ::UnpackagedTheSequel
+class ::UnpackagedTheSequel # error: requires this package to be marked `prelude!`
   # despite being in a constant not governed by this package, we still
   # subject the internals to import restrictions:
   def test

--- a/test/testdata/packager/extra_directives/__package.rb
+++ b/test/testdata/packager/extra_directives/__package.rb
@@ -4,6 +4,7 @@
 # packager-layers: a, b
 
 class Root < PackageSpec
+  prelude!
   strict_dependencies 'false'
   layer 'a'
 end

--- a/test/testdata/packager/package-prefix-enforcement/nested/nested.rb
+++ b/test/testdata/packager/package-prefix-enforcement/nested/nested.rb
@@ -6,7 +6,7 @@ module Wrong
 end
 
 Root::Nested::Foo::Bar = nil
-::Allowed::TopLevel = nil
+::Allowed::TopLevel = nil # error: requires this package to be marked `prelude!`
 
   NotAllowed::Foo::Bar = nil
 # ^^^^^^^^^^^^^^^^^^^^ error: File belongs to package `Root::Nested` but defines a constant that does not match this namespace
@@ -45,7 +45,7 @@ module Root
 end
 
   class Root::Stringy < String
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: This file must only define behavior in enclosing package `Root::Nested`
+#       ^^^^^^^^^^^^^ error: File belongs to package `Root::Nested` but defines a constant that does not match this namespace
 #                       ^^^^^^ error: Superclasses may only be set on constants in the package that owns them
 end
 
@@ -80,7 +80,7 @@ class Root::ClassNotInPackage
     # ^^^^^^^^^^^^^^^^^^^^^^^ error: File belongs to package `Root::Nested` but defines a constant that does not match this namespace
 end
 
-module ::TopLevel
+module ::TopLevel # error: requires this package to be marked `prelude!`
   class Foo
     sig {void}
     def foo

--- a/test/testdata/packager/packagespec_methods/__package.rb
+++ b/test/testdata/packager/packagespec_methods/__package.rb
@@ -2,6 +2,8 @@
 # enable-packager: true
 
 class MyPkg < PackageSpec
+  prelude!
+
   custom_method 'abc'
   custom_method 'abc', 'too_many_args'
   #                    ^^^^^^^^^^^^^^^ error: Too many arguments provided for method `Sorbet::Private::Static::PackageSpec.custom_method`. Expected: `1`, got: `2`

--- a/test/testdata/packager/unpackaged-error/packaged/unpackaged-file.rb
+++ b/test/testdata/packager/unpackaged-error/packaged/unpackaged-file.rb
@@ -3,7 +3,7 @@
 #
 # Explicitly marking this file as not packaged to show how to opt-out of being associated with the package in the path.
 
-class ::UnpackagedTheSequel
+class ::UnpackagedTheSequel # error: requires this package to be marked `prelude!`
   def test
 
     puts MyPackage::MyClass.new


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This reverts commit ef28fbbd0a33cfea862f3cd0995c77a15fd6092d.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.