### PR TITLE
Allow raise before `T.absurd` in dead branches

### DIFF
--- a/infer/environment.cc
+++ b/infer/environment.cc
@@ -774,25 +774,30 @@ void Environment::setTypeAndOrigin(cfg::LocalRef symbol, const core::TypeAndOrig
 }
 
 const Environment &Environment::withCond(core::Context ctx, const Environment &env, Environment &copy, bool isTrue,
-                                         const UnorderedMap<cfg::LocalRef, VariableState> &filter) {
+                                         const UnorderedMap<cfg::LocalRef, VariableState> &filter,
+                                         bool applyKnowledgeInDeadBranch) {
     ENFORCE(env.bb->bexit.cond.variable.exists());
     if (env.bb->bexit.cond.variable == cfg::LocalRef::unconditional() ||
         env.bb->bexit.cond.variable == cfg::LocalRef::blockCall()) {
         return env;
     }
     copy.cloneFrom(env);
-    copy.assumeKnowledge(ctx, isTrue, env.bb->bexit.cond.variable, ctx.locAt(env.bb->bexit.loc), filter);
+    copy.assumeKnowledge(ctx, isTrue, env.bb->bexit.cond.variable, ctx.locAt(env.bb->bexit.loc), filter,
+                         applyKnowledgeInDeadBranch);
     return copy;
 }
 
 void Environment::assumeKnowledge(core::Context ctx, bool isTrue, cfg::LocalRef cond, core::Loc loc,
-                                  const UnorderedMap<cfg::LocalRef, VariableState> &filter) {
+                                  const UnorderedMap<cfg::LocalRef, VariableState> &filter,
+                                  bool applyKnowledgeInDeadBranch) {
     const auto &thisKnowledge = getKnowledge(cond, false);
     thisKnowledge.sanityCheck();
     if (!isTrue) {
         if (getKnownTruthy(cond)) {
             isDead = true;
-            return;
+            if (!applyKnowledgeInDeadBranch) {
+                return;
+            }
         }
 
         core::TypeAndOrigins tp = getTypeAndOrigin(cond);
@@ -803,7 +808,9 @@ void Environment::assumeKnowledge(core::Context ctx, bool isTrue, cfg::LocalRef 
             tp.type = core::Types::all(ctx, tp.type, core::Types::falsyTypes());
             if (tp.type.isBottom()) {
                 isDead = true;
-                return;
+                if (!applyKnowledgeInDeadBranch) {
+                    return;
+                }
             }
         }
         setTypeAndOrigin(cond, tp);
@@ -813,13 +820,15 @@ void Environment::assumeKnowledge(core::Context ctx, bool isTrue, cfg::LocalRef 
         tp.type = core::Types::dropSubtypesOf(ctx, tp.type, core::Types::falsySymbols());
         if (tp.type.isBottom()) {
             isDead = true;
-            return;
+            if (!applyKnowledgeInDeadBranch) {
+                return;
+            }
         }
         setTypeAndOrigin(cond, tp);
         _vars[cond].knownTruthy = true;
     }
 
-    if (isDead) {
+    if (isDead && !applyKnowledgeInDeadBranch) {
         return;
     }
 
@@ -840,7 +849,9 @@ void Environment::assumeKnowledge(core::Context ctx, bool isTrue, cfg::LocalRef 
         setTypeAndOrigin(typeTested.first, tp);
         if (tp.type.isBottom()) {
             isDead = true;
-            return;
+            if (!applyKnowledgeInDeadBranch) {
+                return;
+            }
         }
     }
 
@@ -856,7 +867,9 @@ void Environment::assumeKnowledge(core::Context ctx, bool isTrue, cfg::LocalRef 
             setTypeAndOrigin(typeTested.first, tp);
             if (tp.type.isBottom()) {
                 isDead = true;
-                return;
+                if (!applyKnowledgeInDeadBranch) {
+                    return;
+                }
             }
         }
     }
@@ -1626,14 +1639,24 @@ Environment::processBinding(core::Context ctx, const cfg::CFG &inWhat, cfg::Bind
             [&](cfg::TAbsurd &i) {
                 const core::TypeAndOrigins &typeAndOrigin = getTypeAndOrigin(i.what.variable);
 
-                if (auto e = ctx.beginError(bind.loc, core::errors::Infer::NotExhaustive)) {
-                    if (typeAndOrigin.type.isUntyped()) {
-                        e.setHeader("Control flow could reach `{}` because argument was `{}`", "T.absurd", "T.untyped");
-                    } else {
-                        e.setHeader("Control flow could reach `{}` because the type `{}` wasn't handled", "T.absurd",
-                                    typeAndOrigin.type.show(ctx));
+                // Inference normally visits T.absurd only while control flow is live. Raise-before-absurd blocks
+                // are also checked when dead, where an exhaustive argument can be represented as either bottom
+                // directly or a type semantically equivalent to bottom (for example, T.noreturn).
+
+                const bool isBottom = typeAndOrigin.type.isBottom() ||
+                                      (!typeAndOrigin.type.isUntyped() &&
+                                       core::Types::isSubType(ctx, typeAndOrigin.type, core::Types::bottom()));
+                if (!isBottom) {
+                    if (auto e = ctx.beginError(bind.loc, core::errors::Infer::NotExhaustive)) {
+                        if (typeAndOrigin.type.isUntyped()) {
+                            e.setHeader("Control flow could reach `{}` because argument was `{}`", "T.absurd",
+                                        "T.untyped");
+                        } else {
+                            e.setHeader("Control flow could reach `{}` because the type `{}` wasn't handled",
+                                        "T.absurd", typeAndOrigin.type.show(ctx));
+                        }
+                        e.addErrorSection(typeAndOrigin.explainGot(ctx, ownerLoc));
                     }
-                    e.addErrorSection(typeAndOrigin.explainGot(ctx, ownerLoc));
                 }
 
                 tp.type = core::Types::bottom();

--- a/infer/environment.h
+++ b/infer/environment.h
@@ -228,7 +228,7 @@ class Environment {
     void setTypeAndOrigin(cfg::LocalRef symbol, const core::TypeAndOrigins &typeAndOrigins);
 
     void assumeKnowledge(core::Context ctx, bool isTrue, cfg::LocalRef cond, core::Loc loc,
-                         const UnorderedMap<cfg::LocalRef, VariableState> &filter);
+                         const UnorderedMap<cfg::LocalRef, VariableState> &filter, bool applyKnowledgeInDeadBranch);
 
     void cloneFrom(const Environment &rhs);
 
@@ -262,7 +262,11 @@ public:
 
     /*
      * Create an Environment out of this one that holds if final condition in
-     * this environment was isTrue
+     * this environment was isTrue.
+     *
+     * When applyKnowledgeInDeadBranch is true, apply the branch's knowledge
+     * even if the condition proves that branch unreachable. This supplies the
+     * counterfactual types needed to check T.absurd in a dead branch.
      *
      * Either returns a reference to `env` unchanged, or populates `copy` and
      * returns a reference to that. This odd calling convention is used to avoid
@@ -270,7 +274,8 @@ public:
      * then discard it, so the mixed lifetimes are not a problem in practice.
      */
     static const Environment &withCond(core::Context ctx, const Environment &env, Environment &copy, bool isTrue,
-                                       const UnorderedMap<cfg::LocalRef, VariableState> &filter);
+                                       const UnorderedMap<cfg::LocalRef, VariableState> &filter,
+                                       bool applyKnowledgeInDeadBranch);
 
     void mergeWith(core::Context ctx, const Environment &other, cfg::CFG &inWhat, cfg::BasicBlock *bb,
                    KnowledgeFilter &knowledgeFilter);

--- a/infer/inference.cc
+++ b/infer/inference.cc
@@ -38,8 +38,28 @@ bool Inference::willRun(core::Context ctx, core::LocOffsets loc, core::MethodRef
     return true;
 }
 
-bool silenceDeadCodeError(const cfg::InstructionPtr &value) {
-    return value.isSynthetic() || cfg::isa_instruction<cfg::TAbsurd>(value);
+InlinedVector<core::LocOffsets, 1> raiseLocsBeforeAbsurd(const cfg::BasicBlock &bb) {
+    InlinedVector<core::LocOffsets, 1> result;
+    optional<core::LocOffsets> precedingRaiseLoc;
+    for (const auto &bind : bb.exprs) {
+        auto send = cfg::cast_instruction<cfg::Send>(bind.value);
+        if (send != nullptr && send->fun == core::Names::raise()) {
+            precedingRaiseLoc = bind.loc;
+        } else if (precedingRaiseLoc.has_value() && cfg::isa_instruction<cfg::TAbsurd>(bind.value)) {
+            result.emplace_back(*precedingRaiseLoc);
+            precedingRaiseLoc.reset();
+        }
+    }
+    return result;
+}
+
+bool silenceDeadCodeError(const cfg::Binding &bind, absl::Span<const core::LocOffsets> allowedRaiseLocs) {
+    if (bind.value.isSynthetic() || cfg::isa_instruction<cfg::TAbsurd>(bind.value)) {
+        return true;
+    }
+
+    return bind.loc.exists() &&
+           absl::c_any_of(allowedRaiseLocs, [&](const auto &raiseLoc) { return raiseLoc.contains(bind.loc); });
 }
 
 unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg) {
@@ -130,6 +150,8 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
         }
         Environment &current = outEnvironments[bb->id];
         current.initializeBasicBlockArgs(*bb);
+        const auto allowedRaiseLocs = raiseLocsBeforeAbsurd(*bb);
+        const bool deadButTypecheckAnyways = !allowedRaiseLocs.empty();
 
         // We very much want to limit access to "global" data structures downstream.
         // In particular, processBinding should only need to know about the current binding (nothing
@@ -150,8 +172,8 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
             bool isTrueBranch = parent->bexit.thenb == bb;
             if (!outEnvironments[parent->id].isDead) {
                 Environment tempEnv(methodLoc);
-                auto &envAsSeenFromBranch =
-                    Environment::withCond(ctx, outEnvironments[parent->id], tempEnv, isTrueBranch, current.vars());
+                auto &envAsSeenFromBranch = Environment::withCond(
+                    ctx, outEnvironments[parent->id], tempEnv, isTrueBranch, current.vars(), deadButTypecheckAnyways);
                 current.populateFrom(ctx, envAsSeenFromBranch);
 
                 parentUpdateKnowledgeReceiver = parent->maybeGetUpdateKnowledgeReceiver(*cfg);
@@ -166,8 +188,8 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                 }
                 bool isTrueBranch = parent->bexit.thenb == bb;
                 Environment tempEnv(methodLoc);
-                auto &envAsSeenFromBranch =
-                    Environment::withCond(ctx, outEnvironments[parent->id], tempEnv, isTrueBranch, current.vars());
+                auto &envAsSeenFromBranch = Environment::withCond(
+                    ctx, outEnvironments[parent->id], tempEnv, isTrueBranch, current.vars(), deadButTypecheckAnyways);
                 if (!envAsSeenFromBranch.isDead) {
                     current.isDead = false;
                     current.mergeWith(ctx, envAsSeenFromBranch, *cfg.get(), bb, knowledgeFilter);
@@ -183,6 +205,12 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
         }
 
         visited[bb->id] = true;
+
+        cfg::InstructionPtr *unreachableInstruction = nullptr;
+        core::Loc locForUnreachable;
+        bool dueToSafeNavigation = false;
+        const bool deadAtEntry = current.isDead;
+
         if (current.isDead) {
             bb->firstDeadInstructionIdx = 0;
             // this block is unreachable.
@@ -194,26 +222,21 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
             //
             //   1. If this block is only dead because all jumps into this block are dead,
             //      we already reported an error and don't want a duplicate.
-            //   2. If the block consists only of synthetic bindings or T.absurd, we don't
-            //      want to issue an error.
+            //   2. If the block consists only of synthetic bindings, T.absurd, or a raise
+            //      preceding T.absurd, we don't want to issue a dead-code error.
             //   3. If the block contains a send of the form <Magic>.<nil-for-safe-navigation>(x),
             //      we want to issue an UnnecessarySafeNavigationError, extracting
             //      type-and-origin info from x. (This magic form is inserted by the desugarer
             //      for a "safe navigation" operation, e.g., `x&.foo`.)
             //   4. Otherwise, we want to issue a DeadBranchInferencer error, taking the first
-            //      (non-synthetic, non-"T.absurd") instruction in the block as the loc of the
-            //      error.
+            //      non-silenced instruction in the block as the loc of the error.
 
             if (!absl::c_any_of(bb->backEdges, [&](const auto &bb) { return !outEnvironments[bb->id].isDead; })) {
                 continue;
             }
 
-            cfg::InstructionPtr *unreachableInstruction = nullptr;
-            core::Loc locForUnreachable;
-            bool dueToSafeNavigation = false;
-
             for (auto &expr : bb->exprs) {
-                if (silenceDeadCodeError(expr.value)) {
+                if (silenceDeadCodeError(expr, allowedRaiseLocs)) {
                     continue;
                 }
 
@@ -241,126 +264,50 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
                 }
             }
 
-            if (unreachableInstruction == nullptr) {
+            if (unreachableInstruction == nullptr && !deadButTypecheckAnyways) {
+                // There is no diagnostic to report and no exhaustiveness check to run.
                 continue;
             }
-
-            auto send = cfg::cast_instruction<cfg::Send>(*unreachableInstruction);
-            if (dueToSafeNavigation && send != nullptr) {
-                if (auto e = ctx.state.beginError(locForUnreachable, core::errors::Infer::UnnecessarySafeNavigation)) {
-                    const auto &ty = current.getAndFillTypeAndOrigin(send->argRefs()[0], send->argTypes()[0]);
-
-                    e.setHeader("Used `{}` operator on `{}`, which can never be nil", "&.", ty.type.show(ctx));
-                    e.addErrorSection(ty.explainGot(ctx, current.locForUninitialized()));
-                    if (locForUnreachable.source(ctx) == "&.") {
-                        e.replaceWith("Replace with `.`", locForUnreachable, ".");
-                    }
-                }
-            } else if (auto e = ctx.state.beginError(locForUnreachable, core::errors::Infer::DeadBranchInferencer)) {
-                auto ident = cfg::cast_instruction<cfg::Ident>(*unreachableInstruction);
-
-                bool andAndOrOr = false;
-                if (ident != nullptr) {
-                    auto name = ident->what.data(*cfg)._name;
-                    if (name.isUniqueNameOf(ctx, core::Names::andAnd())) {
-                        e.setHeader("Left side of `{}` condition was always `{}`", "&&", "truthy");
-                        andAndOrOr = true;
-                    } else if (name.isUniqueNameOf(ctx, core::Names::orOr())) {
-                        e.setHeader("Left side of `{}` condition was always `{}`", "||", "falsy");
-                        andAndOrOr = true;
-                    }
-                }
-                if (!andAndOrOr) {
-                    e.setHeader("This code is unreachable");
-                }
-
-                for (const auto &prevBasicBlock : bb->backEdges) {
-                    const auto &prevEnv = outEnvironments[prevBasicBlock->id];
-                    if (prevEnv.isDead) {
-                        // This previous block doesn't actually matter, because it was dead
-                        // (never got to evaluating its jump condition), so don't clutter
-                        // the error message.
-                        continue;
-                    }
-
-                    const auto &cond = prevBasicBlock->bexit.cond;
-                    if (cond.type == nullptr) {
-                        // This previous block is actually a future block we haven't processed yet.
-                        // (Remember: our inference pass is an approximate forwards toposort
-                        // of a graph that can have cycles). It can't have been a block that
-                        // caused the current error.
-                        continue;
-                    }
-
-                    auto alwaysWhat = prevBasicBlock->bexit.thenb->id == bb->id ? "falsy" : "truthy";
-                    auto bexitLoc = ctx.locAt(prevBasicBlock->bexit.loc);
-
-                    auto bexitVar = cond.variable.data(*cfg)._name;
-                    if ((bexitVar.isUniqueNameOf(ctx, core::Names::andAnd()) ||
-                         bexitVar.isUniqueNameOf(ctx, core::Names::orOr())) &&
-                        !prevBasicBlock->exprs.empty() && prevBasicBlock->exprs.back().bind.variable == cond.variable) {
-                        // ^ This condition is a hack that hardcodes the most common structure of the CFG
-                        // we'd need to handle. If we had SSA form in Sorbet's CFG, we wouldn't have to pray
-                        // that the bexit var's initializer is the .back() of the expression in the block
-                        // (despite how rare it is for that to _not_ be the case).
-
-                        // We want to show one location for the "Conditional branch on untyped" warning/error,
-                        // but setting that location clobbers the location we need for this autocorrect to work.
-                        // So we have to claw back what the LHS of the || or && would have been.
-                        bexitLoc = ctx.locAt(prevBasicBlock->exprs.back().loc);
-                    }
-
-                    e.addErrorLine(bexitLoc, "This condition was always `{}` (`{}`)", alwaysWhat, cond.type.show(ctx));
-
-                    if (ctx.state.suggestUnsafe.has_value() && bexitLoc.exists()) {
-                        e.replaceWith(fmt::format("Wrap in `{}`", *ctx.state.suggestUnsafe), bexitLoc, "{}({})",
-                                      *ctx.state.suggestUnsafe, bexitLoc.source(ctx).value());
-                    }
-
-                    const auto &ty = prevEnv.getTypeAndOrigin(cond.variable);
-                    e.addErrorSection(ty.explainGot(ctx, prevEnv.locForUninitialized()));
-                }
-
-                if (andAndOrOr) {
-                    e.addErrorNote("If this is intentional, either delete the redundant code or restructure\n"
-                                   "    it to use `{}` so that Sorbet can check for exhaustiveness.",
-                                   "T.absurd");
-                }
-            }
-
-            continue;
         }
 
         core::Loc madeBlockDead;
-        int i = 0;
-        for (cfg::Binding &bind : bb->exprs) {
-            i++;
-            if (!current.isDead || !ctx.state.lspQuery.isEmpty()) {
-                bind.bind.type =
-                    current.processBinding(ctx, *cfg, bind, bb->outerLoops, bind.bind.variable.minLoops(*cfg),
-                                           knowledgeFilter, *constr, methodReturnType, parentUpdateKnowledgeReceiver);
-                if (cfg::isa_instruction<cfg::Send>(bind.value)) {
-                    totalSendCount++;
-                    if (bind.bind.type && !bind.bind.type.isUntyped()) {
-                        typedSendCount++;
+        if (unreachableInstruction == nullptr || deadButTypecheckAnyways) {
+            int i = 0;
+            for (cfg::Binding &bind : bb->exprs) {
+                i++;
+                const bool typecheckDeadAbsurd =
+                    current.isDead && deadButTypecheckAnyways && cfg::isa_instruction<cfg::TAbsurd>(bind.value);
+                if (!current.isDead || !ctx.state.lspQuery.isEmpty() || typecheckDeadAbsurd) {
+                    bind.bind.type = current.processBinding(ctx, *cfg, bind, bb->outerLoops,
+                                                            bind.bind.variable.minLoops(*cfg), knowledgeFilter, *constr,
+                                                            methodReturnType, parentUpdateKnowledgeReceiver);
+                    if (cfg::isa_instruction<cfg::Send>(bind.value)) {
+                        totalSendCount++;
+                        if (bind.bind.type && !bind.bind.type.isUntyped()) {
+                            typedSendCount++;
+                        }
                     }
+                    ENFORCE(bind.bind.type);
+                    bind.bind.type.sanityCheck(ctx);
+                    if (bind.bind.type.isBottom()) {
+                        current.isDead = true;
+                        madeBlockDead = ctx.locAt(bind.loc);
+                    }
+                    if (current.isDead && bb->firstDeadInstructionIdx == -1) {
+                        // this can also be result of evaluating an instruction, e.g. an always false hard_assert
+                        bb->firstDeadInstructionIdx = i;
+                    }
+                } else if (deadAtEntry && deadButTypecheckAnyways) {
+                    // Only T.absurd needs typechecking in a block that was dead on entry. Dead-code reporting for
+                    // the remaining bindings is deferred until after the exhaustiveness check.
+                    continue;
+                } else if (ctx.state.lspQuery.isEmpty() && !silenceDeadCodeError(bind, allowedRaiseLocs)) {
+                    if (auto e = ctx.beginError(bind.loc, core::errors::Infer::DeadBranchInferencer)) {
+                        e.setHeader("This code is unreachable");
+                        e.addErrorLine(madeBlockDead, "This expression always raises or can never be computed");
+                    }
+                    break;
                 }
-                ENFORCE(bind.bind.type);
-                bind.bind.type.sanityCheck(ctx);
-                if (bind.bind.type.isBottom()) {
-                    current.isDead = true;
-                    madeBlockDead = ctx.locAt(bind.loc);
-                }
-                if (current.isDead && bb->firstDeadInstructionIdx == -1) {
-                    // this can also be result of evaluating an instruction, e.g. an always false hard_assert
-                    bb->firstDeadInstructionIdx = i;
-                }
-            } else if (ctx.state.lspQuery.isEmpty() && current.isDead && !silenceDeadCodeError(bind.value)) {
-                if (auto e = ctx.beginError(bind.loc, core::errors::Infer::DeadBranchInferencer)) {
-                    e.setHeader("This code is unreachable");
-                    e.addErrorLine(madeBlockDead, "This expression always raises or can never be computed");
-                }
-                break;
             }
         }
         if (!current.isDead) {
@@ -384,6 +331,95 @@ unique_ptr<cfg::CFG> Inference::run(core::Context ctx, unique_ptr<cfg::CFG> cfg)
             }
         } else {
             ENFORCE(bb->firstDeadInstructionIdx != -1);
+
+            if (unreachableInstruction != nullptr) {
+                auto send = cfg::cast_instruction<cfg::Send>(*unreachableInstruction);
+                if (dueToSafeNavigation && send != nullptr) {
+                    if (auto e =
+                            ctx.state.beginError(locForUnreachable, core::errors::Infer::UnnecessarySafeNavigation)) {
+                        const auto &ty = current.getAndFillTypeAndOrigin(send->argRefs()[0], send->argTypes()[0]);
+
+                        e.setHeader("Used `{}` operator on `{}`, which can never be nil", "&.", ty.type.show(ctx));
+                        e.addErrorSection(ty.explainGot(ctx, current.locForUninitialized()));
+                        if (locForUnreachable.source(ctx) == "&.") {
+                            e.replaceWith("Replace with `.`", locForUnreachable, ".");
+                        }
+                    }
+                } else if (auto e =
+                               ctx.state.beginError(locForUnreachable, core::errors::Infer::DeadBranchInferencer)) {
+                    auto ident = cfg::cast_instruction<cfg::Ident>(*unreachableInstruction);
+
+                    bool andAndOrOr = false;
+                    if (ident != nullptr) {
+                        auto name = ident->what.data(*cfg)._name;
+                        if (name.isUniqueNameOf(ctx, core::Names::andAnd())) {
+                            e.setHeader("Left side of `{}` condition was always `{}`", "&&", "truthy");
+                            andAndOrOr = true;
+                        } else if (name.isUniqueNameOf(ctx, core::Names::orOr())) {
+                            e.setHeader("Left side of `{}` condition was always `{}`", "||", "falsy");
+                            andAndOrOr = true;
+                        }
+                    }
+                    if (!andAndOrOr) {
+                        e.setHeader("This code is unreachable");
+                    }
+
+                    for (const auto &prevBasicBlock : bb->backEdges) {
+                        const auto &prevEnv = outEnvironments[prevBasicBlock->id];
+                        if (prevEnv.isDead) {
+                            // This previous block doesn't actually matter, because it was dead
+                            // (never got to evaluating its jump condition), so don't clutter
+                            // the error message.
+                            continue;
+                        }
+
+                        const auto &cond = prevBasicBlock->bexit.cond;
+                        if (cond.type == nullptr) {
+                            // This previous block is actually a future block we haven't processed yet.
+                            // (Remember: our inference pass is an approximate forwards toposort
+                            // of a graph that can have cycles). It can't have been a block that
+                            // caused the current error.
+                            continue;
+                        }
+
+                        auto alwaysWhat = prevBasicBlock->bexit.thenb->id == bb->id ? "falsy" : "truthy";
+                        auto bexitLoc = ctx.locAt(prevBasicBlock->bexit.loc);
+
+                        auto bexitVar = cond.variable.data(*cfg)._name;
+                        if ((bexitVar.isUniqueNameOf(ctx, core::Names::andAnd()) ||
+                             bexitVar.isUniqueNameOf(ctx, core::Names::orOr())) &&
+                            !prevBasicBlock->exprs.empty() &&
+                            prevBasicBlock->exprs.back().bind.variable == cond.variable) {
+                            // ^ This condition is a hack that hardcodes the most common structure of the CFG
+                            // we'd need to handle. If we had SSA form in Sorbet's CFG, we wouldn't have to pray
+                            // that the bexit var's initializer is the .back() of the expression in the block
+                            // (despite how rare it is for that to _not_ be the case).
+
+                            // We want to show one location for the "Conditional branch on untyped" warning/error,
+                            // but setting that location clobbers the location we need for this autocorrect to work.
+                            // So we have to claw back what the LHS of the || or && would have been.
+                            bexitLoc = ctx.locAt(prevBasicBlock->exprs.back().loc);
+                        }
+
+                        e.addErrorLine(bexitLoc, "This condition was always `{}` (`{}`)", alwaysWhat,
+                                       cond.type.show(ctx));
+
+                        if (ctx.state.suggestUnsafe.has_value() && bexitLoc.exists()) {
+                            e.replaceWith(fmt::format("Wrap in `{}`", *ctx.state.suggestUnsafe), bexitLoc, "{}({})",
+                                          *ctx.state.suggestUnsafe, bexitLoc.source(ctx).value());
+                        }
+
+                        const auto &ty = prevEnv.getTypeAndOrigin(cond.variable);
+                        e.addErrorSection(ty.explainGot(ctx, prevEnv.locForUninitialized()));
+                    }
+
+                    if (andAndOrOr) {
+                        e.addErrorNote("If this is intentional, either delete the redundant code or restructure\n"
+                                       "    it to use `{}` so that Sorbet can check for exhaustiveness.",
+                                       "T.absurd");
+                    }
+                }
+            }
         }
         histogramInc("infer.environment.size", current.vars().size());
         for (auto &pair : current.vars()) {

--- a/test/testdata/infer/raise_in_dead_branch.rb
+++ b/test/testdata/infer/raise_in_dead_branch.rb
@@ -1,0 +1,89 @@
+# typed: true
+
+extend T::Sig
+
+sig {params(x: String).void}
+def non_exhaustive_dead_branch(x)
+  unless true
+    raise ArgumentError, "Unexpected value: #{x}"
+    T.absurd(x) # error: Control flow could reach `T.absurd` because the type `String` wasn't handled
+  end
+end
+
+sig {params(x: T.any(Integer, String)).void}
+def exhaustive_dead_branch(x)
+  case x
+  when Integer
+  when String
+  else
+    raise ArgumentError, "Unexpected value: #{x}"
+    T.absurd(x)
+  end
+end
+
+sig {params(x: T.any(Integer, String)).void}
+def unresolved_raise_constant_still_errors(x)
+  case x
+  when Integer
+  when String
+  else
+    raise NotFoundConstant # error: Unable to resolve constant
+    T.absurd(x)
+  end
+end
+
+sig {params(x: String).void}
+def unrelated_dead_code_still_errors(x)
+  unless true
+    puts(x) # error: This code is unreachable
+    raise ArgumentError, "Unexpected value: #{x}"
+    T.absurd(x) # error: Control flow could reach `T.absurd` because the type `String` wasn't handled
+  end
+end
+
+sig {params(x: T.any(Integer, String)).void}
+def non_exhaustive_live_branch(x)
+  case x
+  when Integer
+  else
+    raise ArgumentError, "Unexpected value: #{x}"
+    T.absurd(x) # error: Control flow could reach `T.absurd` because the type `String` wasn't handled
+  end
+end
+
+sig {void}
+def unpaired_raise_still_errors
+  unless true
+    raise ArgumentError, "Unexpected value" # error: This code is unreachable
+  end
+end
+
+sig {params(x: String).void}
+def only_closest_raise_is_allowed(x)
+  unless true
+    raise ArgumentError, "First failure" # error: This code is unreachable
+    raise RuntimeError, "Unexpected value: #{x}"
+    T.absurd(x) # error: Control flow could reach `T.absurd` because the type `String` wasn't handled
+  end
+end
+
+sig {params(x: String, y: Integer).void}
+def multiple_raise_absurd_pairs_are_allowed(x, y)
+  unless true
+    raise ArgumentError, "Unexpected value: #{x}"
+    T.absurd(x) # error: Control flow could reach `T.absurd` because the type `String` wasn't handled
+    raise RuntimeError, "Unexpected value: #{y}"
+    T.absurd(y) # error: Control flow could reach `T.absurd` because the type `Integer` wasn't handled
+  end
+end
+
+sig {params(x: T.any(Integer, String)).void}
+def raise_after_absurd_still_errors(x)
+  case x
+  when Integer
+  when String
+  else
+    T.absurd(x)
+    raise ArgumentError, "Unexpected value: #{x}" # error: This code is unreachable
+  end
+end

--- a/website/docs/exhaustiveness.md
+++ b/website/docs/exhaustiveness.md
@@ -46,6 +46,17 @@ And some quick notes:
 
 1.  Sorbet will error statically if the condition to a case statement using `T.absurd` is `T.untyped`. This prevents against losing exhaustiveness checking due to a change in the code that weakens static type information.
 
+To raise a custom exception at runtime while keeping Sorbet's exhaustiveness check, put the `raise` before `T.absurd`:
+
+```ruby
+else
+  raise ArgumentError, "Unexpected value: #{x}"
+  T.absurd(x)
+end
+```
+
+Sorbet still checks the trailing `T.absurd`, while Ruby executes the custom `raise` first if the branch is reached.
+
 Now let's walk through an example explaining not only **how** Sorbet provides exhaustiveness checking, but also **why** it's useful:
 
 ## Example


### PR DESCRIPTION
Alternative approach to https://github.com/sorbet/sorbet/pull/10575 following the discussion in https://github.com/sorbet/sorbet/pull/10575#issuecomment-5348255435.

### Summary

Allow a raise immediately before `T.absurd` in an unreachable branch:

 ```ruby
case value
when Integer
when String
else
  raise ArgumentError, "Unexpected value: #{value}" # ok
  T.absurd(value)
end
```

Sorbet still checks `T.absurd` for exhaustiveness, while Ruby raises the custom exception if the branch is reached.

This completes the dead-branch inference approach prototyped in #9536.

### Motivation

Sorbet normally skips a basic block once it knows that the block is unreachable. Consequently, simply suppressing the dead-code error for raise would also prevent Sorbet from checking the following `T.absurd`.

This change allows the paired raise while preserving normal dead-code detection for unrelated expressions.

### Implementation

- Pair each `T.absurd` with its closest preceding raise in the same basic block
- Exclude the paired raise and its argument bindings from dead-code diagnostics
- Enter eligible blocks that are dead at entry and process their `T.absurd`
- Defer unrelated dead-code diagnostics until after checking `T.absurd`

### Test plan

<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.
