### PR TITLE
Mangle invalid package namespace definitions

### DIFF
--- a/core/GlobalState.cc
+++ b/core/GlobalState.cc
@@ -1161,9 +1161,8 @@ SymbolRef GlobalState::findRenamedSymbol(ClassOrModuleRef owner, SymbolRef sym) 
 ClassOrModuleRef GlobalState::enterClassOrModuleSymbol(Loc loc, ClassOrModuleRef owner, NameRef name) {
     // ENFORCE_NO_TIMER(!owner.exists()); // Owner may not exist on purely synthetic symbols.
     ENFORCE_NO_TIMER(name.isClassName(*this));
-    // We should never enter mangled classes (incremental fast path relies on all constants being
-    // defined first).
-    ENFORCE_NO_TIMER(!name.hasUniqueNameKind(*this, core::UniqueNameKind::MangleRename));
+    // Package namespace violations are entered with mangled names so that they cannot claim a constant belonging to
+    // another package.
     ClassOrModuleData ownerScope = owner.dataAllowingNone(*this);
 
     auto &store = ownerScope->members()[name];
@@ -1225,7 +1224,8 @@ GlobalState::ClassOrModulePackageInfo GlobalState::packageInfoForClassOrModule(C
     }
 
     auto registryName = name;
-    while (registryName.hasUniqueNameKind(*this, UniqueNameKind::Singleton)) {
+    while (registryName.hasUniqueNameKind(*this, UniqueNameKind::Singleton) ||
+           registryName.hasUniqueNameKind(*this, UniqueNameKind::MangleRename)) {
         registryName = registryName.dataUnique(*this)->original;
     }
     auto packageRegistryMember = ownerPackageRegistryOwner.data(*this)->findMember(*this, registryName);

--- a/namer/namer.cc
+++ b/namer/namer.cc
@@ -20,6 +20,7 @@
 #include "core/errors/namer.h"
 #include "core/hashing/hashing.h"
 #include "core/lsp/TypecheckEpochManager.h"
+#include "core/packages/PackageInfo.h"
 
 using namespace std;
 
@@ -40,6 +41,12 @@ struct ParsedFileWithIdx {
 };
 
 using AllFoundDefinitions = vector<pair<core::FileRef, unique_ptr<core::FoundDefinitions>>>;
+
+using namespace core::packages;
+
+// [file, owner, originalName] → owner::mangledName
+using MangledClasses =
+    UnorderedMap<tuple<core::FileRef, core::ClassOrModuleRef, core::NameRef>, core::ClassOrModuleRef>;
 
 core::ClassOrModuleRef methodOwner(core::Context ctx, core::SymbolRef owner, bool isSelfMethod) {
     ENFORCE(owner.exists() && owner != core::Symbols::todo());
@@ -792,6 +799,8 @@ private:
     const core::FoundDefinitions &foundDefs;
 
     vector<core::ClassOrModuleRef> &symbolsToRecompute;
+    MangledClasses &mangledClasses;
+    const PackageInfo *package = nullptr;
 
     // Get the symbol for an already-defined owner. Limited to refs that can own things (classes and methods).
     core::ClassOrModuleRef getOwnerSymbol(const SymbolDefiner::State &state, core::FoundDefinitionRef ref) {
@@ -1204,6 +1213,43 @@ private:
         }
     }
 
+    bool shouldMangleClassDefinition(core::MutableContext ctx, core::ClassOrModuleRef owner, core::NameRef name) {
+        if (this->package == nullptr) {
+            return false;
+        }
+
+        // An enclosing mangled name has already isolated this entire subtree from the source-level namespace, so
+        // mangling classes nested more deeply provides no additional protection.
+        for (auto enclosing = owner; enclosing != core::Symbols::root(); enclosing = enclosing.data(ctx)->owner) {
+            if (enclosing.data(ctx)->name.hasUniqueNameKind(ctx, core::UniqueNameKind::MangleRename)) {
+                return false;
+            }
+        }
+
+        auto packageInfo = ctx.state.packageInfoForClassOrModule(owner, name);
+        return packageInfo.packageRegistryOwner.exists() && packageInfo.package.exists() &&
+               !this->package->ownsNamespace(ctx, packageInfo.package, packageInfo.packageRegistryOwner, true);
+    }
+
+    core::NameRef mangledClassName(core::MutableContext ctx, core::ClassOrModuleRef owner,
+                                   const core::FoundClass &klass) {
+        // We can't always call `nextMangledName` because on the fast path we need to reuse the previous name.
+        // To do that, we search the owner's members for a matching mangled symbol defined in this file.
+        // This intentionally gives subsequent reopenings within the same file the same mangled name. It also
+        // makes us resilient to fast path edits, like whitespace changes, that preserve the definition.
+        for (const auto &[candidateName, candidateSymbol] : owner.data(ctx)->members()) {
+            if (!candidateName.hasUniqueNameKind(ctx, core::UniqueNameKind::MangleRename) ||
+                candidateName.dataUnique(ctx)->original != klass.name || !candidateSymbol.isClassOrModule()) {
+                continue;
+            }
+            auto locs = candidateSymbol.asClassOrModuleRef().data(ctx)->locs();
+            if (absl::c_any_of(locs, [&ctx](core::Loc loc) { return loc.file() == ctx.file; })) {
+                return candidateName;
+            }
+        }
+        return ctx.state.nextMangledName(owner, klass.name);
+    }
+
     core::ClassOrModuleRef getClassSymbol(core::MutableContext ctx, const State &state, const core::FoundClass &klass) {
         core::ClassOrModuleRef symbol;
         if (klass.name == core::Names::Constants::Root()) {
@@ -1212,13 +1258,24 @@ private:
             symbol = ctx.owner.asClassOrModuleRef().data(ctx)->singletonClass(ctx);
         } else {
             auto owner = getOwnerSymbol(state, klass.owner);
-            auto member = owner.data(ctx)->findMember(ctx, klass.name);
+            auto name = klass.name;
+
+            auto shouldMangle = shouldMangleClassDefinition(ctx, owner, klass.name);
+            if (shouldMangle) {
+                name = mangledClassName(ctx, owner, klass);
+            }
+
+            auto member = owner.data(ctx)->findMember(ctx, name);
             if (member.exists()) {
-                // If member exists with this name, it must be a class or module, because we never mangle-rename them.
+                // Class/module definitions are entered before other constants, so this member has the right kind.
                 symbol = member.asClassOrModuleRef();
             } else {
-                auto newClass = ctx.state.enterClassOrModuleSymbol(ctx.locAt(klass.declLoc), owner, klass.name);
+                auto newClass = ctx.state.enterClassOrModuleSymbol(ctx.locAt(klass.declLoc), owner, name);
                 symbol = newClass;
+            }
+
+            if (shouldMangle) {
+                mangledClasses[{ctx.file, owner, klass.name}] = symbol;
             }
         }
         ENFORCE(symbol.exists());
@@ -1782,8 +1839,22 @@ public:
         }
     }
 
-    SymbolDefiner(const core::FoundDefinitions &foundDefs, vector<core::ClassOrModuleRef> &symbolsToRecompute)
-        : foundDefs(foundDefs), symbolsToRecompute{symbolsToRecompute} {}
+    SymbolDefiner(core::Context ctx, const core::FoundDefinitions &foundDefs, vector<core::ClassOrModuleRef> &symbolsToRecompute, MangledClasses &mangledClasses)
+        : foundDefs(foundDefs), symbolsToRecompute{symbolsToRecompute}, mangledClasses(mangledClasses) {
+        // TODO(jez) Should this be a helper somewhere?
+        auto &file = ctx.file.data(ctx);
+        if (!ctx.state.packageDB().enabled() || file.isPackage(ctx)) {
+            return;
+        }
+
+        auto packageName = ctx.state.packageDB().getPackageNameForFile(ctx.file);
+        if (!packageName.exists()) {
+            return;
+        }
+
+        auto &package = ctx.state.packageDB().getPackageInfo(packageName);
+        this->package = package.exists() ? &package : nullptr;
+    }
 
     SymbolDefiner::State enterClassDefinitions(core::MutableContext ctx, bool willDeleteOldDefs,
                                                ClassBehaviorLocsMap &classBehaviorLocs) {
@@ -1927,6 +1998,7 @@ public:
  */
 class TreeSymbolizer {
     friend class Namer;
+    const MangledClasses &mangledClasses;
 
     core::SymbolRef squashNamesInner(core::Context ctx, core::SymbolRef owner, ast::ExpressionPtr &node,
                                      bool firstName) {
@@ -1959,7 +2031,10 @@ class TreeSymbolizer {
         auto newOwner = squashNamesInner(ctx, owner, constLit->scope, firstNameRecursive);
         ENFORCE(newOwner.exists());
 
-        core::SymbolRef existing = ctx.state.lookupClassSymbol(newOwner.asClassOrModuleRef(), constLit->cnst);
+        auto mangled = mangledClasses.find({ctx.file, newOwner.asClassOrModuleRef(), constLit->cnst});
+        core::SymbolRef existing = mangled != mangledClasses.end()
+                                       ? mangled->second
+                                       : ctx.state.lookupClassSymbol(newOwner.asClassOrModuleRef(), constLit->cnst);
         if (firstName && !existing.exists() && newOwner.isClassOrModule()) {
             existing = ctx.state.lookupStaticFieldSymbol(newOwner.asClassOrModuleRef(), constLit->cnst);
             if (existing.exists()) {
@@ -1989,7 +2064,7 @@ class TreeSymbolizer {
     }
 
 public:
-    TreeSymbolizer() {}
+    TreeSymbolizer(const MangledClasses &mangledClasses) : mangledClasses(mangledClasses) {}
 
     void preTransformClassDef(core::Context ctx, ast::ExpressionPtr &tree) {
         auto &klass = ast::cast_tree_nonnull<ast::ClassDef>(tree);
@@ -2451,7 +2526,7 @@ void findConflictingClassDefs(const core::GlobalState &gs, ClassBehaviorLocsMap 
 
 void defineSymbols(core::GlobalState &gs, AllFoundDefinitions allFoundDefinitions,
                    UnorderedMap<core::FileRef, shared_ptr<const core::FileHash>> &&oldFoundHashesForFiles,
-                   core::FoundDefHashesResult *foundHashesOut, vector<core::ClassOrModuleRef> &updatedSymbols) {
+                   core::FoundDefHashesResult *foundHashesOut, vector<core::ClassOrModuleRef> &updatedSymbols, MangledClasses &mangledClasses) {
     Timer timeit(gs.tracer(), "naming.defineSymbols");
     const auto &epochManager = *gs.epochManager;
     uint32_t count = 0;
@@ -2468,7 +2543,7 @@ void defineSymbols(core::GlobalState &gs, AllFoundDefinitions allFoundDefinition
         }
         core::MutableContext ctx(gs, core::Symbols::root(), fref);
 
-        SymbolDefiner symbolDefiner(*fileFoundDefinitions, updatedSymbols);
+        SymbolDefiner symbolDefiner(ctx, *fileFoundDefinitions, updatedSymbols, mangledClasses);
         auto state = symbolDefiner.enterClassDefinitions(ctx, willDeleteOldDefs, classBehaviorLocs);
         if (willDeleteOldDefs) {
             auto frefIt = oldFoundHashesForFiles.find(fref);
@@ -2494,15 +2569,15 @@ void defineSymbols(core::GlobalState &gs, AllFoundDefinitions allFoundDefinition
 
         core::MutableContext ctx(gs, core::Symbols::root(), fref);
 
-        SymbolDefiner symbolDefiner(*fileFoundDefinitions, updatedSymbols);
+        SymbolDefiner symbolDefiner(ctx, *fileFoundDefinitions, updatedSymbols, mangledClasses);
         symbolDefiner.enterNewDefinitions(ctx, move(incrementalDefinitions[fref]));
     }
     return;
 }
 
-void symbolizeTrees(const core::GlobalState &gs, absl::Span<ast::ParsedFile> trees, WorkerPool &workers) {
+void symbolizeTrees(const core::GlobalState &gs, absl::Span<ast::ParsedFile> trees, WorkerPool &workers, const MangledClasses &mangledClasses) {
     Timer timeit(gs.tracer(), "naming.symbolizeTrees");
-    Parallel::iterate(workers, "symbolizeTrees", trees, [&gs, inserter = TreeSymbolizer()](auto &parsedFile) mutable {
+    Parallel::iterate(workers, "symbolizeTrees", trees, [&gs, inserter = TreeSymbolizer(mangledClasses)](auto &parsedFile) mutable {
         Timer timeit(gs.tracer(), "naming.symbolizeTreesOne", {{"file", string(parsedFile.file.data(gs).path())}});
         core::Context ctx(gs, core::Symbols::root(), parsedFile.file);
         ast::TreeWalk::apply(ctx, inserter, parsedFile.tree);
@@ -2524,12 +2599,13 @@ Namer::runInternal(core::GlobalState &gs, absl::Span<ast::ParsedFile> trees, Wor
         ENFORCE(foundDefs.size() == 1,
                 "Producing foundMethodHashes is meant to only happen when hashing a single file");
     }
-    defineSymbols(gs, move(foundDefs), std::move(oldFoundHashesForFiles), foundHashesOut, updatedSymbols);
+    MangledClasses mangledClasses;
+    defineSymbols(gs, move(foundDefs), std::move(oldFoundHashesForFiles), foundHashesOut, updatedSymbols, mangledClasses);
     if (gs.epochManager->wasTypecheckingCanceled()) {
         return true;
     }
 
-    symbolizeTrees(gs, trees, workers);
+    symbolizeTrees(gs, trees, workers, mangledClasses);
     return false;
 }
 

--- a/test/cli/package-import-conflicts/test.out
+++ b/test/cli/package-import-conflicts/test.out
@@ -5,13 +5,6 @@ a/__package.rb:4: Cannot export `A::B` because it is owned by another package ht
      3 |module A::B
         ^^^^^^^^^^^
 
-ab/ab.rb:3: `A::B` was previously defined as a `class` https://srb.help/4012
-     3 |module A::B
-        ^^^^^^^^^^^
-    a/a.rb:4: Previous definition
-     4 |  class B; end
-          ^^^^^^^
-
 a/a.rb:4: File belongs to package `A` but defines a constant that does not match this namespace https://srb.help/3713
      4 |  class B; end
                 ^
@@ -21,4 +14,4 @@ a/a.rb:4: File belongs to package `A` but defines a constant that does not match
     ab/__package.rb:3: Must belong to this package, given constant name `A::B`
      3 |class A::B < PackageSpec
         ^^^^^^^^^^^^^^^^^^^^^^^^
-Errors: 3
+Errors: 2

--- a/test/testdata/packager/directed-open-early/first/__package.rb
+++ b/test/testdata/packager/directed-open-early/first/__package.rb
@@ -1,0 +1,7 @@
+# typed: strict
+# enable-packager: true
+# enable-package-directed: true
+# stratum: 1
+
+class First < PackageSpec
+end

--- a/test/testdata/packager/directed-open-early/first/bad_open.1.rbupdate
+++ b/test/testdata/packager/directed-open-early/first/bad_open.1.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+# assert-slow-path: false
+
+
+module Second
+     # ^^^^^^ error: File belongs to package `First` but defines a constant that does not match this namespace
+  class Foo
+    def foo; end
+  end
+end

--- a/test/testdata/packager/directed-open-early/first/bad_open.2.rbupdate
+++ b/test/testdata/packager/directed-open-early/first/bad_open.2.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+# assert-slow-path: false
+
+
+module Second
+     # ^^^^^^ error: File belongs to package `First` but defines a constant that does not match this namespace
+  class Foo
+    def bar; end
+  end
+end

--- a/test/testdata/packager/directed-open-early/first/bad_open.rb
+++ b/test/testdata/packager/directed-open-early/first/bad_open.rb
@@ -1,0 +1,8 @@
+# typed: true
+
+module Second
+     # ^^^^^^ error: File belongs to package `First` but defines a constant that does not match this namespace
+  class Foo
+    def foo; end
+  end
+end

--- a/test/testdata/packager/directed-open-early/first/bad_test_open.1.rbupdate
+++ b/test/testdata/packager/directed-open-early/first/bad_test_open.1.rbupdate
@@ -1,0 +1,8 @@
+# typed: true
+
+module Test::Second
+     # ^^^^^^^^^^^^ error: File belongs to package `First` but defines a constant that does not match this namespace
+  class FromFirst
+  end
+end
+# exclude-from-file-update: true

--- a/test/testdata/packager/directed-open-early/first/bad_test_open.2.rbupdate
+++ b/test/testdata/packager/directed-open-early/first/bad_test_open.2.rbupdate
@@ -1,0 +1,8 @@
+# typed: true
+
+module Test::Second
+     # ^^^^^^^^^^^^ error: File belongs to package `First` but defines a constant that does not match this namespace
+  class FromFirst
+  end
+end
+# exclude-from-file-update: true

--- a/test/testdata/packager/directed-open-early/first/bad_test_open.rb
+++ b/test/testdata/packager/directed-open-early/first/bad_test_open.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+module Test::Second
+     # ^^^^^^^^^^^^ error: File belongs to package `First` but defines a constant that does not match this namespace
+  class FromFirst
+  end
+end

--- a/test/testdata/packager/directed-open-early/first/nested_bad_open.1.rbupdate
+++ b/test/testdata/packager/directed-open-early/first/nested_bad_open.1.rbupdate
@@ -1,0 +1,8 @@
+# typed: true
+
+module Second::Other
+     # ^^^^^^^^^^^^^ error: File belongs to package `First` but defines a constant that does not match this namespace
+  class Foo
+  end
+end
+# exclude-from-file-update: true

--- a/test/testdata/packager/directed-open-early/first/nested_bad_open.2.rbupdate
+++ b/test/testdata/packager/directed-open-early/first/nested_bad_open.2.rbupdate
@@ -1,0 +1,8 @@
+# typed: true
+
+module Second::Other
+     # ^^^^^^^^^^^^^ error: File belongs to package `First` but defines a constant that does not match this namespace
+  class Foo
+  end
+end
+# exclude-from-file-update: true

--- a/test/testdata/packager/directed-open-early/first/nested_bad_open.rb
+++ b/test/testdata/packager/directed-open-early/first/nested_bad_open.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+module Second::Other
+     # ^^^^^^^^^^^^^ error: File belongs to package `First` but defines a constant that does not match this namespace
+  class Foo
+  end
+end

--- a/test/testdata/packager/directed-open-early/first/root_bad_open.1.rbupdate
+++ b/test/testdata/packager/directed-open-early/first/root_bad_open.1.rbupdate
@@ -1,0 +1,8 @@
+# typed: true
+
+module ::Second
+     # ^^^^^^^^ error: Defining a root-scoped constant requires this package to be marked `prelude!`
+  class Foo
+  end
+end
+# exclude-from-file-update: true

--- a/test/testdata/packager/directed-open-early/first/root_bad_open.2.rbupdate
+++ b/test/testdata/packager/directed-open-early/first/root_bad_open.2.rbupdate
@@ -1,0 +1,8 @@
+# typed: true
+
+module ::Second
+     # ^^^^^^^^ error: Defining a root-scoped constant requires this package to be marked `prelude!`
+  class Foo
+  end
+end
+# exclude-from-file-update: true

--- a/test/testdata/packager/directed-open-early/first/root_bad_open.rb
+++ b/test/testdata/packager/directed-open-early/first/root_bad_open.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+module ::Second
+     # ^^^^^^^^ error: Defining a root-scoped constant requires this package to be marked `prelude!`
+  class Foo
+  end
+end

--- a/test/testdata/packager/directed-open-early/parent/__package.rb
+++ b/test/testdata/packager/directed-open-early/parent/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Parent < PackageSpec
+end

--- a/test/testdata/packager/directed-open-early/parent/first/__package.rb
+++ b/test/testdata/packager/directed-open-early/parent/first/__package.rb
@@ -1,0 +1,5 @@
+# typed: strict
+# stratum: 1
+
+class Parent::First < PackageSpec
+end

--- a/test/testdata/packager/directed-open-early/parent/first/bad_open.1.rbupdate
+++ b/test/testdata/packager/directed-open-early/parent/first/bad_open.1.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+
+module Parent
+  module Second
+       # ^^^^^^ error: File belongs to package `Parent::First` but defines a constant that does not match this namespace
+    class Foo
+    end
+  end
+end
+# exclude-from-file-update: true

--- a/test/testdata/packager/directed-open-early/parent/first/bad_open.2.rbupdate
+++ b/test/testdata/packager/directed-open-early/parent/first/bad_open.2.rbupdate
@@ -1,0 +1,10 @@
+# typed: true
+
+module Parent
+  module Second
+       # ^^^^^^ error: File belongs to package `Parent::First` but defines a constant that does not match this namespace
+    class Foo
+    end
+  end
+end
+# exclude-from-file-update: true

--- a/test/testdata/packager/directed-open-early/parent/first/bad_open.rb
+++ b/test/testdata/packager/directed-open-early/parent/first/bad_open.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+module Parent
+  module Second
+       # ^^^^^^ error: File belongs to package `Parent::First` but defines a constant that does not match this namespace
+    class Foo
+    end
+  end
+end

--- a/test/testdata/packager/directed-open-early/parent/second/__package.rb
+++ b/test/testdata/packager/directed-open-early/parent/second/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# stratum: 2
+
+class Parent::Second < PackageSpec
+  import Parent::First
+end

--- a/test/testdata/packager/directed-open-early/parent/second/foo.rb
+++ b/test/testdata/packager/directed-open-early/parent/second/foo.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+module Parent::Second
+  class Foo
+    extend T::Generic
+
+    X = type_member
+  end
+end

--- a/test/testdata/packager/directed-open-early/prelude/__package.rb
+++ b/test/testdata/packager/directed-open-early/prelude/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# stratum: 0
+
+class Prelude < PackageSpec
+  prelude!
+end

--- a/test/testdata/packager/directed-open-early/prelude/bad_open.rb
+++ b/test/testdata/packager/directed-open-early/prelude/bad_open.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+module ::Second
+  class Foo
+  end
+end

--- a/test/testdata/packager/directed-open-early/second/__package.rb
+++ b/test/testdata/packager/directed-open-early/second/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# stratum: 2
+
+class Second < PackageSpec
+  import First
+end

--- a/test/testdata/packager/directed-open-early/second/foo.rb
+++ b/test/testdata/packager/directed-open-early/second/foo.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+module Second
+  class Foo
+    extend T::Generic
+
+    X = type_member
+  end
+end

--- a/test/testdata/packager/directed-open-early/second/foo.test.rb
+++ b/test/testdata/packager/directed-open-early/second/foo.test.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+module Test::Second
+  class FromSecondTest
+    extend T::Generic
+
+    X = type_member
+  end
+end

--- a/test/testdata/packager/directed-open-early/second/other/foo.rb
+++ b/test/testdata/packager/directed-open-early/second/other/foo.rb
@@ -1,0 +1,9 @@
+# typed: true
+
+module Second::Other
+  class Foo
+    extend T::Generic
+
+    X = type_member
+  end
+end

--- a/test/testdata/packager/package-namespace-mangling/first/__package.rb
+++ b/test/testdata/packager/package-namespace-mangling/first/__package.rb
@@ -1,0 +1,6 @@
+# typed: strict
+# enable-packager: true
+# enable-package-directed: true
+
+class First < PackageSpec
+end

--- a/test/testdata/packager/package-namespace-mangling/first/bad_open.rb
+++ b/test/testdata/packager/package-namespace-mangling/first/bad_open.rb
@@ -1,0 +1,7 @@
+# typed: true
+
+module Second
+     # ^^^^^^ error: File belongs to package `First` but defines a constant that does not match this namespace
+  class FromFirst
+  end
+end

--- a/test/testdata/packager/package-namespace-mangling/first/unreferenced_bad_open.rb
+++ b/test/testdata/packager/package-namespace-mangling/first/unreferenced_bad_open.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+# This scope contains no constant references, but it still cannot claim another package's namespace.
+module Second
+     # ^^^^^^ error: File belongs to package `First` but defines a constant that does not match this namespace
+end

--- a/test/testdata/packager/package-namespace-mangling/pass.name-tree.exp
+++ b/test/testdata/packager/package-namespace-mangling/pass.name-tree.exp
@@ -1,0 +1,24 @@
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class ::<PackageSpecRegistry>::First<<C First>> < (::Sorbet::Private::Static::PackageSpec)
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  class ::<PackageSpecRegistry>::Second<<C Second>> < (::Sorbet::Private::Static::PackageSpec)
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module ::Second<Second$1> < ()
+    class ::Second::FromFirst<<C FromFirst>> < (::<todo sym>)
+    end
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module ::Second<Second$2> < ()
+  end
+end
+class <emptyTree><<C <root>>> < (::<todo sym>)
+  module ::Second<<C Second>> < ()
+    class ::Second::FromSecond<<C FromSecond>> < (::<todo sym>)
+    end
+  end
+end

--- a/test/testdata/packager/package-namespace-mangling/pass.symbol-table.exp
+++ b/test/testdata/packager/package-namespace-mangling/pass.symbol-table.exp
@@ -1,0 +1,49 @@
+class ::<root> < ::Object ()
+  module ::<PackageSpecRegistry> < ::Sorbet::Private::Static::ImplicitModuleSuperclass ()
+    class ::<PackageSpecRegistry>::First < ::Sorbet::Private::Static::PackageSpec () @ test/testdata/packager/package-namespace-mangling/first/__package.rb:5
+    class ::<PackageSpecRegistry>::<Class:First>[<AttachedClass>] < ::Sorbet::Private::Static::<Class:PackageSpec> () @ test/testdata/packager/package-namespace-mangling/first/__package.rb:5
+      type-member(+) ::<PackageSpecRegistry>::<Class:First>::<AttachedClass> -> T.attached_class (of First) @ test/testdata/packager/package-namespace-mangling/first/__package.rb:5
+      method ::<PackageSpecRegistry>::<Class:First>#<static-init> (<blk>) @ test/testdata/packager/package-namespace-mangling/first/__package.rb:5
+        argument <blk><block> @ Loc {file=test/testdata/packager/package-namespace-mangling/first/__package.rb start=??? end=???}
+    class ::<PackageSpecRegistry>::Second < ::Sorbet::Private::Static::PackageSpec () @ test/testdata/packager/package-namespace-mangling/second/__package.rb:3
+    class ::<PackageSpecRegistry>::<Class:Second>[<AttachedClass>] < ::Sorbet::Private::Static::<Class:PackageSpec> () @ test/testdata/packager/package-namespace-mangling/second/__package.rb:3
+      type-member(+) ::<PackageSpecRegistry>::<Class:Second>::<AttachedClass> -> T.attached_class (of Second) @ test/testdata/packager/package-namespace-mangling/second/__package.rb:3
+      method ::<PackageSpecRegistry>::<Class:Second>#<static-init> (<blk>) @ test/testdata/packager/package-namespace-mangling/second/__package.rb:3
+        argument <blk><block> @ Loc {file=test/testdata/packager/package-namespace-mangling/second/__package.rb start=??? end=???}
+  class ::<Class:<root>>[<AttachedClass>] < ::<Class:Object> ()
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/packager/package-namespace-mangling/first/__package.rb:5
+      argument <blk><block> @ Loc {file=test/testdata/packager/package-namespace-mangling/first/__package.rb start=??? end=???}
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/packager/package-namespace-mangling/first/bad_open.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/packager/package-namespace-mangling/first/bad_open.rb start=??? end=???}
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/packager/package-namespace-mangling/first/unreferenced_bad_open.rb:4
+      argument <blk><block> @ Loc {file=test/testdata/packager/package-namespace-mangling/first/unreferenced_bad_open.rb start=??? end=???}
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/packager/package-namespace-mangling/second/__package.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/packager/package-namespace-mangling/second/__package.rb start=??? end=???}
+    method ::<Class:<root>>#<static-init> (<blk>) @ test/testdata/packager/package-namespace-mangling/second/definition.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/packager/package-namespace-mangling/second/definition.rb start=??? end=???}
+  module ::Second < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/packager/package-namespace-mangling/second/definition.rb:3
+    class ::Second::FromSecond < ::Object () @ test/testdata/packager/package-namespace-mangling/second/definition.rb:4
+    class ::Second::<Class:FromSecond>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/packager/package-namespace-mangling/second/definition.rb:4
+      type-member(+) ::Second::<Class:FromSecond>::<AttachedClass> -> T.attached_class (of Second::FromSecond) @ test/testdata/packager/package-namespace-mangling/second/definition.rb:4
+      method ::Second::<Class:FromSecond>#<static-init> (<blk>) @ test/testdata/packager/package-namespace-mangling/second/definition.rb:4
+        argument <blk><block> @ Loc {file=test/testdata/packager/package-namespace-mangling/second/definition.rb start=??? end=???}
+  module ::Second < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/packager/package-namespace-mangling/first/bad_open.rb:3
+    class ::Second::FromFirst < ::Object () @ test/testdata/packager/package-namespace-mangling/first/bad_open.rb:5
+    class ::Second::<Class:FromFirst>[<AttachedClass>] < ::<Class:Object> () @ test/testdata/packager/package-namespace-mangling/first/bad_open.rb:5
+      type-member(+) ::Second::<Class:FromFirst>::<AttachedClass> -> T.attached_class (of Second::FromFirst) @ test/testdata/packager/package-namespace-mangling/first/bad_open.rb:5
+      method ::Second::<Class:FromFirst>#<static-init> (<blk>) @ test/testdata/packager/package-namespace-mangling/first/bad_open.rb:5
+        argument <blk><block> @ Loc {file=test/testdata/packager/package-namespace-mangling/first/bad_open.rb start=??? end=???}
+  module ::Second < ::Sorbet::Private::Static::ImplicitModuleSuperclass () @ test/testdata/packager/package-namespace-mangling/first/unreferenced_bad_open.rb:4
+  class ::<Class:Second>[<AttachedClass>] < ::Module () @ test/testdata/packager/package-namespace-mangling/second/definition.rb:3
+    type-member(+) ::<Class:Second>::<AttachedClass> -> T.attached_class (of Second) @ test/testdata/packager/package-namespace-mangling/second/definition.rb:3
+    method ::<Class:Second>#<static-init> (<blk>) @ test/testdata/packager/package-namespace-mangling/second/definition.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/packager/package-namespace-mangling/second/definition.rb start=??? end=???}
+  class ::<Class:Second>[<AttachedClass>] < ::Module () @ test/testdata/packager/package-namespace-mangling/first/bad_open.rb:3
+    type-member(+) ::<Class:Second>::<AttachedClass> -> T.attached_class (of Second) @ test/testdata/packager/package-namespace-mangling/first/bad_open.rb:3
+    method ::<Class:Second>#<static-init> (<blk>) @ test/testdata/packager/package-namespace-mangling/first/bad_open.rb:3
+      argument <blk><block> @ Loc {file=test/testdata/packager/package-namespace-mangling/first/bad_open.rb start=??? end=???}
+  class ::<Class:Second>[<AttachedClass>] < ::Module () @ test/testdata/packager/package-namespace-mangling/first/unreferenced_bad_open.rb:4
+    type-member(+) ::<Class:Second>::<AttachedClass> -> T.attached_class (of Second) @ test/testdata/packager/package-namespace-mangling/first/unreferenced_bad_open.rb:4
+    method ::<Class:Second>#<static-init> (<blk>) @ test/testdata/packager/package-namespace-mangling/first/unreferenced_bad_open.rb:4
+      argument <blk><block> @ Loc {file=test/testdata/packager/package-namespace-mangling/first/unreferenced_bad_open.rb start=??? end=???}
+

--- a/test/testdata/packager/package-namespace-mangling/second/__package.rb
+++ b/test/testdata/packager/package-namespace-mangling/second/__package.rb
@@ -1,0 +1,4 @@
+# typed: strict
+
+class Second < PackageSpec
+end

--- a/test/testdata/packager/package-namespace-mangling/second/definition.rb
+++ b/test/testdata/packager/package-namespace-mangling/second/definition.rb
@@ -1,0 +1,6 @@
+# typed: true
+
+module Second
+  class FromSecond
+  end
+end


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->


### Motivation & summary
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->


We observed crashes in the package-directed mode: a definition that
doesn't match the enclosing namespace is defined in an earlier stratum,
when it should have been defined only in a later stratum. That means
that if/when we *do* see it in a later stratum, we end up mutating a
symbol defined in an earlier stratum, which escapes our "copy a prefix"
logic.

(It's not enough to just report an error about defining a constant that
doesn't match the enclosing package's namespace: reporting the error but
then proceeding anyway pollutes the symbol-table, mutating state owned
by an earlier stratum.)

To avoid defining symbols that can be referenced and modified by later
strata, we instead define the symbols with mangled names (not actually
using `mangleRenameSymbol`, but rather just by inventing a
`MangleRename` unique name).

This effectively hides the mis-named class definition from symbol-table
prefix copying: it gets associated with the current stratum, but nothing
downstream of us in the strata can ever reference it, so it no longer
matters.

The core decision to mangle lives in SymbolDefiner, because we can only
enter new `core::Name` (for the mangled names) when we have a mutable
GlobalState.

A tricky part is how to communicate that something was mangled out of
`SymbolDefiner` and back into `TreeSymbolizer`. I think the most
expedient way of doing this it to keep track of a lookaside map, which
we can use to find things. The map should, in normal operation, be tiny
(because it is only populated when there are namespace errors).

There are also some considerations around how to make this work on the
fast path, which we can deal with by scanning owner members looking for
a name that we were looking for before. It's a little janky but it
works: the fast path reuses the same unique name because the existing
symbol survives (we don't delete class symbols on the fast path) and
because repeatedly opening the same badly-named class within a file uses
the same mangled name across all usages.

Note that we make one change in `packageInfoForClassOrModule` (the new
helper called by `enterClassOrModuleSymbol`) to see through these
mangled names to the original for the sake of computing package registry
ownership. This preserves the ownership invariants expected by later
naming and resolution phases.



### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

See included automated tests.