### PR TITLE
compute error location only when we know we have an error

### DIFF
--- a/core/types/calls.cc
+++ b/core/types/calls.cc
@@ -390,10 +390,10 @@ unique_ptr<Error> matchArgType(const GlobalState &gs, TypeConstraint &constr, Lo
 unique_ptr<Error> reportMissingKwargs(const GlobalState &gs, const DispatchArgs &args, MethodRef method,
                                       const vector<const ParamInfo *> &missingKwargs, ClassOrModuleRef inClass,
                                       const vector<TypePtr> &targs) {
-    auto errLoc = args.argsLoc(gs).copyEndWithZeroLength();
     if (missingKwargs.empty()) {
         return nullptr;
     }
+    auto errLoc = args.argsLoc(gs).copyEndWithZeroLength();
     if (auto e = gs.beginError(errLoc, errors::Infer::MethodArgumentCountMismatch)) {
         if (missingKwargs.size() == 1) {
             e.setHeader("Missing required keyword argument `{}` for method `{}`", missingKwargs[0]->name.show(gs),


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->

cc @zanker-stripe 

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

This was originally found by zanker when ordering Claude to improve Sorbet performance; it helped with the ability to eagerly drop in-memory file sources.

But it's just a good change on its own.  Computing `argsLoc` is not cheap, and not having any missing kwargs is the common case, so we ought to move the computation regardless of the outcome of dropping the file sources.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Existing tests.