### PR TITLE
Support abstract methods with spaces

### DIFF
--- a/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
+++ b/gems/sorbet-runtime/lib/types/private/methods/call_validation.rb
@@ -7,7 +7,8 @@ module T::Private::Methods::CallValidation
 
   KERNEL_TO_S = Kernel.instance_method(:to_s)
   MODULE_TO_S = Module.instance_method(:to_s)
-  private_constant(:KERNEL_TO_S, :MODULE_TO_S)
+  METHOD_NAME_FOR_EVAL = /\A[A-Za-z_][A-Za-z0-9_]*[!?]?\z/
+  private_constant(:KERNEL_TO_S, :MODULE_TO_S, :METHOD_NAME_FOR_EVAL)
 
   # Wraps a method with a layer of validation for the given type signature.
   # This wrapper is meant to be fast, and is applied by a previous wrapper,
@@ -52,21 +53,35 @@ module T::Private::Methods::CallValidation
   def self.create_abstract_wrapper(mod, method_name, original_visibility)
     T::Configuration.without_ruby_warnings do
       T::Private::DeclState.current.without_on_method_added do
-        mod.module_eval(<<~METHOD, __FILE__, __LINE__ + 1)
-          #{original_visibility}
+        if METHOD_NAME_FOR_EVAL.match?(method_name)
+          mod.module_eval(<<~METHOD, __FILE__, __LINE__ + 1)
+            #{original_visibility}
 
-          def #{method_name}(...)
+            def #{method_name}(...)
+              # We allow abstract methods to be implemented by things further down the ancestor chain.
+              # So, if a super method exists, call it.
+              if defined?(super)
+                super
+              else
+                raise NotImplementedError.new(
+                  "The method `#{method_name}` on #{mod} is declared as `abstract`. It does not have an implementation."
+                )
+              end
+            end
+          METHOD
+        else
+          T::Private::ClassUtils.def_with_visibility(mod, method_name, original_visibility) do |*args, &blk|
             # We allow abstract methods to be implemented by things further down the ancestor chain.
             # So, if a super method exists, call it.
             if defined?(super)
-              super
+              super(*args, &blk)
             else
               raise NotImplementedError.new(
                 "The method `#{method_name}` on #{mod} is declared as `abstract`. It does not have an implementation."
               )
             end
           end
-        METHOD
+        end
       end
     end
   end

--- a/gems/sorbet-runtime/test/types/abstract_validation.rb
+++ b/gems/sorbet-runtime/test/types/abstract_validation.rb
@@ -106,6 +106,32 @@ class Opus::Types::Test::AbstractValidationTest < Critic::Unit::UnitTest
     )
   end
 
+  it "supports abstract method names that are not valid Ruby identifiers" do
+    method_name = :"method name with spaces"
+    implementation_ran = false
+    abstract_class = Class.new do
+      extend T::Sig
+      extend T::Helpers
+      abstract!
+
+      sig { abstract.void }
+      define_method(method_name) {}
+    end
+    concrete_class = Class.new(abstract_class) do
+      extend T::Sig
+
+      sig { override.void }
+      define_method(method_name) { implementation_ran = true }
+    end
+
+    concrete_class.new.public_send(method_name)
+    assert(implementation_ran)
+
+    assert_raises(NotImplementedError) do
+      abstract_class.allocate.public_send(method_name)
+    end
+  end
+
   it "succeeds if a concrete module implements all abstract methods" do
     mod = Module.new do
       extend T::Sig


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

I'm working on a change to allow making abstract `it`-block defined methods (#10602; so
that people can make abstractions that say that a certain test must be
implemented).

For that to work at runtime, we need `abstract` to allow methods with spaces.
This used to work, up until the changes here:

- #8238

which attempted to optimize the `abstract`-defined wrapper method with
`module_eval`. That doesn't allow syntactically-invalid methods to be defined.
We can bring back the slow technique to support those methods.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.

There's a use of `.allocate` that's a bit lurky but is designed to test that the
`NotImplementedError` is actually called.