### PR TITLE
Report current swap usage on Linux

### DIFF
--- a/common/os/emscripten.cc
+++ b/common/os/emscripten.cc
@@ -1,8 +1,13 @@
 #ifdef EMSCRIPTEN
 
+#include "common/os/os.h"
 #include <string>
 
 using namespace std;
+
+optional<size_t> getCurrentProcessSwapUsageKb() {
+    return nullopt;
+}
 
 bool stopInDebugger() {
     return false;

--- a/common/os/linux.cc
+++ b/common/os/linux.cc
@@ -1,11 +1,14 @@
 #ifdef __linux__
 #include "absl/debugging/symbolize.h"
+#include "common/os/os.h"
 #include "spdlog/spdlog.h"
 #include <climits>
 #include <csignal>
 #include <cstdio>
 #include <cstring>
 #include <fcntl.h>
+#include <fstream>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <sys/stat.h>
@@ -85,6 +88,23 @@ bool amIBeingDebugged() {
     }
 
     return false;
+}
+
+optional<size_t> getCurrentProcessSwapUsageKb() {
+    ifstream status("/proc/self/status");
+    string key;
+    while (status >> key) {
+        if (key == "VmSwap:") {
+            size_t swapKb;
+            string unit;
+            if (status >> swapKb >> unit && unit == "kB") {
+                return swapKb;
+            }
+            return nullopt;
+        }
+        status.ignore(numeric_limits<streamsize>::max(), '\n');
+    }
+    return nullopt;
 }
 
 bool stopInDebugger() {

--- a/common/os/mac.cc
+++ b/common/os/mac.cc
@@ -1,5 +1,6 @@
 #ifdef __APPLE__
 #include "absl/debugging/symbolize.h"
+#include "common/os/os.h"
 #include "spdlog/spdlog.h"
 #include <cassert>
 #include <cstdio>
@@ -65,6 +66,10 @@ bool amIBeingDebugged()
     // We're being debugged if the P_TRACED flag is set.
 
     return ((info.kp_proc.p_flag & P_TRACED) != 0);
+}
+
+optional<size_t> getCurrentProcessSwapUsageKb() {
+    return nullopt;
 }
 
 bool stopInDebugger() {

--- a/common/os/os.h
+++ b/common/os/os.h
@@ -46,6 +46,9 @@ bool bindThreadToCore(pthread_t handle, int coreId);
 bool stopInDebugger();
 bool amIBeingDebugged();
 
+/** Returns the amount of swap currently used by this process, in KiB, if supported by the platform. */
+std::optional<size_t> getCurrentProcessSwapUsageKb();
+
 void intentionallyLeakMemory(void *ptr);
 
 void initializeSymbolizer(char *argv0);

--- a/common/statsd/BUILD
+++ b/common/statsd/BUILD
@@ -15,6 +15,7 @@ cc_library(
     deps = [
         "//common",
         "//core",
+        "//common/os",
         "//sorbet_version",
     ] + select({
         "@platforms//cpu:wasm32": [],

--- a/common/statsd/statsd.cc
+++ b/common/statsd/statsd.cc
@@ -1,5 +1,6 @@
 #include "common/statsd/statsd.h"
 #include "common/counters/Counters_impl.h"
+#include "common/os/os.h"
 #include "common/strings/formatting.h"
 #include "sorbet_version/sorbet_version.h"
 
@@ -149,6 +150,9 @@ void StatsD::addStandardMetrics() {
         prodCounterAdd("run.utilization.oublock", usage.ru_oublock);
         prodCounterAdd("run.utilization.context_switch.voluntary", usage.ru_nvcsw);
         prodCounterAdd("run.utilization.context_switch.involuntary", usage.ru_nivcsw);
+    }
+    if (auto swapKb = getCurrentProcessSwapUsageKb()) {
+        prodCounterAdd("run.current_swap", *swapKb);
     }
     prodCounterAdd("release.build_scm_commit_count", sorbet::build_scm_commit_count);
     prodCounterAdd("release.build_timestamp", sorbet::build_timestamp);


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Did not test that we get a non-zero value under heavy pressure, but did test that it shows up there on Linux:

```
❯ bazel-bin/main/sorbet -e '0' --counters |& rg swap
                          run.current_swap :              0
```