### PR TITLE
Avoid namer crash on payload static field namespaces

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1161,9 +1161,6 @@ SymbolRef GlobalState::findRenamedSymbol(ClassOrModuleRef owner, SymbolRef sym) 
 ClassOrModuleRef GlobalState::enterClassOrModuleSymbol(Loc loc, ClassOrModuleRef owner, NameRef name) {
     // ENFORCE_NO_TIMER(!owner.exists()); // Owner may not exist on purely synthetic symbols.
     ENFORCE_NO_TIMER(name.isClassName(*this));
-    // We should never enter mangled classes (incremental fast path relies on all constants being
-    // defined first).
-    ENFORCE_NO_TIMER(!name.hasUniqueNameKind(*this, core::UniqueNameKind::MangleRename));
     ClassOrModuleData ownerScope = owner.dataAllowingNone(*this);
 
     auto &store = ownerScope->members()[name];

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -863,9 +863,6 @@ private:
     void emitRedefinedConstantError(core::MutableContext ctx, core::LocOffsets errorLoc, core::NameRef name,
                                     core::SymbolRef::Kind kind, core::SymbolRef prevSymbol) {
         using Kind = core::SymbolRef::Kind;
-        ENFORCE(
-            kind != Kind::ClassOrModule,
-            "ClassOrModule symbols should always be entered first, so they should never need to mangle something else");
         if (auto e = ctx.beginError(errorLoc, core::errors::Namer::ConstantKindRedefinition)) {
             auto prevSymbolKind = prettySymbolKind(ctx, prevSymbol.kind());
             if (prevSymbol.kind() == Kind::ClassOrModule && prevSymbol.asClassOrModuleRef().data(ctx)->isDeclared()) {
@@ -1214,8 +1211,19 @@ private:
             auto owner = getOwnerSymbol(state, klass.owner);
             auto member = owner.data(ctx)->findMember(ctx, klass.name);
             if (member.exists()) {
-                // If member exists with this name, it must be a class or module, because we never mangle-rename them.
-                symbol = member.asClassOrModuleRef();
+                if (member.isClassOrModule()) {
+                    symbol = member.asClassOrModuleRef();
+                } else {
+                    emitRedefinedConstantError(ctx, klass.declLoc, klass.name, core::SymbolRef::Kind::ClassOrModule,
+                                               member);
+                    // Payload constants already exist before namer runs. Enter the conflicting class under a
+                    // mangled name so that we can still symbolize and visit its body.
+                    symbol = ctx.state.lookupClassSymbol(owner, klass.name);
+                    if (!symbol.exists()) {
+                        auto mangledName = ctx.state.nextMangledName(owner, klass.name);
+                        symbol = ctx.state.enterClassOrModuleSymbol(ctx.locAt(klass.declLoc), owner, mangledName);
+                    }
+                }
             } else {
                 auto newClass = ctx.state.enterClassOrModuleSymbol(ctx.locAt(klass.declLoc), owner, klass.name);
                 symbol = newClass;

--- a/test/testdata/namer/redefines_payload_static_field_as_module.rb
+++ b/test/testdata/namer/redefines_payload_static_field_as_module.rb
@@ -1,0 +1,5 @@
+# typed: false
+
+module CSV::DEFAULT_OPTIONS::Foo # error: Redefining constant `DEFAULT_OPTIONS` as a class or module
+  DoesNotExist # error: Unable to resolve constant `DoesNotExist`
+end


### PR DESCRIPTION
> Alternative implementation of the fix described in [#10431](https://github.com/sorbet/sorbet/pull/10431).

This used to crash when `FOO` came from a payload RBI and was reopened from a user file:

```rb
# payload RBI
FOO = T.let(T.unsafe(nil), Integer)
```

```rb
# user file
module FOO::Bar; end
```

Payload RBI files are loaded into `GlobalState` before namer processes user files. This means payload static fields like `FOO` are already present in `owner.members()` while namer is entering class/module definitions.

That differs from regular input RBI files. For files passed on the command line, namer first records static fields in `FoundDefinitions`, enters all class/module definitions, and only inserts static fields later. Those conflicts are therefore reported from `insertStaticField`.

`getClassSymbol` assumed that an existing member with the requested class/module name must itself be a class/module, because class/module symbols are normally entered before constants. That assumption is false for payload constants. When `module FOO::Bar` tried to open `FOO`, debug builds tripped the `asClassOrModuleRef` `ENFORCE` and release builds could segfault.

### Implementation

When `getClassSymbol` finds an existing non-class symbol:

 1. Emit the normal constant-kind redefinition error.
 2. Look for an existing mangled class or module symbol.
 3. If none exists, enter the conflicting class or module under the next `MangleRename` name.

The original payload static field remains available under its source name, while the mangled class symbol lets namer symbolize and visit the invalid class or module body. This allows Sorbet to report additional errors inside that body instead of discarding it.

This relaxes the previous assumptions that:
 - class and module symbols are never entered under MangleRename names;
 - emitRedefinedConstantError is never called for a class or module definition.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

Closes https://github.com/sorbet/sorbet/pull/10431.