### PR TITLE
Some `update_testdata_exp.sh` fixes for package tests

### DIFF
--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -105,7 +105,7 @@ fi
 rb_src=()
 while IFS='' read -r line; do
   rb_src+=("$line")
-done < <(find "${paths[@]}" -name '*.rb*' | LC_COLLATE=C sort)
+done < <(find "${paths[@]}" \( -name '*.rb' -o -name '*.rbi' -o -name '*.rbupdate' -o -name '*.rbiupdate' \) | LC_COLLATE=C sort)
 
 basename=
 srcs=()
@@ -131,6 +131,16 @@ for this_src in "${rb_src[@]}" DUMMY; do
   fi
 
   if [ -n "$basename" ]; then
+    all_srcs=("${srcs[@]}")
+    srcs=()
+    for src in "${all_srcs[@]}"; do
+      case "$src" in
+        *.rb|*.rbi)
+          srcs+=("$src")
+          ;;
+      esac
+    done
+
     args=()
 
     case "${srcs[0]}" in
@@ -254,9 +264,9 @@ for this_src in "${rb_src[@]}" DUMMY; do
           # See above for why this case is weird.
           for exp in "${document_symbols_candidates[@]}"; do
             wanted_file="${exp%.document-symbols.exp}"
-            # `srcs` contains all of the exp files, too, but including them should be harmless.
+            # Keep update files in `all_srcs` so that document symbol expectations for them can be regenerated.
             echo bazel-bin/test/print_document_symbols \
-              "$wanted_file" "${srcs[@]}" \
+              "$wanted_file" "${all_srcs[@]}" \
               \> "$exp" \
               2\>/dev/null \
               >>"$COMMAND_FILE"

--- a/tools/scripts/update_testdata_exp.sh
+++ b/tools/scripts/update_testdata_exp.sh
@@ -151,6 +151,9 @@ for this_src in "${rb_src[@]}" DUMMY; do
 
     if grep -q '^# enable-packager: true' "${srcs[@]}"; then
       args+=("--sorbet-packages")
+      if grep -q '^# enable-package-directed: true' "${srcs[@]}"; then
+        args+=("--experimental-package-directed")
+      fi
 
       extra_underscore_prefixes=()
       while IFS='' read -r prefix; do


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Commit summary
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


- **Fix update_testdata_exp for packager tests** (011571b258)

  The source discovery glob was using `*.rb*`, which meant treating
  `.rbupdate` and `.rbiupdate` files like actual input files to Sorbet.

  We _do_ still need the `rbupdate` files for the document-symbols test
  specifically. But for the others, we don't want them.

  Found this while trying to write a `test/testdata/packager` test that
  also had an `*.rbupdate` and a `*.name-tree.exp` file in it.

- **`# enable-package-directed: true` support** (89a3e701f7)




### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

Testing manually on my work-in-progress branches.