### PR TITLE
Match package-directed order in stress incremental tests

### DIFF
--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -435,6 +435,93 @@ void autogen(core::GlobalState &gs, vector<core::FileRef> files, ExpectationHand
     handler.checkExpectations();
 }
 
+vector<ast::ParsedFile> indexForStressIncremental(core::GlobalState *gs, absl::Span<core::FileRef> files,
+                                                  ExpectationHandler &handler) {
+    vector<ast::ParsedFile> newTrees;
+    newTrees.reserve(files.size());
+    for (auto &f : files) {
+        if (f.data(*gs).strictLevel == core::StrictLevel::Ignore) {
+            newTrees.emplace_back(ast::make_expression<ast::EmptyTree>(), f);
+            continue;
+        }
+
+        const int prohibitedLines = f.data(*gs).source().size();
+        auto newSource = absl::StrCat(string(prohibitedLines + 1, '\n'), f.data(*gs).source());
+        auto newFile = make_shared<core::File>(string(f.data(*gs).path()), move(newSource), f.data(*gs).sourceType);
+        gs->replaceFile(f, move(newFile));
+
+        core::MutableContext ctx(*gs, core::Symbols::root(), f);
+
+        handler.drainErrors(*gs);
+
+        // this replicates the logic of pipeline::indexOne
+        ast::ExpressionPtr ast;
+        switch (parser) {
+            case realmain::options::Parser::ORIGINAL: {
+                ENFORCE(!gs->cacheSensitiveOptions.rbsEnabled, "RBS mode is only supported with the Prism parser");
+
+                // Parser
+                parser::ParseResult parseResult;
+                {
+                    auto settings = parser::Parser::Settings{false, false, false};
+                    parseResult = parser::Parser::run(*gs, f, settings);
+                }
+
+                handler.addObserved(*gs, "parse-tree", [&]() { return parseResult.tree->toString(*gs); });
+                handler.addObserved(*gs, "parse-tree-whitequark",
+                                    [&]() { return parseResult.tree->toWhitequark(*gs); });
+                handler.addObserved(*gs, "parse-tree-json", [&]() { return parseResult.tree->toJSON(*gs); });
+
+                // Desugarer
+                ast = ast::desugar::node2Tree(ctx, move(parseResult.tree));
+
+                handler.addObserved(*gs, "desguar-tree", [&]() { return ast.toString(*gs); });
+                handler.addObserved(*gs, "desugar-tree-raw", [&]() { return ast.showRaw(*gs); });
+
+                break;
+            }
+
+            case realmain::options::Parser::PRISM: {
+                auto prismResult = parser::Prism::Parser::run(ctx);
+
+                // Run the RBS rewriter
+                if (gs->cacheSensitiveOptions.rbsEnabled) {
+                    auto &prismParser = prismResult.getParser();
+                    rbs::runRBSRewrite(*gs, f, prismResult.getRawNodePointer(), prismResult.getCommentLocations(), ctx,
+                                       prismParser);
+
+                    handler.addObserved(*gs, "rbs-rewrite-tree", [&]() { return prismResult.prettyPrint(); });
+                }
+
+                // Prism Desugarer
+                { ast = ast::Desugar::Prism::node2Tree(ctx, move(prismResult)); }
+
+                // Do *not* check the `desugar-tree` and `desugar-tree-raw` expectations for the Prism parser,
+                // which can be subtly different (e.g. the numbering of unique identifiers).
+                // Instead, we compare the two ASTs in the `index()` function.
+
+                break;
+            }
+        }
+
+        // Rewriter pass
+        ast = rewriter::Rewriter::run(ctx, move(ast));
+        handler.addObserved(*gs, "rewrite-tree", [&]() { return ast.toString(*gs); });
+        handler.addObserved(*gs, "rewrite-tree-raw", [&]() { return ast.showRaw(*gs); });
+
+        // local vars
+        auto file = ast::ParsedFile{move(ast), f};
+        file = local_vars::LocalVars::run(ctx, move(file));
+        testSerialize(*gs, file);
+        handler.addObserved(*gs, "index-tree", [&]() { return file.tree.toString(*gs); });
+        handler.addObserved(*gs, "index-tree-raw", [&]() { return file.tree.showRaw(*gs); });
+
+        newTrees.emplace_back(move(file));
+    }
+    fast_sort(newTrees, [](const auto &lhs, const auto &rhs) { return lhs.file < rhs.file; });
+    return newTrees;
+}
+
 TEST_CASE("PerPhaseTest") {
     Expectations test = Expectations::getExpectations(singleTest);
 
@@ -756,88 +843,7 @@ TEST_CASE("PerPhaseTest") {
     handler.clear(*gs);
     auto symbolsBefore = gs->symbolsUsedTotal();
 
-    vector<ast::ParsedFile> newTrees;
-    for (auto &f : files) {
-        if (f.data(*gs).strictLevel == core::StrictLevel::Ignore) {
-            newTrees.emplace_back(ast::make_expression<ast::EmptyTree>(), f);
-            continue;
-        }
-
-        const int prohibitedLines = f.data(*gs).source().size();
-        auto newSource = absl::StrCat(string(prohibitedLines + 1, '\n'), f.data(*gs).source());
-        auto newFile = make_shared<core::File>(string(f.data(*gs).path()), move(newSource), f.data(*gs).sourceType);
-        gs->replaceFile(f, move(newFile));
-
-        core::MutableContext ctx(*gs, core::Symbols::root(), f);
-
-        handler.drainErrors(*gs);
-
-        // this replicates the logic of pipeline::indexOne
-        ast::ExpressionPtr ast;
-        switch (parser) {
-            case realmain::options::Parser::ORIGINAL: {
-                ENFORCE(!gs->cacheSensitiveOptions.rbsEnabled, "RBS mode is only supported with the Prism parser");
-
-                // Parser
-                parser::ParseResult parseResult;
-                {
-                    auto settings = parser::Parser::Settings{false, false, false};
-                    parseResult = parser::Parser::run(*gs, f, settings);
-                }
-
-                handler.addObserved(*gs, "parse-tree", [&]() { return parseResult.tree->toString(*gs); });
-                handler.addObserved(*gs, "parse-tree-whitequark",
-                                    [&]() { return parseResult.tree->toWhitequark(*gs); });
-                handler.addObserved(*gs, "parse-tree-json", [&]() { return parseResult.tree->toJSON(*gs); });
-
-                // Desugarer
-                ast = ast::desugar::node2Tree(ctx, move(parseResult.tree));
-
-                handler.addObserved(*gs, "desguar-tree", [&]() { return ast.toString(*gs); });
-                handler.addObserved(*gs, "desugar-tree-raw", [&]() { return ast.showRaw(*gs); });
-
-                break;
-            }
-
-            case realmain::options::Parser::PRISM: {
-                auto prismResult = parser::Prism::Parser::run(ctx);
-
-                // Run the RBS rewriter
-                if (gs->cacheSensitiveOptions.rbsEnabled) {
-                    auto &prismParser = prismResult.getParser();
-                    rbs::runRBSRewrite(*gs, f, prismResult.getRawNodePointer(), prismResult.getCommentLocations(), ctx,
-                                       prismParser);
-
-                    handler.addObserved(*gs, "rbs-rewrite-tree", [&]() { return prismResult.prettyPrint(); });
-                }
-
-                // Prism Desugarer
-                { ast = ast::Desugar::Prism::node2Tree(ctx, move(prismResult)); }
-
-                // Do *not* check the `desugar-tree` and `desugar-tree-raw` expectations for the Prism parser,
-                // which can be subtly different (e.g. the numbering of unique identifiers).
-                // Instead, we compare the two ASTs in the `index()` function.
-
-                break;
-            }
-        }
-
-        // Rewriter pass
-        ast = rewriter::Rewriter::run(ctx, move(ast));
-        handler.addObserved(*gs, "rewrite-tree", [&]() { return ast.toString(*gs); });
-        handler.addObserved(*gs, "rewrite-tree-raw", [&]() { return ast.showRaw(*gs); });
-
-        // local vars
-        auto file = ast::ParsedFile{move(ast), f};
-        file = local_vars::LocalVars::run(ctx, move(file));
-        testSerialize(*gs, file);
-        handler.addObserved(*gs, "index-tree", [&]() { return file.tree.toString(*gs); });
-        handler.addObserved(*gs, "index-tree-raw", [&]() { return file.tree.showRaw(*gs); });
-
-        newTrees.emplace_back(move(file));
-    }
-    trees = move(newTrees);
-    fast_sort(trees, [](auto &lhs, auto &rhs) { return lhs.file < rhs.file; });
+    trees = indexForStressIncremental(gs.get(), absl::MakeSpan(files), handler);
 
     bool ranIncrementalNamer = false;
     {

--- a/test/pipeline_test_runner.cc
+++ b/test/pipeline_test_runner.cc
@@ -348,6 +348,7 @@ vector<ast::ParsedFile> index(core::GlobalState &gs, absl::Span<core::FileRef> f
         trees.emplace_back(move(localNamed));
     }
 
+    fast_sort(trees, [](const auto &lhs, const auto &rhs) { return lhs.file < rhs.file; });
     return trees;
 }
 
@@ -587,10 +588,11 @@ TEST_CASE("PerPhaseTest") {
     }
 
     vector<ast::ParsedFile> trees;
+    absl::Span<core::FileRef> inputPackageFiles;
     auto filesSpan = absl::Span<core::FileRef>(files);
     if (opts.cacheSensitiveOptions.sorbetPackages) {
         auto numPackageFiles = realmain::pipeline::partitionPackageFiles(*gs, filesSpan);
-        auto inputPackageFiles = filesSpan.first(numPackageFiles);
+        inputPackageFiles = filesSpan.first(numPackageFiles);
         filesSpan = filesSpan.subspan(numPackageFiles);
 
         trees = index(*gs, inputPackageFiles, handler, test, assertions);
@@ -843,7 +845,12 @@ TEST_CASE("PerPhaseTest") {
     handler.clear(*gs);
     auto symbolsBefore = gs->symbolsUsedTotal();
 
-    trees = indexForStressIncremental(gs.get(), absl::MakeSpan(files), handler);
+    trees = indexForStressIncremental(gs.get(), inputPackageFiles, handler);
+    trees.reserve(files.size());
+    for (auto &stratum : strata.strata) {
+        auto batch = indexForStressIncremental(gs.get(), stratum.sourceFiles, handler);
+        absl::c_move(batch, back_inserter(trees));
+    }
 
     bool ranIncrementalNamer = false;
     {

--- a/test/testdata/packager/directed-unqualified_constant_escapes_later_stratum/pass.package-tree.exp
+++ b/test/testdata/packager/directed-unqualified_constant_escapes_later_stratum/pass.package-tree.exp
@@ -1,0 +1,89 @@
+# -- test/testdata/packager/directed-unqualified_constant_escapes_later_stratum/base/__package.rb --
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class ::<PackageSpecRegistry>::Base<<C Base>> < (::Sorbet::Private::Static::PackageSpec)
+    <self>.import(::<PackageSpecRegistry>::<C P>)
+
+    <self>.export(<emptyTree>::<C Base>::<C Thing>)
+  end
+end
+# -- test/testdata/packager/directed-unqualified_constant_escapes_later_stratum/p/__package.rb --
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class ::<PackageSpecRegistry>::P<<C P>> < (::Sorbet::Private::Static::PackageSpec)
+    <self>.export(<emptyTree>::<C P>::<C Secret2>)
+  end
+end
+# -- test/testdata/packager/directed-unqualified_constant_escapes_later_stratum/p/shared/__package.rb --
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class ::<PackageSpecRegistry>::P::Shared<<C Shared>> < (::Sorbet::Private::Static::PackageSpec)
+    <self>.import(::<PackageSpecRegistry>::<C Base>)
+  end
+end
+# -- test/testdata/packager/directed-unqualified_constant_escapes_later_stratum/p/shared/consumer/__package.rb --
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class ::<PackageSpecRegistry>::P::Shared::Consumer<<C Consumer>> < (::Sorbet::Private::Static::PackageSpec)
+    <self>.import(::<PackageSpecRegistry>::<C P>)
+  end
+end
+# -- test/testdata/packager/directed-unqualified_constant_escapes_later_stratum/p/secret2.rb --
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module ::P<<C P>> < ()
+    class ::P::Secret2<<C Secret2>> < (::<todo sym>)
+    end
+  end
+end
+# -- test/testdata/packager/directed-unqualified_constant_escapes_later_stratum/base/thing.rb --
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module ::Base<<C Base>> < ()
+    class ::Base::Thing<<C Thing>> < (::<todo sym>)
+      def secret(<blk>)
+        <emptyTree>::<C P>::<C Secret2>.new()
+      end
+
+      <runtime method definition of secret>
+    end
+  end
+end
+# -- test/testdata/packager/directed-unqualified_constant_escapes_later_stratum/p/shared/consumer/client.rb --
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module ::P<<C P>> < ()
+    module ::P::Shared<<C Shared>> < ()
+      module ::P::Shared::Consumer<<C Consumer>> < ()
+        class ::P::Shared::Consumer::Client<<C Client>> < (::<todo sym>)
+          def call(<blk>)
+            begin
+              <emptyTree>::<C Secret>
+              <emptyTree>::<C T>.reveal_type(<emptyTree>::<C Secret2>)
+            end
+          end
+
+          <self>.extend(<emptyTree>::<C T>::<C Sig>)
+
+          <runtime method definition of call>
+        end
+      end
+    end
+  end
+end
+# -- test/testdata/packager/directed-unqualified_constant_escapes_later_stratum/p/shared/secret.rb --
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module ::P<<C P>> < ()
+    module ::P::Shared<<C Shared>> < ()
+      class ::P::Shared::Secret<<C Secret>> < (::<todo sym>)
+        def base(<blk>)
+          <emptyTree>::<C Base>::<C Thing>.new()
+        end
+
+        <runtime method definition of base>
+      end
+    end
+  end
+end
+# -- test/testdata/packager/directed-unqualified_constant_escapes_later_stratum/p/shared/secret2.rb --
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module ::P<<C P>> < ()
+    module ::P::Shared<<C Shared>> < ()
+      class ::P::Shared::Secret2<<C Secret2>> < (::<todo sym>)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Review by commit.


### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->

We were only doing the `package-directed` traversal order in the first half of
the pipeline_test_runner, but not in the second, `stress-incremental` pass. This
meant that it was not possible to record `*.exp` files in `package-directed`
packager tests, because there wasn't a sort order that the two halves agreed on.

I'm working on a change to mangle names to solve a packager bug, and I'd like to
be able to show the `*.name-tree.exp` output, so I need this bug fixed.


### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

The first commit message has an example of the way the newly added test fails
before being fixed by these changes.