### PR TITLE
no-op: Remove unused struct

### DIFF
--- a/packager/packager.cc
+++ b/packager/packager.cc
@@ -153,18 +153,6 @@ bool isRootScopedDefinition(const ast::ConstantLit *lit) {
     return false;
 }
 
-struct PackageForSymbolResult {
-    // The closest package for `sym`
-    MangledName bestPkg;
-
-    // The closest owner symbol inside `<PackageSpecRegistry>`. Might not actually correspond to a
-    // package if it's just a namespace, e.g. `<PSR>::Pkg1::NS` for `::Pkg1::Inner::NS::A`
-    core::ClassOrModuleRef bestOwner;
-
-    // Could be a prefix if `sym` is a `ClassOrModuleRef`
-    bool couldBePrefix;
-};
-
 bool ownsPackage(const core::GlobalState &gs, const core::ClassOrModuleRef ownerForScope, MangledName pkg) {
     auto owner = pkg.owner;
     while (owner != core::Symbols::root()) {


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I deleted the last reference of this struct in this PR:

ca67958a34d4ceb61fca3a68f5ac72e9401f6612

(forgot to delete the struct itself)


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.